### PR TITLE
Remove radio button comment

### DIFF
--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -97,7 +97,6 @@ impl FeathersRadio {
                 FocusIndicator
                 ThemeBorderColor(tokens::RADIO_BORDER)
                 Children [(
-                    // Cheesy checkmark: rotated node with L-shaped border.
                     Node {
                         width: px(8),
                         height: px(8),
@@ -172,7 +171,6 @@ pub fn radio_bundle<C: SpawnableList<ChildOf> + Send + Sync + 'static, B: Bundle
                 FocusIndicator,
                 ThemeBorderColor(tokens::RADIO_BORDER),
                 children![(
-                    // Cheesy checkmark: rotated node with L-shaped border.
                     Node {
                         width: px(8),
                         height: px(8),


### PR DESCRIPTION
# Objective

Remove a comment about check mark construction amongst the radio button components that must have been copied from the checkbox widget implementation by mistake.
