### PR TITLE
fix: add missing png feature to bevy_feathers feature

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -270,6 +270,8 @@ bevy_sprite_render = [
   "bevy_gizmos_render?/bevy_sprite_render",
 ]
 bevy_ui_render = ["dep:bevy_ui_render", "bevy_sprite_render", "bevy_ui"]
+# Feathers ships its built-in icons as PNGs, so enable the PNG feature
+bevy_feathers = ["dep:bevy_feathers", "png"]
 bevy_solari = ["dep:bevy_solari", "bevy_pbr"]
 bevy_gizmos = ["dep:bevy_gizmos", "bevy_camera", "bevy_light?/bevy_gizmos"]
 bevy_gizmos_render = ["dep:bevy_gizmos_render", "bevy_gizmos"]


### PR DESCRIPTION
# Objective

If `bevy_feathers` is used without default features, then the built-in feathers icons arn't displayed with no warnings.

## Solution

Add `png` feature flag to `bevy_feathers` since it has all it's widget icons as pngs.

An alternate solution would be to add a warning instead somehow.

## Testing

Add a simple scene with `FeathersDisclosureToggle` (or any other icon using widget) and test it with no default features (but still necessary render features):

Pre-fix there will be nothing dispalyed but it will work fine post-fix.

(Example command for linux)
```
 cargo run --no-default-features  --features "bevy_winit,bevy_ui_render,scene,default_font,x11,bevy_state,bevy_asset,bevy_log,multi_threaded,async_executor,reflect_auto_register,bevy_feathers"
```
Fixes #24682 