### PR TITLE
Fix observers not removing themselves from ObservedBy.

### DIFF
--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -459,7 +459,7 @@ mod tests {
         error::Result,
         event::{EntityComponentsTrigger, Event, GlobalTrigger},
         hierarchy::ChildOf,
-        observer::{Discard, Observer},
+        observer::{Discard, ObservedBy, Observer},
         prelude::*,
         world::DeferredWorld,
     };
@@ -1841,5 +1841,55 @@ mod tests {
                 ("bevy_ecs::lifecycle::Remove", Some(a), None),
             ],
         );
+    }
+
+    #[test]
+    fn despawning_observer_removes_observed_by() {
+        let mut world = World::new();
+
+        #[derive(EntityEvent)]
+        struct Hi {
+            entity: Entity,
+        }
+
+        let target = world.spawn_empty().id();
+        let observer = world
+            .spawn(Observer::new(|_: On<Hi>| {}).with_entity(target))
+            .id();
+
+        assert_eq!(
+            world.entity(target).get::<ObservedBy>().unwrap().get(),
+            &[observer]
+        );
+
+        world.entity_mut(observer).despawn();
+
+        assert!(!world.entity(target).contains::<ObservedBy>());
+    }
+
+    #[test]
+    fn despawning_observer_removes_observed_by_repeated() {
+        let mut world = World::new();
+
+        #[derive(EntityEvent)]
+        struct Hi {
+            entity: Entity,
+        }
+
+        let target = world.spawn_empty().id();
+        let observer = world
+            // Observe the same entity multiple times.
+            .spawn(Observer::new(|_: On<Hi>| {}).with_entities([target, target]))
+            .id();
+
+        // This is likely not desirable, but preventing this is not worth it.
+        assert_eq!(
+            world.entity(target).get::<ObservedBy>().unwrap().get(),
+            &[observer, observer]
+        );
+
+        world.entity_mut(observer).despawn();
+
+        assert!(!world.entity(target).contains::<ObservedBy>());
     }
 }

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -380,6 +380,26 @@ impl World {
 
     /// Remove the observer from the cache, called when an observer gets despawned
     pub(crate) fn unregister_observer(&mut self, entity: Entity, descriptor: ObserverDescriptor) {
+        // Remove this observer from all the corresponding ObservedBy components.
+        for &observing in descriptor.entities.iter() {
+            let Ok(mut observing) = self.get_entity_mut(observing) else {
+                // This can happen when ObservedBy is despawning and is despawning the related
+                // observers.
+                continue;
+            };
+            let Some(mut observed_by) = observing.get_mut::<ObservedBy>() else {
+                // In "normal" usage, this should be impossible, but there's nothing stopping a user
+                // from just removing the ObservedBy component themselves. While that's odd usage,
+                // there's no reason to panic if a user does so.
+                continue;
+            };
+
+            observed_by.0.retain(|e| *e != entity);
+            if observed_by.0.is_empty() {
+                observing.remove::<ObservedBy>();
+            }
+        }
+
         let archetypes = &mut self.archetypes;
         let observers = &mut self.observers;
 

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -1902,7 +1902,8 @@ mod tests {
             .spawn(Observer::new(|_: On<Hi>| {}).with_entities([target, target]))
             .id();
 
-        // This is likely not desirable, but preventing this is not worth it.
+        // Having an observer observe the same entity multiple times is likely not desired, but
+        // preventing this is not worth it, so make sure it behaves correctly.
         assert_eq!(
             world.entity(target).get::<ObservedBy>().unwrap().get(),
             &[observer, observer]


### PR DESCRIPTION
# Objective

- Fixes #24801.

## Solution

- When unregistering an observer, also go through the observer's targets and remove itself from those ObservedBy components.

## Testing

- Added two new tests.