### PR TITLE
Make `PartialReflect::to_dynamic` fallible

### DIFF
--- a/_release-content/migration-guides/to_dynamic_returns_result.md
+++ b/_release-content/migration-guides/to_dynamic_returns_result.md
@@ -20,8 +20,8 @@ In order to make that change properly robust, the per-kind helpers are now falli
 - `Set::to_dynamic_set`
 - `Enum::to_dynamic_enum`
 
-Similarly, `DynamicEnum::from` and `DynamicEnum::from_ref` now return
-`Result<DynamicEnum, ReflectCloneError>`.
+Similarly, `DynamicEnum::from` and `DynamicEnum::from_ref` have been deprecated in favor of `try_from` equivalents,
+which now return `Result<DynamicEnum, ReflectCloneError>`.
 
 Finally, `PartialReflect::try_apply` (and `apply`) build dynamic values internally when applying a value
 onto a larger collection or a different enum variant.

--- a/_release-content/migration-guides/to_dynamic_returns_result.md
+++ b/_release-content/migration-guides/to_dynamic_returns_result.md
@@ -4,7 +4,7 @@ pull_requests: [24748]
 ---
 
 `PartialReflect::to_dynamic` now returns `Result<Box<dyn PartialReflect>, ReflectCloneError>`
-rather than panicking. 
+rather than panicking.
 These methods will fail if *any* value stored inside
 is a an opaque type whose `reflect_clone` fails, *including* nested opaque values.
 

--- a/_release-content/migration-guides/to_dynamic_returns_result.md
+++ b/_release-content/migration-guides/to_dynamic_returns_result.md
@@ -1,11 +1,41 @@
 ---
-title: "`PartialReflect::to_dynamic` now returns a `Result`"
-pull_requests: [13723]
+title: "`PartialReflect::to_dynamic` and its helpers now return a `Result`"
+pull_requests: [TODO]
 ---
 
-The method `PartialReflect::to_dynamic` now returns a `Result` with a `ReflectCloneError` error case rather than panicking.
-Like the previous panicking case, this can only be triggered when attempting to call `to_dynamic` on opaque values.
+`PartialReflect::to_dynamic` now returns `Result<Box<dyn PartialReflect>, ReflectCloneError>`
+rather than panicking. 
+These methods will fail if *any* value stored inside
+is a an opaque type whose `reflect_clone` fails, *including* nested opaque values.
 
-As a result, all prior non-panicking call sites can safely be replaced with an `unwrap`.
-However, related code may be defensively checking for this pattern;
-you may be able to simplify your logic by handling the returned `Result` properly.
+In order to make that change properly robust, the per-kind helpers are now fallible as well, returning
+`Result<_, ReflectCloneError>`:
+
+- `Struct::to_dynamic_struct`
+- `TupleStruct::to_dynamic_tuple_struct`
+- `Tuple::to_dynamic_tuple`
+- `List::to_dynamic_list`
+- `Array::to_dynamic_array`
+- `Map::to_dynamic_map`
+- `Set::to_dynamic_set`
+- `Enum::to_dynamic_enum`
+
+Similarly, `DynamicEnum::from` and `DynamicEnum::from_ref` now return
+`Result<DynamicEnum, ReflectCloneError>`.
+
+Finally, `PartialReflect::try_apply` (and `apply`) build dynamic values internally when applying a value
+onto a larger collection or a different enum variant.
+That conversion can now fail (previously it would panic),
+so `ApplyError` has grown a new `CloneError(ReflectCloneError)` variant.
+
+The migration here should be easy:
+if you were okay with panicking before, just call `.unwrap()`: all panicking cases
+have been replaced with an error, and no new failing paths were added.
+
+However, if your code was defensively guarding against the old panic,
+you can now handle the returned `Result` directly instead and simplify your error handling.
+
+These changes were made to more robustly support the introduction of `PartialReflect::reflect_clone_incomplete`,
+designed for inspector-like use cases.
+That method, which gracefully skips fields excluded from reflectio (such as by `#[reflect(ignore)]`),
+is probably worth considering for many pieces of code that called these methods.

--- a/_release-content/migration-guides/to_dynamic_returns_result.md
+++ b/_release-content/migration-guides/to_dynamic_returns_result.md
@@ -6,7 +6,7 @@ pull_requests: [24748]
 `PartialReflect::to_dynamic` now returns `Result<Box<dyn PartialReflect>, ReflectCloneError>`
 rather than panicking.
 These methods will fail if *any* value stored inside
-is a an opaque type whose `reflect_clone` fails, *including* nested opaque values.
+is an opaque type whose `reflect_clone` fails, *including* nested opaque values.
 
 In order to make that change properly robust, the per-kind helpers are now fallible as well, returning
 `Result<_, ReflectCloneError>`:

--- a/_release-content/migration-guides/to_dynamic_returns_result.md
+++ b/_release-content/migration-guides/to_dynamic_returns_result.md
@@ -1,6 +1,6 @@
 ---
 title: "`PartialReflect::to_dynamic` and its helpers now return a `Result`"
-pull_requests: [TODO]
+pull_requests: [24748]
 ---
 
 `PartialReflect::to_dynamic` now returns `Result<Box<dyn PartialReflect>, ReflectCloneError>`

--- a/_release-content/migration-guides/to_dynamic_returns_result.md
+++ b/_release-content/migration-guides/to_dynamic_returns_result.md
@@ -1,0 +1,11 @@
+---
+title: "`PartialReflect::to_dynamic` now returns a `Result`"
+pull_requests: [13723]
+---
+
+The method `PartialReflect::to_dynamic` now returns a `Result` with a `ReflectCloneError` error case rather than panicking.
+Like the previous panicking case, this can only be triggered when attempting to call `to_dynamic` on opaque values.
+
+As a result, all prior non-panicking call sites can safely be replaced with an `unwrap`.
+However, related code may be defensively checking for this pattern;
+you may be able to simplify your logic by handling the returned `Result` properly.

--- a/_release-content/migration-guides/to_dynamic_returns_result.md
+++ b/_release-content/migration-guides/to_dynamic_returns_result.md
@@ -34,8 +34,3 @@ have been replaced with an error, and no new failing paths were added.
 
 However, if your code was defensively guarding against the old panic,
 you can now handle the returned `Result` directly instead and simplify your error handling.
-
-These changes were made to more robustly support the introduction of `PartialReflect::reflect_clone_incomplete`,
-designed for inspector-like use cases.
-That method, which gracefully skips fields excluded from reflectio (such as by `#[reflect(ignore)]`),
-is probably worth considering for many pieces of code that called these methods.

--- a/benches/benches/bevy_reflect/list.rs
+++ b/benches/benches/bevy_reflect/list.rs
@@ -81,13 +81,13 @@ fn concrete_list_apply(criterion: &mut Criterion) {
     list_apply(&mut group, "empty_base_concrete_patch", empty_base, patch);
 
     list_apply(&mut group, "empty_base_dynamic_patch", empty_base, |size| {
-        patch(size).to_dynamic_list()
+        patch(size).to_dynamic_list().unwrap()
     });
 
     list_apply(&mut group, "same_len_concrete_patch", full_base, patch);
 
     list_apply(&mut group, "same_len_dynamic_patch", full_base, |size| {
-        patch(size).to_dynamic_list()
+        patch(size).to_dynamic_list().unwrap()
     });
 
     group.finish();
@@ -105,7 +105,7 @@ fn concrete_list_to_dynamic_list(criterion: &mut Criterion) {
             |bencher, &size| {
                 let v = iter::repeat_n(0, size).collect::<Vec<_>>();
 
-                bencher.iter(|| black_box(&v).to_dynamic_list());
+                bencher.iter(|| black_box(&v).to_dynamic_list().unwrap());
             },
         );
     }
