### PR TITLE
Solari: Misc BRDF changes

### DIFF
--- a/crates/bevy_solari/src/scene/brdf.wgsl
+++ b/crates/bevy_solari/src/scene/brdf.wgsl
@@ -14,6 +14,7 @@ struct EvaluateAndSampleBrdfResult {
     wi: vec3<f32>,
     throughput: vec3<f32>,
     pdf: f32,
+    diffuse_selected: bool,
 }
 
 struct LobeReflectances {
@@ -40,7 +41,7 @@ fn evaluate_and_sample_brdf(
     rng: ptr<function, u32>,
 ) -> EvaluateAndSampleBrdfResult {
     let NdotV = dot(world_normal, wo);
-    if NdotV < 0.0001 { return EvaluateAndSampleBrdfResult(vec3(0.0), vec3(0.0), 0.0); }
+    if NdotV < 0.0001 { return EvaluateAndSampleBrdfResult(vec3(0.0), vec3(0.0), 0.0, false); }
     let F0_metal = material.base_color;
     let F0_dielectric = calculate_F0_dielectric(vec3(material.reflectance));
     let rho = lobe_reflectances(F0_metal, F0_dielectric, material, F_ab);
@@ -63,7 +64,7 @@ fn evaluate_and_sample_brdf(
     } else {
         wi_tangent = sample_ggx_vndf(wo_tangent, material.roughness, rng);
         if ggx_vndf_sample_invalid(wi_tangent) {
-            return EvaluateAndSampleBrdfResult(vec3(0.0), vec3(0.0), 0.0);
+            return EvaluateAndSampleBrdfResult(vec3(0.0), vec3(0.0), 0.0, false);
         }
         wi = wi_tangent.x * T + wi_tangent.y * B + wi_tangent.z * N;
 
@@ -72,7 +73,8 @@ fn evaluate_and_sample_brdf(
             return EvaluateAndSampleBrdfResult(
                 wi,
                 evaluate_specular_brdf(wo, wi, world_normal, material, F_ab) / specular_weight,
-                bitcast<f32>(0x7F800000u) // INF
+                bitcast<f32>(0x7F800000u), // INF
+                false,
             );
         }
     }
@@ -81,7 +83,7 @@ fn evaluate_and_sample_brdf(
     let specular_pdf = ggx_vndf_pdf(wo_tangent, wi_tangent, material.roughness);
     let pdf = (diffuse_weight * diffuse_pdf) + (specular_weight * specular_pdf);
     let throughput = evaluate_brdf(wo, wi, world_normal, material, F_ab) / pdf;
-    return EvaluateAndSampleBrdfResult(wi, throughput, pdf);
+    return EvaluateAndSampleBrdfResult(wi, throughput, pdf, diffuse_selected);
 }
 
 fn evaluate_brdf(
@@ -91,7 +93,7 @@ fn evaluate_brdf(
     material: ResolvedMaterial,
     F_ab: vec2<f32>,
 ) -> vec3<f32> {
-    return evaluate_diffuse_brdf(wo, wi, world_normal, material, F_ab) + evaluate_specular_brdf(wo, wi, world_normal, material, F_ab);
+    return max(evaluate_diffuse_brdf(wo, wi, world_normal, material, F_ab) + evaluate_specular_brdf(wo, wi, world_normal, material, F_ab), vec3(0.0));
 }
 
 fn evaluate_diffuse_brdf(wo: vec3<f32>, wi: vec3<f32>, world_normal: vec3<f32>, material: ResolvedMaterial, F_ab: vec2<f32>) -> vec3<f32> {


### PR DESCRIPTION
# Description
- Prevent NaNs from weird layering issues related to LUT precision by clamping the result of evaluate_brdf
- Add `EvaluateAndSampleBrdfResult.diffuse_selected` which will be used in a future PR