### PR TITLE
Fix crate name from bevy-setting to bevy_setting

### DIFF
--- a/crates/bevy_settings/Cargo.toml
+++ b/crates/bevy_settings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 # crate was originally published as bevy-settings and can't be renamed on crates.io
-name = "bevy-settings"
+name = "bevy_settings"
 version = "0.20.0-dev"
 edition = "2024"
 description = "User settings framework for Bevy Engine"


### PR DESCRIPTION
Fix the settings crate name to follow the underscore separator as followed in all the other crates

# Objective

The objective is to fix the naming convention followed in the bevy project for crates.

## Solution

Hand coded solution.

## Testing

- Did you test these changes? If so, how? Yes, by compiling. 
- Are there any parts that need more testing? No
- How can other people (reviewers) test your changes? Is there anything specific they need to know? Compile only
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? None

---


