### PR TITLE
Update `sysinfo` dependency to version `0.39.5`

### DIFF
--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -70,14 +70,14 @@ log = { version = "0.4", default-features = false }
 # macOS
 [target.'cfg(all(target_os="macos"))'.dependencies]
 # Some features of sysinfo are not supported by apple. This will disable those features on apple devices
-sysinfo = { version = "0.39.3", optional = true, default-features = false, features = [
+sysinfo = { version = "0.39.5", optional = true, default-features = false, features = [
   "apple-app-store",
   "system",
 ] }
 
 # Only include when on linux/windows/android/freebsd/netbsd
 [target.'cfg(any(target_os = "linux", target_os = "windows", target_os = "android", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
-sysinfo = { version = "0.39.3", optional = true, default-features = false, features = [
+sysinfo = { version = "0.39.5", optional = true, default-features = false, features = [
   "system",
 ] }
 


### PR DESCRIPTION
# Solution

There was a build error on MacOS (M4 Max) for the `sysinfo` dependency. Updating the dependency solves the problem.

## Relevant Issues

- https://github.com/bevyengine/bevy/issues/24698
- https://github.com/GuillaumeGomez/sysinfo/issues/1689

## Testing

- [x] Run `cargo build` on MacOS with an M4 chip
- [x] Verify that no build errors appear