@@ -127,7 +127,7 @@ fn dynamic_list_push(criterion: &mut Criterion) {
                 let dst = DynamicList::default();
 
                 bencher.iter_batched(
-                    || (src.clone(), dst.to_dynamic_list()),
+                    || (src.clone(), dst.to_dynamic_list().unwrap()),
                     |(src, mut dst)| {
                         for item in src {
                             dst.push(item);
@@ -145,20 +145,20 @@ fn dynamic_list_push(criterion: &mut Criterion) {
 fn dynamic_list_apply(criterion: &mut Criterion) {
     let mut group = create_group(criterion, bench!("dynamic_list_apply"));
 
-    let empty_base = |_: usize| || Vec::<u64>::new().to_dynamic_list();
+    let empty_base = |_: usize| || Vec::<u64>::new().to_dynamic_list().unwrap();
     let full_base = |size: usize| move || iter::repeat_n(0, size).collect::<Vec<u64>>();
     let patch = |size: usize| iter::repeat_n(1, size).collect::<Vec<u64>>();
 
     list_apply(&mut group, "empty_base_concrete_patch", empty_base, patch);
 
     list_apply(&mut group, "empty_base_dynamic_patch", empty_base, |size| {
-        patch(size).to_dynamic_list()
+        patch(size).to_dynamic_list().unwrap()
     });
 
     list_apply(&mut group, "same_len_concrete_patch", full_base, patch);
 
     list_apply(&mut group, "same_len_dynamic_patch", full_base, |size| {
-        patch(size).to_dynamic_list()
+        patch(size).to_dynamic_list().unwrap()
     });
 
     group.finish();

--- a/benches/benches/bevy_reflect/map.rs
+++ b/benches/benches/bevy_reflect/map.rs
@@ -108,7 +108,7 @@ fn concrete_map_apply(criterion: &mut Criterion) {
     );
 
     map_apply(&mut group, "empty_base_dynamic_patch", empty_base, |size| {
-        key_range_patch(size).to_dynamic_map()
+        key_range_patch(size).to_dynamic_map().unwrap()
     });
 
     map_apply(
@@ -122,7 +122,7 @@ fn concrete_map_apply(criterion: &mut Criterion) {
         &mut group,
         "same_keys_dynamic_patch",
         key_range_base,
-        |size| key_range_patch(size).to_dynamic_map(),
+        |size| key_range_patch(size).to_dynamic_map().unwrap(),
     );
 
     map_apply(
@@ -136,7 +136,7 @@ fn concrete_map_apply(criterion: &mut Criterion) {
         &mut group,
         "disjoint_keys_dynamic_patch",
         key_range_base,
-        |size| disjoint_patch(size).to_dynamic_map(),
+        |size| disjoint_patch(size).to_dynamic_map().unwrap(),
     );
 }
 
@@ -159,7 +159,7 @@ fn dynamic_map_apply(criterion: &mut Criterion) {
             (0..size as u64)
                 .zip(iter::repeat(0))
                 .collect::<HashMap<u64, u64>>()
-                .to_dynamic_map()
+                .to_dynamic_map().unwrap()
         }
     };
 
@@ -183,7 +183,7 @@ fn dynamic_map_apply(criterion: &mut Criterion) {
     );
 
     map_apply(&mut group, "empty_base_dynamic_patch", empty_base, |size| {
-        key_range_patch(size).to_dynamic_map()
+        key_range_patch(size).to_dynamic_map().unwrap()
     });
 
     map_apply(
@@ -197,7 +197,7 @@ fn dynamic_map_apply(criterion: &mut Criterion) {
         &mut group,
         "same_keys_dynamic_patch",
         key_range_base,
-        |size| key_range_patch(size).to_dynamic_map(),
+        |size| key_range_patch(size).to_dynamic_map().unwrap(),
     );
 
     map_apply(
@@ -211,7 +211,7 @@ fn dynamic_map_apply(criterion: &mut Criterion) {
         &mut group,
         "disjoint_keys_dynamic_patch",
         key_range_base,
-        |size| disjoint_patch(size).to_dynamic_map(),
+        |size| disjoint_patch(size).to_dynamic_map().unwrap(),
     );
 }
 

--- a/benches/benches/bevy_reflect/map.rs
+++ b/benches/benches/bevy_reflect/map.rs
@@ -159,7 +159,8 @@ fn dynamic_map_apply(criterion: &mut Criterion) {
             (0..size as u64)
                 .zip(iter::repeat(0))
                 .collect::<HashMap<u64, u64>>()
-                .to_dynamic_map().unwrap()
+                .to_dynamic_map()
+                .unwrap()
         }
     };
 

--- a/benches/benches/bevy_reflect/struct.rs
+++ b/benches/benches/bevy_reflect/struct.rs
@@ -116,7 +116,7 @@ fn concrete_struct_apply(criterion: &mut Criterion) {
                 bencher.iter_batched(
                     || {
                         let (obj, _) = input();
-                        let patch = obj.to_dynamic_struct();
+                        let patch = obj.to_dynamic_struct().unwrap();
                         (obj, patch)
                     },
                     |(mut obj, patch)| obj.apply(black_box(&patch)),
@@ -206,14 +206,14 @@ fn concrete_struct_to_dynamic_struct(criterion: &mut Criterion) {
             BenchmarkId::new("NonGeneric", field_count),
             &standard,
             |bencher, s| {
-                bencher.iter(|| s.to_dynamic_struct());
+                bencher.iter(|| s.to_dynamic_struct().unwrap());
             },
         );
         group.bench_with_input(
             BenchmarkId::new("Generic", field_count),
             &generic,
             |bencher, s| {
-                bencher.iter(|| s.to_dynamic_struct());
+                bencher.iter(|| s.to_dynamic_struct().unwrap());
             },
         );
     }
@@ -223,11 +223,11 @@ fn dynamic_struct_to_dynamic_struct(criterion: &mut Criterion) {
     let mut group = create_group(criterion, bench!("dynamic_struct_to_dynamic_struct"));
 
     let structs: [Box<dyn Struct>; 5] = [
-        Box::new(Struct1::default().to_dynamic_struct()),
-        Box::new(Struct16::default().to_dynamic_struct()),
-        Box::new(Struct32::default().to_dynamic_struct()),
-        Box::new(Struct64::default().to_dynamic_struct()),
-        Box::new(Struct128::default().to_dynamic_struct()),
+        Box::new(Struct1::default().to_dynamic_struct().unwrap()),
+        Box::new(Struct16::default().to_dynamic_struct().unwrap()),
+        Box::new(Struct32::default().to_dynamic_struct().unwrap()),
+        Box::new(Struct64::default().to_dynamic_struct().unwrap()),
+        Box::new(Struct128::default().to_dynamic_struct().unwrap()),
     ];
 
     for s in structs {
@@ -237,7 +237,7 @@ fn dynamic_struct_to_dynamic_struct(criterion: &mut Criterion) {
             BenchmarkId::from_parameter(field_count),
             &s,
             |bencher, s| {
-                bencher.iter(|| s.to_dynamic_struct());
+                bencher.iter(|| s.to_dynamic_struct().unwrap());
             },
         );
     }
@@ -268,7 +268,7 @@ fn dynamic_struct_apply(criterion: &mut Criterion) {
             &patch,
             |bencher, patch| {
                 bencher.iter_batched(
-                    || (base.to_dynamic_struct(), patch()),
+                    || (base.to_dynamic_struct().unwrap(), patch()),
                     |(mut base, patch)| base.apply(black_box(&*patch)),
                     BatchSize::SmallInput,
                 );
@@ -292,7 +292,7 @@ fn dynamic_struct_apply(criterion: &mut Criterion) {
                 }
 
                 bencher.iter_batched(
-                    || base.to_dynamic_struct(),
+                    || base.to_dynamic_struct().unwrap(),
                     |mut base| base.apply(black_box(&patch)),
                     BatchSize::SmallInput,
                 );
@@ -318,7 +318,7 @@ fn dynamic_struct_insert(criterion: &mut Criterion) {
 
                 let field = format!("field_{field_count}");
                 bencher.iter_batched(
-                    || s.to_dynamic_struct(),
+                    || s.to_dynamic_struct().unwrap(),
                     |mut s| {
                         s.insert(black_box(&field), ());
                     },

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -876,7 +876,7 @@ mod tests {
                     "Cloning the handle with reflect should increase the strong count to 2"
                 );
 
-                let dynamic_handle: Box<dyn PartialReflect> = reflected.to_dynamic();
+                let dynamic_handle: Box<dyn PartialReflect> = reflected.to_dynamic().unwrap();
 
                 assert_eq!(
                     Arc::strong_count(strong),
@@ -910,7 +910,7 @@ mod tests {
         let mut assets = app.world_mut().resource_mut::<Assets<A>>();
         let handle_a = assets.add(A);
 
-        let dynamic_handle_a = handle_a.to_dynamic();
+        let dynamic_handle_a = handle_a.to_dynamic().unwrap();
         let reflected_handle_a = handle_a.as_partial_reflect();
 
         let handle_b_from_reflect_dynamic: Option<Handle<B>> =

--- a/crates/bevy_ecs/src/component/clone.rs
+++ b/crates/bevy_ecs/src/component/clone.rs
@@ -140,7 +140,7 @@ pub fn component_clone_via_reflect(source: &SourceComponent, ctx: &mut Component
         use crate::{entity::EntityMapper, world::World};
 
         let reflect_from_world = reflect_from_world.clone();
-        let source_component_cloned = source_component_reflect.to_dynamic();
+        let source_component_cloned = source_component_reflect.to_dynamic().unwrap();
         let component_layout = component_info.layout();
         let target = ctx.target();
         let component_id = ctx.component_id();

--- a/crates/bevy_ecs/src/component/clone.rs
+++ b/crates/bevy_ecs/src/component/clone.rs
@@ -1,5 +1,4 @@
 use core::marker::PhantomData;
-use log::error;
 
 use crate::component::Component;
 use crate::entity::{ComponentCloneCtx, SourceComponent};
@@ -144,7 +143,7 @@ pub fn component_clone_via_reflect(source: &SourceComponent, ctx: &mut Component
         let Ok(source_component_cloned) = source_component_reflect.to_dynamic() else {
             let component_info = ctx.component_info();
 
-            error!(
+            log::error!(
                 "Failed to clone source component ({}) because to_dynamic call failed. Does your component contain an opaque type that does not implement Reflect?",
                 component_info.name()
             );

--- a/crates/bevy_ecs/src/component/clone.rs
+++ b/crates/bevy_ecs/src/component/clone.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+use log::error;
 
 use crate::component::Component;
 use crate::entity::{ComponentCloneCtx, SourceComponent};
@@ -140,7 +141,15 @@ pub fn component_clone_via_reflect(source: &SourceComponent, ctx: &mut Component
         use crate::{entity::EntityMapper, world::World};
 
         let reflect_from_world = reflect_from_world.clone();
-        let source_component_cloned = source_component_reflect.to_dynamic().unwrap();
+        let Ok(source_component_cloned) = source_component_reflect.to_dynamic() else {
+            let component_info = ctx.component_info();
+
+            error!(
+                "Failed to clone source component ({}) because to_dynamic call failed. Does your component contain an opaque type that does not implement Reflect?",
+                component_info.name()
+            );
+            return;
+        };
         let component_layout = component_info.layout();
         let target = ctx.target();
         let component_id = ctx.component_id();

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -470,7 +470,7 @@ mod tests {
 
         let boxed_reflect_component_a = Box::new(ComponentA(916)) as Box<dyn PartialReflect>;
         let boxed_reflect_component_a_clone = boxed_reflect_component_a.reflect_clone().unwrap();
-        let boxed_reflect_component_a_dynamic = boxed_reflect_component_a.to_dynamic();
+        let boxed_reflect_component_a_dynamic = boxed_reflect_component_a.to_dynamic().unwrap();
 
         commands
             .entity(entity)

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -178,7 +178,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
             }
 
             fn to_dynamic_enum(&self) -> #FQResult<#bevy_reflect_path::enums::DynamicEnum, #bevy_reflect_path::ReflectCloneError> {
-                #bevy_reflect_path::enums::DynamicEnum::from_ref::<Self>(self)
+                #bevy_reflect_path::enums::DynamicEnum::try_from_ref::<Self>(self)
             }
         }
 

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -177,7 +177,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
                 }
             }
 
-            fn to_dynamic_enum(&self) -> #bevy_reflect_path::enums::DynamicEnum {
+            fn to_dynamic_enum(&self) -> #FQResult<#bevy_reflect_path::enums::DynamicEnum, #bevy_reflect_path::ReflectCloneError> {
                 #bevy_reflect_path::enums::DynamicEnum::from_ref::<Self>(self)
             }
         }

--- a/crates/bevy_reflect/derive/src/impls/opaque.rs
+++ b/crates/bevy_reflect/derive/src/impls/opaque.rs
@@ -93,8 +93,8 @@ pub(crate) fn impl_opaque(meta: &ReflectMeta) -> proc_macro2::TokenStream {
             }
 
             #[inline]
-            fn to_dynamic(&self) -> #bevy_reflect_path::__macro_exports::alloc_utils::Box<dyn #bevy_reflect_path::PartialReflect> {
-                #bevy_reflect_path::__macro_exports::alloc_utils::Box::new(#FQClone::clone(self))
+            fn to_dynamic(&self) -> #FQResult<#bevy_reflect_path::__macro_exports::alloc_utils::Box<dyn #bevy_reflect_path::PartialReflect>, #bevy_reflect_path::ReflectCloneError> {
+                #FQResult::Ok(#bevy_reflect_path::__macro_exports::alloc_utils::Box::new(#FQClone::clone(self)))
             }
 
              #[inline]

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -130,11 +130,11 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
                 #bevy_reflect_path::structs::FieldIter::new(self)
             }
 
-            fn to_dynamic_struct(&self) -> #bevy_reflect_path::structs::DynamicStruct {
+            fn to_dynamic_struct(&self) -> #FQResult<#bevy_reflect_path::structs::DynamicStruct, #bevy_reflect_path::ReflectCloneError> {
                 let mut dynamic: #bevy_reflect_path::structs::DynamicStruct = #FQDefault::default();
                 dynamic.set_represented_type(#bevy_reflect_path::PartialReflect::get_represented_type_info(self));
-                #(dynamic.insert_boxed(#field_names, #bevy_reflect_path::PartialReflect::to_dynamic(#fields_ref).unwrap());)*
-                dynamic
+                #(dynamic.insert_boxed(#field_names, #bevy_reflect_path::PartialReflect::to_dynamic(#fields_ref)?);)*
+                #FQResult::Ok(dynamic)
             }
         }
 

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -133,7 +133,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
             fn to_dynamic_struct(&self) -> #bevy_reflect_path::structs::DynamicStruct {
                 let mut dynamic: #bevy_reflect_path::structs::DynamicStruct = #FQDefault::default();
                 dynamic.set_represented_type(#bevy_reflect_path::PartialReflect::get_represented_type_info(self));
-                #(dynamic.insert_boxed(#field_names, #bevy_reflect_path::PartialReflect::to_dynamic(#fields_ref));)*
+                #(dynamic.insert_boxed(#field_names, #bevy_reflect_path::PartialReflect::to_dynamic(#fields_ref).unwrap());)*
                 dynamic
             }
         }

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -90,11 +90,11 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
                 #bevy_reflect_path::tuple_struct::TupleStructFieldIter::new(self)
             }
 
-            fn to_dynamic_tuple_struct(&self) -> #bevy_reflect_path::tuple_struct::DynamicTupleStruct {
+            fn to_dynamic_tuple_struct(&self) -> #FQResult<#bevy_reflect_path::tuple_struct::DynamicTupleStruct, #bevy_reflect_path::ReflectCloneError> {
                 let mut dynamic: #bevy_reflect_path::tuple_struct::DynamicTupleStruct = #FQDefault::default();
                 dynamic.set_represented_type(#bevy_reflect_path::PartialReflect::get_represented_type_info(self));
-                #(dynamic.insert_boxed(#bevy_reflect_path::PartialReflect::to_dynamic(#fields_ref).unwrap());)*
-                dynamic
+                #(dynamic.insert_boxed(#bevy_reflect_path::PartialReflect::to_dynamic(#fields_ref)?);)*
+                #FQResult::Ok(dynamic)
             }
         }
 

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -93,7 +93,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
             fn to_dynamic_tuple_struct(&self) -> #bevy_reflect_path::tuple_struct::DynamicTupleStruct {
                 let mut dynamic: #bevy_reflect_path::tuple_struct::DynamicTupleStruct = #FQDefault::default();
                 dynamic.set_represented_type(#bevy_reflect_path::PartialReflect::get_represented_type_info(self));
-                #(dynamic.insert_boxed(#bevy_reflect_path::PartialReflect::to_dynamic(#fields_ref));)*
+                #(dynamic.insert_boxed(#bevy_reflect_path::PartialReflect::to_dynamic(#fields_ref).unwrap());)*
                 dynamic
             }
         }

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -4,8 +4,8 @@
 use crate::generics::impl_generic_info_methods;
 use crate::{
     ty::impl_type_methods, utility::reflect_hasher, ApplyError, Generics, MaybeTyped,
-    PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo,
-    TypePath,
+    PartialReflect, Reflect, ReflectCloneError, ReflectKind, ReflectMut, ReflectOwned, ReflectRef,
+    Type, TypeInfo, TypePath,
 };
 use alloc::{boxed::Box, vec::Vec};
 use bevy_reflect_derive::impl_type_path;
@@ -72,11 +72,16 @@ pub trait Array: PartialReflect {
     fn drain(self: Box<Self>) -> Vec<Box<dyn PartialReflect>>;
 
     /// Creates a new [`DynamicArray`] from this array.
-    fn to_dynamic_array(&self) -> DynamicArray {
-        DynamicArray {
+    ///
+    /// Returns an error if any element cannot be converted via [`PartialReflect::to_dynamic`].
+    fn to_dynamic_array(&self) -> Result<DynamicArray, ReflectCloneError> {
+        Ok(DynamicArray {
             represented_type: self.get_represented_type_info(),
-            values: self.iter().map(|item| item.to_dynamic().unwrap()).collect(),
-        }
+            values: self
+                .iter()
+                .map(PartialReflect::to_dynamic)
+                .collect::<Result<_, _>>()?,
+        })
     }
 
     /// Will return `None` if [`TypeInfo`] is not available.

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -75,7 +75,7 @@ pub trait Array: PartialReflect {
     fn to_dynamic_array(&self) -> DynamicArray {
         DynamicArray {
             represented_type: self.get_represented_type_info(),
-            values: self.iter().map(PartialReflect::to_dynamic).collect(),
+            values: self.iter().map(|item| item.to_dynamic().unwrap()).collect(),
         }
     }
 

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -173,11 +173,33 @@ impl DynamicEnum {
     /// Create a [`DynamicEnum`] from an existing one.
     ///
     /// This is functionally the same as [`DynamicEnum::from_ref`] except it takes an owned value.
+    #[deprecated(
+        since = "0.20.0",
+        note = "Use `DynamicEnum::try_from` instead, which returns a Result."
+    )]
+    pub fn from<TEnum: Enum>(value: TEnum) -> Self {
+        Self::try_from(value).unwrap()
+    }
+
+    /// Create a [`DynamicEnum`] from an existing one.
+    ///
+    /// This is functionally the same as [`DynamicEnum::from_ref`] except it takes an owned value.
     ///
     /// Returns an error if any field of the active variant cannot be converted via
     /// [`PartialReflect::to_dynamic`].
-    pub fn from<TEnum: Enum>(value: TEnum) -> Result<Self, ReflectCloneError> {
-        Self::from_ref(&value)
+    pub fn try_from<TEnum: Enum>(value: TEnum) -> Result<Self, ReflectCloneError> {
+        Self::try_from_ref(&value)
+    }
+
+    /// Create a [`DynamicEnum`] from an existing one.
+    ///
+    /// This is functionally the same as [`DynamicEnum::from`] except it takes a reference.
+    #[deprecated(
+        since = "0.20.0",
+        note = "Use `DynamicEnum::try_from_ref` instead, which returns a Result."
+    )]
+    pub fn from_ref<TEnum: Enum + ?Sized>(value: &TEnum) -> Self {
+        Self::try_from_ref(value).unwrap()
     }
 
     /// Create a [`DynamicEnum`] from an existing one.
@@ -186,7 +208,7 @@ impl DynamicEnum {
     ///
     /// Returns an error if any field of the active variant cannot be converted via
     /// [`PartialReflect::to_dynamic`].
-    pub fn from_ref<TEnum: Enum + ?Sized>(value: &TEnum) -> Result<Self, ReflectCloneError> {
+    pub fn try_from_ref<TEnum: Enum + ?Sized>(value: &TEnum) -> Result<Self, ReflectCloneError> {
         let type_info = value.get_represented_type_info();
         let mut dyn_enum = match value.variant_type() {
             VariantType::Unit => DynamicEnum::new_with_index(

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -7,8 +7,8 @@ use crate::{
     },
     structs::{DynamicStruct, Struct},
     tuple::{DynamicTuple, Tuple},
-    ApplyError, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef,
-    TypeInfo,
+    ApplyError, PartialReflect, Reflect, ReflectCloneError, ReflectKind, ReflectMut, ReflectOwned,
+    ReflectRef, TypeInfo,
 };
 
 use alloc::{boxed::Box, string::String};
@@ -27,12 +27,19 @@ pub enum DynamicVariant {
     Struct(DynamicStruct),
 }
 
+/// # Panics
+///
+/// `Clone` cannot fail, so deep-cloning a variant whose fields contain a non-cloneable
+/// opaque value panics. This is unavoidable: the field-by-field deep clone relies on
+/// `to_dynamic_*`, which is fallible to avoid exactly this problem.
 impl Clone for DynamicVariant {
     fn clone(&self) -> Self {
         match self {
             DynamicVariant::Unit => DynamicVariant::Unit,
-            DynamicVariant::Tuple(data) => DynamicVariant::Tuple(data.to_dynamic_tuple()),
-            DynamicVariant::Struct(data) => DynamicVariant::Struct(data.to_dynamic_struct()),
+            DynamicVariant::Tuple(data) => DynamicVariant::Tuple(data.to_dynamic_tuple().unwrap()),
+            DynamicVariant::Struct(data) => {
+                DynamicVariant::Struct(data.to_dynamic_struct().unwrap())
+            }
         }
     }
 }
@@ -166,14 +173,20 @@ impl DynamicEnum {
     /// Create a [`DynamicEnum`] from an existing one.
     ///
     /// This is functionally the same as [`DynamicEnum::from_ref`] except it takes an owned value.
-    pub fn from<TEnum: Enum>(value: TEnum) -> Self {
+    ///
+    /// Returns an error if any field of the active variant cannot be converted via
+    /// [`PartialReflect::to_dynamic`].
+    pub fn from<TEnum: Enum>(value: TEnum) -> Result<Self, ReflectCloneError> {
         Self::from_ref(&value)
     }
 
     /// Create a [`DynamicEnum`] from an existing one.
     ///
     /// This is functionally the same as [`DynamicEnum::from`] except it takes a reference.
-    pub fn from_ref<TEnum: Enum + ?Sized>(value: &TEnum) -> Self {
+    ///
+    /// Returns an error if any field of the active variant cannot be converted via
+    /// [`PartialReflect::to_dynamic`].
+    pub fn from_ref<TEnum: Enum + ?Sized>(value: &TEnum) -> Result<Self, ReflectCloneError> {
         let type_info = value.get_represented_type_info();
         let mut dyn_enum = match value.variant_type() {
             VariantType::Unit => DynamicEnum::new_with_index(
@@ -184,7 +197,7 @@ impl DynamicEnum {
             VariantType::Tuple => {
                 let mut data = DynamicTuple::default();
                 for field in value.iter_fields() {
-                    data.insert_boxed(field.value().to_dynamic().unwrap());
+                    data.insert_boxed(field.value().to_dynamic()?);
                 }
                 DynamicEnum::new_with_index(
                     value.variant_index(),
@@ -196,7 +209,7 @@ impl DynamicEnum {
                 let mut data = DynamicStruct::default();
                 for field in value.iter_fields() {
                     let name = field.name().unwrap();
-                    data.insert_boxed(name, field.value().to_dynamic().unwrap());
+                    data.insert_boxed(name, field.value().to_dynamic()?);
                 }
                 DynamicEnum::new_with_index(
                     value.variant_index(),
@@ -207,7 +220,7 @@ impl DynamicEnum {
         };
 
         dyn_enum.set_represented_type(type_info);
-        dyn_enum
+        Ok(dyn_enum)
     }
 }
 
@@ -353,14 +366,14 @@ impl PartialReflect for DynamicEnum {
                 VariantType::Tuple => {
                     let mut dyn_tuple = DynamicTuple::default();
                     for field in value.iter_fields() {
-                        dyn_tuple.insert_boxed(field.value().to_dynamic().unwrap());
+                        dyn_tuple.insert_boxed(field.value().to_dynamic()?);
                     }
                     DynamicVariant::Tuple(dyn_tuple)
                 }
                 VariantType::Struct => {
                     let mut dyn_struct = DynamicStruct::default();
                     for field in value.iter_fields() {
-                        dyn_struct.insert_boxed(field.name().unwrap(), field.value().to_dynamic().unwrap());
+                        dyn_struct.insert_boxed(field.name().unwrap(), field.value().to_dynamic()?);
                     }
                     DynamicVariant::Struct(dyn_struct)
                 }

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -184,7 +184,7 @@ impl DynamicEnum {
             VariantType::Tuple => {
                 let mut data = DynamicTuple::default();
                 for field in value.iter_fields() {
-                    data.insert_boxed(field.value().to_dynamic());
+                    data.insert_boxed(field.value().to_dynamic().unwrap());
                 }
                 DynamicEnum::new_with_index(
                     value.variant_index(),
@@ -196,7 +196,7 @@ impl DynamicEnum {
                 let mut data = DynamicStruct::default();
                 for field in value.iter_fields() {
                     let name = field.name().unwrap();
-                    data.insert_boxed(name, field.value().to_dynamic());
+                    data.insert_boxed(name, field.value().to_dynamic().unwrap());
                 }
                 DynamicEnum::new_with_index(
                     value.variant_index(),
@@ -353,14 +353,14 @@ impl PartialReflect for DynamicEnum {
                 VariantType::Tuple => {
                     let mut dyn_tuple = DynamicTuple::default();
                     for field in value.iter_fields() {
-                        dyn_tuple.insert_boxed(field.value().to_dynamic());
+                        dyn_tuple.insert_boxed(field.value().to_dynamic().unwrap());
                     }
                     DynamicVariant::Tuple(dyn_tuple)
                 }
                 VariantType::Struct => {
                     let mut dyn_struct = DynamicStruct::default();
                     for field in value.iter_fields() {
-                        dyn_struct.insert_boxed(field.name().unwrap(), field.value().to_dynamic());
+                        dyn_struct.insert_boxed(field.name().unwrap(), field.value().to_dynamic().unwrap());
                     }
                     DynamicVariant::Struct(dyn_struct)
                 }

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -183,7 +183,7 @@ impl DynamicEnum {
 
     /// Create a [`DynamicEnum`] from an existing one.
     ///
-    /// This is functionally the same as [`DynamicEnum::from_ref`] except it takes an owned value.
+    /// This is functionally the same as [`DynamicEnum::try_from_ref`] except it takes an owned value.
     ///
     /// Returns an error if any field of the active variant cannot be converted via
     /// [`PartialReflect::to_dynamic`].
@@ -204,7 +204,7 @@ impl DynamicEnum {
 
     /// Create a [`DynamicEnum`] from an existing one.
     ///
-    /// This is functionally the same as [`DynamicEnum::from`] except it takes a reference.
+    /// This is functionally the same as [`DynamicEnum::try_from`] except it takes a reference.
     ///
     /// Returns an error if any field of the active variant cannot be converted via
     /// [`PartialReflect::to_dynamic`].

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -3,7 +3,7 @@ use crate::{
     attributes::{impl_custom_attribute_methods, CustomAttributes},
     enums::{DynamicEnum, VariantInfo, VariantType},
     ty::impl_type_methods,
-    Generics, PartialReflect, Type, TypePath,
+    Generics, PartialReflect, ReflectCloneError, Type, TypePath,
 };
 use alloc::{boxed::Box, format, string::String};
 use bevy_platform::collections::HashMap;
@@ -125,7 +125,10 @@ pub trait Enum: PartialReflect {
     /// The type of the current variant.
     fn variant_type(&self) -> VariantType;
     /// Creates a new [`DynamicEnum`] from this enum.
-    fn to_dynamic_enum(&self) -> DynamicEnum {
+    ///
+    /// Returns an error if any field of the active variant cannot be converted via
+    /// [`PartialReflect::to_dynamic`].
+    fn to_dynamic_enum(&self) -> Result<DynamicEnum, ReflectCloneError> {
         DynamicEnum::from_ref(self)
     }
     /// Returns true if the current variant's type matches the given one.

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -129,7 +129,7 @@ pub trait Enum: PartialReflect {
     /// Returns an error if any field of the active variant cannot be converted via
     /// [`PartialReflect::to_dynamic`].
     fn to_dynamic_enum(&self) -> Result<DynamicEnum, ReflectCloneError> {
-        DynamicEnum::from_ref(self)
+        DynamicEnum::try_from_ref(self)
     }
     /// Returns true if the current variant's type matches the given one.
     fn is_variant(&self, variant_type: VariantType) -> bool {

--- a/crates/bevy_reflect/src/enums/mod.rs
+++ b/crates/bevy_reflect/src/enums/mod.rs
@@ -93,13 +93,13 @@ mod tests {
     fn dynamic_enum_should_set_variant_fields() {
         // === Unit === //
         let mut value = MyEnum::A;
-        let dyn_enum = DynamicEnum::from(MyEnum::A);
+        let dyn_enum = DynamicEnum::from(MyEnum::A).unwrap();
         value.apply(&dyn_enum);
         assert_eq!(MyEnum::A, value);
 
         // === Tuple === //
         let mut value = MyEnum::B(0, 0);
-        let dyn_enum = DynamicEnum::from(MyEnum::B(123, 321));
+        let dyn_enum = DynamicEnum::from(MyEnum::B(123, 321)).unwrap();
         value.apply(&dyn_enum);
         assert_eq!(MyEnum::B(123, 321), value);
 
@@ -111,7 +111,8 @@ mod tests {
         let dyn_enum = DynamicEnum::from(MyEnum::C {
             foo: 1.23,
             bar: true,
-        });
+        })
+        .unwrap();
         value.apply(&dyn_enum);
         assert_eq!(
             MyEnum::C {
@@ -158,8 +159,8 @@ mod tests {
 
     #[test]
     fn dynamic_enum_should_apply_dynamic_enum() {
-        let mut a = DynamicEnum::from(MyEnum::B(123, 321));
-        let b = DynamicEnum::from(MyEnum::B(123, 321));
+        let mut a = DynamicEnum::from(MyEnum::B(123, 321)).unwrap();
+        let b = DynamicEnum::from(MyEnum::B(123, 321)).unwrap();
 
         // Sanity check that equality check works
         assert!(
@@ -182,7 +183,7 @@ mod tests {
         let mut value = MyEnum::A;
 
         // === MyEnum::A -> MyEnum::B === //
-        let mut dyn_enum = DynamicEnum::from(MyEnum::B(123, 321));
+        let mut dyn_enum = DynamicEnum::from(MyEnum::B(123, 321)).unwrap();
         value.apply(&dyn_enum);
         assert_eq!(MyEnum::B(123, 321), value);
 
@@ -216,7 +217,7 @@ mod tests {
 
     #[test]
     fn dynamic_enum_should_return_is_dynamic() {
-        let dyn_enum = DynamicEnum::from(MyEnum::B(123, 321));
+        let dyn_enum = DynamicEnum::from(MyEnum::B(123, 321)).unwrap();
         assert!(dyn_enum.is_dynamic());
     }
 

--- a/crates/bevy_reflect/src/enums/mod.rs
+++ b/crates/bevy_reflect/src/enums/mod.rs
@@ -93,13 +93,13 @@ mod tests {
     fn dynamic_enum_should_set_variant_fields() {
         // === Unit === //
         let mut value = MyEnum::A;
-        let dyn_enum = DynamicEnum::from(MyEnum::A).unwrap();
+        let dyn_enum = DynamicEnum::try_from(MyEnum::A).unwrap();
         value.apply(&dyn_enum);
         assert_eq!(MyEnum::A, value);
 
         // === Tuple === //
         let mut value = MyEnum::B(0, 0);
-        let dyn_enum = DynamicEnum::from(MyEnum::B(123, 321)).unwrap();
+        let dyn_enum = DynamicEnum::try_from(MyEnum::B(123, 321)).unwrap();
         value.apply(&dyn_enum);
         assert_eq!(MyEnum::B(123, 321), value);
 
@@ -108,7 +108,7 @@ mod tests {
             foo: 0.0,
             bar: false,
         };
-        let dyn_enum = DynamicEnum::from(MyEnum::C {
+        let dyn_enum = DynamicEnum::try_from(MyEnum::C {
             foo: 1.23,
             bar: true,
         })
@@ -159,8 +159,8 @@ mod tests {
 
     #[test]
     fn dynamic_enum_should_apply_dynamic_enum() {
-        let mut a = DynamicEnum::from(MyEnum::B(123, 321)).unwrap();
-        let b = DynamicEnum::from(MyEnum::B(123, 321)).unwrap();
+        let mut a = DynamicEnum::try_from(MyEnum::B(123, 321)).unwrap();
+        let b = DynamicEnum::try_from(MyEnum::B(123, 321)).unwrap();
 
         // Sanity check that equality check works
         assert!(
@@ -183,7 +183,7 @@ mod tests {
         let mut value = MyEnum::A;
 
         // === MyEnum::A -> MyEnum::B === //
-        let mut dyn_enum = DynamicEnum::from(MyEnum::B(123, 321)).unwrap();
+        let mut dyn_enum = DynamicEnum::try_from(MyEnum::B(123, 321)).unwrap();
         value.apply(&dyn_enum);
         assert_eq!(MyEnum::B(123, 321), value);
 
@@ -217,7 +217,7 @@ mod tests {
 
     #[test]
     fn dynamic_enum_should_return_is_dynamic() {
-        let dyn_enum = DynamicEnum::from(MyEnum::B(123, 321)).unwrap();
+        let dyn_enum = DynamicEnum::try_from(MyEnum::B(123, 321)).unwrap();
         assert!(dyn_enum.is_dynamic());
     }
 

--- a/crates/bevy_reflect/src/impls/indexmap.rs
+++ b/crates/bevy_reflect/src/impls/indexmap.rs
@@ -68,7 +68,7 @@ where
                     k.reflect_type_path()
                 )
             });
-            dynamic_map.insert_boxed(Box::new(key), v.to_dynamic());
+            dynamic_map.insert_boxed(Box::new(key), v.to_dynamic().unwrap());
         }
         dynamic_map
     }

--- a/crates/bevy_reflect/src/impls/indexmap.rs
+++ b/crates/bevy_reflect/src/impls/indexmap.rs
@@ -58,7 +58,7 @@ where
         self.retain(move |key, value| f(key, value));
     }
 
-    fn to_dynamic_map(&self) -> DynamicMap {
+    fn to_dynamic_map(&self) -> Result<DynamicMap, ReflectCloneError> {
         let mut dynamic_map = DynamicMap::default();
         dynamic_map.set_represented_type(PartialReflect::get_represented_type_info(self));
         for (k, v) in self {
@@ -68,9 +68,9 @@ where
                     k.reflect_type_path()
                 )
             });
-            dynamic_map.insert_boxed(Box::new(key), v.to_dynamic().unwrap());
+            dynamic_map.insert_boxed(Box::new(key), v.to_dynamic()?);
         }
-        dynamic_map
+        Ok(dynamic_map)
     }
 
     fn insert_boxed(

--- a/crates/bevy_reflect/src/impls/macros/map.rs
+++ b/crates/bevy_reflect/src/impls/macros/map.rs
@@ -52,7 +52,7 @@ macro_rules! impl_reflect_for_hashmap {
                                 k.reflect_type_path()
                             )
                         });
-                        dynamic_map.insert_boxed(bevy_platform::prelude::Box::new(key), v.to_dynamic());
+                        dynamic_map.insert_boxed(bevy_platform::prelude::Box::new(key), v.to_dynamic().unwrap());
                     }
                     dynamic_map
                 }

--- a/crates/bevy_reflect/src/impls/macros/map.rs
+++ b/crates/bevy_reflect/src/impls/macros/map.rs
@@ -42,7 +42,7 @@ macro_rules! impl_reflect_for_hashmap {
                     self.retain(move |key, value| f(key, value));
                 }
 
-                fn to_dynamic_map(&self) -> $crate::map::DynamicMap {
+                fn to_dynamic_map(&self) -> Result<$crate::map::DynamicMap, $crate::error::ReflectCloneError> {
                     let mut dynamic_map = $crate::map::DynamicMap::default();
                     dynamic_map.set_represented_type($crate::reflect::PartialReflect::get_represented_type_info(self));
                     for (k, v) in self {
@@ -52,9 +52,9 @@ macro_rules! impl_reflect_for_hashmap {
                                 k.reflect_type_path()
                             )
                         });
-                        dynamic_map.insert_boxed(bevy_platform::prelude::Box::new(key), v.to_dynamic().unwrap());
+                        dynamic_map.insert_boxed(bevy_platform::prelude::Box::new(key), v.to_dynamic()?);
                     }
-                    dynamic_map
+                    Ok(dynamic_map)
                 }
 
                 fn insert_boxed(

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -3765,7 +3765,8 @@ bevy_reflect::tests::Test {
             Struct { value: String },
         }
 
-        let mut patch = DynamicEnum::from(MyType(external_crate::TheirType::Tuple(123))).unwrap();
+        let mut patch =
+            DynamicEnum::try_from(MyType(external_crate::TheirType::Tuple(123))).unwrap();
 
         let mut data = MyType(external_crate::TheirType::Unit);
 
@@ -3773,7 +3774,7 @@ bevy_reflect::tests::Test {
         data.apply(&patch);
         assert_eq!(external_crate::TheirType::Tuple(123), data.0);
 
-        patch = DynamicEnum::from(MyType(external_crate::TheirType::Struct {
+        patch = DynamicEnum::try_from(MyType(external_crate::TheirType::Struct {
             value: "Hello world!".to_string(),
         }))
         .unwrap();
@@ -3796,7 +3797,7 @@ bevy_reflect::tests::Test {
             },
         }
 
-        let patch = DynamicEnum::from(ContainerEnum::Bar {
+        let patch = DynamicEnum::try_from(ContainerEnum::Bar {
             their_type: external_crate::TheirType::Tuple(123),
         })
         .unwrap();

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -220,7 +220,7 @@
 //! });
 //!
 //! // `dynamic` will be a `DynamicStruct` representing a `MyStruct`
-//! let dynamic: Box<dyn PartialReflect> = original.to_dynamic();
+//! let dynamic: Box<dyn PartialReflect> = original.to_dynamic().unwrap();
 //! assert!(dynamic.represents::<MyStruct>());
 //! ```
 //!
@@ -253,7 +253,7 @@
 //!   foo: 123
 //! });
 //!
-//! let dynamic: Box<dyn PartialReflect> = original.to_dynamic();
+//! let dynamic: Box<dyn PartialReflect> = original.to_dynamic().unwrap();
 //! let value = dynamic.try_take::<MyStruct>().unwrap(); // PANIC!
 //! ```
 //!
@@ -278,7 +278,7 @@
 //!   foo: 123
 //! });
 //!
-//! let dynamic: Box<dyn PartialReflect> = original.to_dynamic();
+//! let dynamic: Box<dyn PartialReflect> = original.to_dynamic().unwrap();
 //! let value = <MyStruct as FromReflect>::from_reflect(&*dynamic).unwrap(); // OK!
 //! ```
 //!

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1081,7 +1081,7 @@ mod tests {
 
         let foo = Foo { a: 1 };
         assert!(foo.reflect_hash().is_some());
-        let dynamic = foo.to_dynamic_struct();
+        let dynamic = foo.to_dynamic_struct().unwrap();
 
         let mut map = DynamicMap::default();
         map.insert(dynamic, 11u32);
@@ -2145,7 +2145,7 @@ mod tests {
         list.push(3isize);
         list.push(4isize);
         list.push(5isize);
-        foo_patch.insert("c", list.to_dynamic_list());
+        foo_patch.insert("c", list.to_dynamic_list().unwrap());
 
         let mut map = DynamicMap::default();
         map.insert(2usize, 3i8);
@@ -2154,7 +2154,7 @@ mod tests {
 
         let mut bar_patch = DynamicStruct::default();
         bar_patch.insert("x", 2u32);
-        foo_patch.insert("e", bar_patch.to_dynamic_struct());
+        foo_patch.insert("e", bar_patch.to_dynamic_struct().unwrap());
 
         let mut tuple = DynamicTuple::default();
         tuple.insert(2i32);
@@ -2480,22 +2480,22 @@ mod tests {
     #[test]
     fn not_dynamic_names() {
         let list = Vec::<usize>::new();
-        let dyn_list = list.to_dynamic_list();
+        let dyn_list = list.to_dynamic_list().unwrap();
         assert_ne!(dyn_list.reflect_type_path(), Vec::<usize>::type_path());
 
         let array = [b'0'; 4];
-        let dyn_array = array.to_dynamic_array();
+        let dyn_array = array.to_dynamic_array().unwrap();
         assert_ne!(dyn_array.reflect_type_path(), <[u8; 4]>::type_path());
 
         let map = HashMap::<usize, String>::default();
-        let dyn_map = map.to_dynamic_map();
+        let dyn_map = map.to_dynamic_map().unwrap();
         assert_ne!(
             dyn_map.reflect_type_path(),
             HashMap::<usize, String>::type_path()
         );
 
         let tuple = (0usize, "1".to_string(), 2.0f32);
-        let mut dyn_tuple = tuple.to_dynamic_tuple();
+        let mut dyn_tuple = tuple.to_dynamic_tuple().unwrap();
         dyn_tuple.insert::<usize>(3);
         assert_ne!(
             dyn_tuple.reflect_type_path(),
@@ -2507,13 +2507,13 @@ mod tests {
             a: usize,
         }
         let struct_ = TestStruct { a: 0 };
-        let dyn_struct = struct_.to_dynamic_struct();
+        let dyn_struct = struct_.to_dynamic_struct().unwrap();
         assert_ne!(dyn_struct.reflect_type_path(), TestStruct::type_path());
 
         #[derive(Reflect)]
         struct TestTupleStruct(usize);
         let tuple_struct = TestTupleStruct(0);
-        let dyn_tuple_struct = tuple_struct.to_dynamic_tuple_struct();
+        let dyn_tuple_struct = tuple_struct.to_dynamic_tuple_struct().unwrap();
         assert_ne!(
             dyn_tuple_struct.reflect_type_path(),
             TestTupleStruct::type_path()
@@ -2923,7 +2923,7 @@ mod tests {
     #[test]
     fn should_permit_valid_represented_type_for_dynamic() {
         let type_info = <[i32; 2] as Typed>::type_info();
-        let mut dynamic_array = [123; 2].to_dynamic_array();
+        let mut dynamic_array = [123; 2].to_dynamic_array().unwrap();
         dynamic_array.set_represented_type(Some(type_info));
     }
 
@@ -2931,7 +2931,7 @@ mod tests {
     #[should_panic(expected = "expected TypeInfo::Array but received")]
     fn should_prohibit_invalid_represented_type_for_dynamic() {
         let type_info = <(i32, i32) as Typed>::type_info();
-        let mut dynamic_array = [123; 2].to_dynamic_array();
+        let mut dynamic_array = [123; 2].to_dynamic_array().unwrap();
         dynamic_array.set_represented_type(Some(type_info));
     }
 
@@ -3484,7 +3484,8 @@ bevy_reflect::tests::Test {
             map,
             value: 12,
         }
-        .to_dynamic_struct();
+        .to_dynamic_struct()
+        .unwrap();
 
         // test unknown DynamicStruct
         let mut test_unknown_struct = DynamicStruct::default();
@@ -3764,7 +3765,7 @@ bevy_reflect::tests::Test {
             Struct { value: String },
         }
 
-        let mut patch = DynamicEnum::from(MyType(external_crate::TheirType::Tuple(123)));
+        let mut patch = DynamicEnum::from(MyType(external_crate::TheirType::Tuple(123))).unwrap();
 
         let mut data = MyType(external_crate::TheirType::Unit);
 
@@ -3774,7 +3775,8 @@ bevy_reflect::tests::Test {
 
         patch = DynamicEnum::from(MyType(external_crate::TheirType::Struct {
             value: "Hello world!".to_string(),
-        }));
+        }))
+        .unwrap();
 
         data.apply(&patch);
         assert_eq!(
@@ -3796,7 +3798,8 @@ bevy_reflect::tests::Test {
 
         let patch = DynamicEnum::from(ContainerEnum::Bar {
             their_type: external_crate::TheirType::Tuple(123),
-        });
+        })
+        .unwrap();
 
         let mut data = ContainerEnum::Foo;
 

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -110,7 +110,10 @@ pub trait List: PartialReflect {
     fn to_dynamic_list(&self) -> DynamicList {
         DynamicList {
             represented_type: self.get_represented_type_info(),
-            values: self.iter().map(PartialReflect::to_dynamic).collect(),
+            values: self
+                .iter()
+                .map(|value| value.to_dynamic().unwrap())
+                .collect(),
         }
     }
 
@@ -460,7 +463,7 @@ pub fn list_try_apply<L: List>(a: &mut L, b: &dyn PartialReflect) -> Result<(), 
                 v.try_apply(value)?;
             }
         } else {
-            List::push(a, value.to_dynamic());
+            List::push(a, value.to_dynamic().unwrap());
         }
     }
 

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -13,8 +13,8 @@ use bevy_reflect_derive::impl_type_path;
 use crate::generics::impl_generic_info_methods;
 use crate::{
     ty::impl_type_methods, utility::reflect_hasher, ApplyError, FromReflect, Generics, MaybeTyped,
-    PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo,
-    TypePath,
+    PartialReflect, Reflect, ReflectCloneError, ReflectKind, ReflectMut, ReflectOwned, ReflectRef,
+    Type, TypeInfo, TypePath,
 };
 
 /// A trait used to power [list-like] operations via [reflection].
@@ -107,14 +107,16 @@ pub trait List: PartialReflect {
     fn drain(&mut self) -> Vec<Box<dyn PartialReflect>>;
 
     /// Creates a new [`DynamicList`] from this list.
-    fn to_dynamic_list(&self) -> DynamicList {
-        DynamicList {
+    ///
+    /// Returns an error if any element cannot be converted via [`PartialReflect::to_dynamic`].
+    fn to_dynamic_list(&self) -> Result<DynamicList, ReflectCloneError> {
+        Ok(DynamicList {
             represented_type: self.get_represented_type_info(),
             values: self
                 .iter()
-                .map(|value| value.to_dynamic().unwrap())
-                .collect(),
-        }
+                .map(PartialReflect::to_dynamic)
+                .collect::<Result<_, _>>()?,
+        })
     }
 
     /// Will return `None` if [`TypeInfo`] is not available.
@@ -463,7 +465,7 @@ pub fn list_try_apply<L: List>(a: &mut L, b: &dyn PartialReflect) -> Result<(), 
                 v.try_apply(value)?;
             }
         } else {
-            List::push(a, value.to_dynamic().unwrap());
+            List::push(a, value.to_dynamic()?);
         }
     }
 

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -85,7 +85,7 @@ pub trait Map: PartialReflect {
         let mut map = DynamicMap::default();
         map.set_represented_type(self.get_represented_type_info());
         for (key, value) in self.iter() {
-            map.insert_boxed(key.to_dynamic(), value.to_dynamic());
+            map.insert_boxed(key.to_dynamic().unwrap(), value.to_dynamic().unwrap());
         }
         map
     }
@@ -598,7 +598,7 @@ pub fn map_try_apply<M: Map>(a: &mut M, b: &dyn PartialReflect) -> Result<(), Ap
         if let Some(a_value) = a.get_mut(key) {
             a_value.try_apply(b_value)?;
         } else {
-            a.insert_boxed(key.to_dynamic(), b_value.to_dynamic());
+            a.insert_boxed(key.to_dynamic().unwrap(), b_value.to_dynamic().unwrap());
         }
     }
     a.retain(&mut |key, _| map_value.get(key).is_some());

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -8,8 +8,8 @@ use bevy_reflect_derive::impl_type_path;
 
 use crate::{
     generics::impl_generic_info_methods, ty::impl_type_methods, ApplyError, Generics, MaybeTyped,
-    PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo,
-    TypePath,
+    PartialReflect, Reflect, ReflectCloneError, ReflectKind, ReflectMut, ReflectOwned, ReflectRef,
+    Type, TypeInfo, TypePath,
 };
 use alloc::{boxed::Box, vec::Vec};
 
@@ -81,13 +81,15 @@ pub trait Map: PartialReflect {
     fn retain(&mut self, f: &mut dyn FnMut(&dyn PartialReflect, &mut dyn PartialReflect) -> bool);
 
     /// Creates a new [`DynamicMap`] from this map.
-    fn to_dynamic_map(&self) -> DynamicMap {
+    ///
+    /// Returns an error if any key or value cannot be converted via [`PartialReflect::to_dynamic`].
+    fn to_dynamic_map(&self) -> Result<DynamicMap, ReflectCloneError> {
         let mut map = DynamicMap::default();
         map.set_represented_type(self.get_represented_type_info());
         for (key, value) in self.iter() {
-            map.insert_boxed(key.to_dynamic().unwrap(), value.to_dynamic().unwrap());
+            map.insert_boxed(key.to_dynamic()?, value.to_dynamic()?);
         }
-        map
+        Ok(map)
     }
 
     /// Inserts a key-value pair into the map.
@@ -598,7 +600,7 @@ pub fn map_try_apply<M: Map>(a: &mut M, b: &dyn PartialReflect) -> Result<(), Ap
         if let Some(a_value) = a.get_mut(key) {
             a_value.try_apply(b_value)?;
         } else {
-            a.insert_boxed(key.to_dynamic().unwrap(), b_value.to_dynamic().unwrap());
+            a.insert_boxed(key.to_dynamic()?, b_value.to_dynamic()?);
         }
     }
     a.retain(&mut |key, _| map_value.get(key).is_some());

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -254,16 +254,16 @@ where
     /// If you want to attempt to clone a value but are willing to accept a dynamic representation if cloning fails,
     /// use [`reflect_clone_incomplete`].
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This method will panic if the [kind] is [opaque] and the call to [`reflect_clone`] fails.
+    /// This method will return an error if the [kind] is [opaque] and the call to [`reflect_clone`] fails.
     ///
     /// # Example
     ///
     /// ```
     /// # use bevy_reflect::{PartialReflect};
     /// let value = (1, true, 3.14);
-    /// let dynamic_value = value.to_dynamic();
+    /// let dynamic_value = value.to_dynamic().unwrap();
     /// assert!(dynamic_value.is_dynamic())
     /// ```
     ///
@@ -277,21 +277,21 @@ where
     /// [opaque]: crate::ReflectKind::Opaque
     /// [`reflect_clone`]: PartialReflect::reflect_clone
     /// [`reflect_clone_incomplete`]: PartialReflect::reflect_clone_incomplete
-    fn to_dynamic(&self) -> Box<dyn PartialReflect> {
+    fn to_dynamic(&self) -> Result<Box<dyn PartialReflect>, ReflectCloneError> {
         match self.reflect_ref() {
-            ReflectRef::Struct(dyn_struct) => Box::new(dyn_struct.to_dynamic_struct()),
+            ReflectRef::Struct(dyn_struct) => Ok(Box::new(dyn_struct.to_dynamic_struct())),
             ReflectRef::TupleStruct(dyn_tuple_struct) => {
-                Box::new(dyn_tuple_struct.to_dynamic_tuple_struct())
+                Ok(Box::new(dyn_tuple_struct.to_dynamic_tuple_struct()))
             }
-            ReflectRef::Tuple(dyn_tuple) => Box::new(dyn_tuple.to_dynamic_tuple()),
-            ReflectRef::List(dyn_list) => Box::new(dyn_list.to_dynamic_list()),
-            ReflectRef::Array(dyn_array) => Box::new(dyn_array.to_dynamic_array()),
-            ReflectRef::Map(dyn_map) => Box::new(dyn_map.to_dynamic_map()),
-            ReflectRef::Set(dyn_set) => Box::new(dyn_set.to_dynamic_set()),
-            ReflectRef::Enum(dyn_enum) => Box::new(dyn_enum.to_dynamic_enum()),
+            ReflectRef::Tuple(dyn_tuple) => Ok(Box::new(dyn_tuple.to_dynamic_tuple())),
+            ReflectRef::List(dyn_list) => Ok(Box::new(dyn_list.to_dynamic_list())),
+            ReflectRef::Array(dyn_array) => Ok(Box::new(dyn_array.to_dynamic_array())),
+            ReflectRef::Map(dyn_map) => Ok(Box::new(dyn_map.to_dynamic_map())),
+            ReflectRef::Set(dyn_set) => Ok(Box::new(dyn_set.to_dynamic_set())),
+            ReflectRef::Enum(dyn_enum) => Ok(Box::new(dyn_enum.to_dynamic_enum())),
             #[cfg(feature = "functions")]
-            ReflectRef::Function(dyn_function) => Box::new(dyn_function.to_dynamic_function()),
-            ReflectRef::Opaque(value) => value.reflect_clone().unwrap().into_partial_reflect(),
+            ReflectRef::Function(dyn_function) => Ok(Box::new(dyn_function.to_dynamic_function())),
+            ReflectRef::Opaque(value) => value.reflect_clone().map(|v| v.into_partial_reflect()),
         }
     }
 
@@ -345,10 +345,6 @@ where
     ///
     /// This method prefers the more faithful `reflect_clone` path, falling back to `to_dynamic` when necessary.
     /// Opaque values have no dynamic form, so they will always return an error when `reflect_clone` fails.
-    // Upstreaming notes:
-    // - `clone_incomplete` should just be a method on `PartialReflect`
-    // - remember to cross-link from `PartialReflect::reflect_clone` and `PartialReflect::to_dynamic` for breadcrumbs
-    // - `to_dynamic` should be made to return a `Result` in the same PR that adds this method
     fn reflect_clone_incomplete(&self) -> Result<Box<dyn PartialReflect>, ReflectCloneError> {
         match self.reflect_clone() {
             // Prefer a concrete clone to preserve data
@@ -359,10 +355,7 @@ where
             Err(err) => match self.reflect_ref() {
                 // Opaque values have no dynamic form so just return the error.
                 ReflectRef::Opaque(_) => Err(err),
-                // BUG: this will probably panic with if nested fields have unclonable opaque values.
-                // Fixing to_dynamic to return a Result is much cleaner than working around it here,
-                // so we should just do that during upstreaming.
-                _ => Ok(self.to_dynamic()),
+                _ => Ok(self.to_dynamic()?),
             },
         }
     }

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -66,6 +66,11 @@ pub enum ApplyError {
         /// Name of the missing variant.
         variant_name: Box<str>,
     },
+
+    #[error(transparent)]
+    /// A value could not be converted to its dynamic representation via
+    /// [`PartialReflect::to_dynamic`] while applying it.
+    CloneError(#[from] ReflectCloneError),
 }
 
 impl From<ReflectKindMismatchError> for ApplyError {
@@ -256,7 +261,10 @@ where
     ///
     /// # Errors
     ///
-    /// This method will return an error if the [kind] is [opaque] and the call to [`reflect_clone`] fails.
+    /// This method returns an error whenever any value it must convert is [opaque] and the call to
+    /// [`reflect_clone`] on it fails. This includes opaque values nested anywhere inside the type:
+    /// the conversion is all-or-nothing, so a single non-cloneable opaque field fails the whole call
+    /// rather than producing a partial result.
     ///
     /// # Example
     ///
@@ -279,19 +287,19 @@ where
     /// [`reflect_clone_incomplete`]: PartialReflect::reflect_clone_incomplete
     fn to_dynamic(&self) -> Result<Box<dyn PartialReflect>, ReflectCloneError> {
         match self.reflect_ref() {
-            ReflectRef::Struct(dyn_struct) => Ok(Box::new(dyn_struct.to_dynamic_struct())),
+            ReflectRef::Struct(dyn_struct) => Ok(Box::new(dyn_struct.to_dynamic_struct()?)),
             ReflectRef::TupleStruct(dyn_tuple_struct) => {
-                Ok(Box::new(dyn_tuple_struct.to_dynamic_tuple_struct()))
+                Ok(Box::new(dyn_tuple_struct.to_dynamic_tuple_struct()?))
             }
-            ReflectRef::Tuple(dyn_tuple) => Ok(Box::new(dyn_tuple.to_dynamic_tuple())),
-            ReflectRef::List(dyn_list) => Ok(Box::new(dyn_list.to_dynamic_list())),
-            ReflectRef::Array(dyn_array) => Ok(Box::new(dyn_array.to_dynamic_array())),
-            ReflectRef::Map(dyn_map) => Ok(Box::new(dyn_map.to_dynamic_map())),
-            ReflectRef::Set(dyn_set) => Ok(Box::new(dyn_set.to_dynamic_set())),
-            ReflectRef::Enum(dyn_enum) => Ok(Box::new(dyn_enum.to_dynamic_enum())),
+            ReflectRef::Tuple(dyn_tuple) => Ok(Box::new(dyn_tuple.to_dynamic_tuple()?)),
+            ReflectRef::List(dyn_list) => Ok(Box::new(dyn_list.to_dynamic_list()?)),
+            ReflectRef::Array(dyn_array) => Ok(Box::new(dyn_array.to_dynamic_array()?)),
+            ReflectRef::Map(dyn_map) => Ok(Box::new(dyn_map.to_dynamic_map()?)),
+            ReflectRef::Set(dyn_set) => Ok(Box::new(dyn_set.to_dynamic_set()?)),
+            ReflectRef::Enum(dyn_enum) => Ok(Box::new(dyn_enum.to_dynamic_enum()?)),
             #[cfg(feature = "functions")]
             ReflectRef::Function(dyn_function) => Ok(Box::new(dyn_function.to_dynamic_function())),
-            ReflectRef::Opaque(value) => value.reflect_clone().map(|v| v.into_partial_reflect()),
+            ReflectRef::Opaque(value) => Ok(value.reflect_clone()?.into_partial_reflect()),
         }
     }
 
@@ -347,15 +355,15 @@ where
     /// Opaque values have no dynamic form, so they will always return an error when `reflect_clone` fails.
     fn reflect_clone_incomplete(&self) -> Result<Box<dyn PartialReflect>, ReflectCloneError> {
         match self.reflect_clone() {
-            // Prefer a concrete clone to preserve data
+            // Prefer a concrete clone to preserve data.
             Ok(cloned) => Ok(cloned.into_partial_reflect()),
-            // A concrete clone failed,
-            // almost always because of a non-cloneable field such as `#[reflect(ignore)]`.
-            // We should try to salvage a dynamic copy that simply omits those fields.
+            // A concrete clone failed, almost always because of a field that is excluded from
+            // reflection, such as `#[reflect(ignore)]`. Fall back to a dynamic copy, which drops
+            // those fields. Reflected non-cloneable opaque fields still propagate as an error.
             Err(err) => match self.reflect_ref() {
-                // Opaque values have no dynamic form so just return the error.
+                // Opaque values have no dynamic form, so just return the error.
                 ReflectRef::Opaque(_) => Err(err),
-                _ => Ok(self.to_dynamic()?),
+                _ => self.to_dynamic(),
             },
         }
     }

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -256,8 +256,6 @@ where
     ///
     /// To attempt to clone the value directly such that it returns a concrete instance of this type,
     /// use [`reflect_clone`].
-    /// If you want to attempt to clone a value but are willing to accept a dynamic representation if cloning fails,
-    /// use [`reflect_clone_incomplete`].
     ///
     /// # Errors
     ///
@@ -284,7 +282,6 @@ where
     /// [`DynamicStruct`]: crate::structs::DynamicStruct
     /// [opaque]: crate::ReflectKind::Opaque
     /// [`reflect_clone`]: PartialReflect::reflect_clone
-    /// [`reflect_clone_incomplete`]: PartialReflect::reflect_clone_incomplete
     fn to_dynamic(&self) -> Result<Box<dyn PartialReflect>, ReflectCloneError> {
         match self.reflect_ref() {
             ReflectRef::Struct(dyn_struct) => Ok(Box::new(dyn_struct.to_dynamic_struct()?)),
@@ -308,9 +305,6 @@ where
     /// Unlike [`to_dynamic`], which generally returns a dynamic representation of `Self`,
     /// this method attempts create a clone of `Self` directly, if possible.
     ///
-    /// If you want to attempt to clone a value but are willing to accept a dynamic representation if cloning fails,
-    /// use [`reflect_clone_incomplete`].
-    ///
     /// If the clone cannot be performed, an appropriate [`ReflectCloneError`] is returned.
     ///
     /// # Example
@@ -323,49 +317,10 @@ where
     /// ```
     ///
     /// [`to_dynamic`]: PartialReflect::to_dynamic
-    /// [`reflect_clone_incomplete`]: PartialReflect::reflect_clone_incomplete
     fn reflect_clone(&self) -> Result<Box<dyn Reflect>, ReflectCloneError> {
         Err(ReflectCloneError::NotImplemented {
             type_path: Cow::Owned(self.reflect_type_path().to_string()),
         })
-    }
-
-    /// Clones a reflected value, recovering from errors where possible to produce a partially usable clone.
-    ///
-    /// This is useful for working with reflected values that may contain non-cloneable fields.
-    /// The result may be incomplete: `#[reflect(ignore)]` fields are dropped.
-    /// Complete failures will yield a [`ReflectCloneError`].
-    ///
-    /// # Comparison with other reflection-cloning methods
-    ///
-    /// Bevy offers two other ways to copy a reflected value, and *neither* is a good
-    /// general-purpose choice for the kind of reporting / debugging workflows that you might
-    /// use to make an entity inspector.
-    ///
-    /// [`PartialReflect::reflect_clone`] generates a direct, concrete clone of the value.
-    /// It keeps the real type but fails when any field is non-cloneable.
-    /// This is common when the type contains any `#[reflect(ignore)]` fields.
-    ///
-    /// [`PartialReflect::to_dynamic`] instead builds a dynamic representation that simply omits
-    /// non-cloneable fields, so it succeeds for more types.
-    /// But it can panic on opaque values when cloning fails,
-    /// and sacrifices information about the type and its fields.
-    ///
-    /// This method prefers the more faithful `reflect_clone` path, falling back to `to_dynamic` when necessary.
-    /// Opaque values have no dynamic form, so they will always return an error when `reflect_clone` fails.
-    fn reflect_clone_incomplete(&self) -> Result<Box<dyn PartialReflect>, ReflectCloneError> {
-        match self.reflect_clone() {
-            // Prefer a concrete clone to preserve data.
-            Ok(cloned) => Ok(cloned.into_partial_reflect()),
-            // A concrete clone failed, almost always because of a field that is excluded from
-            // reflection, such as `#[reflect(ignore)]`. Fall back to a dynamic copy, which drops
-            // those fields. Reflected non-cloneable opaque fields still propagate as an error.
-            Err(err) => match self.reflect_ref() {
-                // Opaque values have no dynamic form, so just return the error.
-                ReflectRef::Opaque(_) => Err(err),
-                _ => self.to_dynamic(),
-            },
-        }
     }
 
     /// For a type implementing [`PartialReflect`], combines `reflect_clone` and

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -251,6 +251,8 @@ where
     ///
     /// To attempt to clone the value directly such that it returns a concrete instance of this type,
     /// use [`reflect_clone`].
+    /// If you want to attempt to clone a value but are willing to accept a dynamic representation if cloning fails,
+    /// use [`reflect_clone_incomplete`].
     ///
     /// # Panics
     ///
@@ -274,6 +276,7 @@ where
     /// [`DynamicStruct`]: crate::structs::DynamicStruct
     /// [opaque]: crate::ReflectKind::Opaque
     /// [`reflect_clone`]: PartialReflect::reflect_clone
+    /// [`reflect_clone_incomplete`]: PartialReflect::reflect_clone_incomplete
     fn to_dynamic(&self) -> Box<dyn PartialReflect> {
         match self.reflect_ref() {
             ReflectRef::Struct(dyn_struct) => Box::new(dyn_struct.to_dynamic_struct()),
@@ -297,6 +300,9 @@ where
     /// Unlike [`to_dynamic`], which generally returns a dynamic representation of `Self`,
     /// this method attempts create a clone of `Self` directly, if possible.
     ///
+    /// If you want to attempt to clone a value but are willing to accept a dynamic representation if cloning fails,
+    /// use [`reflect_clone_incomplete`].
+    ///
     /// If the clone cannot be performed, an appropriate [`ReflectCloneError`] is returned.
     ///
     /// # Example
@@ -309,10 +315,56 @@ where
     /// ```
     ///
     /// [`to_dynamic`]: PartialReflect::to_dynamic
+    /// [`reflect_clone_incomplete`]: PartialReflect::reflect_clone_incomplete
     fn reflect_clone(&self) -> Result<Box<dyn Reflect>, ReflectCloneError> {
         Err(ReflectCloneError::NotImplemented {
             type_path: Cow::Owned(self.reflect_type_path().to_string()),
         })
+    }
+
+    /// Clones a reflected value, recovering from errors where possible to produce a partially usable clone.
+    ///
+    /// This is useful for working with reflected values that may contain non-cloneable fields.
+    /// The result may be incomplete: `#[reflect(ignore)]` fields are dropped.
+    /// Complete failures will yield a [`ReflectCloneError`].
+    ///
+    /// # Comparison with other reflection-cloning methods
+    ///
+    /// Bevy offers two other ways to copy a reflected value, and *neither* is a good
+    /// general-purpose choice for the kind of reporting / debugging workflows that you might
+    /// use to make an entity inspector.
+    ///
+    /// [`PartialReflect::reflect_clone`] generates a direct, concrete clone of the value.
+    /// It keeps the real type but fails when any field is non-cloneable.
+    /// This is common when the type contains any `#[reflect(ignore)]` fields.
+    ///
+    /// [`PartialReflect::to_dynamic`] instead builds a dynamic representation that simply omits
+    /// non-cloneable fields, so it succeeds for more types.
+    /// But it can panic on opaque values when cloning fails,
+    /// and sacrifices information about the type and its fields.
+    ///
+    /// This method prefers the more faithful `reflect_clone` path, falling back to `to_dynamic` when necessary.
+    /// Opaque values have no dynamic form, so they will always return an error when `reflect_clone` fails.
+    // Upstreaming notes:
+    // - `clone_incomplete` should just be a method on `PartialReflect`
+    // - remember to cross-link from `PartialReflect::reflect_clone` and `PartialReflect::to_dynamic` for breadcrumbs
+    // - `to_dynamic` should be made to return a `Result` in the same PR that adds this method
+    fn reflect_clone_incomplete(&self) -> Result<Box<dyn PartialReflect>, ReflectCloneError> {
+        match self.reflect_clone() {
+            // Prefer a concrete clone to preserve data
+            Ok(cloned) => Ok(cloned.into_partial_reflect()),
+            // A concrete clone failed,
+            // almost always because of a non-cloneable field such as `#[reflect(ignore)]`.
+            // We should try to salvage a dynamic copy that simply omits those fields.
+            Err(err) => match self.reflect_ref() {
+                // Opaque values have no dynamic form so just return the error.
+                ReflectRef::Opaque(_) => Err(err),
+                // BUG: this will probably panic with if nested fields have unclonable opaque values.
+                // Fixing to_dynamic to return a Result is much cleaner than working around it here,
+                // so we should just do that during upstreaming.
+                _ => Ok(self.to_dynamic()),
+            },
+        }
     }
 
     /// For a type implementing [`PartialReflect`], combines `reflect_clone` and

--- a/crates/bevy_reflect/src/serde/de/mod.rs
+++ b/crates/bevy_reflect/src/serde/de/mod.rs
@@ -382,7 +382,7 @@ mod tests {
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
-        let expected = DynamicEnum::from(MyEnum::Unit);
+        let expected = DynamicEnum::from(MyEnum::Unit).unwrap();
         assert!(expected.reflect_partial_eq(output.as_ref()).unwrap());
 
         // === NewType Variant === //
@@ -393,7 +393,7 @@ mod tests {
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
-        let expected = DynamicEnum::from(MyEnum::NewType(123));
+        let expected = DynamicEnum::from(MyEnum::NewType(123)).unwrap();
         assert!(expected.reflect_partial_eq(output.as_ref()).unwrap());
 
         // === Tuple Variant === //
@@ -404,7 +404,7 @@ mod tests {
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
-        let expected = DynamicEnum::from(MyEnum::Tuple(1.23, 3.21));
+        let expected = DynamicEnum::from(MyEnum::Tuple(1.23, 3.21)).unwrap();
         assert!(expected
             .reflect_partial_eq(output.as_partial_reflect())
             .unwrap());
@@ -421,7 +421,8 @@ mod tests {
 
         let expected = DynamicEnum::from(MyEnum::Struct {
             value: String::from("I <3 Enums"),
-        });
+        })
+        .unwrap();
         assert!(expected
             .reflect_partial_eq(output.as_partial_reflect())
             .unwrap());

--- a/crates/bevy_reflect/src/serde/de/mod.rs
+++ b/crates/bevy_reflect/src/serde/de/mod.rs
@@ -382,7 +382,7 @@ mod tests {
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
-        let expected = DynamicEnum::from(MyEnum::Unit).unwrap();
+        let expected = DynamicEnum::try_from(MyEnum::Unit).unwrap();
         assert!(expected.reflect_partial_eq(output.as_ref()).unwrap());
 
         // === NewType Variant === //
@@ -393,7 +393,7 @@ mod tests {
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
-        let expected = DynamicEnum::from(MyEnum::NewType(123)).unwrap();
+        let expected = DynamicEnum::try_from(MyEnum::NewType(123)).unwrap();
         assert!(expected.reflect_partial_eq(output.as_ref()).unwrap());
 
         // === Tuple Variant === //
@@ -404,7 +404,7 @@ mod tests {
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
-        let expected = DynamicEnum::from(MyEnum::Tuple(1.23, 3.21)).unwrap();
+        let expected = DynamicEnum::try_from(MyEnum::Tuple(1.23, 3.21)).unwrap();
         assert!(expected
             .reflect_partial_eq(output.as_partial_reflect())
             .unwrap());
@@ -419,7 +419,7 @@ mod tests {
         let mut deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let output = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
-        let expected = DynamicEnum::from(MyEnum::Struct {
+        let expected = DynamicEnum::try_from(MyEnum::Struct {
             value: String::from("I <3 Enums"),
         })
         .unwrap();

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -179,7 +179,7 @@ mod tests {
         let mut deserializer = ron::de::Deserializer::from_str(&result).unwrap();
         let reflect_deserializer = ReflectDeserializer::new(&registry);
 
-        let expected = value.to_dynamic();
+        let expected = value.to_dynamic().unwrap();
         let result = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
         assert!(expected

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -168,7 +168,7 @@ mod tests {
         let mut registry = TypeRegistry::default();
         registry.register::<TestStruct>();
 
-        let value: DynamicStruct = TestStruct { a: 123, b: 456 }.to_dynamic_struct();
+        let value: DynamicStruct = TestStruct { a: 123, b: 456 }.to_dynamic_struct().unwrap();
 
         let serializer = ReflectSerializer::new(&value, &registry);
 

--- a/crates/bevy_reflect/src/serde/ser/mod.rs
+++ b/crates/bevy_reflect/src/serde/ser/mod.rs
@@ -408,7 +408,7 @@ mod tests {
             some: Some(SomeStruct { foo: 999999999 }),
             none: None,
         };
-        let dynamic = value.to_dynamic_struct();
+        let dynamic = value.to_dynamic_struct().unwrap();
         let reflect = dynamic.as_partial_reflect();
 
         let registry = get_registry();

--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -9,8 +9,8 @@ use bevy_reflect_derive::impl_type_path;
 
 use crate::{
     generics::impl_generic_info_methods, hash_error, ty::impl_type_methods, ApplyError, Generics,
-    PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo,
-    TypePath,
+    PartialReflect, Reflect, ReflectCloneError, ReflectKind, ReflectMut, ReflectOwned, ReflectRef,
+    Type, TypeInfo, TypePath,
 };
 
 /// A trait used to power [set-like] operations via [reflection].
@@ -76,13 +76,15 @@ pub trait Set: PartialReflect {
     fn retain(&mut self, f: &mut dyn FnMut(&dyn PartialReflect) -> bool);
 
     /// Creates a new [`DynamicSet`] from this set.
-    fn to_dynamic_set(&self) -> DynamicSet {
+    ///
+    /// Returns an error if any value cannot be converted via [`PartialReflect::to_dynamic`].
+    fn to_dynamic_set(&self) -> Result<DynamicSet, ReflectCloneError> {
         let mut set = DynamicSet::default();
         set.set_represented_type(self.get_represented_type_info());
         for value in self.iter() {
-            set.insert_boxed(value.to_dynamic().unwrap());
+            set.insert_boxed(value.to_dynamic()?);
         }
-        set
+        Ok(set)
     }
 
     /// Inserts a value into the set.
@@ -481,7 +483,7 @@ pub fn set_try_apply<S: Set>(a: &mut S, b: &dyn PartialReflect) -> Result<(), Ap
 
     for b_value in set_value.iter() {
         if a.get(b_value).is_none() {
-            a.insert_boxed(b_value.to_dynamic().unwrap());
+            a.insert_boxed(b_value.to_dynamic()?);
         }
     }
     a.retain(&mut |value| set_value.get(value).is_some());

--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -80,7 +80,7 @@ pub trait Set: PartialReflect {
         let mut set = DynamicSet::default();
         set.set_represented_type(self.get_represented_type_info());
         for value in self.iter() {
-            set.insert_boxed(value.to_dynamic());
+            set.insert_boxed(value.to_dynamic().unwrap());
         }
         set
     }
@@ -481,7 +481,7 @@ pub fn set_try_apply<S: Set>(a: &mut S, b: &dyn PartialReflect) -> Result<(), Ap
 
     for b_value in set_value.iter() {
         if a.get(b_value).is_none() {
-            a.insert_boxed(b_value.to_dynamic());
+            a.insert_boxed(b_value.to_dynamic().unwrap());
         }
     }
     a.retain(&mut |value| set_value.get(value).is_some());

--- a/crates/bevy_reflect/src/structs.rs
+++ b/crates/bevy_reflect/src/structs.rs
@@ -5,8 +5,8 @@ use crate::generics::impl_generic_info_methods;
 use crate::{
     attributes::{impl_custom_attribute_methods, CustomAttributes},
     ty::impl_type_methods,
-    ApplyError, Generics, NamedField, PartialReflect, Reflect, ReflectKind, ReflectMut,
-    ReflectOwned, ReflectRef, Type, TypeInfo, TypePath,
+    ApplyError, Generics, NamedField, PartialReflect, Reflect, ReflectCloneError, ReflectKind,
+    ReflectMut, ReflectOwned, ReflectRef, Type, TypeInfo, TypePath,
 };
 use alloc::{borrow::Cow, boxed::Box, vec::Vec};
 use bevy_platform::collections::HashMap;
@@ -77,13 +77,15 @@ pub trait Struct: PartialReflect {
     fn iter_fields(&self) -> FieldIter<'_>;
 
     /// Creates a new [`DynamicStruct`] from this struct.
-    fn to_dynamic_struct(&self) -> DynamicStruct {
+    ///
+    /// Returns an error if any field cannot be converted via [`PartialReflect::to_dynamic`].
+    fn to_dynamic_struct(&self) -> Result<DynamicStruct, ReflectCloneError> {
         let mut dynamic_struct = DynamicStruct::default();
         dynamic_struct.set_represented_type(self.get_represented_type_info());
         for (name, value) in self.iter_fields() {
-            dynamic_struct.insert_boxed(name, value.to_dynamic().unwrap());
+            dynamic_struct.insert_boxed(name, value.to_dynamic()?);
         }
-        dynamic_struct
+        Ok(dynamic_struct)
     }
 
     /// Will return `None` if [`TypeInfo`] is not available.
@@ -786,7 +788,7 @@ mod tests {
 
     #[test]
     fn dynamic_struct_remove_at() {
-        let mut s = OtherStruct::default().to_dynamic_struct();
+        let mut s = OtherStruct::default().to_dynamic_struct().unwrap();
 
         assert_eq!(s.field_len(), 3);
 
@@ -814,7 +816,7 @@ mod tests {
 
     #[test]
     fn dynamic_struct_remove_by_name() {
-        let mut s = OtherStruct::default().to_dynamic_struct();
+        let mut s = OtherStruct::default().to_dynamic_struct().unwrap();
 
         assert_eq!(s.field_len(), 3);
 
@@ -842,7 +844,7 @@ mod tests {
 
     #[test]
     fn dynamic_struct_remove_if() {
-        let mut s = OtherStruct::default().to_dynamic_struct();
+        let mut s = OtherStruct::default().to_dynamic_struct().unwrap();
 
         assert_eq!(s.field_len(), 3);
 
@@ -860,7 +862,7 @@ mod tests {
 
     #[test]
     fn dynamic_struct_remove_combo() {
-        let mut s = OtherStruct::default().to_dynamic_struct();
+        let mut s = OtherStruct::default().to_dynamic_struct().unwrap();
 
         assert_eq!(s.field_len(), 3);
 

--- a/crates/bevy_reflect/src/structs.rs
+++ b/crates/bevy_reflect/src/structs.rs
@@ -81,7 +81,7 @@ pub trait Struct: PartialReflect {
         let mut dynamic_struct = DynamicStruct::default();
         dynamic_struct.set_represented_type(self.get_represented_type_info());
         for (name, value) in self.iter_fields() {
-            dynamic_struct.insert_boxed(name, value.to_dynamic());
+            dynamic_struct.insert_boxed(name, value.to_dynamic().unwrap());
         }
         dynamic_struct
     }

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -62,7 +62,10 @@ pub trait Tuple: PartialReflect {
     fn to_dynamic_tuple(&self) -> DynamicTuple {
         DynamicTuple {
             represented_type: self.get_represented_type_info(),
-            fields: self.iter_fields().map(PartialReflect::to_dynamic).collect(),
+            fields: self
+                .iter_fields()
+                .map(|field| field.to_dynamic().unwrap())
+                .collect(),
         }
     }
 

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -59,14 +59,16 @@ pub trait Tuple: PartialReflect {
     fn drain(self: Box<Self>) -> Vec<Box<dyn PartialReflect>>;
 
     /// Creates a new [`DynamicTuple`] from this tuple.
-    fn to_dynamic_tuple(&self) -> DynamicTuple {
-        DynamicTuple {
+    ///
+    /// Returns an error if any field cannot be converted via [`PartialReflect::to_dynamic`].
+    fn to_dynamic_tuple(&self) -> Result<DynamicTuple, ReflectCloneError> {
+        Ok(DynamicTuple {
             represented_type: self.get_represented_type_info(),
             fields: self
                 .iter_fields()
-                .map(|field| field.to_dynamic().unwrap())
-                .collect(),
-        }
+                .map(PartialReflect::to_dynamic)
+                .collect::<Result<_, _>>()?,
+        })
     }
 
     /// Will return `None` if [`TypeInfo`] is not available.

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -62,7 +62,10 @@ pub trait TupleStruct: PartialReflect {
     fn to_dynamic_tuple_struct(&self) -> DynamicTupleStruct {
         DynamicTupleStruct {
             represented_type: self.get_represented_type_info(),
-            fields: self.iter_fields().map(PartialReflect::to_dynamic).collect(),
+            fields: self
+                .iter_fields()
+                .map(|field| field.to_dynamic().unwrap())
+                .collect(),
         }
     }
 

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -8,8 +8,8 @@ use crate::{
     attributes::{impl_custom_attribute_methods, CustomAttributes},
     tuple::{DynamicTuple, Tuple},
     ty::impl_type_methods,
-    ApplyError, Generics, PartialReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned,
-    ReflectRef, Type, TypeInfo, TypePath, UnnamedField,
+    ApplyError, Generics, PartialReflect, Reflect, ReflectCloneError, ReflectKind, ReflectMut,
+    ReflectOwned, ReflectRef, Type, TypeInfo, TypePath, UnnamedField,
 };
 use alloc::{boxed::Box, vec::Vec};
 use core::{
@@ -59,14 +59,16 @@ pub trait TupleStruct: PartialReflect {
     fn iter_fields(&self) -> TupleStructFieldIter<'_>;
 
     /// Creates a new [`DynamicTupleStruct`] from this tuple struct.
-    fn to_dynamic_tuple_struct(&self) -> DynamicTupleStruct {
-        DynamicTupleStruct {
+    ///
+    /// Returns an error if any field cannot be converted via [`PartialReflect::to_dynamic`].
+    fn to_dynamic_tuple_struct(&self) -> Result<DynamicTupleStruct, ReflectCloneError> {
+        Ok(DynamicTupleStruct {
             represented_type: self.get_represented_type_info(),
             fields: self
                 .iter_fields()
-                .map(|field| field.to_dynamic().unwrap())
-                .collect(),
-        }
+                .map(PartialReflect::to_dynamic)
+                .collect::<Result<_, _>>()?,
+        })
     }
 
     /// Will return `None` if [`TypeInfo`] is not available.

--- a/crates/bevy_world_serialization/src/reflect_utils.rs
+++ b/crates/bevy_world_serialization/src/reflect_utils.rs
@@ -20,6 +20,6 @@ pub(super) fn clone_reflect_value(
                 .data::<ReflectFromReflect>()
                 .and_then(|fr| fr.from_reflect(value.as_partial_reflect()))
                 .map(PartialReflect::into_partial_reflect)
-                .unwrap_or_else(|| value.to_dynamic())
+                .unwrap_or_else(|| value.to_dynamic().unwrap())
         })
 }

--- a/examples/reflection/dynamic_types.rs
+++ b/examples/reflection/dynamic_types.rs
@@ -60,7 +60,7 @@ fn main() {
     // Notice here we bind it as a `dyn PartialReflect` instead of `dyn Reflect`.
     // This is because it returns a dynamic type that simply represents the original type.
     // In this case, because `Player` is a struct, it will return a `DynamicStruct`.
-    let dynamic: Box<dyn PartialReflect> = reflected.to_dynamic();
+    let dynamic: Box<dyn PartialReflect> = reflected.to_dynamic().unwrap();
     assert!(dynamic.is_dynamic());
 
     // And if we try to convert it back to a `dyn Reflect` trait object, we'll get `None`.


### PR DESCRIPTION
# Objective

`to_dynamic` is a useful method, but has all sorts of subtle panicking footguns, which can occur deep inside of nested types.

This is very frustrating when attempting to build an inspector:
panicking during component inspection is bad!

We should instead just bubble up an error when this fails.

## Solution

Both `to_dynamic` and its assorted friends can be easily (if very tediously) made fallible,
simply returning a `ReflectCloneError` rather than swallowing it with a panic.
This change spilled into the `ApplyError`, giving it a new arm for a failure mode that would previously silently panic.

## Context

> While working on https://github.com/alice-i-cecile/feathers_inspector, I needed to be able to record reflected values for later inspection. However, as the doc comment describes, the existing methods were insufficient: I wanted something maximally general, which failed gracefully giving me as much information as I could get my grubby little hands on to *try* and render later for the user.
> 
> Obviously, when upstreamed, what was once a free function that took `&dyn PartialReflect` should just become a defaulted method on `PartialReflect`.
> 
> Changing the existing methods to work like this was a no-go: you want strict, clear behavior for 90% of use cases. This is the "give me what you got" escape hatch.
> 
> Part of the upstreaming process, tracked in #23013.

## Testing

This code, largely unmodified, powered a working entity inspector over in `feathers_inspector` :)