### PR TITLE
Fix clustered decal docs macOS/iOS restriction (again)

### DIFF
--- a/crates/bevy_light/src/cluster/mod.rs
+++ b/crates/bevy_light/src/cluster/mod.rs
@@ -224,8 +224,8 @@ pub struct ClusterableObjectCounts {
 ///
 /// Clustered decals are the highest-quality types of decals that Bevy supports,
 /// but they require bindless textures. This means that they presently can't be
-/// used on WebGL 2, WebGPU, macOS, or iOS. Bevy's clustered decals can be used
-/// with forward or deferred rendering and don't require a prepass.
+/// used on WebGL 2 or WebGPU. Bevy's clustered decals can be used with forward
+/// or deferred rendering and don't require a prepass.
 #[derive(Component, Debug, Clone, Default, Reflect)]
 #[reflect(Component, Debug, Clone, Default)]
 #[require(Transform, ViewVisibility, Visibility, VisibilityClass)]

--- a/crates/bevy_pbr/src/decal/clustered.rs
+++ b/crates/bevy_pbr/src/decal/clustered.rs
@@ -6,8 +6,8 @@
 //!
 //! Clustered decals are the highest-quality types of decals that Bevy supports,
 //! but they require bindless textures. This means that they presently can't be
-//! used on WebGL 2 or WebGPU. Bevy's clustered decals can be used
-//! with forward or deferred rendering and don't require a prepass.
+//! used on WebGL 2 or WebGPU. Bevy's clustered decals can be used with forward
+//! or deferred rendering and don't require a prepass.
 //!
 //! Each clustered decal may contain up to 4 textures. By default, the 4
 //! textures correspond to the base color, a normal map, a metallic-roughness


### PR DESCRIPTION
#21332 did this but missed the component docs. So I fixed it and also tidied up the spacing of the other doc block.

[Originally asked in Discord](https://discord.com/channels/691052431525675048/866787577687310356/1520073810684940401) but when making my PR I discovered #21332 which would have been nice to find earlier.