### PR TITLE
Solari: Make light tiles properly random

### DIFF
--- a/crates/bevy_solari/src/realtime/presample_light_tiles.wgsl
+++ b/crates/bevy_solari/src/realtime/presample_light_tiles.wgsl
@@ -13,7 +13,7 @@ enable wgpu_ray_query;
 @compute @workgroup_size(1024, 1, 1)
 fn presample_light_tiles(@builtin(workgroup_id) workgroup_id: vec3<u32>, @builtin(local_invocation_index) sample_index: u32) {
     let tile_id = workgroup_id.x;
-    var rng = (tile_id * 5782582u) + sample_index + constants.frame_index;
+    var rng = (tile_id * 0x9E3779B9u) + sample_index + constants.frame_index;
 
     let sample = generate_random_light_sample(&rng);
 


### PR DESCRIPTION
# Objective

- Due to reusing the same constant in presample_light_tiles RNG as I used in the frame_index RNG, the light tiles were not properly random. Tile N+1 on frame X+1 would use the same pool of light as tile N on frame X - it was just "scrolling" each frame.

## Solution

- Use a different constant to properly randomize the pool