### PR TITLE
Add missing import for light probe const `..._LIGHTMAPPED_MESH_DIFFUSE` in irradiance_volume.wgsl

### DIFF
--- a/crates/bevy_pbr/src/light_probe/irradiance_volume.wgsl
+++ b/crates/bevy_pbr/src/light_probe/irradiance_volume.wgsl
@@ -9,6 +9,10 @@
 };
 #import bevy_pbr::clustered_forward::ClusterableObjectIndexRanges
 
+#ifdef LIGHTMAP
+#import bevy_pbr::mesh_view_types::LIGHT_PROBE_FLAG_AFFECTS_LIGHTMAPPED_MESH_DIFFUSE;
+#endif
+
 #ifdef IRRADIANCE_VOLUMES_ARE_USABLE
 
 // See:


### PR DESCRIPTION
# Objective

- Fix an issue someone reported in [#rendering-dev](https://discord.com/channels/691052431525675048/743663924229963868/1518669667344846942) 
- https://github.com/bevyengine/bevy/blob/main/crates/bevy_pbr/src/light_probe/irradiance_volume.wgsl#L41-L47 currently breaks

## Solution

- Import the missing const

## Testing

- This is simple to verify by eye so I didn’t test this myself
- However, this just reminds me that there needs to be more automated testing for rendering to discover such defects.