### PR TITLE
Packed Vals

### DIFF
--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -361,13 +361,13 @@ impl Val {
     /// Packs a [`Val`] into a u8 unit discriminator and f32 numeric value.
     ///
     /// ```
-    /// # use bevy_ui::Val;
-    /// let (unit, value) = Val::pack(percent(50.));
+    /// # use bevy_ui::{Val, percent};
+    /// let (unit, value) = percent(50.).pack();
     ///
     /// assert_eq!(Val::unpack(unit, value), percent(50.));
     /// ```
-    pub const fn pack(val: Val) -> (u8, f32) {
-        match val {
+    pub const fn pack(self) -> (u8, f32) {
+        match self {
             Val::Auto => (Self::AUTO, 0.),
             Val::Px(value) => (Self::PX, value),
             Val::Percent(value) => (Self::PERCENT, value),

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -166,6 +166,13 @@ impl PartialEq for Val {
 impl Val {
     pub const DEFAULT: Self = Self::Auto;
     pub const ZERO: Self = Self::Px(0.0);
+    pub(crate) const AUTO: u8 = 0;
+    pub(crate) const PX: u8 = 1;
+    pub(crate) const PERCENT: u8 = 2;
+    pub(crate) const VW: u8 = 3;
+    pub(crate) const VH: u8 = 4;
+    pub(crate) const VMIN: u8 = 5;
+    pub(crate) const VMAX: u8 = 6;
 
     /// Returns a [`UiRect`] with its `left` equal to this value,
     /// and all other fields set to `Val::ZERO`.
@@ -348,6 +355,39 @@ impl Val {
             (Val::VMin(u), Val::VMin(v)) => Ok(Val::VMin(u - v)),
             (Val::VMax(u), Val::VMax(v)) => Ok(Val::VMax(u - v)),
             _ => Err(ValArithmeticError::IncompatibleUnits),
+        }
+    }
+
+    /// Packs a [`Val`] into a u8 unit discriminator and f32 numeric value.
+    ///
+    /// ```
+    /// # use bevy_ui::Val;
+    /// let (unit, value) = Val::pack(percent(50.));
+    ///
+    /// assert_eq!(Val::unpack(unit, value), percent(50.));
+    /// ```
+    pub const fn pack(val: Val) -> (u8, f32) {
+        match val {
+            Val::Auto => (Self::AUTO, 0.),
+            Val::Px(value) => (Self::PX, value),
+            Val::Percent(value) => (Self::PERCENT, value),
+            Val::Vw(value) => (Self::VW, value),
+            Val::Vh(value) => (Self::VH, value),
+            Val::VMin(value) => (Self::VMIN, value),
+            Val::VMax(value) => (Self::VMAX, value),
+        }
+    }
+
+    /// Unpacks  a u8 unit discriminator and f32 numeric value into a [`Val`].
+    pub const fn unpack(unit: u8, value: f32) -> Val {
+        match unit {
+            Self::PX => Val::Px(value),
+            Self::PERCENT => Val::Percent(value),
+            Self::VW => Val::Vw(value),
+            Self::VH => Val::Vh(value),
+            Self::VMIN => Val::VMin(value),
+            Self::VMAX => Val::VMax(value),
+            _ => Val::Auto,
         }
     }
 }

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -29,24 +29,17 @@ pub struct Val2 {
 }
 
 impl Val2 {
-    const AUTO: u8 = 0;
-    const PX: u8 = 1;
-    const PERCENT: u8 = 2;
-    const VW: u8 = 3;
-    const VH: u8 = 4;
-    const VMIN: u8 = 5;
-    const VMAX: u8 = 6;
     const MASK: u8 = 0x0f;
 
     pub const ZERO: Self = Self {
         values: [0.; 2],
-        units: Self::PX | (Self::PX << 4),
+        units: Val::PX | (Val::PX << 4),
     };
 
     /// Creates a new [`Val2`]
     pub const fn new(x: Val, y: Val) -> Self {
-        let (ux, vx) = Self::pack(x);
-        let (uy, vy) = Self::pack(y);
+        let (ux, vx) = Val::pack(x);
+        let (uy, vy) = Val::pack(y);
         Self {
             values: [vx, vy],
             units: ux | uy << 4,
@@ -71,13 +64,13 @@ impl Val2 {
     /// Returns the x-axis value.
     #[inline]
     pub const fn x(&self) -> Val {
-        Self::unpack(self.units & Self::MASK, self.values[0])
+        Val::unpack(self.units & Self::MASK, self.values[0])
     }
 
     /// Returns the y-axis value.
     #[inline]
     pub const fn y(&self) -> Val {
-        Self::unpack((self.units >> 4) & Self::MASK, self.values[1])
+        Val::unpack((self.units >> 4) & Self::MASK, self.values[1])
     }
 
     /// Resolves this [`Val2`] from the given `scale_factor`, `parent_size`,
@@ -131,30 +124,6 @@ impl Val2 {
             return Err(ValArithmeticError::IncompatibleUnits);
         };
         Ok(Self::new(x, y))
-    }
-
-    const fn pack(val: Val) -> (u8, f32) {
-        match val {
-            Val::Auto => (Self::AUTO, 0.),
-            Val::Px(value) => (Self::PX, value),
-            Val::Percent(value) => (Self::PERCENT, value),
-            Val::Vw(value) => (Self::VW, value),
-            Val::Vh(value) => (Self::VH, value),
-            Val::VMin(value) => (Self::VMIN, value),
-            Val::VMax(value) => (Self::VMAX, value),
-        }
-    }
-
-    const fn unpack(unit: u8, value: f32) -> Val {
-        match unit {
-            Self::PX => Val::Px(value),
-            Self::PERCENT => Val::Percent(value),
-            Self::VW => Val::Vw(value),
-            Self::VH => Val::Vh(value),
-            Self::VMIN => Val::VMin(value),
-            Self::VMAX => Val::VMax(value),
-            _ => Val::Auto,
-        }
     }
 }
 

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -36,8 +36,8 @@ impl Val2 {
 
     /// Creates a new [`Val2`]
     pub const fn new(x: Val, y: Val) -> Self {
-        let (ux, vx) = Val::pack(x);
-        let (uy, vy) = Val::pack(y);
+        let (ux, vx) = x.pack();
+        let (uy, vy) = y.pack();
         Self {
             values: [vx, vy],
             units: ux | uy << 4,

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -9,10 +9,14 @@ use bevy_math::Mat2;
 use bevy_math::Rot2;
 use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
+use core::fmt;
 use core::ops::Mul;
 
 /// A pair of [`Val`]s used to represent a 2-dimensional size or offset.
-#[derive(Debug, PartialEq, Clone, Copy, Reflect)]
+///
+/// - `Val::Percent` x/y values are resolved based on the computed length of the Ui Node on the respective axis.
+/// - `Val::Auto` is resolved to `0.`.
+#[derive(Clone, Copy, Reflect, PartialEq)]
 #[reflect(Default, PartialEq, Debug, Clone)]
 #[cfg_attr(
     feature = "serialize",
@@ -20,25 +24,33 @@ use core::ops::Mul;
     reflect(Serialize, Deserialize)
 )]
 pub struct Val2 {
-    /// Translate the node along the x-axis.
-    /// `Val::Percent` values are resolved based on the computed width of the Ui Node.
-    /// `Val::Auto` is resolved to `0.`.
-    pub x: Val,
-    /// Translate the node along the y-axis.
-    /// `Val::Percent` values are resolved based on the computed height of the UI Node.
-    /// `Val::Auto` is resolved to `0.`.
-    pub y: Val,
+    values: [f32; 2],
+    units: u8,
 }
 
 impl Val2 {
+    const AUTO: u8 = 0;
+    const PX: u8 = 1;
+    const PERCENT: u8 = 2;
+    const VW: u8 = 3;
+    const VH: u8 = 4;
+    const VMIN: u8 = 5;
+    const VMAX: u8 = 6;
+    const MASK: u8 = 0x0f;
+
     pub const ZERO: Self = Self {
-        x: Val::ZERO,
-        y: Val::ZERO,
+        values: [0.; 2],
+        units: Self::PX | (Self::PX << 4),
     };
 
     /// Creates a new [`Val2`]
     pub const fn new(x: Val, y: Val) -> Self {
-        Self { x, y }
+        let (ux, vx) = Self::pack(x);
+        let (uy, vy) = Self::pack(y);
+        Self {
+            values: [vx, vy],
+            units: ux | uy << 4,
+        }
     }
 
     /// Creates a new [`Val2`] where both components are the same value
@@ -56,16 +68,28 @@ impl Val2 {
         Self::new(Val::Percent(x.val_num_f32()), Val::Percent(y.val_num_f32()))
     }
 
+    /// Returns the x-axis value.
+    #[inline]
+    pub const fn x(&self) -> Val {
+        Self::unpack(self.units & Self::MASK, self.values[0])
+    }
+
+    /// Returns the y-axis value.
+    #[inline]
+    pub const fn y(&self) -> Val {
+        Self::unpack((self.units >> 4) & Self::MASK, self.values[1])
+    }
+
     /// Resolves this [`Val2`] from the given `scale_factor`, `parent_size`,
     /// and `viewport_size`.
     ///
     /// Component values of [`Val::Auto`] are resolved to 0.
     pub fn resolve(&self, scale_factor: f32, base_size: Vec2, viewport_size: Vec2) -> Vec2 {
         Vec2::new(
-            self.x
+            self.x()
                 .resolve(scale_factor, base_size.x, viewport_size)
                 .unwrap_or(0.),
-            self.y
+            self.y()
                 .resolve(scale_factor, base_size.y, viewport_size)
                 .unwrap_or(0.),
         )
@@ -84,10 +108,10 @@ impl Val2 {
     /// );
     /// ```
     pub fn try_add(self, other: Val2) -> Result<Self, ValArithmeticError> {
-        let (Ok(x), Ok(y)) = (self.x.try_add(other.x), self.y.try_add(other.y)) else {
+        let (Ok(x), Ok(y)) = (self.x().try_add(other.x()), self.y().try_add(other.y())) else {
             return Err(ValArithmeticError::IncompatibleUnits);
         };
-        Ok(Self { x, y })
+        Ok(Self::new(x, y))
     }
 
     /// Try to subtract two `Val2`s component-wise.
@@ -103,10 +127,43 @@ impl Val2 {
     /// );
     /// ```
     pub fn try_sub(self, other: Val2) -> Result<Self, ValArithmeticError> {
-        let (Ok(x), Ok(y)) = (self.x.try_sub(other.x), self.y.try_sub(other.y)) else {
+        let (Ok(x), Ok(y)) = (self.x().try_sub(other.x()), self.y().try_sub(other.y())) else {
             return Err(ValArithmeticError::IncompatibleUnits);
         };
-        Ok(Self { x, y })
+        Ok(Self::new(x, y))
+    }
+
+    const fn pack(val: Val) -> (u8, f32) {
+        match val {
+            Val::Auto => (Self::AUTO, 0.),
+            Val::Px(value) => (Self::PX, value),
+            Val::Percent(value) => (Self::PERCENT, value),
+            Val::Vw(value) => (Self::VW, value),
+            Val::Vh(value) => (Self::VH, value),
+            Val::VMin(value) => (Self::VMIN, value),
+            Val::VMax(value) => (Self::VMAX, value),
+        }
+    }
+
+    const fn unpack(unit: u8, value: f32) -> Val {
+        match unit {
+            Self::PX => Val::Px(value),
+            Self::PERCENT => Val::Percent(value),
+            Self::VW => Val::Vw(value),
+            Self::VH => Val::Vh(value),
+            Self::VMIN => Val::VMin(value),
+            Self::VMAX => Val::VMax(value),
+            _ => Val::Auto,
+        }
+    }
+}
+
+impl fmt::Debug for Val2 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Val2")
+            .field("x", &self.x())
+            .field("y", &self.y())
+            .finish()
     }
 }
 

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -71,6 +71,40 @@ impl Val2 {
         Val::unpack(self.units >> 4, self.values[1])
     }
 
+    /// Set a new x value.
+    ///
+    /// ```
+    /// # use bevy_ui::{px, percent, Val2};
+    /// let mut val = Val2::new(percent(50), px(20));
+    /// val.set_x(px(10));
+    ///
+    /// assert_eq!(val.x(), px(10));
+    /// assert_eq!(val.y(), px(20));
+    /// ```
+    #[inline]
+    pub const fn set_x(&mut self, x: Val) {
+        let (unit, value) = x.pack();
+        self.values[0] = value;
+        self.units = (self.units & 0xf0) | unit;
+    }
+
+    /// Set a new y value.
+    ///
+    /// ```
+    /// # use bevy_ui::{px, percent, Val2};
+    /// let mut val = Val2::new(px(10), percent(50));
+    /// val.set_y(px(20));
+    ///
+    /// assert_eq!(val.x(), px(10));
+    /// assert_eq!(val.y(), px(20));
+    /// ```
+    #[inline]
+    pub const fn set_y(&mut self, y: Val) {
+        let (unit, value) = y.pack();
+        self.values[1] = value;
+        self.units = (self.units & 0x0f) | (unit << 4);
+    }
+
     /// Resolves this [`Val2`] from the given `scale_factor`, `parent_size`,
     /// and `viewport_size`.
     ///

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -29,8 +29,6 @@ pub struct Val2 {
 }
 
 impl Val2 {
-    const MASK: u8 = 0x0f;
-
     pub const ZERO: Self = Self {
         values: [0.; 2],
         units: Val::PX | (Val::PX << 4),
@@ -64,13 +62,13 @@ impl Val2 {
     /// Returns the x-axis value.
     #[inline]
     pub const fn x(&self) -> Val {
-        Val::unpack(self.units & Self::MASK, self.values[0])
+        Val::unpack(self.units & 0x0f, self.values[0])
     }
 
     /// Returns the y-axis value.
     #[inline]
     pub const fn y(&self) -> Val {
-        Val::unpack((self.units >> 4) & Self::MASK, self.values[1])
+        Val::unpack(self.units >> 4, self.values[1])
     }
 
     /// Resolves this [`Val2`] from the given `scale_factor`, `parent_size`,

--- a/examples/ui/scroll_and_overflow/overflow_debug.rs
+++ b/examples/ui/scroll_and_overflow/overflow_debug.rs
@@ -49,8 +49,10 @@ struct Move;
 
 impl UpdateTransform for Move {
     fn update(&self, t: f32, transform: &mut UiTransform) {
-        transform.translation.x = percent(ops::sin(t * TAU - FRAC_PI_2) * 50.);
-        transform.translation.y = percent(-ops::cos(t * TAU - FRAC_PI_2) * 50.);
+        transform.translation = Val2::new(
+            percent(ops::sin(t * TAU - FRAC_PI_2) * 50.),
+            percent(-ops::cos(t * TAU - FRAC_PI_2) * 50.),
+        );
     }
 }
 

--- a/examples/ui/ui_transform.rs
+++ b/examples/ui/ui_transform.rs
@@ -86,7 +86,8 @@ fn translation_system(
         if input.pressed(key_code) {
             for mut transform in translation_query.iter_mut() {
                 let d = direction * 50.0 * time.delta_secs();
-                let (Val::Px(x), Val::Px(y)) = (transform.translation.x, transform.translation.y)
+                let (Val::Px(x), Val::Px(y)) =
+                    (transform.translation.x(), transform.translation.y())
                 else {
                     continue;
                 };


### PR DESCRIPTION
# Objective

A `Val` is 8 bytes, which can't realistically be reduced without using f16s which aren't accurate enough.

However with `Val2`, `UiRect` and `BorderRadius` you can combine the `Val` enum discriminators into one value. The reduces 
`Val2` from 16 bytes down to 12, and `UiRect`/`BorderRadius` goes from 32 bytes down to 20 bytes. If `BorderRadius` is extended to support elliptical radii (#24779) it would need 64 bytes which could be packed down to 36 bytes.

## Solution

- `pack` and `unpack` functions on Val, map it to and from a (u8, f32) pair.
- Changed `Val2` to use packed `Val`s.

---

- The discriminator might be better as a #[repr(u8)] enum with explicit values, though then you'd have to do a match or transmute to unpack.

- It might not a be a very popular change, I'm not quite sure how well it works API wise. Maybe something could be done with bsn! though.
