### PR TITLE
document settings save location and TOML format

### DIFF
--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -51,6 +51,34 @@ use store_wasm::SettingsStore;
 /// afford one, use a reverse domain based on the URL of your repo (GitHub, GitLab, Codeberg
 /// and so on).
 ///
+/// # Storage location and format
+///
+/// Settings are stored as **TOML** files. Each [`SettingsGroup`] type becomes a top-level section
+/// in the file. The default filename is `settings`, which produces `settings.toml`.
+///
+/// On desktop platforms, files are written to `{preferences_dir()}/{app_name}/{filename}.toml`,
+/// where [`preferences_dir()`](bevy_platform::dirs::preferences_dir) is provided by
+/// [`bevy_platform::dirs::preferences_dir`]. With `app_name = "com.example.myapp"` and the default
+/// filename, typical paths are:
+///
+/// - Linux: `~/.config/com.example.myapp/settings.toml` (or under `$XDG_CONFIG_HOME` when set)
+/// - macOS: `~/Library/Preferences/com.example.myapp/settings.toml`
+/// - Windows: `%LocalAppData%\com.example.myapp\settings.toml`
+///
+/// On `wasm32`, settings are stored in browser `localStorage` under the key
+/// `{app_name}-{filename}` as a TOML string.
+///
+/// A file with one [`SettingsGroup`] named `counter` might look like:
+///
+/// ```toml
+/// [counter]
+/// count = 5
+/// enabled = true
+/// ```
+///
+/// Use `settings_group(file = "...")` on a [`SettingsGroup`] to write to a different file in the
+/// same app directory (see [`SettingsGroup`] for details).
+///
 /// Adding this plugin causes an immediate load of settings (from either the filesystem or
 /// browser local storage, depending on platform).
 ///

--- a/examples/app/settings.rs
+++ b/examples/app/settings.rs
@@ -4,7 +4,8 @@
 //! Its value persists between app sessions via settings.
 //!
 //! On desktop, if you quit the app and then restart it, the counter value should display
-//! the most recent value the app had before exiting.
+//! the most recent value the app had before exiting. Settings are saved as TOML at
+//! `{preferences_dir}/org.bevy.examples.settings/settings.toml` (see [`SettingsPlugin`]).
 //! On web, if you navigate away and then come back to the window, the counter
 //! should display the most recent value the app had before navigating away.
 use std::time::Duration;


### PR DESCRIPTION
Fixes #24699

Documents where SettingsPlugin writes settings on Linux, macOS, Windows, and WASM, and that the format is TOML.

## Test plan
- [x] cargo doc -p bevy-settings --no-deps