### PR TITLE
Fix Visibility component having no effect on infinite grid

### DIFF
--- a/crates/bevy_dev_tools/src/infinite_grid.rs
+++ b/crates/bevy_dev_tools/src/infinite_grid.rs
@@ -390,6 +390,12 @@ fn queue_infinite_grids(
         let Some(render_visible_mesh_entities) = entities.get::<InfiniteGrid>() else {
             continue;
         };
+
+        // Remove meshes that have been despawned or removed due to Visibility settings
+        for (render_entity, main_entity) in &render_visible_mesh_entities.removed_entities {
+            phase.remove(*render_entity, *main_entity);
+        }
+
         for (render_entity, main_entity) in render_visible_mesh_entities.iter_visible() {
             let Ok(transform) = infinite_grids.get(*render_entity) else {
                 continue;
@@ -415,7 +421,7 @@ fn queue_infinite_grids(
     }
 }
 
-/// Checks if the point is one the plane
+/// Checks if the point is on the plane
 fn plane_check(plane: &GlobalTransform, point: Vec3) -> bool {
     plane.up().dot(plane.translation() - point).abs() > f32::EPSILON
 }

--- a/examples/dev_tools/infinite_grid.rs
+++ b/examples/dev_tools/infinite_grid.rs
@@ -19,6 +19,7 @@ fn main() {
             InfiniteGridPlugin,
         ))
         .add_systems(Startup, setup_system)
+        .add_systems(Update, toggle_visibility)
         .run();
 }
 
@@ -65,4 +66,23 @@ fn setup_system(
         ),
         Transform::from_xyz(0.0, -2.0, 0.0),
     ));
+}
+
+fn toggle_visibility(
+    query: Single<(&mut Visibility, &InheritedVisibility), With<InfiniteGrid>>,
+    input: Res<ButtonInput<KeyCode>>,
+) {
+    let (mut visibility, inherited_visibility) = query.into_inner();
+
+    // Toggle infinite plane visibility by pressing 'P'
+    if input.just_pressed(KeyCode::KeyP) {
+        match inherited_visibility.get() {
+            true => {
+                *visibility = Visibility::Hidden;
+            }
+            false => {
+                *visibility = Visibility::Visible;
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Objective

The custom render phase for infinite grid did not clear invisible or despawned meshes before rendering, meaning the Visibility component had no effect on the InfiniteGrid component when it was changed.

## Solution

Added a removal pass in the infinite_grid render queue.

## Testing

'toggle_visibilty' system added to the infinite_grid example.
