### PR TITLE
implement `Clone` for `IsDefaultUiCamera`

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2970,7 +2970,7 @@ impl UiTargetCamera {
 ///     ));
 /// }
 /// ```
-#[derive(Component, Default, Reflect)]
+#[derive(Component, Default, Clone, Copy, Reflect)]
 #[reflect(Component, Default)]
 pub struct IsDefaultUiCamera;
 


### PR DESCRIPTION
I noticed that `IsDefaultUiCamera` is not allowed atm inside of the `bsn!` macro.

```
    | |_____^ the trait `Clone` is not implemented for `bevy::prelude::IsDefaultUiCamera`
    |
    = help: the following other types implement trait `FromTemplate`:
              AnimationGraphHandle
              Atmosphere
              AudioPlayer<Source>
              CustomCursor
              CustomCursorImage
              DirectionalLightTexture
              DynamicWorldRoot
              EnvironmentMapLight
            and 34 others
    = note: required for `bevy::prelude::IsDefaultUiCamera` to implement `FromTemplate`
    = note: this error originates in the macro `bsn` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR adds the `Clone` and `Copy` (it's a unit struct so it shouldn't hurt) derives to the component.