### PR TITLE
Targeted feathers fixes

### DIFF
--- a/crates/bevy_feathers/src/controls/dialog.rs
+++ b/crates/bevy_feathers/src/controls/dialog.rs
@@ -168,6 +168,7 @@ impl FeathersFloatingDialog {
                         padding: UiRect::all(px(6.0)),
                     }
                     DialogDragHandle
+                    InheritableThemeTextColor(tokens::DIALOG_HEADER_TEXT)
                     ThemeBackgroundColor(tokens::DIALOG_HEADER_BG)
                     InheritableFont {
                         font: fonts::REGULAR,

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -96,6 +96,7 @@ impl FeathersSlider {
             EntityCursor::System(bevy_window::SystemCursorIcon::EwResize)
             TabIndex(0)
             FocusIndicator
+            InheritableThemeTextColor(tokens::SLIDER_TEXT)
             // Use a gradient to draw the moving bar
             BackgroundGradient(vec![Gradient::Linear(LinearGradient {
                 angle: PI * 0.5,
@@ -116,7 +117,6 @@ impl FeathersSlider {
                     align_items: AlignItems::Center,
                     justify_content: JustifyContent::Center,
                 }
-                InheritableThemeTextColor(tokens::SLIDER_TEXT)
                 InheritableFont {
                     font: fonts::MONO,
                     font_size: size::SMALL_FONT,
@@ -168,6 +168,7 @@ pub fn slider_bundle<B: Bundle>(props: FeathersSliderProps, overrides: B) -> imp
         EntityCursor::System(bevy_window::SystemCursorIcon::EwResize),
         TabIndex(0),
         FocusIndicator,
+        InheritableThemeTextColor(tokens::SLIDER_TEXT),
         // Use a gradient to draw the moving bar
         BackgroundGradient(vec![Gradient::Linear(LinearGradient {
             angle: PI * 0.5,
@@ -190,7 +191,6 @@ pub fn slider_bundle<B: Bundle>(props: FeathersSliderProps, overrides: B) -> imp
                 justify_content: JustifyContent::Center,
                 ..Default::default()
             },
-            InheritableThemeTextColor(tokens::SLIDER_TEXT),
             InheritableFont {
                 font_size: size::SMALL_FONT,
                 weight: FontWeight::NORMAL,
@@ -209,6 +209,7 @@ fn update_slider_styles(
             Has<Pressed>,
             &Hovered,
             &mut BackgroundGradient,
+            &InheritableThemeTextColor,
         ),
         (
             With<FeathersSlider>,
@@ -223,7 +224,7 @@ fn update_slider_styles(
     theme: Res<UiTheme>,
     mut commands: Commands,
 ) {
-    for (slider_ent, disabled, pressed, hovered, mut gradient) in q_sliders.iter_mut() {
+    for (slider_ent, disabled, pressed, hovered, mut gradient, font_color) in q_sliders.iter_mut() {
         set_slider_styles(
             slider_ent,
             &theme,
@@ -231,6 +232,7 @@ fn update_slider_styles(
             pressed,
             hovered.0,
             gradient.as_mut(),
+            font_color,
             &mut commands,
         );
     }
@@ -244,6 +246,7 @@ fn update_slider_styles_remove(
             Has<Pressed>,
             &Hovered,
             &mut BackgroundGradient,
+            &InheritableThemeTextColor,
         ),
         With<FeathersSlider>,
     >,
@@ -256,7 +259,7 @@ fn update_slider_styles_remove(
         .read()
         .chain(remove_pressed.read())
         .for_each(|ent| {
-            if let Ok((slider_ent, disabled, pressed, hovered, mut gradient)) =
+            if let Ok((slider_ent, disabled, pressed, hovered, mut gradient, font_color)) =
                 q_sliders.get_mut(ent)
             {
                 set_slider_styles(
@@ -266,6 +269,7 @@ fn update_slider_styles_remove(
                     pressed,
                     hovered.0,
                     gradient.as_mut(),
+                    font_color,
                     &mut commands,
                 );
             }
@@ -281,6 +285,7 @@ fn update_slider_styles_theme(
             Has<Pressed>,
             &Hovered,
             &mut BackgroundGradient,
+            &InheritableThemeTextColor,
         ),
         With<FeathersSlider>,
     >,
@@ -290,7 +295,7 @@ fn update_slider_styles_theme(
     if !theme.is_changed() {
         return;
     }
-    for (slider_ent, disabled, pressed, hovered, mut gradient) in q_sliders.iter_mut() {
+    for (slider_ent, disabled, pressed, hovered, mut gradient, font_color) in q_sliders.iter_mut() {
         set_slider_styles(
             slider_ent,
             &theme,
@@ -298,6 +303,7 @@ fn update_slider_styles_theme(
             pressed,
             hovered.0,
             gradient.as_mut(),
+            font_color,
             &mut commands,
         );
     }
@@ -310,6 +316,7 @@ fn set_slider_styles(
     pressed: bool,
     hovered: bool,
     gradient: &mut BackgroundGradient,
+    font_color: &InheritableThemeTextColor,
     commands: &mut Commands,
 ) {
     let bar_color = theme.color(&if disabled {
@@ -332,6 +339,12 @@ fn set_slider_styles(
         tokens::SLIDER_BG
     });
 
+    let text_token = if disabled {
+        tokens::SLIDER_TEXT_DISABLED
+    } else {
+        tokens::SLIDER_TEXT
+    };
+
     let cursor_shape = match disabled {
         true => bevy_window::SystemCursorIcon::NotAllowed,
         false => bevy_window::SystemCursorIcon::EwResize,
@@ -342,6 +355,13 @@ fn set_slider_styles(
         linear_gradient.stops[1].color = bar_color;
         linear_gradient.stops[2].color = bg_color;
         linear_gradient.stops[3].color = bg_color;
+    }
+
+    // Change value-text color (dim when disabled)
+    if font_color.0 != text_token {
+        commands
+            .entity(slider_ent)
+            .insert(InheritableThemeTextColor(text_token));
     }
 
     // Change cursor shape

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -311,9 +311,10 @@ pub fn create_dark_theme() -> ThemeProps {
                 palette::WHITE.with_alpha(0.5),
             ),
             (tokens::DIALOG_BG, palette::GRAY_1),
-            (tokens::DIALOG_BORDER, palette::BLACK),
+            (tokens::DIALOG_BORDER, palette::WARM_GRAY_1),
             (tokens::DIALOG_HEADER_BG, palette::GRAY_0),
             (tokens::DIALOG_TEXT, palette::LIGHT_GRAY_1),
+            (tokens::DIALOG_HEADER_TEXT, palette::LIGHT_GRAY_1),
         ]),
     }
 }

--- a/crates/bevy_feathers/src/tokens.rs
+++ b/crates/bevy_feathers/src/tokens.rs
@@ -10,7 +10,7 @@ use crate::theme::ThemeToken;
 pub const WINDOW_BG: ThemeToken = ThemeToken::new_static("feathers.window.bg");
 
 /// Focus ring
-pub const FOCUS_RING: ThemeToken = ThemeToken::new_static("feathers.focus");
+pub const FOCUS_RING: ThemeToken = ThemeToken::new_static("feathers.focus.ring");
 
 /// Regular text
 pub const TEXT_MAIN: ThemeToken = ThemeToken::new_static("feathers.text.main");
@@ -413,4 +413,6 @@ pub const DIALOG_BORDER: ThemeToken = ThemeToken::new_static("feathers.dialog.bo
 /// Dialog header background
 pub const DIALOG_HEADER_BG: ThemeToken = ThemeToken::new_static("feathers.dialog.header.bg");
 /// Dialog text
-pub const DIALOG_TEXT: ThemeToken = ThemeToken::new_static("feathers.dialog.txt");
+pub const DIALOG_TEXT: ThemeToken = ThemeToken::new_static("feathers.dialog.text");
+/// Dialog header text
+pub const DIALOG_HEADER_TEXT: ThemeToken = ThemeToken::new_static("feathers.dialog.header.text");

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -51,6 +51,9 @@ struct HexColorInput;
 struct DemoDisabledButton;
 
 #[derive(Component, Clone, Copy, Default)]
+struct DemoDialogToggle;
+
+#[derive(Component, Clone, Copy, Default)]
 struct DemoScalarField;
 
 #[derive(Component, Clone, Copy, Default, VariantDefaults)]
@@ -292,6 +295,23 @@ fn demo_column_1() -> impl Scene {
                             flex_grow: 1.0,
                         }
                         on(spawn_quit_dialog)
+                    ),
+                ]
+            ),
+            (
+                Node {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::Start,
+                    column_gap: px(8),
+                }
+                Children [
+                    label("Dialog:"),
+                    (
+                        @FeathersToggleSwitch
+                        DemoDialogToggle
+                        on(toggle_demo_dialog)
                     ),
                 ]
             ),
@@ -908,4 +928,39 @@ fn spawn_quit_dialog(activate: On<Activate>, mut commands: Commands) {
                 commands.entity(close.event_target()).despawn();
             })
         ));
+}
+
+fn toggle_demo_dialog(
+    change: On<ValueChange<bool>>,
+    mut commands: Commands,
+    dialogs: Query<Entity, With<FeathersFloatingDialog>>,
+) {
+    let toggle = change.source;
+    if change.value {
+        commands.entity(toggle).insert(Checked);
+        // Spawn at the root rather than as a child of the toggle, so clicks on the
+        // dialog don't bubble up to the toggle switch.
+        commands.spawn_scene(bsn! {
+            @FeathersFloatingDialog {
+                @title: {"Hello".to_string()},
+                @width: px(280),
+                @contents: bsn_list! {
+                    Text("Close this dialog to unset the toggle.") ThemedText
+                }
+            }
+            // The dialog despawns itself on close; this just clears the toggle.
+            on(|_close: On<RequestClose>,
+                mut commands: Commands,
+                toggles: Query<Entity, With<DemoDialogToggle>>| {
+                for toggle in toggles.iter() {
+                    commands.entity(toggle).remove::<Checked>();
+                }
+            })
+        });
+    } else {
+        commands.entity(toggle).remove::<Checked>();
+        for dialog in dialogs.iter() {
+            commands.entity(dialog).despawn();
+        }
+    }
 }


### PR DESCRIPTION

# Objective

- Adds a DIALOG_HEADER_TEXT token so themes can differentiate the header text from dialog body text (minor)
- Properly inherit text color on sliders (behaviour change)
- Renamed FOCUS_RING token to feathers.focus.ring so a theme editor ui which uses the second section as a title won't be confused (minor) 
- added a FeathersFloatingDialog to feathers gallary

## Testing

- Tested mostly using local changes to themes and the feathers_gallery example

## Showcase

- Sliders properly changing text color when disabled
<img width="286" height="50" alt="image" src="https://github.com/user-attachments/assets/b4e6e4f4-5132-4b29-b47d-8159aebf321e" />

- feathers_gallery with a toggleable dialog
<img width="307" height="76" alt="image" src="https://github.com/user-attachments/assets/4f060b77-934a-45fc-9e91-ea5a22dd8bd1" />

- Dialog header text color can change
<img width="212" height="53" alt="image" src="https://github.com/user-attachments/assets/2f650d52-acab-4065-9fb3-0a95cab3e4f8" />

