### PR TITLE
Add `EnvironmentMapLight::with_intensity` builder method

### DIFF
--- a/crates/bevy_light/src/probe.rs
+++ b/crates/bevy_light/src/probe.rs
@@ -167,6 +167,12 @@ impl EnvironmentMapLight {
         }
     }
 
+    /// Sets the intensity of this environment map and returns it.
+    pub fn with_intensity(mut self, intensity: f32) -> Self {
+        self.intensity = intensity;
+        self
+    }
+
     pub(crate) fn hemispherical_gradient_cubemap(
         top_color: Color,
         mid_color: Color,


### PR DESCRIPTION
closes #23911 
# Objective

- Add a way to set the intensity of an EnvironmentMapLight.

## Solution

- Create a builder-style `with_intensity` method so that you can set intensity easily while constructing.

```rust
EnvironmentMapLight::hemispherical_gradient(assets, sky, horizon, ground)
    .with_intensity(250.0)
```

## Testing

- This is a small convenience method with no behavioral change to existing code, so no new tests were added.
- CI