### PR TITLE
feat(scroll): change scroll dt to_pixels

### DIFF
--- a/crates/bevy_ui_widgets/src/scrollarea.rs
+++ b/crates/bevy_ui_widgets/src/scrollarea.rs
@@ -35,7 +35,7 @@ fn scrollarea_on_scroll(
         let can_scroll_x = node.overflow.x == OverflowAxis::Scroll;
         let can_scroll_y = node.overflow.y == OverflowAxis::Scroll;
 
-        let scroll_delta = scroll.to_lines(&scroll_conversion_ratio);
+        let scroll_delta = scroll.to_pixels(&scroll_conversion_ratio);
         let scroll_delta = Vec2::new(scroll_delta.x, scroll_delta.y);
 
         let max_range = (content_size - visible_size).max(Vec2::ZERO);


### PR DESCRIPTION
# Objective

Fixes #24610 

## Solution

-current scroll conversion ratio after  `to_lines()`  was yielding 1px per notch for mousewheel scroll delta.  It was converting scroll dt to line values then applying them to `scroll_pos.y`- which could be pixels instead. 
-So I changed to `to_pixels()`. This applied to scroll dt yields 100px per notch .
 
## Testing
-`cargo run --example scroll` is visually snappier. I'd be happy to provide comparison demo gifs if y'all want. 
-Could tweak notch speed via `MouseScrollPixelsPerLine `

---

