### PR TITLE
Another text measurement fix

### DIFF
--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -23,7 +23,7 @@ use bevy_text::{
     LineHeight, RemSize, ScaleCx, TextBounds, TextColor, TextError, TextFont, TextLayout,
     TextLayoutInfo, TextMeasureInfo, TextPipeline, TextReader, TextSection, TextWriter,
 };
-use taffy::{style::AvailableSpace, MaybeMath};
+use taffy::{style::AvailableSpace, MaybeMath, ResolveOrZero};
 use tracing::error;
 
 /// UI text system flags.
@@ -181,15 +181,33 @@ impl TextMeasure {
 
 impl Measure for TextMeasure {
     fn measure(&mut self, measure_args: MeasureArgs) -> Vec2 {
-        let width = measure_args.resolve_width();
+        let mut width = measure_args.resolve_width();
         let height = measure_args.resolve_height();
 
         let MeasureArgs {
             available_width,
             buffer,
             font_system,
+            style,
             ..
         } = measure_args;
+
+        // The text is wrapped inside the content box, so subtract horizontal padding and border.
+        if style.box_sizing == taffy::style::BoxSizing::BorderBox {
+            let context = taffy::Size {
+                width: width.effective,
+                height: height.effective,
+            };
+            let calc = |_, _| 0.;
+            let padding = style.padding.resolve_or_zero(context, calc);
+            let border = style.border.resolve_or_zero(context, calc);
+            let total_x_inset = padding.left + padding.right + border.left + border.right;
+            width.min = width.min.map(|min| (min - total_x_inset).max(0.));
+            width.max = width.max.map(|max| (max - total_x_inset).max(0.));
+            width.effective = width
+                .effective
+                .map(|effective| (effective - total_x_inset).max(0.));
+        }
 
         let x = width
             .effective

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -954,23 +954,24 @@ mod text_wrap {
             }
         }
 
-        commands.spawn_scene(bsn! {
+        commands.spawn((
             Node {
                 position_type: PositionType::Absolute,
                 padding: UiRect::px(10.0, 10.0, 8.0, 6.0),
                 top: px(300.0),
                 left: px(300.0),
                 width: vmin(30.0),
-            }
-            BackgroundColor(bevy::color::palettes::css::GREEN)
-            Text("initial text here")
-            TextColor(Color::WHITE)
+                ..default()
+            },
+            BackgroundColor::from(bevy::color::palettes::css::GREEN),
+            Text::new("initial text here"),
+            TextColor(Color::WHITE),
             TextLayout {
                 justify: Justify::Left,
-                linebreak: LineBreak::WordBoundary
-            }
-            DespawnOnExit({ Scene::TextWrap })
-        });
+                linebreak: LineBreak::WordBoundary,
+            },
+            DespawnOnExit(super::Scene::TextWrap),
+        ));
     }
 }
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -953,6 +953,23 @@ mod text_wrap {
                 ));
             }
         }
+
+        commands.spawn_scene(bsn! {
+            Node {
+                position_type: PositionType::Absolute,
+                padding: UiRect::px(10.0, 10.0, 8.0, 6.0),
+                top: px(300.0),
+                left: px(300.0),
+                width: vmin(30.0),
+            }
+            BackgroundColor(bevy::color::palettes::css::GREEN)
+            Text("initial text here")
+            TextColor(Color::WHITE)
+            TextLayout {
+                justify: Justify::Left,
+                linebreak: LineBreak::WordBoundary
+            }
+        });
     }
 }
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -969,7 +969,7 @@ mod text_wrap {
                 justify: Justify::Left,
                 linebreak: LineBreak::WordBoundary
             }
-            DespawnOnExit(super::Scene::TextWrap)
+            DespawnOnExit({ Scene::TextWrap })
         });
     }
 }

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -969,6 +969,7 @@ mod text_wrap {
                 justify: Justify::Left,
                 linebreak: LineBreak::WordBoundary
             }
+            DespawnOnExit(super::Scene::TextWrap)
         });
     }
 }


### PR DESCRIPTION
# Objective

Text is wrapped to fit inside the node's content box but the node is sized as though the text isn't wrapped.

Fixes #24664

## Solution

Subtract the total of the horizontal padding and border insets.

## Testing

Added the replication from #24664 to `testbed_ui`'s `TextWrap` scene:
```
cargo run --example testbed_ui -- textwrap
```

<img width="500" alt="image" src="https://github.com/user-attachments/assets/e37884d1-7ae6-4aab-b16f-c5af004f5556" />

---

The other examples, particularly `text_debug`, shouldn't demonstrate any changes.