### PR TITLE
Fix BSN dynamic macro error for entity names and references

### DIFF
--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -1,6 +1,6 @@
 use crate::bsn::types::{
-    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot,
-    BsnName, BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn, BsnSceneListItem, BsnSceneListItems,
+    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot, BsnName,
+    BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn, BsnSceneListItem, BsnSceneListItems,
     BsnType, BsnValue,
 };
 use bevy_macro_utils::{fq_std::FQDefault, path_to_string};

--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -1,6 +1,6 @@
 use crate::bsn::types::{
     Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot,
-    BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn, BsnSceneListItem, BsnSceneListItems,
+    BsnName, BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn, BsnSceneListItem, BsnSceneListItems,
     BsnType, BsnValue,
 };
 use bevy_macro_utils::{fq_std::FQDefault, path_to_string};
@@ -286,11 +286,20 @@ impl BsnEntry {
             }
             BsnEntry::UncachedScene(s) => EntryResult::NewSceneImpl(s.to_tokens(ctx)?),
             BsnEntry::CachedScene(s) => EntryResult::NewSceneImpl(s.to_tokens(ctx)?),
-            BsnEntry::Name(ident) => {
-                let (name, index) = ctx.fixed_entity_ref(ident);
+            BsnEntry::Name(bsn_name) => {
+                let (name_expr, index) = match bsn_name {
+                    BsnName::Ident(ident) => {
+                        let (name, index) = ctx.fixed_entity_ref(ident);
+                        (quote! { #name }, index)
+                    }
+                    BsnName::Expr(expr) => {
+                        let index = ctx.entity_refs.get(expr.to_string());
+                        (quote! { #expr }, index)
+                    }
+                };
                 let invocation = ctx.invocation_index.clone();
                 EntryResult::CombinedSceneFunction(quote! {
-                    #bevy_scene::NameEntityReference { name: #bevy_ecs::name::Name(#name.into()), reference: #bevy_ecs::template::SceneEntityReference::new(#invocation, #index, _call_id,) }.resolve_inline(_context, _scene);
+                    #bevy_scene::NameEntityReference { name: #bevy_ecs::name::Name(#name_expr.into()), reference: #bevy_ecs::template::SceneEntityReference::new(#invocation, #index, _call_id,) }.resolve_inline(_context, _scene);
                 })
             }
         })
@@ -572,8 +581,12 @@ impl BsnType {
                 let value = value.unwrap();
                 assignments.push(quote! { #(#base_path.)*#member = #value; });
             }
-            Some(BsnValue::Name(ident)) => {
-                let index = ctx.entity_refs.get(ident.to_string());
+            Some(BsnValue::Name(name)) => {
+                let name_str = match name {
+                    BsnName::Ident(ident) => ident.to_string(),
+                    BsnName::Expr(expr) => expr.to_string(),
+                };
+                let index = ctx.entity_refs.get(name_str);
                 let bevy_ecs = ctx.bevy_ecs;
                 let invocation = ctx.invocation_index.clone();
                 assignments.push(quote! {
@@ -699,8 +712,12 @@ impl BsnTokenStream for BsnFnArg {
     fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
         let bevy_ecs = ctx.bevy_ecs;
         match self {
-            BsnFnArg::EntityName(ident) => {
-                let index = ctx.entity_refs.get(ident.to_string());
+            BsnFnArg::EntityName(name) => {
+                let name_str = match name {
+                    BsnName::Ident(ident) => ident.to_string(),
+                    BsnName::Expr(expr) => expr.to_string(),
+                };
+                let index = ctx.entity_refs.get(name_str);
                 let invocation = ctx.invocation_index.clone();
                 quote! {
                     #bevy_ecs::template::EntityTemplate::SceneEntityReference(

--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -1,5 +1,5 @@
 use crate::bsn::types::{
-    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot, BsnNamedField,
+    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot, BsnName, BsnNamedField,
     BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn, BsnSceneList, BsnSceneListItem,
     BsnSceneListItems, BsnTuple, BsnType, BsnUnnamedField, BsnValue,
 };
@@ -102,7 +102,7 @@ impl BsnEntry {
             BsnEntry::CachedScene(BsnScene::parse(input)?)
         } else if input.peek(Token![#]) {
             input.parse::<Token![#]>()?;
-            BsnEntry::Name(input.parse::<Ident>()?)
+            BsnEntry::Name(input.parse::<BsnName>()?)
         } else if input.peek(Brace) || input.peek(At) {
             BsnEntry::UncachedScene(BsnScene::parse(input)?)
         } else {
@@ -540,7 +540,7 @@ impl Parse for BsnValue {
             BsnValue::Tuple(input.parse::<BsnTuple>()?)
         } else if input.peek(Token![#]) {
             input.parse::<Token![#]>()?;
-            BsnValue::Name(input.parse::<Ident>()?)
+            BsnValue::Name(input.parse::<BsnName>()?)
         } else {
             return Err(input.error("Unexpected input: Invalid BsnValue. This does not match any expected BSN value type."));
         })
@@ -573,12 +573,22 @@ impl Parse for BsnFnArg {
     }
 }
 
-struct EntityNameIdent(Ident);
+struct EntityNameIdent(BsnName);
 
 impl Parse for EntityNameIdent {
     fn parse(input: ParseStream) -> Result<Self> {
         input.parse::<Token![#]>()?;
-        Ok(EntityNameIdent(input.parse::<Ident>()?))
+        Ok(EntityNameIdent(input.parse::<BsnName>()?))
+    }
+}
+
+impl Parse for BsnName {
+    fn parse(input: ParseStream) -> Result<Self> {
+        if input.peek(Brace) {
+            Ok(BsnName::Expr(braced_tokens(input)?))
+        } else {
+            Ok(BsnName::Ident(input.parse::<Ident>()?))
+        }
     }
 }
 

--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -1,7 +1,7 @@
 use crate::bsn::types::{
-    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot, BsnName, BsnNamedField,
-    BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn, BsnSceneList, BsnSceneListItem,
-    BsnSceneListItems, BsnTuple, BsnType, BsnUnnamedField, BsnValue,
+    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot, BsnName,
+    BsnNamedField, BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn, BsnSceneList,
+    BsnSceneListItem, BsnSceneListItems, BsnTuple, BsnType, BsnUnnamedField, BsnValue,
 };
 use bevy_macro_utils::{path_to_string, PathType};
 use proc_macro2::{Delimiter, TokenStream, TokenTree};

--- a/crates/bevy_scene/macros/src/bsn/types.rs
+++ b/crates/bevy_scene/macros/src/bsn/types.rs
@@ -14,7 +14,7 @@ pub struct Bsn<const ALLOW_FLAT: bool> {
 
 #[derive(Debug)]
 pub enum BsnEntry {
-    Name(Ident),
+    Name(BsnName),
     FromTemplatePatch(BsnType),
     TemplatePatch(BsnType),
     FromTemplateConstructor(BsnConstructor),
@@ -105,6 +105,12 @@ pub struct BsnUnnamedField {
 }
 
 #[derive(Debug)]
+pub enum BsnName {
+    Ident(Ident),
+    Expr(TokenStream),
+}
+
+#[derive(Debug)]
 pub enum BsnValue {
     Expr(TokenStream),
     Closure(TokenStream),
@@ -112,12 +118,12 @@ pub enum BsnValue {
     Lit(Lit),
     Type(BsnType),
     Tuple(BsnTuple),
-    Name(Ident),
+    Name(BsnName),
 }
 
 #[derive(Debug)]
 pub enum BsnFnArg {
-    EntityName(Ident),
+    EntityName(BsnName),
     Tokens(TokenStream),
 }
 

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1511,6 +1511,43 @@ mod tests {
                 .0
         );
     }
+
+    #[test]
+    fn bsn_dynamic_name_references() {
+        let mut app = test_app();
+        let world = app.world_mut();
+
+        fn a(root_name: &str, child_name: &str) -> impl Scene {
+            let root_name_str = root_name.to_string();
+            let child_name_str = child_name.to_string();
+            bsn! {
+                #{root_name_str}
+                Children [
+                    (
+                        #{child_name_str}
+                        Reference(#{root_name_str})
+                    )
+                ]
+            }
+        }
+
+        let id = world.spawn_scene(a("root_entity", "child_entity")).unwrap().id();
+
+        let root = world.entity(id);
+        let root_name = root.get::<Name>().unwrap();
+        assert_eq!(root_name.as_str(), "root_entity");
+
+        let children = root.get::<Children>().unwrap();
+        assert_eq!(children.len(), 1);
+
+        let child = world.entity(children[0]);
+        let child_name = child.get::<Name>().unwrap();
+        assert_eq!(child_name.as_str(), "child_entity");
+
+        let reference = child.get::<Reference>().unwrap();
+        assert_eq!(reference.0, id);
+    }
+
     #[test]
     fn bsn_reverse_reference() {
         let mut app = test_app();

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1531,7 +1531,10 @@ mod tests {
             }
         }
 
-        let id = world.spawn_scene(a("root_entity", "child_entity")).unwrap().id();
+        let id = world
+            .spawn_scene(a("root_entity", "child_entity"))
+            .unwrap()
+            .id();
 
         let root = world.entity(id);
         let root_name = root.get::<Name>().unwrap();


### PR DESCRIPTION
This PR implements BsnName to support dynamic braced expressions #{expr} for entity naming and references in the bsn! macro. Fixes #24780.