### PR TITLE
Fix sorted batching without indirect drawing

### DIFF
--- a/crates/bevy_render/src/batching/gpu_preprocessing.rs
+++ b/crates/bevy_render/src/batching/gpu_preprocessing.rs
@@ -1658,6 +1658,9 @@ pub fn batch_and_prepare_sorted_render_phase<I, GFBD>(
                         if *current_batch_set_key == *batch_set_key {
                             if *current_bin_key == *bin_key {
                                 SortedPhaseItemBatchability::BatchOk
+                            } else if no_indirect_drawing {
+                                // Without indirect drawing, different meshes need separate batch sets
+                                SortedPhaseItemBatchability::BreakBatchSet
                             } else {
                                 SortedPhaseItemBatchability::BreakBatch
                             }


### PR DESCRIPTION
# Objective

Fix incorrect sorted batching when indirect drawing is unavailable.

While testing some glTF files on the web, I noticed transparent meshes rendering with the wrong geometry or transforms: some objects appeared duplicated or at incorrect positions. The same scenes rendered correctly on native Windows.




Disabling automatic batching for `Transparent3d` avoided the issue by setting `AUTOMATIC_BATCHING` to `false`, which pointed the investigation toward batching.

After investigation, the issue came from the `NoIndirectDrawing` path used when indirect drawing is unavailable. Different meshes could still be grouped as if indirect multi-draw was supported.

## Solution

When `NoIndirectDrawing` is active, sorted phase items with different meshes now start a new batch set instead of using `BreakBatch`.


## Testing

The original glTF asset that exposed the issue is confidential, but I can share it privately with maintainers if needed. 

I was able to reproduce the issue natively on Windows by adding `NoIndirectDrawing`, which matches the path used on web when indirect drawing is unavailable. Press Space to test the `NoIndirectDrawing` path.

```
use bevy::{prelude::*, render::view::NoIndirectDrawing};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .insert_resource(ClearColor(Color::srgb(0.48, 0.48, 0.48)))
        .add_systems(Startup, setup)
        .add_systems(Update, toggle_no_indirect_drawing)
        .run();
}

fn setup(
    mut commands: Commands,
    mut meshes: ResMut<Assets<Mesh>>,
    mut materials: ResMut<Assets<StandardMaterial>>,
) {
    let meshes = [
        meshes.add(Cuboid::new(0.55, 0.55, 0.55)),
        meshes.add(Sphere::new(0.36).mesh().uv(32, 18)),
        meshes.add(Cylinder::new(0.32, 0.68).mesh().resolution(36)),
    ];
    let material = materials.add(StandardMaterial {
        base_color: Color::srgba(0.05, 0.75, 1.0, 0.48),
        alpha_mode: AlphaMode::Blend,
        ..default()
    });

    for (mesh, position) in [
        (0, Vec3::new(-1.0, -0.35, -1.8)),
        (1, Vec3::new(0.0, -0.25, -1.35)),
        (2, Vec3::new(1.0, -0.15, -0.9)),
        (0, Vec3::new(-1.0, 0.35, -0.45)),
        (1, Vec3::new(0.0, 0.45, 0.0)),
        (2, Vec3::new(1.0, 0.55, 0.45)),
    ] {
        commands.spawn((
            Mesh3d(meshes[mesh].clone()),
            MeshMaterial3d(material.clone()),
            Transform::from_translation(position),
        ));
    }

    commands.spawn((
        DirectionalLight::default(),
        Transform::from_xyz(4.0, 6.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
    ));

    let transform = Transform::from_xyz(0.0, 1.4, 4.4).looking_at(Vec3::ZERO, Vec3::Y);
    commands.spawn((Camera3d::default(), transform));
    commands.spawn((
        Camera3d::default(),
        Camera {
            is_active: false,
            ..default()
        },
        NoIndirectDrawing,
        transform,
    ));
}

fn toggle_no_indirect_drawing(
    keys: Res<ButtonInput<KeyCode>>,
    mut indirect: Single<&mut Camera, Without<NoIndirectDrawing>>,
    mut direct: Single<&mut Camera, With<NoIndirectDrawing>>,
) {
    if keys.just_pressed(KeyCode::Space) {
        let direct_enabled = indirect.is_active;
        indirect.is_active = !direct_enabled;
        direct.is_active = direct_enabled;
    }
}

```

https://github.com/user-attachments/assets/3f8f1dff-5702-430a-9ee0-f4ab24a5251b

---

## Showcase

Before this change, transparent glTF meshes on web could render with duplicated geometry or wrong transforms when automatic batching was enabled.

https://github.com/user-attachments/assets/c6516baa-5a56-4830-ba44-cca0dd5bf540

After this change, the same scenes render correctly:

https://github.com/user-attachments/assets/a8e2099c-f7fc-40d5-8240-ebcb5c42d367
