### PR TITLE
Try despawning the related Observer from ObservedBy.

### DIFF
--- a/crates/bevy_ecs/src/observer/distributed_storage.rs
+++ b/crates/bevy_ecs/src/observer/distributed_storage.rs
@@ -536,7 +536,7 @@ impl Component for ObservedBy {
 
                 // Despawn Observer if it has no more active sources.
                 if total_entities == despawned_watched_entities {
-                    world.commands().entity(e).despawn();
+                    world.commands().entity(e).try_despawn();
                 }
             }
         })


### PR DESCRIPTION
# Objective

- Fixes #24700

## Solution

- Switch despawn to try_despawn.
    - It looks like this happens if the relationship despawns the observer, and then the ObservedBy tries to despawn the observer.

## Testing

- Ran the example in #24700. No more warning!
- I couldn't really add a test for this because testing logging is kinda difficult.