### PR TITLE
Downgrade gpu_readback closed-channel log from warn to debug

### DIFF
--- a/crates/bevy_render/src/gpu_readback.rs
+++ b/crates/bevy_render/src/gpu_readback.rs
@@ -26,7 +26,7 @@ use bevy_ecs::{
 };
 use bevy_ecs::{schedule::IntoScheduleConfigs, template::FromTemplate};
 use bevy_image::{Image, TextureFormatPixelInfo};
-use bevy_log::warn;
+use bevy_log::{debug, warn};
 use bevy_platform::collections::HashMap;
 use bevy_reflect::Reflect;
 use bevy_render_macros::ExtractComponent;
@@ -408,7 +408,7 @@ fn map_buffers(mut readbacks: ResMut<GpuReadbacks>) {
             drop(data);
             buffer.unmap();
             if let Err(e) = tx.try_send((entity, buffer, result)) {
-                warn!("Failed to send readback result: {}", e);
+                debug!("Failed to send readback result: {}", e);
             }
         });
         readbacks.mapped.push(readback);


### PR DESCRIPTION
`map_async` callbacks in `map_buffers` fire during wgpu's shutdown device-poll, after `GpuReadbacks` (which owns the channel receivers) has already been dropped. The `try_send` fails with `Closed` — expected, since the consumer is gone because the app is exiting. The same happens when a `Readback` entity is intentionally despawned.

This produces two `WARN bevy_render::gpu_readback: Failed to send readback result: ...` lines on every app exit for any app using `Readback`. The warning is never actionable.

Downgrade to `debug!` so the message is still available for diagnosis but doesn't pollute default log output.