### PR TITLE
Fix shadows for directional lights on non-default render layers #24792

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1908,6 +1908,7 @@ pub fn prepare_lights(
                         light_entity: *light_entity,
                         cascade_index,
                     },
+                    view_layers.clone(),
                 ));
 
                 if !matches!(gpu_preprocessing_mode, GpuPreprocessingMode::Culling) {


### PR DESCRIPTION
# Objective

Fixes #24792

## Solution

When spawning the shadow view also insert the cameras render layers.

## Testing

The change is tested as described in #24792 with screenshots attached.
