### PR TITLE
:bug: Fixes BSN support for fully qualified component paths

### DIFF
--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -98,7 +98,7 @@ impl<const ALLOW_FLAT: bool> Parse for Bsn<ALLOW_FLAT> {
 
 impl BsnEntry {
     fn parse(input: ParseStream) -> Result<Self> {
-        Ok(if input.peek(Token![:]) {
+        Ok(if input.peek(Token![:]) && !input.peek(Token![::]) {
             BsnEntry::CachedScene(BsnScene::parse(input)?)
         } else if input.peek(Token![#]) {
             input.parse::<Token![#]>()?;

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1115,6 +1115,18 @@ mod tests {
     }
 
     #[test]
+    fn supports_fully_qualified_component_paths() {
+        let mut app = test_app();
+        let world = app.world_mut();
+
+        assert!(world
+            .spawn_scene(bsn! {
+              ::bevy_ecs::prelude::Children[]
+            })
+            .is_ok());
+    }
+
+    #[test]
     fn cached_patching() {
         let mut app = test_app();
         let world = app.world_mut();


### PR DESCRIPTION
# Objective

Currently using fully qualified paths in `bsn!` fails compilation

```rs
bsn! {
  ::bevy::ui::Node
}
```

This is due to the parser seeing the `:` token and immediately going to the scene parsing path.

## Solution

Check that the token isn't part of `::` when checking for that branch.

## Testing

There didn't seem to be any testing of the actual macro parsing (that I could find) so I put a simple test that just makes sure it compiled and produces a valid scene, though doesn't check that the scene is ACTUALLY "correct".
