### PR TITLE
Updated multiple_text_inputs example to use an observer

### DIFF
--- a/examples/ui/text/multiple_text_inputs.rs
+++ b/examples/ui/text/multiple_text_inputs.rs
@@ -14,21 +14,15 @@ use bevy::input_focus::{
     InputFocus,
 };
 use bevy::prelude::*;
-use bevy::text::{EditableText, TextCursorStyle};
+use bevy::text::{EditableText, TextCursorStyle, TextEditChange};
 
 fn main() {
     App::new()
         // `EditableTextInputPlugin` is part of `DefaultPlugins`
         .add_plugins((DefaultPlugins, TabNavigationPlugin))
         .add_systems(Startup, setup)
-        .add_systems(
-            Update,
-            (
-                synchronize_output_text,
-                submit_text,
-                update_row_border_colors,
-            ),
-        )
+        .add_systems(Update, (submit_text, update_row_border_colors))
+        .add_observer(synchronize_output_text)
         .run();
 }
 
@@ -196,10 +190,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 /// This system keeps the text of the [`TextOutput`] [`Text`] nodes synchronized with the text
 /// of the [`EditableText`] node on the same row.
 fn synchronize_output_text(
-    changed_inputs: Query<(&EditableText, &TextInputRow), Changed<EditableText>>,
+    on: On<TextEditChange>,
+    inputs: Query<(&EditableText, &TextInputRow)>,
     mut outputs: Query<(&mut Text, &TextInputRow), With<TextOutput>>,
 ) {
-    for (editable_text, input_row) in &changed_inputs {
+    if let Ok((editable_text, input_row)) = &inputs.get(on.event_target()) {
         for (mut text, output_row) in &mut outputs {
             if output_row.0 == input_row.0 {
                 // `EditableText::value()` returns a `SplitString` because Parley may keep IME preedit text


### PR DESCRIPTION
# Objective

The existing example updates the output fields every frame because `Changed<EditableText>` is triggered every frame.

## Solution

Replaced the sync system as an observer to only update the outputs `On<TextEditChange>`