### PR TITLE
Ensure RenderLayers is a Component on every ExtractedLight and its ShadowView/ExtractedView

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -121,7 +121,6 @@ pub struct ExtractedDirectionalLight {
     pub cascade_shadow_config: CascadeShadowConfig,
     pub cascades: EntityHashMap<Vec<Cascade>>,
     pub frusta: EntityHashMap<Vec<Frustum>>,
-    pub render_layers: RenderLayers,
     pub soft_shadow_size: Option<f32>,
     /// True if this light is using two-phase occlusion culling.
     pub occlusion_culling: bool,
@@ -340,6 +339,7 @@ pub fn extract_lights(
                 &GlobalTransform,
                 &ViewVisibility,
                 &CubemapFrusta,
+                Option<&RenderLayers>,
                 Option<&VolumetricLight>,
             ),
             Or<(
@@ -347,6 +347,7 @@ pub fn extract_lights(
                 Changed<CubemapVisibleEntities>,
                 Changed<GlobalTransform>,
                 Changed<ViewVisibility>,
+                Changed<RenderLayers>,
                 Changed<CubemapFrusta>,
                 Changed<VolumetricLight>,
             )>,
@@ -362,6 +363,7 @@ pub fn extract_lights(
                 &GlobalTransform,
                 &ViewVisibility,
                 &Frustum,
+                Option<&RenderLayers>,
                 Option<&VolumetricLight>,
             ),
             Or<(
@@ -369,6 +371,7 @@ pub fn extract_lights(
                 Changed<VisibleMeshEntities>,
                 Changed<GlobalTransform>,
                 Changed<ViewVisibility>,
+                Changed<RenderLayers>,
                 Changed<Frustum>,
                 Changed<VolumetricLight>,
             )>,
@@ -417,11 +420,13 @@ pub fn extract_lights(
                 &RectLight,
                 &GlobalTransform,
                 &ViewVisibility,
+                Option<&RenderLayers>,
             ),
             Or<(
                 Changed<RectLight>,
                 Changed<GlobalTransform>,
                 Changed<ViewVisibility>,
+                Changed<RenderLayers>,
             )>,
         >,
     >,
@@ -460,6 +465,7 @@ pub fn extract_lights(
         transform,
         view_visibility,
         frusta,
+        maybe_render_layers,
         volumetric_light,
     ) in point_lights.iter()
     {
@@ -561,6 +567,7 @@ pub fn extract_lights(
             extracted_point_light,
             (*frusta).clone(),
             MainEntity::from(main_entity),
+            maybe_render_layers.unwrap_or_default().clone(),
         ));
     }
 
@@ -572,6 +579,7 @@ pub fn extract_lights(
         transform,
         view_visibility,
         frustum,
+        maybe_render_layers,
         volumetric_light,
     ) in spot_lights.iter()
     {
@@ -674,6 +682,7 @@ pub fn extract_lights(
             extracted_spot_light,
             *frustum,
             MainEntity::from(main_entity),
+            maybe_render_layers.unwrap_or_default().clone(),
         ));
     }
 
@@ -687,7 +696,7 @@ pub fn extract_lights(
         frusta,
         transform,
         view_visibility,
-        maybe_layers,
+        maybe_render_layers,
         volumetric_light,
         occlusion_culling,
         sun_disk,
@@ -822,7 +831,6 @@ pub fn extract_lights(
             cascade_shadow_config: cascade_config.clone(),
             cascades: extracted_cascades,
             frusta: extracted_frusta,
-            render_layers: maybe_layers.unwrap_or_default().clone(),
             occlusion_culling,
             sun_disk_angular_size: sun_disk.unwrap_or_default().angular_size,
             sun_disk_intensity: sun_disk.unwrap_or_default().intensity,
@@ -831,10 +839,16 @@ pub fn extract_lights(
         let mut entity_commands = commands
             .get_entity(entity)
             .expect("Light entity wasn't synced.");
-        entity_commands.insert((extracted_directional_light, MainEntity::from(main_entity)));
+        entity_commands.insert((
+            extracted_directional_light,
+            MainEntity::from(main_entity),
+            maybe_render_layers.unwrap_or_default().clone(),
+        ));
     }
 
-    for (main_entity, render_entity, rect_light, transform, view_visibility) in &rect_lights {
+    for (main_entity, render_entity, rect_light, transform, view_visibility, maybe_render_layers) in
+        &rect_lights
+    {
         if !cfg!(feature = "area_light_luts") && !*rect_light_missing_luts_warning_emitted {
             warn!(
                 "RectLight will not work properly because the `area_light_luts` cargo feature is not enabled."
@@ -851,21 +865,22 @@ pub fn extract_lights(
         let affine = transform.affine();
         let effective_width = rect_light.width * affine.matrix3.x_axis.length();
         let effective_height = rect_light.height * affine.matrix3.y_axis.length();
-        commands
+        let mut entity_commands = commands
             .get_entity(render_entity)
-            .expect("RectLight entity wasn't synced.")
-            .insert((
-                ExtractedRectLight {
-                    color: rect_light.color.into(),
-                    intensity: rect_light.intensity
-                        / (effective_width * effective_height * core::f32::consts::PI),
-                    width: effective_width,
-                    height: effective_height,
-                    range: rect_light.range,
-                    transform: *transform,
-                },
-                MainEntity::from(main_entity),
-            ));
+            .expect("RectLight entity wasn't synced.");
+        entity_commands.insert((
+            ExtractedRectLight {
+                color: rect_light.color.into(),
+                intensity: rect_light.intensity
+                    / (effective_width * effective_height * core::f32::consts::PI),
+                width: effective_width,
+                height: effective_height,
+                range: rect_light.range,
+                transform: *transform,
+            },
+            MainEntity::from(main_entity),
+            maybe_render_layers.unwrap_or_default().clone(),
+        ));
     }
 
     /// Clears out any shadow maps that may be present for a light with shadow
@@ -1033,6 +1048,7 @@ pub fn prepare_lights(
             &MainEntity,
             &ExtractedPointLight,
             &mut PointAndSpotLightViewEntities,
+            &RenderLayers,
             AnyOf<(&CubemapFrusta, &Frustum)>,
         )>,
         Query<
@@ -1041,10 +1057,16 @@ pub fn prepare_lights(
                 Changed<ExtractedPointLight>,
                 Changed<CubemapFrusta>,
                 Changed<Frustum>,
+                Changed<RenderLayers>,
             )>,
         >,
-        Query<(Entity, &MainEntity, &ExtractedDirectionalLight)>,
-        Query<(Entity, &MainEntity, &ExtractedRectLight)>,
+        Query<(
+            Entity,
+            &MainEntity,
+            &ExtractedDirectionalLight,
+            &RenderLayers,
+        )>,
+        Query<(Entity, &MainEntity, &ExtractedRectLight, &RenderLayers)>,
         Query<&mut DirectionalLightViewEntities>,
     ),
     sorted_cameras: Res<SortedCameras>,
@@ -1078,15 +1100,15 @@ pub fn prepare_lights(
 
     let mut point_light_entities: Vec<_> = point_lights
         .iter()
-        .map(|(entity, _, _, _, _)| entity)
+        .map(|(entity, _, _, _, _, _)| entity)
         .collect::<Vec<_>>();
     let mut directional_light_entities: Vec<_> = directional_lights
         .iter()
-        .map(|(entity, _, _)| entity)
+        .map(|(entity, _, _, _)| entity)
         .collect::<Vec<_>>();
     let rect_light_entities: Vec<_> = rect_lights
         .iter()
-        .map(|(entity, _, _)| entity)
+        .map(|(entity, _, _, _)| entity)
         .collect::<Vec<_>>();
 
     #[cfg(any(
@@ -1127,9 +1149,9 @@ pub fn prepare_lights(
     }
 
     if !*max_cascades_per_light_warning_emitted
-        && directional_lights
-            .iter()
-            .any(|(_, _, light)| light.cascade_shadow_config.bounds.len() > MAX_CASCADES_PER_LIGHT)
+        && directional_lights.iter().any(|(_, _, light, _)| {
+            light.cascade_shadow_config.bounds.len() > MAX_CASCADES_PER_LIGHT
+        })
     {
         warn!(
             "The number of cascades configured for a directional light exceeds the supported limit of {}.",
@@ -1145,7 +1167,7 @@ pub fn prepare_lights(
 
     let point_light_volumetric_enabled_count = point_lights
         .iter()
-        .filter(|(_, _, light, _, _)| light.volumetric && light.spot_light_angles.is_none())
+        .filter(|(_, _, light, _, _, _)| light.volumetric && light.spot_light_angles.is_none())
         .count()
         .min(max_texture_cubes);
 
@@ -1158,32 +1180,32 @@ pub fn prepare_lights(
     let directional_volumetric_enabled_count = directional_lights
         .iter()
         .take(MAX_DIRECTIONAL_LIGHTS)
-        .filter(|(_, _, light)| light.volumetric)
+        .filter(|(_, _, light, _)| light.volumetric)
         .count()
         .min(max_texture_array_layers / MAX_CASCADES_PER_LIGHT);
 
     let directional_shadow_enabled_count = directional_lights
         .iter()
         .take(MAX_DIRECTIONAL_LIGHTS)
-        .filter(|(_, _, light)| light.shadow_maps_enabled)
+        .filter(|(_, _, light, _)| light.shadow_maps_enabled)
         .count()
         .min(max_texture_array_layers / MAX_CASCADES_PER_LIGHT);
 
     let spot_light_count = point_lights
         .iter()
-        .filter(|(_, _, light, _, _)| light.spot_light_angles.is_some())
+        .filter(|(_, _, light, _, _, _)| light.spot_light_angles.is_some())
         .count()
         .min(max_texture_array_layers - directional_shadow_enabled_count * MAX_CASCADES_PER_LIGHT);
 
     let spot_light_volumetric_enabled_count = point_lights
         .iter()
-        .filter(|(_, _, light, _, _)| light.volumetric && light.spot_light_angles.is_some())
+        .filter(|(_, _, light, _, _, _)| light.volumetric && light.spot_light_angles.is_some())
         .count()
         .min(max_texture_array_layers - directional_shadow_enabled_count * MAX_CASCADES_PER_LIGHT);
 
     let spot_light_shadow_maps_count = point_lights
         .iter()
-        .filter(|(_, _, light, _, _)| {
+        .filter(|(_, _, light, _, _, _)| {
             light.shadow_maps_enabled && light.spot_light_angles.is_some()
         })
         .count()
@@ -1348,8 +1370,8 @@ pub fn prepare_lights(
         let render_layers = maybe_layers.unwrap_or_default();
 
         for light_entity in directional_light_entities.iter() {
-            let light = directional_lights.get(*light_entity).unwrap().2;
-            if light.shadow_maps_enabled && light.render_layers.intersects(render_layers) {
+            let (_, _, light, light_render_layers) = directional_lights.get(*light_entity).unwrap();
+            if light.shadow_maps_enabled && light_render_layers.intersects(render_layers) {
                 num_directional_cascades_for_this_view += light
                     .cascade_shadow_config
                     .bounds
@@ -1477,6 +1499,7 @@ pub fn prepare_lights(
             light_main_entity,
             light,
             mut point_and_spot_light_view_entities,
+            light_render_layers,
             (point_light_frusta, _),
         ) = point_lights.get_mut(*light_entity).unwrap();
 
@@ -1502,7 +1525,7 @@ pub fn prepare_lights(
                     &light_view_entities,
                 ),
                 &point_light_depth_texture,
-                (light_entity, light_main_entity, light),
+                (light_entity, light_main_entity, light, light_render_layers),
                 point_light_shadow_map.size as u32,
                 gpu_preprocessing_support.max_supported_mode,
             );
@@ -1520,7 +1543,7 @@ pub fn prepare_lights(
                     &point_and_spot_light_view_entities.0,
                 ),
                 &point_light_depth_texture,
-                (light_entity, light_main_entity, light),
+                (light_entity, light_main_entity, light, light_render_layers),
                 point_light_shadow_map.size as u32,
                 gpu_preprocessing_support.max_supported_mode,
             );
@@ -1551,6 +1574,7 @@ pub fn prepare_lights(
             light_main_entity,
             light,
             mut point_and_spot_light_view_entities,
+            light_render_layers,
             (_, spot_light_frustum),
         ) = point_lights.get_mut(*light_entity).unwrap();
 
@@ -1575,7 +1599,7 @@ pub fn prepare_lights(
                 (num_directional_cascades_enabled, light_index),
                 &directional_light_depth_texture,
                 view_light_entity,
-                (light_entity, light_main_entity, light),
+                (light_entity, light_main_entity, light, light_render_layers),
                 spot_light_frustum,
                 directional_light_shadow_map.size as u32,
                 gpu_preprocessing_support.max_supported_mode,
@@ -1590,7 +1614,7 @@ pub fn prepare_lights(
                 &directional_light_depth_texture,
                 // There should only be one view light entity for spotlights
                 point_and_spot_light_view_entities.0[0],
-                (light_entity, light_main_entity, light),
+                (light_entity, light_main_entity, light, light_render_layers),
                 spot_light_frustum,
                 directional_light_shadow_map.size as u32,
                 gpu_preprocessing_support.max_supported_mode,
@@ -1655,8 +1679,7 @@ pub fn prepare_lights(
                 directional_lights
                     .get(**light_entity)
                     .unwrap()
-                    .2
-                    .render_layers
+                    .3
                     .intersects(view_layers)
             })
             .enumerate()
@@ -1761,8 +1784,7 @@ pub fn prepare_lights(
             !directional_lights
                 .get(**light_entity)
                 .unwrap()
-                .2
-                .render_layers
+                .3
                 .intersects(view_layers)
         }) {
             let Ok(mut light_view_entities) =
@@ -1782,14 +1804,14 @@ pub fn prepare_lights(
                 directional_lights
                     .get(**light_entity)
                     .unwrap()
-                    .2
-                    .render_layers
+                    .3
                     .intersects(view_layers)
             })
             .enumerate()
             .take(MAX_DIRECTIONAL_LIGHTS)
         {
-            let (_, light_main_entity, light) = directional_lights.get(*light_entity).unwrap();
+            let (_, light_main_entity, light, light_render_layers) =
+                directional_lights.get(*light_entity).unwrap();
 
             let Ok(mut light_view_entities) =
                 directional_light_view_entities.get_mut(*light_entity)
@@ -1908,6 +1930,7 @@ pub fn prepare_lights(
                         light_entity: *light_entity,
                         cascade_index,
                     },
+                    (*light_render_layers).clone(),
                 ));
 
                 if !matches!(gpu_preprocessing_mode, GpuPreprocessingMode::Culling) {
@@ -1955,7 +1978,8 @@ pub fn prepare_lights(
         // effort spent on introducing that mechanism would be better spent on
         // making rect lights clusterable.
         gpu_lights.n_rect_lights = 0;
-        for (index, (_, _, rect_light)) in rect_lights.iter().enumerate().take(MAX_RECT_LIGHTS) {
+        // TODO use light_render_layers whenever that is supported for rect_lights
+        for (index, (_, _, rect_light, _)) in rect_lights.iter().enumerate().take(MAX_RECT_LIGHTS) {
             let right = rect_light.transform.right().into();
             let up = rect_light.transform.up().into();
             gpu_lights.rect_lights[index] = GpuRectLight {
@@ -2022,7 +2046,12 @@ fn create_point_shadow_maps(
         &Vec<Entity>,
     ),
     point_light_depth_texture: &CachedTexture,
-    (light_entity, light_main_entity, light): (&Entity, &MainEntity, &ExtractedPointLight),
+    (light_entity, light_main_entity, light, light_render_layers): (
+        &Entity,
+        &MainEntity,
+        &ExtractedPointLight,
+        &RenderLayers,
+    ),
     point_light_shadow_map_size: u32,
     gpu_preprocessing_support_max_supported_mode: GpuPreprocessingMode,
 ) {
@@ -2105,6 +2134,7 @@ fn create_point_shadow_maps(
                 light_entity: *light_entity,
                 face_index,
             },
+            (*light_render_layers).clone(),
             RootNonCameraView(Core3d.intern()),
         ));
 
@@ -2125,7 +2155,12 @@ fn create_spot_shadow_map(
     (num_directional_cascades_enabled, light_index): (usize, usize),
     directional_light_depth_texture: &CachedTexture,
     view_light_entity: Entity,
-    (light_entity, light_main_entity, light): (&Entity, &MainEntity, &ExtractedPointLight),
+    (light_entity, light_main_entity, light, light_render_layers): (
+        &Entity,
+        &MainEntity,
+        &ExtractedPointLight,
+        &RenderLayers,
+    ),
     spot_light_frustum: Option<&Frustum>,
     directional_light_shadow_map_size: u32,
     gpu_preprocessing_support_max_supported_mode: GpuPreprocessingMode,
@@ -2186,6 +2221,7 @@ fn create_spot_shadow_map(
         LightEntity::Spot {
             light_entity: *light_entity,
         },
+        (*light_render_layers).clone(),
         RootNonCameraView(Core3d.intern()),
     ));
 
@@ -2524,13 +2560,13 @@ pub fn queue_shadows(
     mut shadow_render_phases: ResMut<ViewBinnedRenderPhases<Shadow>>,
     gpu_preprocessing_support: Res<GpuPreprocessingSupport>,
     mesh_allocator: Res<MeshAllocator>,
-    view_light_entities: Query<(&LightEntity, &ExtractedView, Option<&RenderLayers>)>,
+    view_light_entities: Query<(&LightEntity, &ExtractedView, &RenderLayers)>,
     shadow_map_visible_entities_query: Query<&RenderShadowMapVisibleEntities>,
     specialized_material_pipeline_cache: Res<SpecializedShadowMaterialPipelineCache>,
     mut pending_shadow_queues: ResMut<PendingShadowQueues>,
     dirty_specializations: Res<DirtySpecializations>,
 ) {
-    for (light_entity, extracted_view_light, maybe_view_render_layers) in &view_light_entities {
+    for (light_entity, extracted_view_light, view_light_render_layers) in &view_light_entities {
         let Some(shadow_phase) =
             shadow_render_phases.get_mut(&extracted_view_light.retained_view_entity)
         else {
@@ -2595,8 +2631,7 @@ pub fn queue_shadows(
             }
 
             let mesh_layers = mesh_instance.render_layers.as_ref().unwrap_or_default();
-            let view_render_layers = maybe_view_render_layers.unwrap_or_default();
-            if !view_render_layers.intersects(mesh_layers) {
+            if !view_light_render_layers.intersects(mesh_layers) {
                 continue;
             }
 


### PR DESCRIPTION
# Objective

Fixes #24792 

`queue_shadows()` currently queues shadows erroneously because the view light entity never has the `RenderLayers` component correctly attached. This not only affects directional lights as described in the issue, but all the light types.

## Solution

- Ensure all four types of lights (point, spot, directional, rect) have their render layers extracted (or set to the default layer if not specified).
- Ensure that the filtering in `queue_shadows()` actually works with render layers by ensuring that the light entity always has render layers specified. (rect light is an exception since it doesn’t have shadows currently)
- I standardized the way `RenderLayers` is attached to extracted lights — I figured that, since it’s a component, it should be attached separately (i.e. not set directly to the extracted structure a la `ExtractedDirectionalLight`. I remove the `RenderLayers` from that component.).

Note that this issue/fix is separate from the problem described in #23264. This only ensures the light <-> mesh render layer relationship is respected when queueing shadows. This doesn’t fix anything about the light illuminating the wrong meshes and does not touch any shader code.

## Testing

- The minimal reproduction example in #24792 is fixed
- Ran the `pcss` example and changed between the lights and `rect_light` just to make sure there isn't a regression.