### PR TITLE
Update rust-version to 1.96 in root Cargo.toml so all tests compile and pass

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bevyengine/bevy"
 documentation = "https://docs.rs/bevy"
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 
 [workspace]
 resolver = "3"


### PR DESCRIPTION
# Objective
Update the `rust-version` to 1.96.

If we use Rust 1.95 as the active Rust version, running `cargo run -p ci` fails because there is usage of [assert_matches!](https://doc.rust-lang.org/stable/std/macro.assert_matches.html) in some tests, which requires Rust 1.96

Minimum reproduction:
```bash
# following the rust-version in Cargo.toml
RUSTUP_TOOLCHAIN=1.95.0 cargo test -p bevy_math --lib --no-run
```

## Solution

- Change the `rust-version` line [here](https://github.com/bevyengine/bevy/blob/main/Cargo.toml#L13) to 1.96

## Testing

- Did you test these changes? If so, how? 
I ran `cargo run -p ci` locally using Rust 1.96 successfully, whereas it fails using 1.95.

Success:
```bash
RUSTUP_TOOLCHAIN=1.96.0 cargo test -p bevy_math --lib --no-run
```

Failure:
```bash
# following the rust-version in Cargo.toml
RUSTUP_TOOLCHAIN=1.95.0 cargo test -p bevy_math --lib --no-run
```

- Are there any parts that need more testing? 
No

- How can other people (reviewers) test your changes? Is there anything specific they need to know? 
Pull down the main branch of the repo, run the minimum reproduction command above.

It's worth noting that these compilation errors do not surface in CI because the toolchain is set to stable: https://github.com/bevyengine/bevy/blob/main/.github/workflows/ci.yml#L54
In effect, the tests in CI are already enforced against 1.96 as of the time of this PR.

Because I'm a first-time contributor and new to this project, I'm not 100% sure if there are additional things to consider.

- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? 
N/A