### PR TITLE
`Access` uses `InvertibleComponentIdSet`

### DIFF
--- a/_release-content/migration-guides/access_is_invertible.md
+++ b/_release-content/migration-guides/access_is_invertible.md
@@ -1,0 +1,16 @@
+---
+title: "Reads and writes from `Access` are exposed"
+pull_requests: []
+---
+
+Removed from [`bevy_ecs::query::Access`] methods that gave `Result<ComponentIdSet, UnboundedAccessError>>`:
+
+- `try_reads_and_writes()`
+- `try_writes()`
+
+Added new functions that return a new enum `InvertibleComponentIdSet`:
+
+- `reads_and_writes()`
+- `writes()`
+
+The `try_` methods would fail for exclusion queries.

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -407,30 +407,22 @@ impl Access {
         &self.archetypal
     }
 
-    /// Returns the set of components with read or write access,
-    /// or an error if the access is unbounded.
-    pub fn try_reads_and_writes(&self) -> Result<&ComponentIdSet, UnboundedAccessError> {
+    /// Returns the set of components with read or write access
+    pub fn reads_and_writes(&self) -> InvertibleComponentIdSet<'_> {
         // writes_inverted is only ever true when read_and_writes_inverted is
         // also true. Therefore it is sufficient to check just read_and_writes_inverted.
         if self.read_and_writes_inverted {
-            return Err(UnboundedAccessError {
-                writes_inverted: self.writes_inverted,
-                read_and_writes_inverted: self.read_and_writes_inverted,
-            });
+            return InvertibleComponentIdSet::Excluded(&self.read_and_writes);
         }
-        Ok(&self.read_and_writes)
+        InvertibleComponentIdSet::Included(&self.read_and_writes)
     }
 
-    /// Returns the set of components with write access,
-    /// or an error if the access is unbounded.
-    pub fn try_writes(&self) -> Result<&ComponentIdSet, UnboundedAccessError> {
+    /// Returns the set of components with write access
+    pub fn writes(&self) -> InvertibleComponentIdSet<'_> {
         if self.writes_inverted {
-            return Err(UnboundedAccessError {
-                writes_inverted: self.writes_inverted,
-                read_and_writes_inverted: self.read_and_writes_inverted,
-            });
+            return InvertibleComponentIdSet::Excluded(&self.writes);
         }
-        Ok(&self.writes)
+        InvertibleComponentIdSet::Included(&self.writes)
     }
 
     /// Returns an iterator over the component IDs and their [`ComponentAccessKind`].
