### PR TITLE
Have command error handling take `impl FnOnce` instead of a function pointer

### DIFF
--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -10,7 +10,7 @@ use crate::{
     bundle::{Bundle, InsertMode, NoBundleEffect},
     change_detection::MaybeLocation,
     entity::Entity,
-    error::{CommandOutput, ErrorContext, ErrorHandler, Result},
+    error::{BevyError, CommandOutput, ErrorContext, Result},
     event::Event,
     message::{Message, Messages},
     resource::Resource,
@@ -63,7 +63,10 @@ pub trait Command: Send + 'static {
     /// Takes a [`Command`] that returns a Result and uses a given error handler function to convert it into
     /// a [`Command`] that internally handles an error if it occurs and returns `()`.
     #[inline]
-    fn handle_error_with(self, error_handler: ErrorHandler) -> impl Command<Out = ()>
+    fn handle_error_with(
+        self,
+        error_handler: impl FnOnce(BevyError, ErrorContext) + Send + 'static,
+    ) -> impl Command<Out = ()>
     where
         Self: Sized,
     {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -695,7 +695,7 @@ impl<'w, 's> Commands<'w, 's> {
     pub fn queue_handled(
         &mut self,
         command: impl Command,
-        error_handler: fn(BevyError, ErrorContext),
+        error_handler: impl FnOnce(BevyError, ErrorContext) + Send + 'static,
     ) {
         self.queue_internal(command.handle_error_with(error_handler));
     }
@@ -2069,7 +2069,7 @@ impl<'a> EntityCommands<'a> {
     pub fn queue_handled(
         &mut self,
         command: impl EntityCommand,
-        error_handler: fn(BevyError, ErrorContext),
+        error_handler: impl FnOnce(BevyError, ErrorContext) + Send + 'static,
     ) -> &mut Self {
         self.commands
             .queue_handled(command.with_entity(self.entity), error_handler);


### PR DESCRIPTION
# Objective

Reduce the memory consumption of commands.  

`Command::handle_error_with` takes an error handler as a function pointer that gets included in the wrapped command.  This means commands that always use a custom error handler, such as `despawn()` and `remove<B>()`, will need to include that function pointer in the command buffer.  

## Solution

Change `Command::handle_error_with`, `Commands::queue_handled`, and `EntityCommands::queue_handled` to take `impl FnOnce(...) + Send + 'static` instead of `fn(...)`.  Passing a function name will now pass a zero-sized function type that takes up no space in the command buffer.  

Function pointers implement `FnOnce`, so they can still be used when necessary.  

This could cause additional copies of a command to be compiled due to monomorphization, although the calls within the engine only ever pass `warn` and so will still only have one copy.  

## Testing

Measured the size of a command queue after enqueuing `despawn()` (which does `queue_handled(entity_command::despawn(), warn)`): 

```rust
let mut world = World::new();
let entity = world.spawn_empty().id();
let mut command_queue = CommandQueue::default();
let mut commands = Commands::new(&mut command_queue, &mut world);
commands.entity(entity).despawn();
println!("{:?}", command_queue);
```

Before:
```
CommandQueue { len_bytes: 24, caller: MaybeLocation { marker: PhantomData<&core::panic::location::Location<'_>> }, .. }
```

After:
```
CommandQueue { len_bytes: 16, caller: MaybeLocation { marker: PhantomData<&core::panic::location::Location<'_>> }, .. }
```

The number of bytes added to the command buffer for `despawn()` dropped from 24 to 16!  