### PR TITLE
Fix version bump ci

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -57,7 +57,8 @@ jobs:
             --exclude auto_register_static \
             --exclude mipmap_generator \
             --exclude caldera_hotel \
-            --exclude bistro
+            --exclude bistro \
+            --exclude bevy_city
 
       - name: Create PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -54,7 +54,7 @@ jobs:
             --exclude build-wasm-example \
             --exclude no_std_library \
             --exclude export-content \
-            --exclude auto_register_static
+            --exclude auto_register_static \
             --exclude mipmap_generator \
             --exclude caldera_hotel \
             --exclude bistro


### PR DESCRIPTION
# Objective

- Workflow fails because of a missing `\`: https://github.com/bevyengine/bevy/actions/runs/27897567873/job/82551836353

## Solution

- Add it
- Also exclude bevy_city