@@ -466,7 +458,16 @@ impl Access {
     pub fn try_iter_access(
         &self,
     ) -> Result<impl Iterator<Item = ComponentAccessKind> + '_, UnboundedAccessError> {
-        let reads_and_writes = self.try_reads_and_writes()?.iter().map(|index| {
+        let a = self.reads_and_writes();
+
+        let InvertibleComponentIdSet::Included(b) = a else {
+            return Err(UnboundedAccessError {
+                writes_inverted: self.writes_inverted,
+                read_and_writes_inverted: self.read_and_writes_inverted,
+            });
+        };
+
+        let reads_and_writes = b.iter().map(|index| {
             if self.writes.contains(index) {
                 ComponentAccessKind::Exclusive(index)
             } else {
@@ -481,6 +482,15 @@ impl Access {
 
         Ok(reads_and_writes.chain(archetypal))
     }
+}
+
+/// Either all or nothing in a [`ComponentIdSet`]
+#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
+pub enum InvertibleComponentIdSet<'a> {
+    /// All components in the set
+    Included(&'a ComponentIdSet),
+    /// All components *not* in the set
+    Excluded(&'a ComponentIdSet),
 }
 
 /// Performs an in-place union of `other` into `self`, where either set may be inverted.

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -122,22 +122,22 @@ impl Access {
 
     /// Returns `true` if this can access the component given by `index`.
     pub fn has_read(&self, index: ComponentId) -> bool {
-        self.read_and_writes._inverted() ^ self.read_and_writes.contains(index)
+        self.read_and_writes.inverted() ^ self.read_and_writes.contains(index)
     }
 
     /// Returns `true` if this can access any component.
     pub fn has_any_read(&self) -> bool {
-        self.read_and_writes._inverted() || !self.read_and_writes.is_clear()
+        self.read_and_writes.inverted() || !self.read_and_writes.is_clear()
     }
 
     /// Returns `true` if this can exclusively access the component given by `index`.
     pub fn has_write(&self, index: ComponentId) -> bool {
-        self.writes._inverted() ^ self.writes.contains(index)
+        self.writes.inverted() ^ self.writes.contains(index)
     }
 
     /// Returns `true` if this accesses any component mutably.
     pub fn has_any_write(&self) -> bool {
-        self.writes._inverted() || !self.writes.is_clear()
+        self.writes.inverted() || !self.writes.is_clear()
     }
 
     /// Returns true if this has an archetypal (indirect) access to the component given by `index`.
@@ -170,13 +170,13 @@ impl Access {
     /// Returns `true` if this has access to all components (i.e. `EntityRef` and `&World`).
     #[inline]
     pub fn has_read_all(&self) -> bool {
-        self.read_and_writes._inverted() && self.read_and_writes.is_clear()
+        self.read_and_writes.inverted() && self.read_and_writes.is_clear()
     }
 
     /// Returns `true` if this has write access to all components (i.e. `EntityMut` and `&mut World`).
     #[inline]
     pub fn has_write_all(&self) -> bool {
-        self.writes._inverted() && self.writes.is_clear()
+        self.writes.inverted() && self.writes.is_clear()
     }
 
     /// Removes all writes.
@@ -195,7 +195,8 @@ impl Access {
 
     /// Adds all access from `other`.
     pub fn extend(&mut self, other: &Access) {
-        self.read_and_writes.invertible_union_with(&other.read_and_writes);
+        self.read_and_writes
+            .invertible_union_with(&other.read_and_writes);
         self.writes.invertible_union_with(&other.writes);
         self.archetypal.union_with(&other.archetypal);
     }
@@ -204,8 +205,10 @@ impl Access {
     /// This removes any reads and writes for any component written by `other`,
     /// and removes any writes for any component read by `other`.
     pub fn remove_conflicting_access(&mut self, other: &Access) {
-        self.read_and_writes.invertible_difference_with(&other.writes);
-        self.writes.invertible_difference_with(&other.read_and_writes);
+        self.read_and_writes
+            .invertible_difference_with(&other.writes);
+        self.writes
+            .invertible_difference_with(&other.read_and_writes);
     }
 
     /// Returns `true` if the access and `other` can be active at the same time.
@@ -219,7 +222,7 @@ impl Access {
             (&self.writes, &other.read_and_writes),
             (&other.writes, &self.read_and_writes),
         ] {
-            let a = lhs_writes.foo2(rhs_reads_and_writes);
+            let a = lhs_writes.is_compatible(rhs_reads_and_writes);
             if let Some(b) = a {
                 return b;
             }
@@ -235,7 +238,7 @@ impl Access {
             (&self.read_and_writes, &other.read_and_writes),
             (&self.writes, &other.writes),
         ] {
-            let a = our_components.foo3(their_components);
+            let a = our_components.is_invertible_subset(their_components);
             if let Some(b) = a {
                 return b;
             }
@@ -255,12 +258,12 @@ impl Access {
             (&self.writes, &other.read_and_writes),
             (&other.writes, &self.read_and_writes),
         ] {
-            if lhs_writes._inverted() && rhs_reads_and_writes._inverted() {
+            if lhs_writes.inverted() && rhs_reads_and_writes.inverted() {
                 return AccessConflicts::All;
             }
             // There's no way that I can see to do this without a temporary.
             // Neither CNF nor DNF allows us to avoid one.
-            let temp_conflicts: ComponentIdSet = lhs_writes.foo4(rhs_reads_and_writes);
+            let temp_conflicts: ComponentIdSet = lhs_writes.get_conflicts(rhs_reads_and_writes);
             conflicts.union_with(&temp_conflicts);
         }
 
@@ -326,8 +329,8 @@ impl Access {
 
         let InvertibleComponentIdSet::Included(component_set) = invertible_set else {
             return Err(UnboundedAccessError {
-                writes_inverted: self.writes._inverted(),
-                read_and_writes_inverted: self.read_and_writes._inverted(),
+                writes_inverted: self.writes.inverted(),
+                read_and_writes_inverted: self.read_and_writes.inverted(),
             });
         };
 
@@ -374,7 +377,7 @@ impl InvertibleComponentIdSet {
 
     /// Returns true if this is Excluded, otherwise false
     #[inline]
-    pub fn _inverted(&self) -> bool {
+    pub fn inverted(&self) -> bool {
         match self {
             Self::Included(_) => false,
             Self::Excluded(_) => true,
@@ -402,7 +405,7 @@ impl InvertibleComponentIdSet {
 
     /// Adds access to the component given by `index`.
     pub fn add_read(&mut self, index: ComponentId) {
-        if !self._inverted() {
+        if !self.inverted() {
             self.insert(index);
         } else {
             self.remove(index);
@@ -411,7 +414,7 @@ impl InvertibleComponentIdSet {
 
     /// Adds exclusive access to the component given by `index`.
     pub fn add_write(&mut self, index: ComponentId) {
-        if !self._inverted() {
+        if !self.inverted() {
             self.insert(index);
         } else {
             self.remove(index);
@@ -420,7 +423,7 @@ impl InvertibleComponentIdSet {
 
     /// Removes both read and write access to the component given by `index`.
     pub fn remove_read(&mut self, index: ComponentId) {
-        if self._inverted() {
+        if self.inverted() {
             self.insert(index);
         } else {
             self.remove(index);
@@ -429,16 +432,16 @@ impl InvertibleComponentIdSet {
 
     /// Removes write access to the component given by `index`.
     pub fn remove_write(&mut self, index: ComponentId) {
-        if self._inverted() {
+        if self.inverted() {
             self.insert(index);
         } else {
             self.remove(index);
         }
     }
 
-    /// Needs a name
-    pub fn foo2(&self, other: &InvertibleComponentIdSet) -> Option<bool> {
-        match (self._inverted(), other._inverted()) {
+    /// Returns true if is compatible
+    pub fn is_compatible(&self, other: &InvertibleComponentIdSet) -> Option<bool> {
+        match (self.inverted(), other.inverted()) {
             (true, true) => return Some(false),
             (false, true) => {
                 if !self.is_subset(other) {
@@ -459,9 +462,9 @@ impl InvertibleComponentIdSet {
         None
     }
 
-    /// Needs a name
-    pub fn foo3(&self, other: &InvertibleComponentIdSet) -> Option<bool> {
-        match (self._inverted(), other._inverted()) {
+    /// Determines if is invertible subset
+    pub fn is_invertible_subset(&self, other: &InvertibleComponentIdSet) -> Option<bool> {
+        match (self.inverted(), other.inverted()) {
             (true, true) => {
                 if !other.is_subset(self) {
                     return Some(false);
@@ -484,9 +487,10 @@ impl InvertibleComponentIdSet {
         None
     }
 
-    /// Needs a name
-    pub fn foo4(&self, other: &InvertibleComponentIdSet) -> ComponentIdSet {
-        match (self._inverted(), other._inverted()) {
+    /// We have a conflict if we write and they read or write, or if they
+    /// write and we read or write.
+    pub fn get_conflicts(&self, other: &InvertibleComponentIdSet) -> ComponentIdSet {
+        match (self.inverted(), other.inverted()) {
             (true, true) => ComponentIdSet::new(),
             (false, true) => self.underlying().difference(other.underlying()).collect(),
             (true, false) => other.underlying().difference(self.underlying()).collect(),
@@ -537,7 +541,7 @@ impl InvertibleComponentIdSet {
         self: &mut InvertibleComponentIdSet,
         other: &InvertibleComponentIdSet,
     ) {
-        match (self._inverted(), other._inverted()) {
+        match (self.inverted(), other.inverted()) {
             (true, true) => self.underlying_mut().intersect_with(other.underlying()),
             (true, false) => self.underlying_mut().difference_with(other.underlying()),
             (false, true) => {
@@ -568,7 +572,7 @@ impl InvertibleComponentIdSet {
     }
 
     fn set_inverted(self: &mut InvertibleComponentIdSet, target: bool) {
-        let current = self._inverted();
+        let current = self.inverted();
         if current != target {
             self.swap_inverted();
         }
@@ -581,7 +585,6 @@ impl InvertibleComponentIdSet {
             *self = InvertibleComponentIdSet::Included(core::mem::take(content));
         }
     }
-
 }
 
 /// Error returned when attempting to iterate over items included in an [`Access`]

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -73,21 +73,13 @@ impl Access {
 
     /// Adds access to the component given by `index`.
     pub fn add_read(&mut self, index: ComponentId) {
-        if !self.read_and_writes.inverted() {
-            self.read_and_writes.insert(index);
-        } else {
-            self.read_and_writes.remove(index);
-        }
+        self.read_and_writes.add_read(index);
     }
 
     /// Adds exclusive access to the component given by `index`.
     pub fn add_write(&mut self, index: ComponentId) {
         self.add_read(index);
-        if !self.writes.inverted() {
-            self.writes.insert(index);
-        } else {
-            self.writes.remove(index);
-        }
+        self.writes.add_write(index);
     }
 
     /// Removes both read and write access to the component given by `index`.
@@ -100,11 +92,7 @@ impl Access {
     /// `remove_read`.
     pub fn remove_read(&mut self, index: ComponentId) {
         self.remove_write(index);
-        if self.read_and_writes.inverted() {
-            self.read_and_writes.insert(index);
-        } else {
-            self.read_and_writes.remove(index);
-        }
+        self.read_and_writes.remove_read(index);
     }
 
     /// Removes write access to the component given by `index`.
@@ -116,11 +104,7 @@ impl Access {
     /// `extend` with a call to `extend` followed by a call to
     /// `remove_write`.
     pub fn remove_write(&mut self, index: ComponentId) {
-        if self.writes.inverted() {
-            self.writes.insert(index);
-        } else {
-            self.writes.remove(index);
-        }
+        self.writes.remove_write(index);
     }
 
     /// Adds an archetypal (indirect) access to the component given by `index`.
@@ -138,22 +122,22 @@ impl Access {
 
     /// Returns `true` if this can access the component given by `index`.
     pub fn has_read(&self, index: ComponentId) -> bool {
-        self.read_and_writes.inverted() ^ self.read_and_writes.contains(index)
+        self.read_and_writes._inverted() ^ self.read_and_writes.contains(index)
     }
 
     /// Returns `true` if this can access any component.
     pub fn has_any_read(&self) -> bool {
-        self.read_and_writes.inverted() || !self.read_and_writes.is_clear()
+        self.read_and_writes._inverted() || !self.read_and_writes.is_clear()
     }
 
     /// Returns `true` if this can exclusively access the component given by `index`.
     pub fn has_write(&self, index: ComponentId) -> bool {
-        self.writes.inverted() ^ self.writes.contains(index)
+        self.writes._inverted() ^ self.writes.contains(index)
     }
 
     /// Returns `true` if this accesses any component mutably.
     pub fn has_any_write(&self) -> bool {
-        self.writes.inverted() || !self.writes.is_clear()
+        self.writes._inverted() || !self.writes.is_clear()
     }
 
     /// Returns true if this has an archetypal (indirect) access to the component given by `index`.
@@ -171,7 +155,7 @@ impl Access {
     /// Sets this as having access to all components (i.e. `EntityRef` and `&World`).
     #[inline]
     pub fn read_all(&mut self) {
-        set_inverted(&mut self.read_and_writes, true);
+        self.read_and_writes.set_inverted(true);
         self.read_and_writes.clear();
     }
 
@@ -179,40 +163,40 @@ impl Access {
     #[inline]
     pub fn write_all(&mut self) {
         self.read_all();
-        set_inverted(&mut self.writes, true);
+        self.writes.set_inverted(true);
         self.writes.clear();
     }
 
     /// Returns `true` if this has access to all components (i.e. `EntityRef` and `&World`).
     #[inline]
     pub fn has_read_all(&self) -> bool {
-        self.read_and_writes.inverted() && self.read_and_writes.is_clear()
+        self.read_and_writes._inverted() && self.read_and_writes.is_clear()
     }
 
     /// Returns `true` if this has write access to all components (i.e. `EntityMut` and `&mut World`).
     #[inline]
     pub fn has_write_all(&self) -> bool {
-        self.writes.inverted() && self.writes.is_clear()
+        self.writes._inverted() && self.writes.is_clear()
     }
 
     /// Removes all writes.
     pub fn clear_writes(&mut self) {
-        set_inverted(&mut self.writes, false);
+        self.writes.set_inverted(false);
         self.writes.clear();
     }
 
     /// Removes all accesses.
     pub fn clear(&mut self) {
-        set_inverted(&mut self.read_and_writes, false);
-        set_inverted(&mut self.writes, false);
+        self.read_and_writes.set_inverted(false);
+        self.writes.set_inverted(false);
         self.read_and_writes.clear();
         self.writes.clear();
     }
 
     /// Adds all access from `other`.
     pub fn extend(&mut self, other: &Access) {
-        invertible_union_with(&mut self.read_and_writes, &other.read_and_writes);
-        invertible_union_with(&mut self.writes, &other.writes);
+        self.read_and_writes.invertible_union_with(&other.read_and_writes);
+        self.writes.invertible_union_with(&other.writes);
         self.archetypal.union_with(&other.archetypal);
     }
 
@@ -220,8 +204,8 @@ impl Access {
     /// This removes any reads and writes for any component written by `other`,
     /// and removes any writes for any component read by `other`.
     pub fn remove_conflicting_access(&mut self, other: &Access) {
-        invertible_difference_with(&mut self.read_and_writes, &other.writes);
-        invertible_difference_with(&mut self.writes, &other.read_and_writes);
+        self.read_and_writes.invertible_difference_with(&other.writes);
+        self.writes.invertible_difference_with(&other.read_and_writes);
     }
 
     /// Returns `true` if the access and `other` can be active at the same time.
@@ -235,23 +219,9 @@ impl Access {
             (&self.writes, &other.read_and_writes),
             (&other.writes, &self.read_and_writes),
         ] {
-            match (lhs_writes.inverted(), rhs_reads_and_writes.inverted()) {
-                (true, true) => return false,
-                (false, true) => {
-                    if !lhs_writes.is_subset(rhs_reads_and_writes) {
-                        return false;
-                    }
-                }
-                (true, false) => {
-                    if !rhs_reads_and_writes.is_subset(lhs_writes) {
-                        return false;
-                    }
-                }
-                (false, false) => {
-                    if !lhs_writes.is_disjoint(rhs_reads_and_writes) {
-                        return false;
-                    }
-                }
+            let a = lhs_writes.foo2(rhs_reads_and_writes);
+            if let Some(b) = a {
+                return b;
             }
         }
 
@@ -265,25 +235,9 @@ impl Access {
             (&self.read_and_writes, &other.read_and_writes),
             (&self.writes, &other.writes),
         ] {
-            match (our_components.inverted(), their_components.inverted()) {
-                (true, true) => {
-                    if !their_components.is_subset(our_components) {
-                        return false;
-                    }
-                }
-                (true, false) => {
-                    return false;
-                }
-                (false, true) => {
-                    if !our_components.is_disjoint(their_components) {
-                        return false;
-                    }
-                }
-                (false, false) => {
-                    if !our_components.is_subset(their_components) {
-                        return false;
-                    }
-                }
+            let a = our_components.foo3(their_components);
+            if let Some(b) = a {
+                return b;
             }
         }
 
@@ -301,15 +255,12 @@ impl Access {
             (&self.writes, &other.read_and_writes),
             (&other.writes, &self.read_and_writes),
         ] {
+            if lhs_writes._inverted() && rhs_reads_and_writes._inverted() {
+                return AccessConflicts::All;
+            }
             // There's no way that I can see to do this without a temporary.
             // Neither CNF nor DNF allows us to avoid one.
-            let temp_conflicts: ComponentIdSet =
-                match (lhs_writes.inverted(), rhs_reads_and_writes.inverted()) {
-                    (true, true) => return AccessConflicts::All,
-                    (false, true) => lhs_writes.difference(rhs_reads_and_writes).collect(),
-                    (true, false) => rhs_reads_and_writes.difference(lhs_writes).collect(),
-                    (false, false) => lhs_writes.intersection(rhs_reads_and_writes).collect(),
-                };
+            let temp_conflicts: ComponentIdSet = lhs_writes.foo4(rhs_reads_and_writes);
             conflicts.union_with(&temp_conflicts);
         }
 
@@ -375,8 +326,8 @@ impl Access {
 
         let InvertibleComponentIdSet::Included(component_set) = invertible_set else {
             return Err(UnboundedAccessError {
-                writes_inverted: self.writes.inverted(),
-                read_and_writes_inverted: self.read_and_writes.inverted(),
+                writes_inverted: self.writes._inverted(),
+                read_and_writes_inverted: self.read_and_writes._inverted(),
             });
         };
 
@@ -423,7 +374,7 @@ impl InvertibleComponentIdSet {
 
     /// Returns true if this is Excluded, otherwise false
     #[inline]
-    pub fn inverted(&self) -> bool {
+    pub fn _inverted(&self) -> bool {
         match self {
             Self::Included(_) => false,
             Self::Excluded(_) => true,
@@ -449,6 +400,100 @@ impl InvertibleComponentIdSet {
         self.underlying_mut().clear();
     }
 
+    /// Adds access to the component given by `index`.
+    pub fn add_read(&mut self, index: ComponentId) {
+        if !self._inverted() {
+            self.insert(index);
+        } else {
+            self.remove(index);
+        }
+    }
+
+    /// Adds exclusive access to the component given by `index`.
+    pub fn add_write(&mut self, index: ComponentId) {
+        if !self._inverted() {
+            self.insert(index);
+        } else {
+            self.remove(index);
+        }
+    }
+
+    /// Removes both read and write access to the component given by `index`.
+    pub fn remove_read(&mut self, index: ComponentId) {
+        if self._inverted() {
+            self.insert(index);
+        } else {
+            self.remove(index);
+        }
+    }
+
+    /// Removes write access to the component given by `index`.
+    pub fn remove_write(&mut self, index: ComponentId) {
+        if self._inverted() {
+            self.insert(index);
+        } else {
+            self.remove(index);
+        }
+    }
+
+    /// Needs a name
+    pub fn foo2(&self, other: &InvertibleComponentIdSet) -> Option<bool> {
+        match (self._inverted(), other._inverted()) {
+            (true, true) => return Some(false),
+            (false, true) => {
+                if !self.is_subset(other) {
+                    return Some(false);
+                }
+            }
+            (true, false) => {
+                if !other.is_subset(self) {
+                    return Some(false);
+                }
+            }
+            (false, false) => {
+                if !self.is_disjoint(other) {
+                    return Some(false);
+                }
+            }
+        }
+        None
+    }
+
+    /// Needs a name
+    pub fn foo3(&self, other: &InvertibleComponentIdSet) -> Option<bool> {
+        match (self._inverted(), other._inverted()) {
+            (true, true) => {
+                if !other.is_subset(self) {
+                    return Some(false);
+                }
+            }
+            (true, false) => {
+                return Some(false);
+            }
+            (false, true) => {
+                if !self.is_disjoint(other) {
+                    return Some(false);
+                }
+            }
+            (false, false) => {
+                if !self.is_subset(other) {
+                    return Some(false);
+                }
+            }
+        }
+        None
+    }
+
+    /// Needs a name
+    pub fn foo4(&self, other: &InvertibleComponentIdSet) -> ComponentIdSet {
+        match (self._inverted(), other._inverted()) {
+            (true, true) => ComponentIdSet::new(),
+            (false, true) => self.underlying().difference(other.underlying()).collect(),
+            (true, false) => other.underlying().difference(self.underlying()).collect(),
+            (false, false) => self.underlying().intersection(other.underlying()).collect(),
+        }
+    }
+
     // NOTE: here we are relying on [`Access`] to manage inverted, perhaps higher level methods should move
     #[inline]
     fn insert(&mut self, index: ComponentId) {
@@ -471,42 +516,6 @@ impl InvertibleComponentIdSet {
     }
 
     #[inline]
-    fn difference_with(&mut self, other: &InvertibleComponentIdSet) {
-        self.underlying_mut().difference_with(other.underlying());
-    }
-
-    #[inline]
-    fn intersect_with(&mut self, other: &InvertibleComponentIdSet) {
-        self.underlying_mut().intersect_with(other.underlying());
-    }
-
-    #[inline]
-    fn difference_from(&mut self, other: &InvertibleComponentIdSet) {
-        self.underlying_mut().difference_from(other.underlying());
-    }
-
-    #[inline]
-    fn union_with(&mut self, other: &InvertibleComponentIdSet) {
-        self.underlying_mut().union_with(other.underlying());
-    }
-
-    #[inline]
-    fn difference<'a>(
-        &'a self,
-        other: &'a InvertibleComponentIdSet,
-    ) -> ComponentIdIter<Difference<'a>> {
-        self.underlying().difference(other.underlying())
-    }
-
-    #[inline]
-    fn intersection<'a>(
-        &'a self,
-        other: &'a InvertibleComponentIdSet,
-    ) -> ComponentIdIter<Intersection<'a>> {
-        self.underlying().intersection(other.underlying())
-    }
-
-    #[inline]
     fn is_disjoint(&self, other: &InvertibleComponentIdSet) -> bool {
         self.underlying().is_disjoint(other.underlying())
     }
@@ -515,63 +524,64 @@ impl InvertibleComponentIdSet {
     fn is_subset(&self, other: &InvertibleComponentIdSet) -> bool {
         self.underlying().is_subset(other.underlying())
     }
-}
 
-fn swap_inverted(value: &mut InvertibleComponentIdSet) {
-    if let InvertibleComponentIdSet::Included(content) = value {
-        *value = InvertibleComponentIdSet::Excluded(core::mem::take(content));
-    } else if let InvertibleComponentIdSet::Excluded(content) = value {
-        *value = InvertibleComponentIdSet::Included(core::mem::take(content));
-    }
-}
-
-fn set_inverted(value: &mut InvertibleComponentIdSet, target: bool) {
-    let current = value.inverted();
-    if current != target {
-        swap_inverted(value);
-    }
-}
-
-/// Performs an in-place union of `other` into `self`, where either set may be inverted.
-///
-/// Each set corresponds to a `FixedBitSet` if `inverted` is `false`,
-/// or to the infinite (co-finite) complement of the `FixedBitSet` if `inverted` is `true`.
-///
-/// This updates the `self` set to include any elements in the `other` set.
-/// Note that this may change `self_inverted` to `true` if we add an infinite
-/// set to a finite one, resulting in a new infinite set.
-fn invertible_union_with(
-    self_set: &mut InvertibleComponentIdSet,
-    other_set: &InvertibleComponentIdSet,
-) {
-    match (self_set.inverted(), other_set.inverted()) {
-        (true, true) => self_set.intersect_with(other_set),
-        (true, false) => self_set.difference_with(other_set),
-        (false, true) => {
-            set_inverted(self_set, true);
-            self_set.difference_from(other_set);
+    /// Performs an in-place union of `other` into `self`, where either set may be inverted.
+    ///
+    /// Each set corresponds to a `FixedBitSet` if `inverted` is `false`,
+    /// or to the infinite (co-finite) complement of the `FixedBitSet` if `inverted` is `true`.
+    ///
+    /// This updates the `self` set to include any elements in the `other` set.
+    /// Note that this may change `self_inverted` to `true` if we add an infinite
+    /// set to a finite one, resulting in a new infinite set.
+    fn invertible_union_with(
+        self: &mut InvertibleComponentIdSet,
+        other: &InvertibleComponentIdSet,
+    ) {
+        match (self._inverted(), other._inverted()) {
+            (true, true) => self.underlying_mut().intersect_with(other.underlying()),
+            (true, false) => self.underlying_mut().difference_with(other.underlying()),
+            (false, true) => {
+                self.set_inverted(true);
+                self.underlying_mut().difference_from(other.underlying());
+            }
+            (false, false) => self.underlying_mut().union_with(other.underlying()),
         }
-        (false, false) => self_set.union_with(other_set),
     }
-}
 
-/// Performs an in-place set difference of `other` from `self`, where either set may be inverted.
-///
-/// Each set corresponds to a `FixedBitSet` if `inverted` is `false`,
-/// or to the infinite (co-finite) complement of the `FixedBitSet` if `inverted` is `true`.
-///
-/// This updates the `self` set to remove any elements in the `other` set.
-/// Note that this may change `self_inverted` to `false` if we remove an
-/// infinite set from another infinite one, resulting in a finite difference.
-fn invertible_difference_with(
-    self_set: &mut InvertibleComponentIdSet,
-    other_set: &InvertibleComponentIdSet,
-) {
-    // We can share the implementation of `invertible_union_with` with some algebra:
-    // A - B = A & !B = !(!A | B)
-    swap_inverted(self_set);
-    invertible_union_with(self_set, other_set);
-    swap_inverted(self_set);
+    /// Performs an in-place set difference of `other` from `self`, where either set may be inverted.
+    ///
+    /// Each set corresponds to a `FixedBitSet` if `inverted` is `false`,
+    /// or to the infinite (co-finite) complement of the `FixedBitSet` if `inverted` is `true`.
+    ///
+    /// This updates the `self` set to remove any elements in the `other` set.
+    /// Note that this may change `self_inverted` to `false` if we remove an
+    /// infinite set from another infinite one, resulting in a finite difference.
+    fn invertible_difference_with(
+        self: &mut InvertibleComponentIdSet,
+        other: &InvertibleComponentIdSet,
+    ) {
+        // We can share the implementation of `invertible_union_with` with some algebra:
+        // A - B = A & !B = !(!A | B)
+        self.swap_inverted();
+        self.invertible_union_with(other);
+        self.swap_inverted();
+    }
+
+    fn set_inverted(self: &mut InvertibleComponentIdSet, target: bool) {
+        let current = self._inverted();
+        if current != target {
+            self.swap_inverted();
+        }
+    }
+
+    fn swap_inverted(self: &mut InvertibleComponentIdSet) {
+        if let InvertibleComponentIdSet::Included(content) = self {
+            *self = InvertibleComponentIdSet::Excluded(core::mem::take(content));
+        } else if let InvertibleComponentIdSet::Excluded(content) = self {
+            *self = InvertibleComponentIdSet::Included(core::mem::take(content));
+        }
+    }
+
 }
 
 /// Error returned when attempting to iterate over items included in an [`Access`]
@@ -1369,7 +1379,6 @@ impl<I: FusedIterator<Item = usize>> FusedIterator for ComponentIdIter<I> {}
 
 #[cfg(test)]
 mod tests {
-    use super::{invertible_difference_with, invertible_union_with};
     use crate::{
         component::ComponentId,
         query::{
@@ -1738,7 +1747,7 @@ mod tests {
             // Check all four possible bit states: In both sets, the first, the second, or neither
             let mut self_set = invertible(bit_set(4, [0, 1]), self_inverted);
             let other_set = invertible(bit_set(4, [0, 2]), other_inverted);
-            invertible_union_with(&mut self_set, &other_set);
+            self_set.invertible_union_with(&other_set);
             self_set
         };
 
@@ -1768,7 +1777,7 @@ mod tests {
         // which would incorrectly treat it as included in the output set.
         let mut self_set = invertible(bit_set(1, [0]), false);
         let other_set = invertible(bit_set(3, [0, 1]), true);
-        invertible_union_with(&mut self_set, &other_set);
+        self_set.invertible_union_with(&other_set);
 
         // [0] | [2, ...] = [0, 2, ...]
         assert_eq!(self_set, invertible(bit_set(3, [1]), true));
@@ -1780,7 +1789,7 @@ mod tests {
             // Check all four possible bit states: In both sets, the first, the second, or neither
             let mut self_set = invertible(bit_set(4, [0, 1]), self_inverted);
             let other_set = invertible(bit_set(4, [0, 2]), other_inverted);
-            invertible_difference_with(&mut self_set, &other_set);
+            self_set.invertible_difference_with(&other_set);
             self_set
         };
 

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -520,6 +520,8 @@ impl InvertibleComponentIdSet {
 fn swap_inverted(value: &mut InvertibleComponentIdSet) {
     if let InvertibleComponentIdSet::Included(content) = value {
         *value = InvertibleComponentIdSet::Excluded(core::mem::take(content));
+    } else if let InvertibleComponentIdSet::Excluded(content) = value {
+        *value = InvertibleComponentIdSet::Included(core::mem::take(content));
     }
 }
 

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -503,7 +503,7 @@ impl InvertibleComponentIdSet<'_> {
     }
 
     /// Iterate the underlying component ids
-    pub fn iter(&self) -> ComponentIdIter<Ones<'_>> {
+    pub fn iter_underlying(&self) -> ComponentIdIter<Ones<'_>> {
         match self {
             InvertibleComponentIdSet::Included(b) | InvertibleComponentIdSet::Excluded(b) => {
                 b.iter()

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -493,6 +493,23 @@ pub enum InvertibleComponentIdSet<'a> {
     Excluded(&'a ComponentIdSet),
 }
 
+impl InvertibleComponentIdSet<'_> {
+    /// Returns true if this is Excluded, otherwise false
+    pub fn inverted(&self) -> bool {
+        match self {
+            InvertibleComponentIdSet::Included(_) => false,
+            InvertibleComponentIdSet::Excluded(_) => true,
+        }
+    }
+
+    /// Iterate the underlying component ids
+    pub fn iter(&self) -> ComponentIdIter<Ones<'_>> {
+        match self {
+            InvertibleComponentIdSet::Included(b) | InvertibleComponentIdSet::Excluded(b) => b.iter(),
+        }
+    }
+}
+
 /// Performs an in-place union of `other` into `self`, where either set may be inverted.
 ///
 /// Each set corresponds to a `FixedBitSet` if `inverted` is `false`,

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -458,16 +458,16 @@ impl Access {
     pub fn try_iter_access(
         &self,
     ) -> Result<impl Iterator<Item = ComponentAccessKind> + '_, UnboundedAccessError> {
-        let a = self.reads_and_writes();
+        let invertible_set = self.reads_and_writes();
 
-        let InvertibleComponentIdSet::Included(b) = a else {
+        let InvertibleComponentIdSet::Included(component_set) = invertible_set else {
             return Err(UnboundedAccessError {
                 writes_inverted: self.writes_inverted,
                 read_and_writes_inverted: self.read_and_writes_inverted,
             });
         };
 
-        let reads_and_writes = b.iter().map(|index| {
+        let reads_and_writes = component_set.iter().map(|index| {
             if self.writes.contains(index) {
                 ComponentAccessKind::Exclusive(index)
             } else {

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -13,18 +13,11 @@ use thiserror::Error;
 /// See the [`is_compatible`](Access::is_compatible) and [`get_conflicts`](Access::get_conflicts) functions.
 #[derive(Eq, PartialEq, Default, Hash, Debug)]
 pub struct Access {
-    /// All accessed components, or forbidden components if
-    /// `Self::component_read_and_writes_inverted` is set.
-    read_and_writes: ComponentIdSet,
+    /// All accessed components, or forbidden components if `Excluded`.
+    read_and_writes: InvertibleComponentIdSet,
     /// All exclusively-accessed components, or components that may not be
-    /// exclusively accessed if `Self::component_writes_inverted` is set.
-    writes: ComponentIdSet,
-    /// Is `true` if this component can read all components *except* those
-    /// present in `Self::read_and_writes`.
-    read_and_writes_inverted: bool,
-    /// Is `true` if this component can write to all components *except* those
-    /// present in `Self::writes`.
-    writes_inverted: bool,
+    /// exclusively accessed if `Excluded`.
+    writes: InvertibleComponentIdSet,
     // Components that are not accessed, but whose presence in an archetype affect query results.
     archetypal: ComponentIdSet,
 }
@@ -35,8 +28,6 @@ impl Clone for Access {
         Self {
             read_and_writes: self.read_and_writes.clone(),
             writes: self.writes.clone(),
-            read_and_writes_inverted: self.read_and_writes_inverted,
-            writes_inverted: self.writes_inverted,
             archetypal: self.archetypal.clone(),
         }
     }
@@ -44,8 +35,6 @@ impl Clone for Access {
     fn clone_from(&mut self, source: &Self) {
         self.read_and_writes.clone_from(&source.read_and_writes);
         self.writes.clone_from(&source.writes);
-        self.read_and_writes_inverted = source.read_and_writes_inverted;
-        self.writes_inverted = source.writes_inverted;
         self.archetypal.clone_from(&source.archetypal);
     }
 }
@@ -54,10 +43,8 @@ impl Access {
     /// Creates an empty [`Access`] collection.
     pub const fn new() -> Self {
         Self {
-            read_and_writes_inverted: false,
-            writes_inverted: false,
-            read_and_writes: ComponentIdSet::new(),
-            writes: ComponentIdSet::new(),
+            read_and_writes: InvertibleComponentIdSet::new(),
+            writes: InvertibleComponentIdSet::new(),
             archetypal: ComponentIdSet::new(),
         }
     }
@@ -66,23 +53,22 @@ impl Access {
     /// This is equivalent to calling `read_all()` on `Access::new()`,
     /// but is available in a `const` context.
     pub(crate) const fn new_read_all() -> Self {
-        let mut access = Self::new();
-        // Note that we cannot use `read_all()`
-        // because `FixedBitSet::clear()` is not `const`.
-        access.read_and_writes_inverted = true;
-        access
+        Self {
+            read_and_writes: InvertibleComponentIdSet::new_excluded(),
+            writes: InvertibleComponentIdSet::new(),
+            archetypal: ComponentIdSet::new(),
+        }
     }
 
     /// Creates an [`Access`] with read and write access to all components.
     /// This is equivalent to calling `write_all()` on `Access::new()`,
     /// but is available in a `const` context.
     pub(crate) const fn new_write_all() -> Self {
-        let mut access = Self::new();
-        // Note that we cannot use `write_all()`
-        // because `FixedBitSet::clear()` is not `const`.
-        access.read_and_writes_inverted = true;
-        access.writes_inverted = true;
-        access
+        Self {
+            read_and_writes: InvertibleComponentIdSet::new_excluded(),
+            writes: InvertibleComponentIdSet::new_excluded(),
+            archetypal: ComponentIdSet::new(),
+        }
     }
 
     /// Adds access to the component given by `index`.
@@ -226,16 +212,12 @@ impl Access {
     /// Adds all access from `other`.
     pub fn extend(&mut self, other: &Access) {
         invertible_union_with(
-            &mut self.read_and_writes,
-            &mut self.read_and_writes_inverted,
-            &other.read_and_writes,
-            other.read_and_writes_inverted,
+            self.read_and_writes.underlying(),
+            other.read_and_writes.underlying(),
         );
         invertible_union_with(
-            &mut self.writes,
-            &mut self.writes_inverted,
-            &other.writes,
-            other.writes_inverted,
+            self.writes.underlying_mut(),
+            other.writes.underlying(),
         );
         self.archetypal.union_with(&other.archetypal);
     }
@@ -246,15 +228,11 @@ impl Access {
     pub fn remove_conflicting_access(&mut self, other: &Access) {
         invertible_difference_with(
             &mut self.read_and_writes,
-            &mut self.read_and_writes_inverted,
             &other.writes,
-            other.writes_inverted,
         );
         invertible_difference_with(
             &mut self.writes,
-            &mut self.writes_inverted,
             &other.read_and_writes,
-            other.read_and_writes_inverted,
         );
     }
 
@@ -268,23 +246,17 @@ impl Access {
         for (
             lhs_writes,
             rhs_reads_and_writes,
-            lhs_writes_inverted,
-            rhs_reads_and_writes_inverted,
         ) in [
             (
                 &self.writes,
                 &other.read_and_writes,
-                self.writes_inverted,
-                other.read_and_writes_inverted,
             ),
             (
                 &other.writes,
                 &self.read_and_writes,
-                other.writes_inverted,
-                self.read_and_writes_inverted,
             ),
         ] {
-            match (lhs_writes_inverted, rhs_reads_and_writes_inverted) {
+            match (lhs_writes.inverted(), rhs_reads_and_writes.inverted()) {
                 (true, true) => return false,
                 (false, true) => {
                     if !lhs_writes.is_subset(rhs_reads_and_writes) {
@@ -313,23 +285,17 @@ impl Access {
         for (
             our_components,
             their_components,
-            our_components_inverted,
-            their_components_inverted,
         ) in [
             (
                 &self.read_and_writes,
                 &other.read_and_writes,
-                self.read_and_writes_inverted,
-                other.read_and_writes_inverted,
             ),
             (
                 &self.writes,
                 &other.writes,
-                self.writes_inverted,
-                other.writes_inverted,
             ),
         ] {
-            match (our_components_inverted, their_components_inverted) {
+            match (our_components.inverted(), their_components.inverted()) {
                 (true, true) => {
                     if !their_components.is_subset(our_components) {
                         return false;
@@ -364,26 +330,20 @@ impl Access {
         for (
             lhs_writes,
             rhs_reads_and_writes,
-            lhs_writes_inverted,
-            rhs_reads_and_writes_inverted,
         ) in [
             (
                 &self.writes,
                 &other.read_and_writes,
-                self.writes_inverted,
-                other.read_and_writes_inverted,
             ),
             (
                 &other.writes,
                 &self.read_and_writes,
-                other.writes_inverted,
-                self.read_and_writes_inverted,
             ),
         ] {
             // There's no way that I can see to do this without a temporary.
             // Neither CNF nor DNF allows us to avoid one.
             let temp_conflicts: ComponentIdSet =
-                match (lhs_writes_inverted, rhs_reads_and_writes_inverted) {
+                match (lhs_writes.inverted(), rhs_reads_and_writes.inverted()) {
                     (true, true) => return AccessConflicts::All,
                     (false, true) => lhs_writes.difference(rhs_reads_and_writes).collect(),
                     (true, false) => rhs_reads_and_writes.difference(lhs_writes).collect(),
@@ -408,21 +368,13 @@ impl Access {
     }
 
     /// Returns the set of components with read or write access
-    pub fn reads_and_writes(&self) -> InvertibleComponentIdSet<'_> {
-        // writes_inverted is only ever true when read_and_writes_inverted is
-        // also true. Therefore it is sufficient to check just read_and_writes_inverted.
-        if self.read_and_writes_inverted {
-            return InvertibleComponentIdSet::Excluded(&self.read_and_writes);
-        }
-        InvertibleComponentIdSet::Included(&self.read_and_writes)
+    pub fn reads_and_writes(&self) -> &InvertibleComponentIdSet {
+        &self.read_and_writes
     }
 
     /// Returns the set of components with write access
-    pub fn writes(&self) -> InvertibleComponentIdSet<'_> {
-        if self.writes_inverted {
-            return InvertibleComponentIdSet::Excluded(&self.writes);
-        }
-        InvertibleComponentIdSet::Included(&self.writes)
+    pub fn writes(&self) -> &InvertibleComponentIdSet {
+        &self.writes
     }
 
     /// Returns an iterator over the component IDs and their [`ComponentAccessKind`].
@@ -462,8 +414,8 @@ impl Access {
 
         let InvertibleComponentIdSet::Included(component_set) = invertible_set else {
             return Err(UnboundedAccessError {
-                writes_inverted: self.writes_inverted,
-                read_and_writes_inverted: self.read_and_writes_inverted,
+                writes_inverted: self.writes.inverted(),
+                read_and_writes_inverted: self.read_and_writes.inverted(),
             });
         };
 
@@ -485,29 +437,46 @@ impl Access {
 }
 
 /// A set of [`ComponentId`]s that is either a finite set, or the complement of a finite set.
-#[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
-pub enum InvertibleComponentIdSet<'a> {
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
+pub enum InvertibleComponentIdSet {
     /// A finite [`InvertibleComponentIdSet`] that includes all components in the inner set.
-    Included(&'a ComponentIdSet),
+    Included(ComponentIdSet),
     /// An unbounded [`InvertibleComponentIdSet`] that includes all components *not* in the inner set.
-    Excluded(&'a ComponentIdSet),
+    Excluded(ComponentIdSet),
 }
 
-impl InvertibleComponentIdSet<'_> {
+impl Default for InvertibleComponentIdSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InvertibleComponentIdSet {
+    const fn new() -> Self {
+        Self::Included(ComponentIdSet::new())
+    }
+
+    const fn new_excluded() -> Self {
+        Self::Excluded(ComponentIdSet::new())
+    }
+
     /// Returns true if this is Excluded, otherwise false
     pub fn inverted(&self) -> bool {
         match self {
-            InvertibleComponentIdSet::Included(_) => false,
-            InvertibleComponentIdSet::Excluded(_) => true,
+            Self::Included(_) => false,
+            Self::Excluded(_) => true,
         }
     }
 
-    /// Iterate the underlying component ids
-    pub fn iter_underlying(&self) -> ComponentIdIter<Ones<'_>> {
+    fn underlying(&self) -> &ComponentIdSet {
         match self {
-            InvertibleComponentIdSet::Included(b) | InvertibleComponentIdSet::Excluded(b) => {
-                b.iter()
-            }
+            Self::Included(b) | Self::Excluded(b) => b,
+        }
+    }
+
+    fn underlying_mut(&mut self) -> &mut ComponentIdSet {
+        match self {
+            Self::Included(b) | Self::Excluded(b) => b,
         }
     }
 }
@@ -521,12 +490,10 @@ impl InvertibleComponentIdSet<'_> {
 /// Note that this may change `self_inverted` to `true` if we add an infinite
 /// set to a finite one, resulting in a new infinite set.
 fn invertible_union_with(
-    self_set: &mut ComponentIdSet,
-    self_inverted: &mut bool,
-    other_set: &ComponentIdSet,
-    other_inverted: bool,
+    self_set: &mut InvertibleComponentIdSet,
+    other_set: &InvertibleComponentIdSet,
 ) {
-    match (*self_inverted, other_inverted) {
+    match (self_set.inverted(), other_set.inverted()) {
         (true, true) => self_set.intersect_with(other_set),
         (true, false) => self_set.difference_with(other_set),
         (false, true) => {

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -505,7 +505,9 @@ impl InvertibleComponentIdSet<'_> {
     /// Iterate the underlying component ids
     pub fn iter(&self) -> ComponentIdIter<Ones<'_>> {
         match self {
-            InvertibleComponentIdSet::Included(b) | InvertibleComponentIdSet::Excluded(b) => b.iter(),
+            InvertibleComponentIdSet::Included(b) | InvertibleComponentIdSet::Excluded(b) => {
+                b.iter()
+            }
         }
     }
 }

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -73,7 +73,7 @@ impl Access {
 
     /// Adds access to the component given by `index`.
     pub fn add_read(&mut self, index: ComponentId) {
-        if !self.read_and_writes_inverted {
+        if !self.read_and_writes.inverted() {
             self.read_and_writes.insert(index);
         } else {
             self.read_and_writes.remove(index);
@@ -83,7 +83,7 @@ impl Access {
     /// Adds exclusive access to the component given by `index`.
     pub fn add_write(&mut self, index: ComponentId) {
         self.add_read(index);
-        if !self.writes_inverted {
+        if !self.writes.inverted() {
             self.writes.insert(index);
         } else {
             self.writes.remove(index);
@@ -100,7 +100,7 @@ impl Access {
     /// `remove_read`.
     pub fn remove_read(&mut self, index: ComponentId) {
         self.remove_write(index);
-        if self.read_and_writes_inverted {
+        if self.read_and_writes.inverted() {
             self.read_and_writes.insert(index);
         } else {
             self.read_and_writes.remove(index);
@@ -116,7 +116,7 @@ impl Access {
     /// `extend` with a call to `extend` followed by a call to
     /// `remove_write`.
     pub fn remove_write(&mut self, index: ComponentId) {
-        if self.writes_inverted {
+        if self.writes.inverted() {
             self.writes.insert(index);
         } else {
             self.writes.remove(index);
@@ -138,22 +138,22 @@ impl Access {
 
     /// Returns `true` if this can access the component given by `index`.
     pub fn has_read(&self, index: ComponentId) -> bool {
-        self.read_and_writes_inverted ^ self.read_and_writes.contains(index)
+        self.read_and_writes.inverted() ^ self.read_and_writes.contains(index)
     }
 
     /// Returns `true` if this can access any component.
     pub fn has_any_read(&self) -> bool {
-        self.read_and_writes_inverted || !self.read_and_writes.is_clear()
+        self.read_and_writes.inverted() || !self.read_and_writes.is_clear()
     }
 
     /// Returns `true` if this can exclusively access the component given by `index`.
     pub fn has_write(&self, index: ComponentId) -> bool {
-        self.writes_inverted ^ self.writes.contains(index)
+        self.writes.inverted() ^ self.writes.contains(index)
     }
 
     /// Returns `true` if this accesses any component mutably.
     pub fn has_any_write(&self) -> bool {
-        self.writes_inverted || !self.writes.is_clear()
+        self.writes.inverted() || !self.writes.is_clear()
     }
 
     /// Returns true if this has an archetypal (indirect) access to the component given by `index`.
@@ -171,7 +171,7 @@ impl Access {
     /// Sets this as having access to all components (i.e. `EntityRef` and `&World`).
     #[inline]
     pub fn read_all(&mut self) {
-        self.read_and_writes_inverted = true;
+        set_inverted(&mut self.read_and_writes, true);
         self.read_and_writes.clear();
     }
 
@@ -179,46 +179,40 @@ impl Access {
     #[inline]
     pub fn write_all(&mut self) {
         self.read_all();
-        self.writes_inverted = true;
+        set_inverted(&mut self.writes, true);
         self.writes.clear();
     }
 
     /// Returns `true` if this has access to all components (i.e. `EntityRef` and `&World`).
     #[inline]
     pub fn has_read_all(&self) -> bool {
-        self.read_and_writes_inverted && self.read_and_writes.is_clear()
+        self.read_and_writes.inverted() && self.read_and_writes.is_clear()
     }
 
     /// Returns `true` if this has write access to all components (i.e. `EntityMut` and `&mut World`).
     #[inline]
     pub fn has_write_all(&self) -> bool {
-        self.writes_inverted && self.writes.is_clear()
+        self.writes.inverted() && self.writes.is_clear()
     }
 
     /// Removes all writes.
     pub fn clear_writes(&mut self) {
-        self.writes_inverted = false;
+        set_inverted(&mut self.writes, false);
         self.writes.clear();
     }
 
     /// Removes all accesses.
     pub fn clear(&mut self) {
-        self.read_and_writes_inverted = false;
-        self.writes_inverted = false;
+        set_inverted(&mut self.read_and_writes, false);
+        set_inverted(&mut self.writes, false);
         self.read_and_writes.clear();
         self.writes.clear();
     }
 
     /// Adds all access from `other`.
     pub fn extend(&mut self, other: &Access) {
-        invertible_union_with(
-            self.read_and_writes.underlying(),
-            other.read_and_writes.underlying(),
-        );
-        invertible_union_with(
-            self.writes.underlying_mut(),
-            other.writes.underlying(),
-        );
+        invertible_union_with(&mut self.read_and_writes, &other.read_and_writes);
+        invertible_union_with(&mut self.writes, &other.writes);
         self.archetypal.union_with(&other.archetypal);
     }
 
@@ -226,14 +220,8 @@ impl Access {
     /// This removes any reads and writes for any component written by `other`,
     /// and removes any writes for any component read by `other`.
     pub fn remove_conflicting_access(&mut self, other: &Access) {
-        invertible_difference_with(
-            &mut self.read_and_writes,
-            &other.writes,
-        );
-        invertible_difference_with(
-            &mut self.writes,
-            &other.read_and_writes,
-        );
+        invertible_difference_with(&mut self.read_and_writes, &other.writes);
+        invertible_difference_with(&mut self.writes, &other.read_and_writes);
     }
 
     /// Returns `true` if the access and `other` can be active at the same time.
@@ -243,18 +231,9 @@ impl Access {
     pub fn is_compatible(&self, other: &Access) -> bool {
         // We have a conflict if we write and they read or write, or if they
         // write and we read or write.
-        for (
-            lhs_writes,
-            rhs_reads_and_writes,
-        ) in [
-            (
-                &self.writes,
-                &other.read_and_writes,
-            ),
-            (
-                &other.writes,
-                &self.read_and_writes,
-            ),
+        for (lhs_writes, rhs_reads_and_writes) in [
+            (&self.writes, &other.read_and_writes),
+            (&other.writes, &self.read_and_writes),
         ] {
             match (lhs_writes.inverted(), rhs_reads_and_writes.inverted()) {
                 (true, true) => return false,
@@ -282,18 +261,9 @@ impl Access {
     /// Returns `true` if the set is a subset of another, i.e. `other` contains
     /// at least all the values in `self`.
     pub fn is_subset(&self, other: &Access) -> bool {
-        for (
-            our_components,
-            their_components,
-        ) in [
-            (
-                &self.read_and_writes,
-                &other.read_and_writes,
-            ),
-            (
-                &self.writes,
-                &other.writes,
-            ),
+        for (our_components, their_components) in [
+            (&self.read_and_writes, &other.read_and_writes),
+            (&self.writes, &other.writes),
         ] {
             match (our_components.inverted(), their_components.inverted()) {
                 (true, true) => {
@@ -327,18 +297,9 @@ impl Access {
 
         // We have a conflict if we write and they read or write, or if they
         // write and we read or write.
-        for (
-            lhs_writes,
-            rhs_reads_and_writes,
-        ) in [
-            (
-                &self.writes,
-                &other.read_and_writes,
-            ),
-            (
-                &other.writes,
-                &self.read_and_writes,
-            ),
+        for (lhs_writes, rhs_reads_and_writes) in [
+            (&self.writes, &other.read_and_writes),
+            (&other.writes, &self.read_and_writes),
         ] {
             // There's no way that I can see to do this without a temporary.
             // Neither CNF nor DNF allows us to avoid one.
@@ -429,7 +390,7 @@ impl Access {
 
         let archetypal = self
             .archetypal
-            .difference(&self.read_and_writes)
+            .difference(&self.read_and_writes.underlying())
             .map(ComponentAccessKind::Archetypal);
 
         Ok(reads_and_writes.chain(archetypal))
@@ -461,6 +422,7 @@ impl InvertibleComponentIdSet {
     }
 
     /// Returns true if this is Excluded, otherwise false
+    #[inline]
     pub fn inverted(&self) -> bool {
         match self {
             Self::Included(_) => false,
@@ -468,16 +430,103 @@ impl InvertibleComponentIdSet {
         }
     }
 
+    #[inline]
     fn underlying(&self) -> &ComponentIdSet {
         match self {
             Self::Included(b) | Self::Excluded(b) => b,
         }
     }
 
+    #[inline]
     fn underlying_mut(&mut self) -> &mut ComponentIdSet {
         match self {
             Self::Included(b) | Self::Excluded(b) => b,
         }
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        self.underlying_mut().clear()
+    }
+
+    // NOTE: here we are relying on [`Access`] to manage inverted, perhaps higher level methods should move
+    #[inline]
+    fn insert(&mut self, index: ComponentId) {
+        self.underlying_mut().insert(index)
+    }
+
+    #[inline]
+    fn remove(&mut self, index: ComponentId) {
+        self.underlying_mut().remove(index)
+    }
+
+    #[inline]
+    fn contains(&self, index: ComponentId) -> bool {
+        self.underlying().contains(index)
+    }
+
+    #[inline]
+    fn is_clear(&self) -> bool {
+        self.underlying().is_clear()
+    }
+
+    #[inline]
+    fn difference_with(&mut self, other: &InvertibleComponentIdSet) {
+        self.underlying_mut().difference_with(&other.underlying())
+    }
+
+    #[inline]
+    fn intersect_with(&mut self, other: &InvertibleComponentIdSet) {
+        self.underlying_mut().intersect_with(&other.underlying())
+    }
+
+    #[inline]
+    fn difference_from(&mut self, other: &InvertibleComponentIdSet) {
+        self.underlying_mut().difference_from(&other.underlying())
+    }
+
+    #[inline]
+    fn union_with(&mut self, other: &InvertibleComponentIdSet) {
+        self.underlying_mut().union_with(&other.underlying())
+    }
+
+    #[inline]
+    fn difference<'a>(
+        &'a self,
+        other: &'a InvertibleComponentIdSet,
+    ) -> ComponentIdIter<Difference<'a>> {
+        self.underlying().difference(&other.underlying())
+    }
+
+    #[inline]
+    fn intersection<'a>(
+        &'a self,
+        other: &'a InvertibleComponentIdSet,
+    ) -> ComponentIdIter<Intersection<'a>> {
+        self.underlying().intersection(&other.underlying())
+    }
+
+    #[inline]
+    fn is_disjoint(&self, other: &InvertibleComponentIdSet) -> bool {
+        self.underlying().is_disjoint(&other.underlying())
+    }
+
+    #[inline]
+    fn is_subset(&self, other: &InvertibleComponentIdSet) -> bool {
+        self.underlying().is_subset(&other.underlying())
+    }
+}
+
+fn swap_inverted(value: &mut InvertibleComponentIdSet) {
+    if let InvertibleComponentIdSet::Included(content) = value {
+        *value = InvertibleComponentIdSet::Excluded(core::mem::take(content));
+    }
+}
+
+fn set_inverted(value: &mut InvertibleComponentIdSet, target: bool) {
+    let current = value.inverted();
+    if current != target {
+        swap_inverted(value);
     }
 }
 
@@ -497,7 +546,7 @@ fn invertible_union_with(
         (true, true) => self_set.intersect_with(other_set),
         (true, false) => self_set.difference_with(other_set),
         (false, true) => {
-            *self_inverted = true;
+            set_inverted(self_set, true);
             self_set.difference_from(other_set);
         }
         (false, false) => self_set.union_with(other_set),
@@ -513,16 +562,14 @@ fn invertible_union_with(
 /// Note that this may change `self_inverted` to `false` if we remove an
 /// infinite set from another infinite one, resulting in a finite difference.
 fn invertible_difference_with(
-    self_set: &mut ComponentIdSet,
-    self_inverted: &mut bool,
-    other_set: &ComponentIdSet,
-    other_inverted: bool,
+    self_set: &mut InvertibleComponentIdSet,
+    other_set: &InvertibleComponentIdSet,
 ) {
     // We can share the implementation of `invertible_union_with` with some algebra:
     // A - B = A & !B = !(!A | B)
-    *self_inverted = !*self_inverted;
-    invertible_union_with(self_set, self_inverted, other_set, other_inverted);
-    *self_inverted = !*self_inverted;
+    swap_inverted(self_set);
+    invertible_union_with(self_set, other_set);
+    swap_inverted(self_set);
 }
 
 /// Error returned when attempting to iterate over items included in an [`Access`]
@@ -1325,7 +1372,7 @@ mod tests {
         component::ComponentId,
         query::{
             access::AccessFilters, Access, AccessConflicts, ComponentAccessKind, ComponentIdSet,
-            FilteredAccess, FilteredAccessSet, UnboundedAccessError,
+            FilteredAccess, FilteredAccessSet, InvertibleComponentIdSet, UnboundedAccessError,
         },
     };
     use alloc::{vec, vec::Vec};
@@ -1667,6 +1714,14 @@ mod tests {
         );
     }
 
+    fn invertible(content: ComponentIdSet, inverted: bool) -> InvertibleComponentIdSet {
+        if inverted {
+            InvertibleComponentIdSet::Excluded(content)
+        } else {
+            InvertibleComponentIdSet::Included(content)
+        }
+    }
+
     /// Create a `ComponentIdSet` with a given number of total bits and a given list of bits to set.
     /// Setting the number of bits is important in tests since the `PartialEq` impl checks that the length matches.
     fn bit_set(bits: usize, iter: impl IntoIterator<Item = usize>) -> ComponentIdSet {
@@ -1679,33 +1734,28 @@ mod tests {
     fn invertible_union_with_tests() {
         let invertible_union = |mut self_inverted: bool, other_inverted: bool| {
             // Check all four possible bit states: In both sets, the first, the second, or neither
-            let mut self_set = bit_set(4, [0, 1]);
-            let other_set = bit_set(4, [0, 2]);
-            invertible_union_with(
-                &mut self_set,
-                &mut self_inverted,
-                &other_set,
-                other_inverted,
-            );
-            (self_set, self_inverted)
+            let mut self_set = invertible(bit_set(4, [0, 1]), self_inverted);
+            let other_set = invertible(bit_set(4, [0, 2]), other_inverted);
+            invertible_union_with(&mut self_set, &other_set);
+            self_set
         };
 
         // Check each combination of `inverted` flags
-        let (s, i) = invertible_union(false, false);
+        let s = invertible_union(false, false);
         // [0, 1] | [0, 2] = [0, 1, 2]
-        assert_eq!((s, i), (bit_set(4, [0, 1, 2]), false));
+        assert_eq!(s, invertible(bit_set(4, [0, 1, 2]), false));
 
-        let (s, i) = invertible_union(false, true);
+        let s = invertible_union(false, true);
         // [0, 1] | [1, 3, ...] = [0, 1, 3, ...]
-        assert_eq!((s, i), (bit_set(4, [2]), true));
+        assert_eq!(s, invertible(bit_set(4, [2]), true));
 
-        let (s, i) = invertible_union(true, false);
+        let s = invertible_union(true, false);
         // [2, 3, ...] | [0, 2] = [0, 2, 3, ...]
-        assert_eq!((s, i), (bit_set(4, [1]), true));
+        assert_eq!(s, invertible(bit_set(4, [1]), true));
 
-        let (s, i) = invertible_union(true, true);
+        let s = invertible_union(true, true);
         // [2, 3, ...] | [1, 3, ...] = [1, 2, 3, ...]
-        assert_eq!((s, i), (bit_set(4, [0]), true));
+        assert_eq!(s, invertible(bit_set(4, [0]), true));
     }
 
     #[test]
@@ -1714,52 +1764,40 @@ mod tests {
         // make sure we invert the bits beyond the original length.
         // Failing to call `grow` before `toggle_range` would cause bit 1 to be zero,
         // which would incorrectly treat it as included in the output set.
-        let mut self_set = bit_set(1, [0]);
-        let mut self_inverted = false;
-        let other_set = bit_set(3, [0, 1]);
-        let other_inverted = true;
-        invertible_union_with(
-            &mut self_set,
-            &mut self_inverted,
-            &other_set,
-            other_inverted,
-        );
+        let mut self_set = invertible(bit_set(1, [0]), false);
+        let other_set = invertible(bit_set(3, [0, 1]), true);
+        invertible_union_with(&mut self_set, &other_set);
 
         // [0] | [2, ...] = [0, 2, ...]
-        assert_eq!((self_set, self_inverted), (bit_set(3, [1]), true));
+        assert_eq!(self_set, invertible(bit_set(3, [1]), true));
     }
 
     #[test]
     fn invertible_difference_with_tests() {
         let invertible_difference = |mut self_inverted: bool, other_inverted: bool| {
             // Check all four possible bit states: In both sets, the first, the second, or neither
-            let mut self_set = bit_set(4, [0, 1]);
-            let other_set = bit_set(4, [0, 2]);
-            invertible_difference_with(
-                &mut self_set,
-                &mut self_inverted,
-                &other_set,
-                other_inverted,
-            );
-            (self_set, self_inverted)
+            let mut self_set = invertible(bit_set(4, [0, 1]), self_inverted);
+            let other_set = invertible(bit_set(4, [0, 2]), other_inverted);
+            invertible_difference_with(&mut self_set, &other_set);
+            self_set
         };
 
         // Check each combination of `inverted` flags
-        let (s, i) = invertible_difference(false, false);
+        let s = invertible_difference(false, false);
         // [0, 1] - [0, 2] = [1]
-        assert_eq!((s, i), (bit_set(4, [1]), false));
+        assert_eq!(s, invertible(bit_set(4, [1]), false));
 
-        let (s, i) = invertible_difference(false, true);
+        let s = invertible_difference(false, true);
         // [0, 1] - [1, 3, ...] = [0]
-        assert_eq!((s, i), (bit_set(4, [0]), false));
+        assert_eq!(s, invertible(bit_set(4, [0]), false));
 
-        let (s, i) = invertible_difference(true, false);
+        let s = invertible_difference(true, false);
         // [2, 3, ...] - [0, 2] = [3, ...]
-        assert_eq!((s, i), (bit_set(4, [0, 1, 2]), true));
+        assert_eq!(s, invertible(bit_set(4, [0, 1, 2]), true));
 
-        let (s, i) = invertible_difference(true, true);
+        let s = invertible_difference(true, true);
         // [2, 3, ...] - [1, 3, ...] = [2]
-        assert_eq!((s, i), (bit_set(4, [2]), false));
+        assert_eq!(s, invertible(bit_set(4, [2]), false));
     }
 
     #[test]

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -390,7 +390,7 @@ impl Access {
 
         let archetypal = self
             .archetypal
-            .difference(&self.read_and_writes.underlying())
+            .difference(self.read_and_writes.underlying())
             .map(ComponentAccessKind::Archetypal);
 
         Ok(reads_and_writes.chain(archetypal))
@@ -446,18 +446,18 @@ impl InvertibleComponentIdSet {
 
     #[inline]
     fn clear(&mut self) {
-        self.underlying_mut().clear()
+        self.underlying_mut().clear();
     }
 
     // NOTE: here we are relying on [`Access`] to manage inverted, perhaps higher level methods should move
     #[inline]
     fn insert(&mut self, index: ComponentId) {
-        self.underlying_mut().insert(index)
+        self.underlying_mut().insert(index);
     }
 
     #[inline]
     fn remove(&mut self, index: ComponentId) {
-        self.underlying_mut().remove(index)
+        self.underlying_mut().remove(index);
     }
 
     #[inline]
@@ -472,22 +472,22 @@ impl InvertibleComponentIdSet {
 
     #[inline]
     fn difference_with(&mut self, other: &InvertibleComponentIdSet) {
-        self.underlying_mut().difference_with(&other.underlying())
+        self.underlying_mut().difference_with(other.underlying());
     }
 
     #[inline]
     fn intersect_with(&mut self, other: &InvertibleComponentIdSet) {
-        self.underlying_mut().intersect_with(&other.underlying())
+        self.underlying_mut().intersect_with(other.underlying());
     }
 
     #[inline]
     fn difference_from(&mut self, other: &InvertibleComponentIdSet) {
-        self.underlying_mut().difference_from(&other.underlying())
+        self.underlying_mut().difference_from(other.underlying());
     }
 
     #[inline]
     fn union_with(&mut self, other: &InvertibleComponentIdSet) {
-        self.underlying_mut().union_with(&other.underlying())
+        self.underlying_mut().union_with(other.underlying());
     }
 
     #[inline]
@@ -495,7 +495,7 @@ impl InvertibleComponentIdSet {
         &'a self,
         other: &'a InvertibleComponentIdSet,
     ) -> ComponentIdIter<Difference<'a>> {
-        self.underlying().difference(&other.underlying())
+        self.underlying().difference(other.underlying())
     }
 
     #[inline]
@@ -503,17 +503,17 @@ impl InvertibleComponentIdSet {
         &'a self,
         other: &'a InvertibleComponentIdSet,
     ) -> ComponentIdIter<Intersection<'a>> {
-        self.underlying().intersection(&other.underlying())
+        self.underlying().intersection(other.underlying())
     }
 
     #[inline]
     fn is_disjoint(&self, other: &InvertibleComponentIdSet) -> bool {
-        self.underlying().is_disjoint(&other.underlying())
+        self.underlying().is_disjoint(other.underlying())
     }
 
     #[inline]
     fn is_subset(&self, other: &InvertibleComponentIdSet) -> bool {
-        self.underlying().is_subset(&other.underlying())
+        self.underlying().is_subset(other.underlying())
     }
 }
 
@@ -1732,7 +1732,7 @@ mod tests {
 
     #[test]
     fn invertible_union_with_tests() {
-        let invertible_union = |mut self_inverted: bool, other_inverted: bool| {
+        let invertible_union = |self_inverted: bool, other_inverted: bool| {
             // Check all four possible bit states: In both sets, the first, the second, or neither
             let mut self_set = invertible(bit_set(4, [0, 1]), self_inverted);
             let other_set = invertible(bit_set(4, [0, 2]), other_inverted);
@@ -1774,7 +1774,7 @@ mod tests {
 
     #[test]
     fn invertible_difference_with_tests() {
-        let invertible_difference = |mut self_inverted: bool, other_inverted: bool| {
+        let invertible_difference = |self_inverted: bool, other_inverted: bool| {
             // Check all four possible bit states: In both sets, the first, the second, or neither
             let mut self_set = invertible(bit_set(4, [0, 1]), self_inverted);
             let other_set = invertible(bit_set(4, [0, 2]), other_inverted);

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -484,12 +484,12 @@ impl Access {
     }
 }
 
-/// Either all or nothing in a [`ComponentIdSet`]
+/// A set of [`ComponentId`]s that is either a finite set, or the complement of a finite set.
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
 pub enum InvertibleComponentIdSet<'a> {
-    /// All components in the set
+    /// A finite [`InvertibleComponentIdSet`] that includes all components in the inner set.
     Included(&'a ComponentIdSet),
-    /// All components *not* in the set
+    /// An unbounded [`InvertibleComponentIdSet`] that includes all components *not* in the inner set.
     Excluded(&'a ComponentIdSet),
 }
 


### PR DESCRIPTION
# Objective

- `Access` only lets you know what reads and writes it has for inclusion queries, this means that you can't inspect `EntityMutExcept<B>` style queries

## Solution

- Update `Access` to use `InvertibleComponentIsSet` rather than store `inverted` as boolean
- Alternative to https://github.com/bevyengine/bevy/pull/24771

## Testing

- CI