### PR TITLE
Add stricter `nonmax` crate version requirement

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -113,7 +113,7 @@ derive_more = { version = "2", default-features = false, features = [
   "into",
   "as_ref",
 ] }
-nonmax = { version = "0.5", default-features = false }
+nonmax = { version = "0.5.4", default-features = false }
 arrayvec = { version = "0.7.4", default-features = false }
 smallvec = { version = "1", default-features = false, features = [
   "union",


### PR DESCRIPTION
# Objective

`bevy_ecs` fails to compile when using `nonmax` crate version <= 0.5.3, but version 0.5.3 satisifes the Cargo.toml `nonmax = "0.5"`. Specifically, `bevy_ecs` uses the `nonmax::NonMaxU32::MAX` associated item, which was added in version 0.5.4.

## Solution

Update the `bevy_ecs` Cargo.toml to require a version of `nonmax` newer than 0.5.4

## Testing

I compiled an empty application with the following Cargo.toml, which causes a compile error in `bevy_ecs`.

```
[package]
name = "app"
version = "0.1.0"
edition = "2024"

[dependencies]
bevy = "0.19"
nonmax = "=0.5.3"
```

Updating to `nonmax = "=0.5.4"` or `nonmax = "=0.5.5"` fixes the issue.