### PR TITLE
Ignore ttf-parser advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,10 @@ all-features = true
 [advisories]
 version = 2
 ignore = [
+  # ttf-parser was announced as unmaintained.
+  # See: https://rustsec.org/advisories/RUSTSEC-2026-0192
+  # Ignoring to unblock ci
+  "RUSTSEC-2026-0192",
   # paste was announced as unmaintained with no explanation or replacement
   # See: https://rustsec.org/advisories/RUSTSEC-2024-0436
   # Bevy relies on this in multiple indirect ways, so ignoring it is the only feasible current solution


### PR DESCRIPTION
# Objective

- Unblock ci for changes that affect dependencies (not fixing the root cause)
- Filed the issue as #24818 for a more formal decision on what to do with the advisory
- This can be closed if we’re ok with the advisory popping up / we decide to go another route

## Solution

- Add the new advisory to the ignore list

## Testing

- ci