### PR TITLE
Lower default size for `AtmosphereEnvironmentMapLight`

### DIFF
--- a/crates/bevy_light/src/probe.rs
+++ b/crates/bevy_light/src/probe.rs
@@ -321,7 +321,7 @@ impl Default for AtmosphereEnvironmentMapLight {
         Self {
             intensity: 1.0,
             affects_lightmapped_mesh_diffuse: true,
-            size: UVec2::new(512, 512),
+            size: UVec2::new(128, 128),
         }
     }
 }


### PR DESCRIPTION
# Objective

`AtmosphereEnvironmentMapLight` can cause a pretty heavy performance hit on lower-end systems (#24517). This is notably due to it using a high-res `GeneratedEnvironmentMapLight` by default.

## Solution

Lower the default for `AtmosphereEnvironmentMapLight.size` from 512x512 to 128x128.  This is quite conservative, and we could probably get away with even lower values in scenes that aren't reflection-heavy.

## Testing
- Tested the atmosphere example and `bevy_city`

Performance on `bevy_city` at size 5, running on igpu. PR is in yellow, main is in red:

<img width="1160" height="805" alt="tracy" src="https://github.com/user-attachments/assets/73f0399a-9b84-46cb-a50e-b5b253c7e5da" />


---

## Showcase

I was never able to perceive any difference in lighting. 
For reflections, the horizon line is slightly blurrier in the extreme case where it is visible in a mirror.

| Main | PR |
|---|---|
| <img width="100%" alt="main" src="https://github.com/user-attachments/assets/31c6af6b-b19c-461e-88b2-5bf38bba7ab0" /> | <img width="100%" alt="pr" src="https://github.com/user-attachments/assets/7b9002e9-8144-4ecf-869f-85e270ecaa5c" /> |
| <img width="1920" height="1133" alt="main" src="https://github.com/user-attachments/assets/6c09c8fb-2fa4-4013-abaa-a3ff9e464280" /> | <img width="1920" height="1133" alt="pr" src="https://github.com/user-attachments/assets/58dafc11-d4d5-4c00-bfce-5675d80a4e30" /> |
| <img width="1920" height="1133" alt="main" src="https://github.com/user-attachments/assets/f6454d3e-b13e-4537-b758-6ac4a1679b6e" /> |<img width="1920" height="1133" alt="pr" src="https://github.com/user-attachments/assets/ef84ea97-de16-47f3-8139-94736d4e1613" /> |



