### PR TITLE
Return `InvertibleComponentIdSetRef` from `Access` for `reads_and_writes` and `writes`

### DIFF
--- a/_release-content/migration-guides/access_is_invertible.md
+++ b/_release-content/migration-guides/access_is_invertible.md
@@ -1,0 +1,16 @@
+---
+title: "Reads and writes from `Access` are exposed"
+pull_requests: []
+---
+
+Removed from [`bevy_ecs::query::Access`] methods that gave `Result<ComponentIdSet, UnboundedAccessError>>`:
+
+- `try_reads_and_writes()`
+- `try_writes()`
+
+Added new functions that return a new enum `InvertibleComponentIdSet`:
+
+- `reads_and_writes()`
+- `writes()`
+
+The `try_` methods would fail for exclusion queries.

--- a/_release-content/migration-guides/access_is_invertible.md
+++ b/_release-content/migration-guides/access_is_invertible.md
@@ -8,7 +8,7 @@ Removed from [`bevy_ecs::query::Access`] methods that gave `Result<ComponentIdSe
 - `try_reads_and_writes()`
 - `try_writes()`
 
-Added new functions that return a new enum `InvertibleComponentIdSet`:
+Added new functions that return a new enum `InvertibleComponentIdSetRef`:
 
 - `reads_and_writes()`
 - `writes()`

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -407,30 +407,22 @@ impl Access {
         &self.archetypal
     }
 
-    /// Returns the set of components with read or write access,
-    /// or an error if the access is unbounded.
-    pub fn try_reads_and_writes(&self) -> Result<&ComponentIdSet, UnboundedAccessError> {
+    /// Returns the set of components with read or write access
+    pub fn reads_and_writes(&self) -> InvertibleComponentIdSet<'_> {
         // writes_inverted is only ever true when read_and_writes_inverted is
         // also true. Therefore it is sufficient to check just read_and_writes_inverted.
         if self.read_and_writes_inverted {
-            return Err(UnboundedAccessError {
-                writes_inverted: self.writes_inverted,
-                read_and_writes_inverted: self.read_and_writes_inverted,
-            });
+            return InvertibleComponentIdSet::Excluded(&self.read_and_writes);
         }
-        Ok(&self.read_and_writes)
+        InvertibleComponentIdSet::Included(&self.read_and_writes)
     }
 
-    /// Returns the set of components with write access,
-    /// or an error if the access is unbounded.
-    pub fn try_writes(&self) -> Result<&ComponentIdSet, UnboundedAccessError> {
+    /// Returns the set of components with write access
+    pub fn writes(&self) -> InvertibleComponentIdSet<'_> {
         if self.writes_inverted {
-            return Err(UnboundedAccessError {
-                writes_inverted: self.writes_inverted,
-                read_and_writes_inverted: self.read_and_writes_inverted,
-            });
+            return InvertibleComponentIdSet::Excluded(&self.writes);
         }
-        Ok(&self.writes)
+        InvertibleComponentIdSet::Included(&self.writes)
     }
 
     /// Returns an iterator over the component IDs and their [`ComponentAccessKind`].
@@ -466,7 +458,16 @@ impl Access {
     pub fn try_iter_access(
         &self,
     ) -> Result<impl Iterator<Item = ComponentAccessKind> + '_, UnboundedAccessError> {
-        let reads_and_writes = self.try_reads_and_writes()?.iter().map(|index| {
+        let a = self.reads_and_writes();
+
+        let InvertibleComponentIdSet::Included(b) = a else {
+            return Err(UnboundedAccessError {
+                writes_inverted: self.writes_inverted,
+                read_and_writes_inverted: self.read_and_writes_inverted,
+            });
+        };
+
+        let reads_and_writes = b.iter().map(|index| {
             if self.writes.contains(index) {
                 ComponentAccessKind::Exclusive(index)
             } else {
@@ -481,6 +482,15 @@ impl Access {
 
         Ok(reads_and_writes.chain(archetypal))
     }
+}
+
+/// Either all or nothing in a [`ComponentIdSet`]
+#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
+pub enum InvertibleComponentIdSet<'a> {
+    /// All components in the set
+    Included(&'a ComponentIdSet),
+    /// All components *not* in the set
+    Excluded(&'a ComponentIdSet),
 }
 
 /// Performs an in-place union of `other` into `self`, where either set may be inverted.

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -503,7 +503,7 @@ impl InvertibleComponentIdSet<'_> {
     }
 
     /// Iterate the underlying component ids
-    pub fn iter(&self) -> ComponentIdIter<Ones<'_>> {
+    pub fn iter_underlying(&self) -> ComponentIdIter<Ones<'_>> {
         match self {
             InvertibleComponentIdSet::Included(b) | InvertibleComponentIdSet::Excluded(b) => {
                 b.iter()

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -493,6 +493,23 @@ pub enum InvertibleComponentIdSet<'a> {
     Excluded(&'a ComponentIdSet),
 }
 
+impl InvertibleComponentIdSet<'_> {
+    /// Returns true if this is Excluded, otherwise false
+    pub fn inverted(&self) -> bool {
+        match self {
+            InvertibleComponentIdSet::Included(_) => false,
+            InvertibleComponentIdSet::Excluded(_) => true,
+        }
+    }
+
+    /// Iterate the underlying component ids
+    pub fn iter(&self) -> ComponentIdIter<Ones<'_>> {
+        match self {
+            InvertibleComponentIdSet::Included(b) | InvertibleComponentIdSet::Excluded(b) => b.iter(),
+        }
+    }
+}
+
 /// Performs an in-place union of `other` into `self`, where either set may be inverted.
 ///
 /// Each set corresponds to a `FixedBitSet` if `inverted` is `false`,

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -458,16 +458,16 @@ impl Access {
     pub fn try_iter_access(
         &self,
     ) -> Result<impl Iterator<Item = ComponentAccessKind> + '_, UnboundedAccessError> {
-        let a = self.reads_and_writes();
+        let invertible_set = self.reads_and_writes();
 
-        let InvertibleComponentIdSet::Included(b) = a else {
+        let InvertibleComponentIdSet::Included(component_set) = invertible_set else {
             return Err(UnboundedAccessError {
                 writes_inverted: self.writes_inverted,
                 read_and_writes_inverted: self.read_and_writes_inverted,
             });
         };
 
-        let reads_and_writes = b.iter().map(|index| {
+        let reads_and_writes = component_set.iter().map(|index| {
             if self.writes.contains(index) {
                 ComponentAccessKind::Exclusive(index)
             } else {

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -408,21 +408,21 @@ impl Access {
     }
 
     /// Returns the set of components with read or write access
-    pub fn reads_and_writes(&self) -> InvertibleComponentIdSet<'_> {
+    pub fn reads_and_writes(&self) -> InvertibleComponentIdSetRef<'_> {
         // writes_inverted is only ever true when read_and_writes_inverted is
         // also true. Therefore it is sufficient to check just read_and_writes_inverted.
         if self.read_and_writes_inverted {
-            return InvertibleComponentIdSet::Excluded(&self.read_and_writes);
+            return InvertibleComponentIdSetRef::Excluded(&self.read_and_writes);
         }
-        InvertibleComponentIdSet::Included(&self.read_and_writes)
+        InvertibleComponentIdSetRef::Included(&self.read_and_writes)
     }
 
     /// Returns the set of components with write access
-    pub fn writes(&self) -> InvertibleComponentIdSet<'_> {
+    pub fn writes(&self) -> InvertibleComponentIdSetRef<'_> {
         if self.writes_inverted {
-            return InvertibleComponentIdSet::Excluded(&self.writes);
+            return InvertibleComponentIdSetRef::Excluded(&self.writes);
         }
-        InvertibleComponentIdSet::Included(&self.writes)
+        InvertibleComponentIdSetRef::Included(&self.writes)
     }
 
     /// Returns an iterator over the component IDs and their [`ComponentAccessKind`].
@@ -460,7 +460,7 @@ impl Access {
     ) -> Result<impl Iterator<Item = ComponentAccessKind> + '_, UnboundedAccessError> {
         let invertible_set = self.reads_and_writes();
 
-        let InvertibleComponentIdSet::Included(component_set) = invertible_set else {
+        let InvertibleComponentIdSetRef::Included(component_set) = invertible_set else {
             return Err(UnboundedAccessError {
                 writes_inverted: self.writes_inverted,
                 read_and_writes_inverted: self.read_and_writes_inverted,
@@ -486,28 +486,19 @@ impl Access {
 
 /// A set of [`ComponentId`]s that is either a finite set, or the complement of a finite set.
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
-pub enum InvertibleComponentIdSet<'a> {
-    /// A finite [`InvertibleComponentIdSet`] that includes all components in the inner set.
+pub enum InvertibleComponentIdSetRef<'a> {
+    /// A finite [`InvertibleComponentIdSetRef`] that includes all components in the inner set.
     Included(&'a ComponentIdSet),
-    /// An unbounded [`InvertibleComponentIdSet`] that includes all components *not* in the inner set.
+    /// An unbounded [`InvertibleComponentIdSetRef`] that includes all components *not* in the inner set.
     Excluded(&'a ComponentIdSet),
 }
 
-impl InvertibleComponentIdSet<'_> {
+impl InvertibleComponentIdSetRef<'_> {
     /// Returns true if this is Excluded, otherwise false
     pub fn inverted(&self) -> bool {
         match self {
-            InvertibleComponentIdSet::Included(_) => false,
-            InvertibleComponentIdSet::Excluded(_) => true,
-        }
-    }
-
-    /// Iterate the underlying component ids
-    pub fn iter_underlying(&self) -> ComponentIdIter<Ones<'_>> {
-        match self {
-            InvertibleComponentIdSet::Included(b) | InvertibleComponentIdSet::Excluded(b) => {
-                b.iter()
-            }
+            InvertibleComponentIdSetRef::Included(_) => false,
+            InvertibleComponentIdSetRef::Excluded(_) => true,
         }
     }
 }

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -505,7 +505,9 @@ impl InvertibleComponentIdSet<'_> {
     /// Iterate the underlying component ids
     pub fn iter(&self) -> ComponentIdIter<Ones<'_>> {
         match self {
-            InvertibleComponentIdSet::Included(b) | InvertibleComponentIdSet::Excluded(b) => b.iter(),
+            InvertibleComponentIdSet::Included(b) | InvertibleComponentIdSet::Excluded(b) => {
+                b.iter()
+            }
         }
     }
 }

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -484,12 +484,12 @@ impl Access {
     }
 }
 
-/// Either all or nothing in a [`ComponentIdSet`]
+/// A set of [`ComponentId`]s that is either a finite set, or the complement of a finite set.
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
 pub enum InvertibleComponentIdSet<'a> {
-    /// All components in the set
+    /// A finite [`InvertibleComponentIdSet`] that includes all components in the inner set.
     Included(&'a ComponentIdSet),
-    /// All components *not* in the set
+    /// An unbounded [`InvertibleComponentIdSet`] that includes all components *not* in the inner set.
     Excluded(&'a ComponentIdSet),
 }
 


### PR DESCRIPTION
# Objective

- `Access` only lets you know what reads and writes it has for inclusion queries, this means that you can't inspect `EntityMutExcept<B>` style queries

## Solution

- Change the `try_` methods to regular methods that return a new enum `InvertibleComponentIdSetRef`
- Alternative to https://github.com/bevyengine/bevy/pull/24789

## Testing

- CI