### PR TITLE
Fix wrong border radius corners on diagnostics overlay

### DIFF
--- a/crates/bevy_dev_tools/src/diagnostics_overlay.rs
+++ b/crates/bevy_dev_tools/src/diagnostics_overlay.rs
@@ -389,7 +389,7 @@ fn build_overlay(
             (
                 Node {
                     padding: DEFAULT_PADDING,
-                    border_radius: BorderRadius::bottom(Val::Px(4.)),
+                    border_radius: BorderRadius::top(Val::Px(4.)),
                     ..Default::default()
                 },
                 DiagnosticsOverlayHeader,


### PR DESCRIPTION
# Objective

Closes #24712 

## Solution

Use `BorderRadius` on the correct corners

## Testing

Added overlay to `many_foxes`
