### PR TITLE
Fix sigil default color to match label color, move border 1px

### DIFF
--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -106,7 +106,7 @@ pub struct FeathersNumberInputProps {
 impl Default for FeathersNumberInputProps {
     fn default() -> Self {
         Self {
-            sigil_color: tokens::TEXT_INPUT_BG,
+            sigil_color: tokens::TEXT_INPUT_LABEL_BG,
             label_text: None,
         }
     }
@@ -119,7 +119,7 @@ impl FeathersNumberInput {
             Node {
                 column_gap: px(0),
                 border: UiRect {
-                    left: px(if props.label_text.is_some() { 3.0 } else { 0.0 }),
+                    left: px(if props.label_text.is_some() { 4.0 } else { 0.0 }),
                 },
                 padding: UiRect {
                     left: px(0.0),


### PR DESCRIPTION

# Objective

- Default sigil was much darker than the default label so I equalized them to same token
- Sigil positioning was out by 1px so there was a thin line (see before/after)

## Showcase

image shows before state (top section, see the default sigil is dark to the point where you can barely see it and has a distinct dark line on its right on the rgb ones) and after state (bottom section)
<img width="801" height="101" alt="image" src="https://github.com/user-attachments/assets/0490c99a-652f-4184-8e6d-2a625a30ac2d" />
