### PR TITLE
Add bindless support for 2D materials.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5600,3 +5600,14 @@ name = "Light Probe Blending"
 description = "Demonstrates blending between multiple reflection probes"
 category = "3D Rendering"
 wasm = false
+
+[[example]]
+name = "shader_material_2d_bindless"
+path = "examples/shader/shader_material_2d_bindless.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.shader_material_2d_bindless]
+name = "Material - 2D Bindless"
+description = "Demonstrates bindless materials in 2D"
+category = "Shaders"
+wasm = false

--- a/assets/shaders/custom_material_2d_bindless.wgsl
+++ b/assets/shaders/custom_material_2d_bindless.wgsl
@@ -1,0 +1,48 @@
+#import bevy_sprite::mesh2d_vertex_output::VertexOutput
+#import bevy_sprite::mesh2d_bindings::mesh
+#import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d}
+// we can import items from shader modules in the assets folder with a quoted path
+#import "shaders/custom_material_import.wgsl"::COLOR_MULTIPLIER
+
+struct Color {
+    base_color: vec4<f32>,
+}
+
+// This structure is a mapping from bindless index to the index in the
+// appropriate slab
+struct MaterialBindings {
+    material: u32,              // 0
+    color_texture: u32,         // 1
+    color_texture_sampler: u32, // 2
+}
+
+#ifdef BINDLESS
+@group(#{MATERIAL_BIND_GROUP}) @binding(0) var<storage> materials: array<MaterialBindings>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(10) var<storage> material_color: binding_array<Color>;
+#else   // BINDLESS
+@group(#{MATERIAL_BIND_GROUP}) @binding(0) var<uniform> material_color: Color;
+@group(#{MATERIAL_BIND_GROUP}) @binding(1) var material_color_texture: texture_2d<f32>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(2) var material_color_sampler: sampler;
+#endif  // BINDLESS
+
+@fragment
+fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
+#ifdef BINDLESS
+    let slot = mesh[in.instance_index].material_bind_group_slot;
+    let base_color = material_color[materials[slot].material].base_color;
+#else   // BINDLESS
+    let base_color = material_color.base_color;
+#endif  // BINDLESS
+
+    return base_color * textureSampleLevel(
+#ifdef BINDLESS
+        bindless_textures_2d[materials[slot].color_texture],
+        bindless_samplers_filtering[materials[slot].color_texture_sampler],
+#else   // BINDLESS
+        material_color_texture,
+        material_color_sampler,
+#endif  // BINDLESS
+        in.uv,
+        0.0
+    );
+}

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -122,7 +122,7 @@ pub struct Opaque2dBinKey {
     /// Normally, this is the ID of the mesh, but for non-mesh items it might be
     /// the ID of another type of asset.
     pub asset_id: UntypedAssetId,
-    /// The ID of a bind group specific to the material.
+    /// The index of a bind group specific to the material.
     pub material_bind_group_index: Option<u32>,
 }
 
@@ -236,7 +236,7 @@ pub struct AlphaMask2dBinKey {
     /// Normally, this is the ID of the mesh, but for non-mesh items it might be
     /// the ID of another type of asset.
     pub asset_id: UntypedAssetId,
-    /// The ID of a bind group specific to the material.
+    /// The index of a bind group specific to the material.
     pub material_bind_group_index: Option<u32>,
 }
 

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -34,8 +34,7 @@ use bevy_render::{
         ViewSortedRenderPhases,
     },
     render_resource::{
-        BindGroupId, CachedRenderPipelineId, TextureDescriptor, TextureDimension, TextureFormat,
-        TextureUsages,
+        CachedRenderPipelineId, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
     },
     renderer::RenderDevice,
     sync_world::MainEntity,
@@ -112,7 +111,7 @@ pub struct Opaque2d {
 }
 
 /// Data that must be identical in order to batch phase items together.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct Opaque2dBinKey {
     /// The identifier of the render pipeline.
     pub pipeline: CachedRenderPipelineId,
@@ -124,7 +123,7 @@ pub struct Opaque2dBinKey {
     /// the ID of another type of asset.
     pub asset_id: UntypedAssetId,
     /// The ID of a bind group specific to the material.
-    pub material_bind_group_id: Option<BindGroupId>,
+    pub material_bind_group_index: Option<u32>,
 }
 
 impl PhaseItem for Opaque2d {
@@ -226,7 +225,7 @@ pub struct AlphaMask2d {
 }
 
 /// Data that must be identical in order to batch phase items together.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct AlphaMask2dBinKey {
     /// The identifier of the render pipeline.
     pub pipeline: CachedRenderPipelineId,
@@ -238,7 +237,7 @@ pub struct AlphaMask2dBinKey {
     /// the ID of another type of asset.
     pub asset_id: UntypedAssetId,
     /// The ID of a bind group specific to the material.
-    pub material_bind_group_id: Option<BindGroupId>,
+    pub material_bind_group_index: Option<u32>,
 }
 
 impl PhaseItem for AlphaMask2d {

--- a/crates/bevy_gizmos_render/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos_render/src/pipeline_2d.rs
@@ -53,11 +53,7 @@ impl Plugin for LineGizmo2dPlugin {
                 GizmoRenderSystems::QueueLineGizmos2d
                     .in_set(RenderSystems::Queue)
                     .ambiguous_with(bevy_sprite_render::queue_sprites)
-                    .ambiguous_with(
-                        bevy_sprite_render::queue_material2d_meshes::<
-                            bevy_sprite_render::ColorMaterial,
-                        >,
-                    ),
+                    .ambiguous_with(bevy_sprite_render::queue_material2d_meshes),
             )
             .add_systems(
                 RenderStartup,

--- a/crates/bevy_mesh/src/lib.rs
+++ b/crates/bevy_mesh/src/lib.rs
@@ -25,6 +25,7 @@ pub use mesh::*;
 pub use mikktspace::*;
 pub use primitives::*;
 pub use vertex::*;
+use wgpu_types::IndexFormat;
 pub use wgpu_types::VertexFormat;
 
 /// The mesh prelude.
@@ -87,14 +88,14 @@ impl BaseMeshPipelineKey {
     /// For non-strip topologies, [`Self::STRIP_INDEX_FORMAT_NONE`] is set regardless of the `strip_index_format` argument.
     pub fn from_primitive_topology_and_strip_index(
         primitive_topology: PrimitiveTopology,
-        strip_index_format: Option<wgpu_types::IndexFormat>,
+        strip_index_format: Option<IndexFormat>,
     ) -> Self {
         let index_bits = if primitive_topology.is_strip() {
             match strip_index_format {
                 None => BaseMeshPipelineKey::STRIP_INDEX_FORMAT_NONE,
                 Some(index_format) => match index_format {
-                    wgpu_types::IndexFormat::Uint16 => BaseMeshPipelineKey::STRIP_INDEX_FORMAT_U16,
-                    wgpu_types::IndexFormat::Uint32 => BaseMeshPipelineKey::STRIP_INDEX_FORMAT_U32,
+                    IndexFormat::Uint16 => BaseMeshPipelineKey::STRIP_INDEX_FORMAT_U16,
+                    IndexFormat::Uint32 => BaseMeshPipelineKey::STRIP_INDEX_FORMAT_U32,
                 },
             }
         } else {
@@ -117,6 +118,17 @@ impl BaseMeshPipelineKey {
             x if x == PrimitiveTopology::TriangleList as u64 => PrimitiveTopology::TriangleList,
             x if x == PrimitiveTopology::TriangleStrip as u64 => PrimitiveTopology::TriangleStrip,
             _ => PrimitiveTopology::default(),
+        }
+    }
+
+    /// Returns the [`IndexFormat`] that this mesh pipeline key specifies.
+    pub fn strip_index_format(&self) -> Option<IndexFormat> {
+        let index_bits = self.bits() & Self::STRIP_INDEX_FORMAT_RESERVED_BITS.bits();
+        match index_bits {
+            x if x == Self::STRIP_INDEX_FORMAT_U16.bits() => Some(IndexFormat::Uint16),
+            x if x == Self::STRIP_INDEX_FORMAT_U32.bits() => Some(IndexFormat::Uint32),
+            x if x == Self::STRIP_INDEX_FORMAT_NONE.bits() => None,
+            _ => unreachable!(),
         }
     }
 }

--- a/crates/bevy_pbr/src/diagnostic.rs
+++ b/crates/bevy_pbr/src/diagnostic.rs
@@ -7,9 +7,11 @@ use bevy_app::{Plugin, PreUpdate};
 use bevy_diagnostic::{Diagnostic, DiagnosticPath, Diagnostics, RegisterDiagnostic};
 use bevy_ecs::{resource::Resource, system::Res};
 use bevy_platform::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use bevy_render::{Extract, ExtractSchedule, RenderApp};
+use bevy_render::{
+    material_bind_groups::MaterialBindGroupAllocators, Extract, ExtractSchedule, RenderApp,
+};
 
-use crate::{Material, MaterialBindGroupAllocators};
+use crate::Material;
 
 pub struct MaterialAllocatorDiagnosticPlugin<M: Material> {
     suffix: &'static str,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -49,7 +49,6 @@ mod fog;
 mod light_probe;
 mod lightmap;
 mod material;
-mod material_bind_groups;
 mod medium;
 mod mesh_material;
 mod parallax;
@@ -75,7 +74,6 @@ pub use fog::*;
 pub use light_probe::*;
 pub use lightmap::*;
 pub use material::*;
-pub use material_bind_groups::*;
 pub use medium::*;
 pub use mesh_material::*;
 pub use parallax::*;
@@ -367,11 +365,7 @@ impl Plugin for PbrPlugin {
         render_app
             .add_systems(
                 RenderStartup,
-                (
-                    init_shadow_samplers,
-                    init_global_clusterable_object_meta,
-                    init_fallback_bindless_resources,
-                ),
+                (init_shadow_samplers, init_global_clusterable_object_meta),
             )
             .add_systems(
                 ExtractSchedule,
@@ -409,9 +403,7 @@ impl Plugin for PbrPlugin {
                 ),
             )
             .init_gpu_resource::<LightMeta>()
-            .init_gpu_resource::<RenderMaterialBindings>()
-            .init_resource::<RenderShadowLodOrigin>()
-            .allow_ambiguous_resource::<RenderMaterialBindings>();
+            .init_resource::<RenderShadowLodOrigin>();
 
         render_app.world_mut().add_observer(add_light_view_entities);
         render_app

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1,6 +1,3 @@
-use crate::material_bind_groups::{
-    FallbackBindlessResources, MaterialBindGroupAllocator, MaterialBindingId,
-};
 use crate::*;
 use alloc::sync::Arc;
 use bevy_asset::prelude::AssetChanged;
@@ -43,8 +40,12 @@ use bevy_render::camera::{DirtySpecializationSystems, DirtySpecializations, Pend
 use bevy_render::erased_render_asset::{
     ErasedRenderAsset, ErasedRenderAssetPlugin, ErasedRenderAssets, PrepareAssetError,
 };
+use bevy_render::material_bind_groups::{
+    material_uses_bindless_resources, MaterialBindGroupAllocators, MaterialBindingId,
+    RenderMaterialBindings,
+};
 use bevy_render::render_asset::{prepare_assets, RenderAssets};
-use bevy_render::renderer::RenderQueue;
+use bevy_render::view::RenderVisibleEntities;
 use bevy_render::GpuResourceAppExt;
 use bevy_render::RenderStartup;
 use bevy_render::{
@@ -60,7 +61,6 @@ use bevy_render::{
     Extract,
 };
 use bevy_render::{mesh::allocator::MeshAllocator, sync_world::MainEntityHashMap};
-use bevy_render::{texture::FallbackImage, view::RenderVisibleEntities};
 use bevy_shader::{Shader, ShaderDefVal};
 use bevy_utils::Parallel;
 use core::{
@@ -371,8 +371,6 @@ impl Plugin for MaterialsPlugin {
                 .init_resource::<DrawFunctions<Shadow>>()
                 .init_resource::<RenderMaterialInstances>()
                 .allow_ambiguous_resource::<RenderMaterialInstances>()
-                .init_resource::<MaterialBindGroupAllocators>()
-                .allow_ambiguous_resource::<MaterialBindGroupAllocators>()
                 .init_gpu_resource::<PendingMeshMaterialQueues>()
                 .allow_ambiguous_resource::<PendingMeshMaterialQueues>()
                 .init_gpu_resource::<PendingShadowQueues>()
@@ -396,15 +394,6 @@ impl Plugin for MaterialsPlugin {
                             .after(set_mesh_motion_vector_flags),
                         queue_material_meshes.in_set(RenderSystems::QueueMeshes),
                     ),
-                )
-                .add_systems(
-                    Render,
-                    (
-                        prepare_material_bind_groups,
-                        write_material_bind_group_buffers,
-                    )
-                        .chain()
-                        .in_set(RenderSystems::PrepareBindGroups),
                 )
                 .add_systems(
                     Render,
@@ -485,18 +474,7 @@ fn add_material_bind_group_allocator<M: Material>(
     render_device: Res<RenderDevice>,
     mut bind_group_allocators: ResMut<MaterialBindGroupAllocators>,
 ) {
-    bind_group_allocators.insert(
-        TypeId::of::<M>(),
-        MaterialBindGroupAllocator::new(
-            &render_device,
-            M::label(),
-            material_uses_bindless_resources::<M>(&render_device)
-                .then(|| M::bindless_descriptor())
-                .flatten(),
-            M::bind_group_layout_descriptor(&render_device),
-            M::bindless_slot_count(),
-        ),
-    );
+    bind_group_allocators.add::<M>(&render_device);
 }
 
 /// A key uniquely identifying a specialized [`MaterialPipeline`].
@@ -1496,14 +1474,6 @@ pub struct ShadowsDrawFunction;
 #[derive(DrawFunctionLabel, Debug, Hash, PartialEq, Eq, Clone, Default)]
 pub struct ShadowsDepthOnlyDrawFunction;
 
-/// A resource that maps each untyped material ID to its binding.
-///
-/// This duplicates information in `RenderAssets<M>`, but it doesn't have the
-/// `M` type parameter, so it can be used in untyped contexts like
-/// [`crate::render::mesh::collect_meshes_for_gpu_building`].
-#[derive(Resource, Default, Deref, DerefMut)]
-pub struct RenderMaterialBindings(HashMap<UntypedAssetId, MaterialBindingId>);
-
 /// Data prepared for a [`Material`] instance.
 pub struct PreparedMaterial {
     pub binding: MaterialBindingId,
@@ -1631,62 +1601,16 @@ where
         ): &mut SystemParamItem<Self::Param>,
     ) -> Result<Self::ErasedAsset, PrepareAssetError<Self::SourceAsset>> {
         let material_layout = M::bind_group_layout_descriptor(render_device);
-        let actual_material_layout = pipeline_cache.get_bind_group_layout(&material_layout);
 
-        let binding = match material.unprepared_bind_group(
-            &actual_material_layout,
-            render_device,
+        let binding = render_material_bindings.prepare_material(
+            &material,
+            material_id,
             material_param,
-            false,
-        ) {
-            Ok(unprepared) => {
-                let bind_group_allocator =
-                    bind_group_allocators.get_mut(&TypeId::of::<M>()).unwrap();
-                // Allocate or update the material.
-                match render_material_bindings.entry(material_id.into()) {
-                    Entry::Occupied(mut occupied_entry) => {
-                        // TODO: Have a fast path that doesn't require
-                        // recreating the bind group if only buffer contents
-                        // change. For now, we just delete and recreate the bind
-                        // group.
-                        bind_group_allocator.free(*occupied_entry.get());
-                        let new_binding =
-                            bind_group_allocator.allocate_unprepared(unprepared, &material_layout);
-                        *occupied_entry.get_mut() = new_binding;
-                        new_binding
-                    }
-                    Entry::Vacant(vacant_entry) => *vacant_entry.insert(
-                        bind_group_allocator.allocate_unprepared(unprepared, &material_layout),
-                    ),
-                }
-            }
-            Err(AsBindGroupError::RetryNextUpdate) => {
-                return Err(PrepareAssetError::RetryNextUpdate(material))
-            }
-            Err(AsBindGroupError::CreateBindGroupDirectly) => {
-                match material.as_bind_group(
-                    &material_layout,
-                    render_device,
-                    pipeline_cache,
-                    material_param,
-                ) {
-                    Ok(prepared_bind_group) => {
-                        let bind_group_allocator =
-                            bind_group_allocators.get_mut(&TypeId::of::<M>()).unwrap();
-                        // Store the resulting bind group directly in the slot.
-                        let material_binding_id =
-                            bind_group_allocator.allocate_prepared(prepared_bind_group);
-                        render_material_bindings.insert(material_id.into(), material_binding_id);
-                        material_binding_id
-                    }
-                    Err(AsBindGroupError::RetryNextUpdate) => {
-                        return Err(PrepareAssetError::RetryNextUpdate(material))
-                    }
-                    Err(other) => return Err(PrepareAssetError::AsBindGroupError(other)),
-                }
-            }
-            Err(other) => return Err(PrepareAssetError::AsBindGroupError(other)),
-        };
+            &material_layout,
+            bind_group_allocators,
+            render_device,
+            pipeline_cache,
+        )?;
 
         let shadows_enabled = M::enable_shadows();
         let prepass_enabled = M::enable_prepass();
@@ -1800,46 +1724,7 @@ where
             Self::Param,
         >,
     ) {
-        let Some(material_binding_id) = render_material_bindings.remove(&source_asset.untyped())
-        else {
-            return;
-        };
-        let bind_group_allocator = bind_group_allocators.get_mut(&TypeId::of::<M>()).unwrap();
-        bind_group_allocator.free(material_binding_id);
-    }
-}
-
-/// Creates and/or recreates any bind groups that contain materials that were
-/// modified this frame.
-pub fn prepare_material_bind_groups(
-    mut allocators: ResMut<MaterialBindGroupAllocators>,
-    render_device: Res<RenderDevice>,
-    pipeline_cache: Res<PipelineCache>,
-    fallback_image: Res<FallbackImage>,
-    fallback_resources: Res<FallbackBindlessResources>,
-) {
-    for (_, allocator) in allocators.iter_mut() {
-        allocator.prepare_bind_groups(
-            &render_device,
-            &pipeline_cache,
-            &fallback_resources,
-            &fallback_image,
-        );
-    }
-}
-
-/// Uploads the contents of all buffers that the [`MaterialBindGroupAllocator`]
-/// manages to the GPU.
-///
-/// Non-bindless allocators don't currently manage any buffers, so this method
-/// only has an effect for bindless allocators.
-pub fn write_material_bind_group_buffers(
-    mut allocators: ResMut<MaterialBindGroupAllocators>,
-    render_device: Res<RenderDevice>,
-    render_queue: Res<RenderQueue>,
-) {
-    for (_, allocator) in allocators.iter_mut() {
-        allocator.write_buffers(&render_device, &render_queue);
+        render_material_bindings.unload_material(source_asset, bind_group_allocators);
     }
 }
 

--- a/crates/bevy_pbr/src/meshlet/instance_manager.rs
+++ b/crates/bevy_pbr/src/meshlet/instance_manager.rs
@@ -1,7 +1,7 @@
 use super::{meshlet_mesh_manager::MeshletMeshManager, MeshletMesh, MeshletMesh3d};
 use crate::{
-    meshlet::asset::MeshletAabb, MaterialBindingId, MeshFlags, MeshTransforms, MeshUniform,
-    PreviousGlobalTransform, RenderMaterialBindings, RenderMaterialInstances,
+    meshlet::asset::MeshletAabb, MeshFlags, MeshTransforms, MeshUniform, PreviousGlobalTransform,
+    RenderMaterialInstances,
 };
 use bevy_asset::{AssetEvent, AssetServer, Assets, UntypedAssetId};
 use bevy_camera::visibility::RenderLayers;
@@ -14,7 +14,12 @@ use bevy_ecs::{
 };
 use bevy_light::{NotShadowCaster, NotShadowReceiver};
 use bevy_platform::collections::{HashMap, HashSet};
-use bevy_render::{render_resource::StorageBuffer, sync_world::MainEntity, MainWorld};
+use bevy_render::{
+    material_bind_groups::{MaterialBindingId, RenderMaterialBindings},
+    render_resource::StorageBuffer,
+    sync_world::MainEntity,
+    MainWorld,
+};
 use bevy_transform::components::GlobalTransform;
 use core::ops::DerefMut;
 

--- a/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
+++ b/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
@@ -21,7 +21,10 @@ use bevy_mesh::{
 };
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_render::{camera::ExtractedCamera, erased_render_asset::ErasedRenderAssets};
-use bevy_render::{camera::TemporalJitter, render_resource::*, view::ExtractedView};
+use bevy_render::{
+    camera::TemporalJitter, material_bind_groups::MaterialBindGroupAllocators, render_resource::*,
+    view::ExtractedView,
+};
 use bevy_utils::default;
 use core::any::TypeId;
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1,9 +1,5 @@
 use crate::contact_shadows::ViewContactShadowsUniformOffset;
-use crate::{
-    material_bind_groups::{MaterialBindGroupIndex, MaterialBindGroupSlot},
-    resources::prepare_atmosphere_buffers,
-    skin::skin_uniforms_from_world,
-};
+use crate::{resources::prepare_atmosphere_buffers, skin::skin_uniforms_from_world};
 use alloc::sync::Arc;
 use bevy_asset::uuid::Uuid;
 use bevy_asset::{embedded_asset, load_embedded_asset, AssetId, AssetIndex, AssetServer};
@@ -44,6 +40,9 @@ use bevy_render::batching::gpu_preprocessing::{
     BufferDataInput, PreviousInstanceInputUniformBuffer,
 };
 use bevy_render::impl_atomic_pod;
+use bevy_render::material_bind_groups::{
+    MaterialBindGroupIndex, MaterialBindGroupSlot, MaterialBindingId, RenderMaterialBindings,
+};
 use bevy_render::mesh::allocator::{MeshSlabId, MeshSlabs};
 use bevy_render::mesh::morph::{
     MorphTargetImage, MorphTargetsResource, RenderMorphTargetAllocator,
@@ -79,7 +78,6 @@ use core::iter;
 use core::mem::size_of;
 use core::sync::atomic::{AtomicU64, Ordering};
 use indexmap::IndexSet;
-use material_bind_groups::MaterialBindingId;
 use static_assertions::const_assert_eq;
 use std::sync::mpsc;
 #[cfg(feature = "trace")]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -128,6 +128,7 @@ indexmap = { version = "2" }
 bitflags = "2"
 itertools = "0.14"
 weak-table = "0.3"
+tracing = "0.1"
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -86,7 +86,7 @@ use crate::{
     error_handler::{RenderErrorHandler, RenderState},
     extract_plugin::ExtractPlugin,
     gpu_readback::GpuReadbackPlugin,
-    material_bind_groups::MaterialBindGroupsPlugin,
+    material_bind_groups::MaterialBindGroupPlugin,
     mesh::{MeshRenderAssetPlugin, RenderMesh},
     render_asset::prepare_assets,
     render_resource::{PipelineCache, SparseBufferPlugin},
@@ -379,7 +379,7 @@ impl Plugin for RenderPlugin {
             GpuReadbackPlugin::default(),
             OcclusionCullingPlugin,
             SparseBufferPlugin,
-            MaterialBindGroupsPlugin,
+            MaterialBindGroupPlugin,
             #[cfg(feature = "tracing-tracy")]
             diagnostic::RenderDiagnosticsPlugin,
         ));

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -49,6 +49,7 @@ pub mod extract_resource;
 pub mod globals;
 pub mod gpu_component_array_buffer;
 pub mod gpu_readback;
+pub mod material_bind_groups;
 pub mod mesh;
 pub mod occlusion_culling;
 #[cfg(not(target_arch = "wasm32"))]
@@ -85,6 +86,7 @@ use crate::{
     error_handler::{RenderErrorHandler, RenderState},
     extract_plugin::ExtractPlugin,
     gpu_readback::GpuReadbackPlugin,
+    material_bind_groups::MaterialBindGroupsPlugin,
     mesh::{MeshRenderAssetPlugin, RenderMesh},
     render_asset::prepare_assets,
     render_resource::{PipelineCache, SparseBufferPlugin},
@@ -377,6 +379,7 @@ impl Plugin for RenderPlugin {
             GpuReadbackPlugin::default(),
             OcclusionCullingPlugin,
             SparseBufferPlugin,
+            MaterialBindGroupsPlugin,
             #[cfg(feature = "tracing-tracy")]
             diagnostic::RenderDiagnosticsPlugin,
         ));

--- a/crates/bevy_render/src/material_bind_groups.rs
+++ b/crates/bevy_render/src/material_bind_groups.rs
@@ -4,16 +4,29 @@
 //! allocator manages each bind group, assigning slots to materials as
 //! appropriate.
 
-use crate::Material;
+use bevy_app::{App, Plugin};
+use bevy_asset::{Asset, AssetId, UntypedAssetId};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     resource::Resource,
-    system::{Commands, Res},
+    schedule::IntoScheduleConfigs as _,
+    system::{Commands, Res, ResMut, SystemParamItem},
 };
-use bevy_platform::collections::{HashMap, HashSet};
+use bevy_platform::collections::{hash_map::Entry, HashMap, HashSet};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
-use bevy_render::render_resource::{BindlessSlabResourceLimit, PipelineCache};
-use bevy_render::{
+use bevy_utils::{default, TypeIdMap};
+use bytemuck::{Pod, Zeroable};
+use core::hash::Hash;
+use core::{cmp::Ordering, iter, mem, ops::Range};
+use std::any::TypeId;
+use tracing::{error, trace};
+
+use crate::{
+    erased_render_asset::PrepareAssetError,
+    render_resource::{AsBindGroup, AsBindGroupError, BindlessSlabResourceLimit, PipelineCache},
+    GpuResourceAppExt as _, Render, RenderApp, RenderStartup, RenderSystems,
+};
+use crate::{
     render_resource::{
         BindGroup, BindGroupEntry, BindGroupLayoutDescriptor, BindingNumber, BindingResource,
         BindingResources, BindlessDescriptor, BindlessIndex, BindlessIndexTableDescriptor,
@@ -27,14 +40,24 @@ use bevy_render::{
     settings::WgpuFeatures,
     texture::FallbackImage,
 };
-use bevy_utils::{default, TypeIdMap};
-use bytemuck::{Pod, Zeroable};
-use core::hash::Hash;
-use core::{cmp::Ordering, iter, mem, ops::Range};
-use tracing::{error, trace};
+
+/// A [`Plugin`] that provides the material bind group allocator.
+///
+/// The material bind group allocator is infrastructure for bindless resources.
+/// It packs multiple materials into a small number of bind groups, allowing
+/// Bevy to render large parts of the scene with a small number of drawcalls.
+pub struct MaterialBindGroupsPlugin;
 
 #[derive(Resource, Deref, DerefMut, Default)]
 pub struct MaterialBindGroupAllocators(TypeIdMap<MaterialBindGroupAllocator>);
+
+/// A resource that maps each untyped material ID to its binding.
+///
+/// This duplicates information in `RenderAssets<M>`, but it doesn't have the
+/// `M` type parameter, so it can be used in untyped contexts like
+/// [`crate::render::mesh::collect_meshes_for_gpu_building`].
+#[derive(Resource, Default, Deref, DerefMut)]
+pub struct RenderMaterialBindings(HashMap<UntypedAssetId, MaterialBindingId>);
 
 /// A resource that places materials into bind groups and tracks their
 /// resources.
@@ -455,6 +478,30 @@ impl GetBindingResourceId for TextureView {
             _ => panic!("Resource type is not a texture"),
         };
         BindingResourceId::TextureView(texture_view_dimension, self.id())
+    }
+}
+
+impl Plugin for MaterialBindGroupsPlugin {
+    fn build(&self, app: &mut App) {
+        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+
+        render_app
+            .init_resource::<MaterialBindGroupAllocators>()
+            .allow_ambiguous_resource::<MaterialBindGroupAllocators>()
+            .init_gpu_resource::<RenderMaterialBindings>()
+            .allow_ambiguous_resource::<RenderMaterialBindings>()
+            .add_systems(RenderStartup, init_fallback_bindless_resources)
+            .add_systems(
+                Render,
+                (
+                    prepare_material_bind_groups,
+                    write_material_bind_group_buffers,
+                )
+                    .chain()
+                    .in_set(RenderSystems::PrepareBindGroups),
+            );
     }
 }
 
@@ -1641,7 +1688,7 @@ where
     /// of the slot it was inserted into.
     fn insert(&mut self, binding_resource_id: BindingResourceId, resource: R) -> u32 {
         match self.resource_to_slot.entry(binding_resource_id) {
-            bevy_platform::collections::hash_map::Entry::Occupied(o) => {
+            Entry::Occupied(o) => {
                 let slot = *o.get();
 
                 self.bindings[slot as usize]
@@ -1651,7 +1698,7 @@ where
 
                 slot
             }
-            bevy_platform::collections::hash_map::Entry::Vacant(v) => {
+            Entry::Vacant(v) => {
                 let slot = self.free_slots.pop().unwrap_or(self.len);
                 v.insert(slot);
 
@@ -1715,7 +1762,7 @@ where
 /// into account.
 pub fn material_uses_bindless_resources<M>(render_device: &RenderDevice) -> bool
 where
-    M: Material,
+    M: AsBindGroup,
 {
     M::bindless_slot_count().is_some_and(|bindless_slot_count| {
         M::bindless_supported(render_device) && bindless_slot_count.resolve() > 1
@@ -2081,5 +2128,152 @@ impl MaterialDataBuffer {
     fn remove(&mut self, slot: u32) {
         self.free_slots.push(slot);
         self.len -= 1;
+    }
+}
+
+/// Creates and/or recreates any bind groups that contain materials that were
+/// modified this frame.
+pub fn prepare_material_bind_groups(
+    mut allocators: ResMut<MaterialBindGroupAllocators>,
+    render_device: Res<RenderDevice>,
+    pipeline_cache: Res<PipelineCache>,
+    fallback_image: Res<FallbackImage>,
+    fallback_resources: Res<FallbackBindlessResources>,
+) {
+    for (_, allocator) in allocators.iter_mut() {
+        allocator.prepare_bind_groups(
+            &render_device,
+            &pipeline_cache,
+            &fallback_resources,
+            &fallback_image,
+        );
+    }
+}
+
+/// Uploads the contents of all buffers that the [`MaterialBindGroupAllocator`]
+/// manages to the GPU.
+///
+/// Non-bindless allocators don't currently manage any buffers, so this method
+/// only has an effect for bindless allocators.
+pub fn write_material_bind_group_buffers(
+    mut allocators: ResMut<MaterialBindGroupAllocators>,
+    render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
+) {
+    for (_, allocator) in allocators.iter_mut() {
+        allocator.write_buffers(&render_device, &render_queue);
+    }
+}
+
+impl MaterialBindGroupAllocators {
+    /// Adds a new [`MaterialBindGroupAllocator`] to this resource to manage
+    /// materials of the given type.
+    pub fn add<M>(&mut self, render_device: &RenderDevice)
+    where
+        M: AsBindGroup + 'static,
+    {
+        self.insert(
+            TypeId::of::<M>(),
+            MaterialBindGroupAllocator::new(
+                render_device,
+                M::label(),
+                material_uses_bindless_resources::<M>(render_device)
+                    .then(|| M::bindless_descriptor())
+                    .flatten(),
+                M::bind_group_layout_descriptor(render_device),
+                M::bindless_slot_count(),
+            ),
+        );
+    }
+}
+
+impl RenderMaterialBindings {
+    /// Prepares a material asset for the render world.
+    ///
+    /// This method allocates the material in the bind group allocators and
+    /// returns its [`MaterialBindingId`].
+    pub fn prepare_material<M>(
+        &mut self,
+        material: &M,
+        material_id: AssetId<M>,
+        material_param: &mut SystemParamItem<'_, '_, M::Param>,
+        material_layout: &BindGroupLayoutDescriptor,
+        bind_group_allocators: &mut MaterialBindGroupAllocators,
+        render_device: &RenderDevice,
+        pipeline_cache: &PipelineCache,
+    ) -> Result<MaterialBindingId, PrepareAssetError<M>>
+    where
+        M: AsBindGroup + Asset + Clone,
+    {
+        let actual_material_layout = pipeline_cache.get_bind_group_layout(material_layout);
+
+        match material.unprepared_bind_group(
+            &actual_material_layout,
+            render_device,
+            material_param,
+            false,
+        ) {
+            Ok(unprepared) => {
+                let bind_group_allocator =
+                    bind_group_allocators.get_mut(&TypeId::of::<M>()).unwrap();
+                // Allocate or update the material.
+                match self.entry(material_id.into()) {
+                    Entry::Occupied(mut occupied_entry) => {
+                        // TODO: Have a fast path that doesn't require
+                        // recreating the bind group if only buffer contents
+                        // change. For now, we just delete and recreate the bind
+                        // group.
+                        bind_group_allocator.free(*occupied_entry.get());
+                        let new_binding =
+                            bind_group_allocator.allocate_unprepared(unprepared, material_layout);
+                        *occupied_entry.get_mut() = new_binding;
+                        Ok(new_binding)
+                    }
+                    Entry::Vacant(vacant_entry) => Ok(*vacant_entry.insert(
+                        bind_group_allocator.allocate_unprepared(unprepared, material_layout),
+                    )),
+                }
+            }
+            Err(AsBindGroupError::RetryNextUpdate) => {
+                Err(PrepareAssetError::RetryNextUpdate((*material).clone()))
+            }
+            Err(AsBindGroupError::CreateBindGroupDirectly) => {
+                match material.as_bind_group(
+                    material_layout,
+                    render_device,
+                    pipeline_cache,
+                    material_param,
+                ) {
+                    Ok(prepared_bind_group) => {
+                        let bind_group_allocator =
+                            bind_group_allocators.get_mut(&TypeId::of::<M>()).unwrap();
+                        // Store the resulting bind group directly in the slot.
+                        let material_binding_id =
+                            bind_group_allocator.allocate_prepared(prepared_bind_group);
+                        self.insert(material_id.into(), material_binding_id);
+                        Ok(material_binding_id)
+                    }
+                    Err(AsBindGroupError::RetryNextUpdate) => {
+                        Err(PrepareAssetError::RetryNextUpdate((*material).clone()))
+                    }
+                    Err(other) => Err(PrepareAssetError::AsBindGroupError(other)),
+                }
+            }
+            Err(other) => Err(PrepareAssetError::AsBindGroupError(other)),
+        }
+    }
+
+    /// Removes a material asset from the render world.
+    pub fn unload_material<M>(
+        &mut self,
+        source_asset: AssetId<M>,
+        bind_group_allocators: &mut MaterialBindGroupAllocators,
+    ) where
+        M: Asset + AsBindGroup + Clone,
+    {
+        if let Some(material_binding_id) = self.remove(&source_asset.untyped()) {
+            let bind_group_allocator = bind_group_allocators.get_mut(&TypeId::of::<M>()).unwrap();
+            bind_group_allocator.free(material_binding_id);
+        }
     }
 }

--- a/crates/bevy_render/src/material_bind_groups.rs
+++ b/crates/bevy_render/src/material_bind_groups.rs
@@ -55,7 +55,7 @@ pub struct MaterialBindGroupAllocators(TypeIdMap<MaterialBindGroupAllocator>);
 ///
 /// This duplicates information in `RenderAssets<M>`, but it doesn't have the
 /// `M` type parameter, so it can be used in untyped contexts like
-/// [`crate::render::mesh::collect_meshes_for_gpu_building`].
+/// `collect_meshes_for_gpu_building`.
 #[derive(Resource, Default, Deref, DerefMut)]
 pub struct RenderMaterialBindings(HashMap<UntypedAssetId, MaterialBindingId>);
 

--- a/crates/bevy_render/src/material_bind_groups.rs
+++ b/crates/bevy_render/src/material_bind_groups.rs
@@ -46,7 +46,7 @@ use crate::{
 /// The material bind group allocator is infrastructure for bindless resources.
 /// It packs multiple materials into a small number of bind groups, allowing
 /// Bevy to render large parts of the scene with a small number of drawcalls.
-pub struct MaterialBindGroupsPlugin;
+pub struct MaterialBindGroupPlugin;
 
 #[derive(Resource, Deref, DerefMut, Default)]
 pub struct MaterialBindGroupAllocators(TypeIdMap<MaterialBindGroupAllocator>);
@@ -481,7 +481,7 @@ impl GetBindingResourceId for TextureView {
     }
 }
 
-impl Plugin for MaterialBindGroupsPlugin {
+impl Plugin for MaterialBindGroupPlugin {
     fn build(&self, app: &mut App) {
         let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;

--- a/crates/bevy_sprite_render/Cargo.toml
+++ b/crates/bevy_sprite_render/Cargo.toml
@@ -45,6 +45,7 @@ bitflags = "2.3"
 nonmax = "0.5"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 smallvec = { version = "1", default-features = false }
+static_assertions = "1"
 
 [lints]
 workspace = true

--- a/crates/bevy_sprite_render/Cargo.toml
+++ b/crates/bevy_sprite_render/Cargo.toml
@@ -44,6 +44,7 @@ derive_more = { version = "2", default-features = false, features = ["from"] }
 bitflags = "2.3"
 nonmax = "0.5"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+smallvec = { version = "1", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/bevy_sprite_render/src/lib.rs
+++ b/crates/bevy_sprite_render/src/lib.rs
@@ -72,6 +72,7 @@ impl Plugin for SpriteRenderPlugin {
 
         app.add_plugins((
             Mesh2dRenderPlugin,
+            Materials2dPlugin,
             ColorMaterialPlugin,
             SpriteMeshPlugin,
             TilemapChunkPlugin,
@@ -113,7 +114,7 @@ impl Plugin for SpriteRenderPlugin {
                     (
                         queue_sprites
                             .in_set(RenderSystems::Queue)
-                            .ambiguous_with(queue_material2d_meshes::<ColorMaterial>),
+                            .ambiguous_with(queue_material2d_meshes),
                         prepare_sprite_image_bind_groups.in_set(RenderSystems::PrepareBindGroups),
                         prepare_sprite_view_bind_groups.in_set(RenderSystems::PrepareBindGroups),
                         sort_binned_render_phase::<Opaque2d>.in_set(RenderSystems::PhaseSort),

--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -300,6 +300,7 @@ impl Plugin for Materials2dPlugin {
             .add_render_command::<AlphaMask2d, DrawMaterial2d>()
             .add_render_command::<Transparent2d, DrawMaterial2d>()
             .init_resource::<RenderMaterial2dInstances>()
+            .allow_ambiguous_resource::<RenderMaterial2dInstances>()
             .add_systems(
                 RenderStartup,
                 init_material_2d_pipeline.after(init_mesh_2d_pipeline),

--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -2,6 +2,7 @@ use crate::{
     init_mesh_2d_pipeline, DrawMesh2d, Mesh2d, Mesh2dPipeline, Mesh2dPipelineKey,
     RenderMesh2dInstances, SetMesh2dBindGroup, SetMesh2dViewBindGroup, ViewKeyCache,
 };
+use alloc::sync::Arc;
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_asset::prelude::AssetChanged;
 use bevy_asset::{
@@ -15,6 +16,7 @@ use bevy_core_pipeline::{
     tonemapping::Tonemapping,
 };
 use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::system::{SystemParam, SystemState};
 use bevy_ecs::{
     prelude::*,
     system::{
@@ -22,32 +24,37 @@ use bevy_ecs::{
         SystemParamItem,
     },
 };
+use bevy_material::key::{ErasedMaterialKey, ErasedMaterialPipelineKey, ErasedMeshPipelineKey};
+use bevy_material::labels::{DrawFunctionLabel, InternedShaderLabel, ShaderLabel};
+use bevy_material::{AlphaMode, MaterialProperties, OpaqueRendererMethod, RenderPhaseType};
 use bevy_math::FloatOrd;
 use bevy_mesh::MeshVertexBufferLayoutRef;
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_platform::hash::FixedHasher;
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_render::camera::{DirtySpecializationSystems, DirtySpecializations, PendingQueues};
-use bevy_render::render_resource::BindGroupLayoutDescriptor;
+use bevy_render::erased_render_asset::{
+    ErasedRenderAsset, ErasedRenderAssetPlugin, ErasedRenderAssets, PrepareAssetError,
+};
+use bevy_render::material_bind_groups::{
+    material_uses_bindless_resources, MaterialBindGroupAllocators, MaterialBindingId,
+    RenderMaterialBindings,
+};
 use bevy_render::view::{RenderVisibleEntities, RetainedViewEntity};
 use bevy_render::{
     mesh::RenderMesh,
-    render_asset::{
-        prepare_assets, PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssets,
-    },
+    render_asset::{prepare_assets, RenderAssets},
     render_phase::{
-        AddRenderCommand, BinnedRenderPhaseType, DrawFunctionId, DrawFunctions, InputUniformIndex,
-        PhaseItem, PhaseItemExtraIndex, RenderCommand, RenderCommandResult, SetItemPipeline,
+        AddRenderCommand, BinnedRenderPhaseType, DrawFunctions, InputUniformIndex, PhaseItem,
+        PhaseItemExtraIndex, RenderCommand, RenderCommandResult, SetItemPipeline,
         TrackedRenderPass, ViewBinnedRenderPhases, ViewSortedRenderPhases,
     },
     render_resource::{
-        AsBindGroup, AsBindGroupError, BindGroup, BindGroupId, BindingResources,
-        CachedRenderPipelineId, PipelineCache, RenderPipelineDescriptor, SpecializedMeshPipeline,
-        SpecializedMeshPipelineError, SpecializedMeshPipelines,
+        AsBindGroup, BindGroupId, CachedRenderPipelineId, PipelineCache, RenderPipelineDescriptor,
+        SpecializedMeshPipeline, SpecializedMeshPipelineError, SpecializedMeshPipelines,
     },
     renderer::RenderDevice,
     sync_world::{MainEntity, MainEntityHashMap},
-    texture::GpuImage,
     view::ExtractedView,
     Extract, ExtractSchedule, GpuResourceAppExt, Render, RenderApp, RenderStartup, RenderSystems,
 };
@@ -55,6 +62,8 @@ use bevy_shader::{Shader, ShaderDefVal, ShaderRef};
 use bevy_utils::Parallel;
 use core::{hash::Hash, marker::PhantomData};
 use derive_more::derive::From;
+use smallvec::SmallVec;
+use std::any::{Any, TypeId};
 use tracing::error;
 
 pub const MATERIAL_2D_BIND_GROUP_INDEX: usize = 2;
@@ -163,6 +172,7 @@ pub trait Material2d: AsBindGroup + Asset + Clone + Sized {
     )]
     #[inline]
     fn specialize(
+        pipeline: &Material2dPipeline,
         descriptor: &mut RenderPipelineDescriptor,
         layout: &MeshVertexBufferLayoutRef,
         key: Material2dKey<Self>,
@@ -263,6 +273,50 @@ pub enum AlphaMode2d {
     Blend,
 }
 
+impl From<AlphaMode2d> for AlphaMode {
+    fn from(alpha_mode: AlphaMode2d) -> Self {
+        match alpha_mode {
+            AlphaMode2d::Opaque => AlphaMode::Opaque,
+            AlphaMode2d::Mask(mask) => AlphaMode::Mask(mask),
+            AlphaMode2d::Blend => AlphaMode::Blend,
+        }
+    }
+}
+
+/// A [`Plugin`] that supplies generic infrastructure for 2D materials.
+#[derive(Default)]
+pub struct Materials2dPlugin;
+
+impl Plugin for Materials2dPlugin {
+    fn build(&self, app: &mut App) {
+        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+
+        render_app
+            .init_gpu_resource::<SpecializedMaterial2dPipelineCache>()
+            .init_gpu_resource::<SpecializedMeshPipelines<Material2dPipelineSpecializer>>()
+            .add_render_command::<Opaque2d, DrawMaterial2d>()
+            .add_render_command::<AlphaMask2d, DrawMaterial2d>()
+            .add_render_command::<Transparent2d, DrawMaterial2d>()
+            .init_resource::<RenderMaterial2dInstances>()
+            .add_systems(
+                RenderStartup,
+                init_material_2d_pipeline.after(init_mesh_2d_pipeline),
+            )
+            .add_systems(
+                Render,
+                (
+                    specialize_material2d_meshes
+                        .in_set(RenderSystems::Specialize)
+                        .after(prepare_assets::<RenderMesh>)
+                        .after(prepare_pending_mesh_material2d_queues),
+                    queue_material2d_meshes.in_set(RenderSystems::QueueMeshes),
+                ),
+            );
+    }
+}
+
 /// Adds the necessary ECS resources and render logic to enable rendering entities using the given [`Material2d`]
 /// asset type (which includes [`Material2d`] types).
 pub struct Material2dPlugin<M: Material2d>(PhantomData<M>);
@@ -281,26 +335,19 @@ where
         app.init_asset::<M>()
             .init_resource::<EntitiesNeedingSpecialization<M>>()
             .register_type::<MeshMaterial2d<M>>()
-            .add_plugins(RenderAssetPlugin::<PreparedMaterial2d<M>, GpuImage>::default())
+            .add_plugins(ErasedRenderAssetPlugin::<MeshMaterial2d<M>>::default())
             .add_systems(
                 PostUpdate,
                 check_entities_needing_specialization::<M>.after(AssetEventSystems),
             );
 
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
+            let shaders = initialize_material2d_shaders::<M>(render_app.world());
             render_app
-                .init_gpu_resource::<SpecializedMaterial2dPipelineCache<M>>()
-                .add_render_command::<Opaque2d, DrawMaterial2d<M>>()
-                .add_render_command::<AlphaMask2d, DrawMaterial2d<M>>()
-                .add_render_command::<Transparent2d, DrawMaterial2d<M>>()
-                .init_resource::<RenderMaterial2dInstances<M>>()
-                .init_gpu_resource::<SpecializedMeshPipelines<Material2dPipeline<M>>>()
+                .insert_resource(Material2dShaders::<M>::with_shader_cache(shaders))
                 .init_resource::<PendingMeshMaterial2dQueues>()
                 .allow_ambiguous_resource::<PendingMeshMaterial2dQueues>()
-                .add_systems(
-                    RenderStartup,
-                    init_material_2d_pipeline::<M>.after(init_mesh_2d_pipeline),
-                )
+                .add_systems(RenderStartup, add_material2d_bind_group_allocator::<M>)
                 .add_systems(
                     ExtractSchedule,
                     (
@@ -310,36 +357,29 @@ where
                             .in_set(DirtySpecializationSystems::CheckForRemovals),
                         extract_mesh_materials_2d::<M>,
                     ),
-                )
-                .add_systems(
-                    Render,
-                    (
-                        specialize_material2d_meshes::<M>
-                            .in_set(RenderSystems::Specialize)
-                            .after(prepare_assets::<PreparedMaterial2d<M>>)
-                            .after(prepare_assets::<RenderMesh>)
-                            .after(prepare_pending_mesh_material2d_queues),
-                        queue_material2d_meshes::<M>
-                            .in_set(RenderSystems::QueueMeshes)
-                            .after(prepare_assets::<PreparedMaterial2d<M>>),
-                    ),
                 );
         }
     }
 }
 
-#[derive(Resource, Deref, DerefMut)]
-pub struct RenderMaterial2dInstances<M: Material2d>(MainEntityHashMap<AssetId<M>>);
-
-impl<M: Material2d> Default for RenderMaterial2dInstances<M> {
-    fn default() -> Self {
-        Self(Default::default())
-    }
+/// A render app system that creates a bind group allocator for a new 2D
+/// material.
+fn add_material2d_bind_group_allocator<M>(
+    render_device: Res<RenderDevice>,
+    mut bind_group_allocators: ResMut<MaterialBindGroupAllocators>,
+) where
+    M: Material2d,
+{
+    bind_group_allocators.add::<M>(&render_device);
 }
 
+/// A resource, part of the render world, that maps each renderable main-world
+/// entity to its material's asset ID.
+#[derive(Default, Resource, Deref, DerefMut)]
+pub struct RenderMaterial2dInstances(MainEntityHashMap<UntypedAssetId>);
+
 pub fn extract_mesh_materials_2d<M: Material2d>(
-    mut material_instances: ResMut<RenderMaterial2dInstances<M>>,
-    mut render_material_2d_ids: ResMut<RenderMaterial2dIds>,
+    mut material_instances: ResMut<RenderMaterial2dInstances>,
     changed_meshes_query: Extract<
         Query<
             (Entity, &ViewVisibility, &MeshMaterial2d<M>),
@@ -350,14 +390,9 @@ pub fn extract_mesh_materials_2d<M: Material2d>(
 ) {
     for (entity, view_visibility, material) in &changed_meshes_query {
         if view_visibility.get() {
-            add_mesh_instance(
-                entity,
-                material,
-                &mut material_instances,
-                &mut render_material_2d_ids,
-            );
+            add_mesh_instance(entity, material, &mut material_instances);
         } else {
-            remove_mesh_instance(entity, &mut material_instances, &mut render_material_2d_ids);
+            remove_mesh_instance(entity, &mut material_instances);
         }
     }
 
@@ -366,42 +401,38 @@ pub fn extract_mesh_materials_2d<M: Material2d>(
         // It's possible that a necessary component was removed and re-added in
         // the same frame.
         if !changed_meshes_query.contains(entity) {
-            remove_mesh_instance(entity, &mut material_instances, &mut render_material_2d_ids);
+            remove_mesh_instance(entity, &mut material_instances);
         }
     }
 
     fn add_mesh_instance<M>(
         entity: Entity,
         material: &MeshMaterial2d<M>,
-        material_instances: &mut RenderMaterial2dInstances<M>,
-        render_material_2d_ids: &mut RenderMaterial2dIds,
+        material_instances: &mut RenderMaterial2dInstances,
     ) where
         M: Material2d,
     {
-        material_instances.insert(entity.into(), material.id());
-        render_material_2d_ids.insert(entity.into(), material.id().into());
+        material_instances.insert(entity.into(), material.id().untyped());
     }
 
-    fn remove_mesh_instance<M>(
-        entity: Entity,
-        material_instances: &mut RenderMaterial2dInstances<M>,
-        render_material_2d_ids: &mut RenderMaterial2dIds,
-    ) where
-        M: Material2d,
-    {
+    fn remove_mesh_instance(entity: Entity, material_instances: &mut RenderMaterial2dInstances) {
         material_instances.remove(&MainEntity::from(entity));
-        render_material_2d_ids.remove(&MainEntity::from(entity));
     }
 }
 
 /// Render pipeline data for a given [`Material2d`]
-#[derive(Resource)]
-pub struct Material2dPipeline<M: Material2d> {
+#[derive(Resource, Clone)]
+pub struct Material2dPipeline {
     pub mesh2d_pipeline: Mesh2dPipeline,
-    pub material2d_layout: BindGroupLayoutDescriptor,
-    pub vertex_shader: Option<Handle<Shader>>,
-    pub fragment_shader: Option<Handle<Shader>>,
-    marker: PhantomData<M>,
+}
+
+/// A type that implements [`SpecializedMeshPipeline`], allowing pipelines to be
+/// specialized for a single material.
+pub struct Material2dPipelineSpecializer {
+    /// The material 2D pipeline to be specialized.
+    pub(crate) pipeline: Material2dPipeline,
+    /// Common material properties for that material.
+    pub(crate) properties: Arc<MaterialProperties>,
 }
 
 pub struct Material2dKey<M: Material2d> {
@@ -442,30 +473,20 @@ where
     }
 }
 
-impl<M: Material2d> Clone for Material2dPipeline<M> {
-    fn clone(&self) -> Self {
-        Self {
-            mesh2d_pipeline: self.mesh2d_pipeline.clone(),
-            material2d_layout: self.material2d_layout.clone(),
-            vertex_shader: self.vertex_shader.clone(),
-            fragment_shader: self.fragment_shader.clone(),
-            marker: PhantomData,
-        }
-    }
-}
-
-impl<M: Material2d> SpecializedMeshPipeline for Material2dPipeline<M>
-where
-    M::Data: PartialEq + Eq + Hash + Clone,
-{
-    type Key = Material2dKey<M>;
+impl SpecializedMeshPipeline for Material2dPipelineSpecializer {
+    type Key = ErasedMaterialPipelineKey;
 
     fn specialize(
         &self,
         key: Self::Key,
         layout: &MeshVertexBufferLayoutRef,
     ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
-        let mut descriptor = self.mesh2d_pipeline.specialize(key.mesh_key, layout)?;
+        let concrete_mesh_key: Mesh2dPipelineKey = key.mesh_key.downcast();
+        let mut descriptor = self
+            .pipeline
+            .mesh2d_pipeline
+            .specialize(concrete_mesh_key, layout)?;
+
         descriptor.vertex.shader_defs.push(ShaderDefVal::UInt(
             "MATERIAL_BIND_GROUP".into(),
             MATERIAL_2D_BIND_GROUP_INDEX as u32,
@@ -476,64 +497,54 @@ where
                 MATERIAL_2D_BIND_GROUP_INDEX as u32,
             ));
         }
-        if let Some(vertex_shader) = &self.vertex_shader {
+        if let Some(vertex_shader) = self.properties.get_shader(Material2dVertexShader) {
             descriptor.vertex.shader = vertex_shader.clone();
         }
 
-        if let Some(fragment_shader) = &self.fragment_shader {
+        if let Some(fragment_shader) = self.properties.get_shader(Material2dFragmentShader) {
             descriptor.fragment.as_mut().unwrap().shader = fragment_shader.clone();
         }
-        descriptor.layout = vec![
-            self.mesh2d_pipeline.view_layout.clone(),
-            self.mesh2d_pipeline.mesh_layout.clone(),
-            self.material2d_layout.clone(),
-        ];
 
-        M::specialize(&mut descriptor, layout, key)?;
+        descriptor
+            .layout
+            .insert(2, self.properties.material_layout.as_ref().unwrap().clone());
+
+        if let Some(specialize) = self.properties.user_specialize {
+            specialize(&self.pipeline as &dyn Any, &mut descriptor, layout, key)?;
+        }
+
+        // If bindless mode is on, add a `BINDLESS` define.
+        if self.properties.bindless {
+            descriptor.vertex.shader_defs.push("BINDLESS".into());
+            if let Some(ref mut fragment) = descriptor.fragment {
+                fragment.shader_defs.push("BINDLESS".into());
+            }
+        }
+
         Ok(descriptor)
     }
 }
 
-pub fn init_material_2d_pipeline<M: Material2d>(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-    render_device: Res<RenderDevice>,
-    mesh_2d_pipeline: Res<Mesh2dPipeline>,
-) {
-    let material2d_layout = M::bind_group_layout_descriptor(&render_device);
-
-    commands.insert_resource(Material2dPipeline::<M> {
+pub fn init_material_2d_pipeline(mut commands: Commands, mesh_2d_pipeline: Res<Mesh2dPipeline>) {
+    commands.insert_resource(Material2dPipeline {
         mesh2d_pipeline: mesh_2d_pipeline.clone(),
-        material2d_layout,
-        vertex_shader: match M::vertex_shader() {
-            ShaderRef::Default => None,
-            ShaderRef::Handle(handle) => Some(handle),
-            ShaderRef::Path(path) => Some(asset_server.load(path)),
-        },
-        fragment_shader: match M::fragment_shader() {
-            ShaderRef::Default => None,
-            ShaderRef::Handle(handle) => Some(handle),
-            ShaderRef::Path(path) => Some(asset_server.load(path)),
-        },
-        marker: PhantomData,
     });
 }
 
-pub(super) type DrawMaterial2d<M> = (
+pub(super) type DrawMaterial2d = (
     SetItemPipeline,
     SetMesh2dViewBindGroup<0>,
     SetMesh2dBindGroup<1>,
-    SetMaterial2dBindGroup<M, MATERIAL_2D_BIND_GROUP_INDEX>,
+    SetMaterial2dBindGroup<MATERIAL_2D_BIND_GROUP_INDEX>,
     DrawMesh2d,
 );
 
-pub struct SetMaterial2dBindGroup<M: Material2d, const I: usize>(PhantomData<M>);
-impl<P: PhaseItem, M: Material2d, const I: usize> RenderCommand<P>
-    for SetMaterial2dBindGroup<M, I>
-{
+pub struct SetMaterial2dBindGroup<const I: usize>;
+impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMaterial2dBindGroup<I> {
     type Param = (
-        SRes<RenderAssets<PreparedMaterial2d<M>>>,
-        SRes<RenderMaterial2dInstances<M>>,
+        SRes<ErasedRenderAssets<PreparedMaterial2d>>,
+        SRes<RenderMaterial2dInstances>,
+        SRes<MaterialBindGroupAllocators>,
     );
     type ViewQuery = ();
     type ItemQuery = ();
@@ -543,9 +554,15 @@ impl<P: PhaseItem, M: Material2d, const I: usize> RenderCommand<P>
         item: &P,
         _view: (),
         _item_query: Option<()>,
-        (materials, material_instances): SystemParamItem<'w, '_, Self::Param>,
+        (materials, material_instances, material_bind_group_allocators): SystemParamItem<
+            'w,
+            '_,
+            Self::Param,
+        >,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
+        let material_bind_group_allocators = material_bind_group_allocators.into_inner();
+
         let materials = materials.into_inner();
         let material_instances = material_instances.into_inner();
         let Some(material_instance) = material_instances.get(&item.main_entity()) else {
@@ -554,15 +571,31 @@ impl<P: PhaseItem, M: Material2d, const I: usize> RenderCommand<P>
         let Some(material2d) = materials.get(*material_instance) else {
             return RenderCommandResult::Skip;
         };
-        pass.set_bind_group(I, &material2d.bind_group, &[]);
+        let Some(material_bind_group_allocator) =
+            material_bind_group_allocators.get(&material_instance.type_id())
+        else {
+            return RenderCommandResult::Skip;
+        };
+        let Some(material_bind_group) = material_bind_group_allocator.get(material2d.binding.group)
+        else {
+            return RenderCommandResult::Skip;
+        };
+        let Some(bind_group) = material_bind_group.bind_group() else {
+            return RenderCommandResult::Skip;
+        };
+        pass.set_bind_group(I, bind_group, &[]);
         RenderCommandResult::Success
     }
 }
 
-pub const fn alpha_mode_pipeline_key(alpha_mode: AlphaMode2d) -> Mesh2dPipelineKey {
+/// Returns the 2D pipeline key for the given transparent alpha mode.
+///
+/// If the alpha mode is opaque, or if the alpha mode isn't supported by the 2D
+/// pipeline, returns [`Mesh2dPipelineKey::NONE`].
+pub const fn alpha_mode_pipeline_key_2d(alpha_mode: AlphaMode) -> Mesh2dPipelineKey {
     match alpha_mode {
-        AlphaMode2d::Blend => Mesh2dPipelineKey::BLEND_ALPHA,
-        AlphaMode2d::Mask(_) => Mesh2dPipelineKey::MAY_DISCARD,
+        AlphaMode::Blend => Mesh2dPipelineKey::BLEND_ALPHA,
+        AlphaMode::Mask(_) => Mesh2dPipelineKey::MAY_DISCARD,
         _ => Mesh2dPipelineKey::NONE,
     }
 }
@@ -636,40 +669,20 @@ impl<M> Default for EntitiesNeedingSpecialization<M> {
 }
 
 /// Stores the [`SpecializedMaterial2dViewPipelineCache`] for each view.
-#[derive(Resource, Deref, DerefMut)]
-pub struct SpecializedMaterial2dPipelineCache<M> {
+#[derive(Default, Resource, Deref, DerefMut)]
+pub struct SpecializedMaterial2dPipelineCache {
     // view_entity -> view pipeline cache
     #[deref]
-    map: MainEntityHashMap<SpecializedMaterial2dViewPipelineCache<M>>,
-    marker: PhantomData<M>,
+    map: HashMap<RetainedViewEntity, SpecializedMaterial2dViewPipelineCache>,
 }
 
 /// Stores the cached render pipeline ID for each entity in a single view, as
 /// well as the last time it was changed.
-#[derive(Deref, DerefMut)]
-pub struct SpecializedMaterial2dViewPipelineCache<M> {
+#[derive(Default, Deref, DerefMut)]
+pub struct SpecializedMaterial2dViewPipelineCache {
     // material entity -> (tick, pipeline_id)
     #[deref]
     map: MainEntityHashMap<CachedRenderPipelineId>,
-    marker: PhantomData<M>,
-}
-
-impl<M> Default for SpecializedMaterial2dPipelineCache<M> {
-    fn default() -> Self {
-        Self {
-            map: MainEntityHashMap::default(),
-            marker: PhantomData,
-        }
-    }
-}
-
-impl<M> Default for SpecializedMaterial2dViewPipelineCache<M> {
-    fn default() -> Self {
-        Self {
-            map: MainEntityHashMap::default(),
-            marker: PhantomData,
-        }
-    }
 }
 
 /// Finds 2D entities that have changed in such a way as to potentially require
@@ -740,151 +753,226 @@ pub fn prepare_pending_mesh_material2d_queues(
     pending_mesh_material2d_queues.expire_stale_views(&all_views);
 }
 
-pub fn specialize_material2d_meshes<M: Material2d>(
-    material2d_pipeline: Res<Material2dPipeline<M>>,
-    mut pipelines: ResMut<SpecializedMeshPipelines<Material2dPipeline<M>>>,
-    pipeline_cache: Res<PipelineCache>,
-    (render_meshes, render_materials): (
-        Res<RenderAssets<RenderMesh>>,
-        Res<RenderAssets<PreparedMaterial2d<M>>>,
-    ),
-    mut render_mesh_instances: ResMut<RenderMesh2dInstances>,
-    render_material_instances: Res<RenderMaterial2dInstances<M>>,
-    transparent_render_phases: Res<ViewSortedRenderPhases<Transparent2d>>,
-    opaque_render_phases: Res<ViewBinnedRenderPhases<Opaque2d>>,
-    alpha_mask_render_phases: Res<ViewBinnedRenderPhases<AlphaMask2d>>,
-    views: Query<(&MainEntity, &ExtractedView, &RenderVisibleEntities)>,
-    view_key_cache: Res<ViewKeyCache>,
-    dirty_specializations: Res<DirtySpecializations>,
-    mut pending_mesh_material2d_queues: ResMut<PendingMeshMaterial2dQueues>,
-    mut specialized_material_pipeline_cache: ResMut<SpecializedMaterial2dPipelineCache<M>>,
-) where
-    M::Data: PartialEq + Eq + Hash + Clone,
-{
-    if render_material_instances.is_empty() {
-        return;
-    }
-
-    for (view_entity, view, visible_entities) in &views {
-        if !transparent_render_phases.contains_key(&view.retained_view_entity)
-            && !opaque_render_phases.contains_key(&view.retained_view_entity)
-            && !alpha_mask_render_phases.contains_key(&view.retained_view_entity)
-        {
-            continue;
-        }
-
-        let Some(view_key) = view_key_cache.get(view_entity) else {
-            continue;
-        };
-
-        let view_specialized_material_pipeline_cache = specialized_material_pipeline_cache
-            .entry(*view_entity)
-            .or_default();
-
-        let Some(visible_entities) = visible_entities.get::<Mesh2d>() else {
-            continue;
-        };
-
-        // Remove cached pipeline IDs corresponding to entities that either
-        // have been removed or need to be re-specialized.
-        if dirty_specializations.must_wipe_specializations_for_view(view.retained_view_entity) {
-            view_specialized_material_pipeline_cache.clear();
-        } else {
-            for &renderable_entity in dirty_specializations.iter_to_despecialize() {
-                view_specialized_material_pipeline_cache.remove(&renderable_entity);
-            }
-        }
-
-        let Some(view_pending_mesh_material2d_queues) =
-            pending_mesh_material2d_queues.get_mut(&view.retained_view_entity)
-        else {
-            continue;
-        };
-
-        // Now process all 2D meshes that need to be re-specialized.
-        for (render_entity, visible_entity) in dirty_specializations.iter_to_specialize(
-            view.retained_view_entity,
-            visible_entities,
-            &view_pending_mesh_material2d_queues.prev_frame,
-        ) {
-            if view_specialized_material_pipeline_cache.contains_key(visible_entity) {
-                continue;
-            }
-
-            let Some(material_asset_id) = render_material_instances.get(visible_entity) else {
-                // Entity doesn't have this material type. Skip it; the
-                // correct material type's specialize system will handle it.
-                continue;
-            };
-            let Some(mesh_instance) = render_mesh_instances.get_mut(visible_entity) else {
-                continue;
-            };
-            let Some(material_2d) = render_materials.get(*material_asset_id) else {
-                // We couldn't fetch the material instance, probably because the
-                // material hasn't been loaded yet. Add the entity to the list
-                // of pending mesh materials and bail.
-                view_pending_mesh_material2d_queues
-                    .current_frame
-                    .insert((*render_entity, *visible_entity));
-                continue;
-            };
-            let Some(mesh) = render_meshes.get(mesh_instance.mesh_asset_id) else {
-                continue;
-            };
-            let mesh_key = *view_key
-                | Mesh2dPipelineKey::from_primitive_topology_and_strip_index(
-                    mesh.primitive_topology(),
-                    mesh.index_format(),
-                )
-                | material_2d.properties.mesh_pipeline_key_bits;
-
-            let pipeline_id = pipelines.specialize(
-                &pipeline_cache,
-                &material2d_pipeline,
-                Material2dKey {
-                    mesh_key,
-                    bind_group_data: material_2d.key.clone(),
-                },
-                &mesh.layout,
-            );
-
-            let pipeline_id = match pipeline_id {
-                Ok(id) => id,
-                Err(err) => {
-                    error!("{}", err);
-                    continue;
-                }
-            };
-
-            view_specialized_material_pipeline_cache.insert(*visible_entity, pipeline_id);
-        }
-    }
+/// The system parameter that [`specialize_material2d_meshes`] uses.
+///
+/// This has to be declared separately because [`specialize_material2d_meshes`]
+/// takes the [`World`] directly.
+#[derive(SystemParam)]
+pub struct SpecializeMaterial2dMeshesSystemParam<'w, 's> {
+    render_meshes: Res<'w, RenderAssets<RenderMesh>>,
+    render_materials: Res<'w, ErasedRenderAssets<PreparedMaterial2d>>,
+    render_mesh_instances: ResMut<'w, RenderMesh2dInstances>,
+    render_material_instances: Res<'w, RenderMaterial2dInstances>,
+    transparent_render_phases: Res<'w, ViewSortedRenderPhases<Transparent2d>>,
+    opaque_render_phases: Res<'w, ViewBinnedRenderPhases<Opaque2d>>,
+    alpha_mask_render_phases: Res<'w, ViewBinnedRenderPhases<AlphaMask2d>>,
+    views: Query<
+        'w,
+        's,
+        (
+            &'static MainEntity,
+            &'static ExtractedView,
+            &'static RenderVisibleEntities,
+        ),
+    >,
+    view_key_cache: Res<'w, ViewKeyCache>,
+    specialized_material2d_pipeline_cache: ResMut<'w, SpecializedMaterial2dPipelineCache>,
+    dirty_specializations: Res<'w, DirtySpecializations>,
+    pending_mesh_material2d_queues: ResMut<'w, PendingMeshMaterial2dQueues>,
 }
 
-pub fn queue_material2d_meshes<M: Material2d>(
+/// Specializes and compiles pipelines for 2D materials that haven't been seen
+/// yet.
+pub fn specialize_material2d_meshes(
+    world: &mut World,
+    state: &mut SystemState<SpecializeMaterial2dMeshesSystemParam>,
+    mut work_items: Local<Vec<Specialization2dWorkItem>>,
+    mut all_views: Local<HashSet<RetainedViewEntity, FixedHasher>>,
+) {
+    work_items.clear();
+    all_views.clear();
+
+    {
+        let SpecializeMaterial2dMeshesSystemParam {
+            render_meshes,
+            render_materials,
+            mut render_mesh_instances,
+            render_material_instances,
+            transparent_render_phases,
+            opaque_render_phases,
+            alpha_mask_render_phases,
+            views,
+            view_key_cache,
+            mut specialized_material2d_pipeline_cache,
+            dirty_specializations,
+            mut pending_mesh_material2d_queues,
+        } = state.get_mut(world).unwrap();
+
+        if render_material_instances.is_empty() {
+            return;
+        }
+
+        for (view_entity, view, visible_entities) in &views {
+            all_views.insert(view.retained_view_entity);
+
+            if !transparent_render_phases.contains_key(&view.retained_view_entity)
+                && !opaque_render_phases.contains_key(&view.retained_view_entity)
+                && !alpha_mask_render_phases.contains_key(&view.retained_view_entity)
+            {
+                continue;
+            }
+
+            let Some(view_key) = view_key_cache.get(view_entity) else {
+                continue;
+            };
+
+            let view_specialized_material_pipeline_cache = specialized_material2d_pipeline_cache
+                .entry(view.retained_view_entity)
+                .or_default();
+
+            let Some(visible_entities) = visible_entities.get::<Mesh2d>() else {
+                continue;
+            };
+
+            // Remove cached pipeline IDs corresponding to entities that either
+            // have been removed or need to be re-specialized.
+            if dirty_specializations.must_wipe_specializations_for_view(view.retained_view_entity) {
+                view_specialized_material_pipeline_cache.clear();
+            } else {
+                for &renderable_entity in dirty_specializations.iter_to_despecialize() {
+                    view_specialized_material_pipeline_cache.remove(&renderable_entity);
+                }
+            }
+
+            let Some(view_pending_mesh_material2d_queues) =
+                pending_mesh_material2d_queues.get_mut(&view.retained_view_entity)
+            else {
+                continue;
+            };
+
+            // Now process all 2D meshes that need to be re-specialized.
+            for (render_entity, visible_entity) in dirty_specializations.iter_to_specialize(
+                view.retained_view_entity,
+                visible_entities,
+                &view_pending_mesh_material2d_queues.prev_frame,
+            ) {
+                if view_specialized_material_pipeline_cache.contains_key(visible_entity) {
+                    continue;
+                }
+
+                let Some(material_asset_id) = render_material_instances.get(visible_entity) else {
+                    // Entity doesn't have this material type. Skip it; the
+                    // correct material type's specialize system will handle it.
+                    continue;
+                };
+                let Some(mesh_instance) = render_mesh_instances.get_mut(visible_entity) else {
+                    // We couldn't fetch the mesh instance, probably because the
+                    // material hasn't been loaded yet. Add the entity to the
+                    // list of pending mesh materials and bail.
+                    view_pending_mesh_material2d_queues
+                        .current_frame
+                        .insert((*render_entity, *visible_entity));
+                    continue;
+                };
+                let Some(material_2d) = render_materials.get(*material_asset_id) else {
+                    // We couldn't fetch the material instance, probably because the
+                    // material hasn't been loaded yet. Add the entity to the list
+                    // of pending mesh materials and bail.
+                    view_pending_mesh_material2d_queues
+                        .current_frame
+                        .insert((*render_entity, *visible_entity));
+                    continue;
+                };
+                let Some(mesh) = render_meshes.get(mesh_instance.mesh_asset_id) else {
+                    continue;
+                };
+
+                let mut mesh_pipeline_key_bits: Mesh2dPipelineKey =
+                    material_2d.properties.mesh_pipeline_key_bits.downcast();
+                mesh_pipeline_key_bits.insert(alpha_mode_pipeline_key_2d(
+                    material_2d.properties.alpha_mode,
+                ));
+                let mesh_key = *view_key
+                    | Mesh2dPipelineKey::from_bits_retain(mesh.key_bits.bits())
+                    | mesh_pipeline_key_bits;
+
+                work_items.push(Specialization2dWorkItem {
+                    visible_entity: *visible_entity,
+                    retained_view_entity: view.retained_view_entity,
+                    mesh_key,
+                    layout: mesh.layout.clone(),
+                    properties: material_2d.properties.clone(),
+                    material_type_id: material_asset_id.type_id(),
+                });
+            }
+        }
+    }
+
+    for item in work_items.drain(..) {
+        let key = ErasedMaterialPipelineKey {
+            type_id: item.material_type_id,
+            mesh_key: ErasedMeshPipelineKey::new(item.mesh_key),
+            material_key: item.properties.material_key.clone(),
+        };
+
+        let pipeline_id = base_specialize(world, key, &item.layout, &item.properties);
+
+        let pipeline_id = match pipeline_id {
+            Ok(id) => id,
+            Err(err) => {
+                error!("{}", err);
+                continue;
+            }
+        };
+
+        let mut specialized_material_pipeline_cache =
+            world.resource_mut::<SpecializedMaterial2dPipelineCache>();
+        let view_specialized_material_pipeline_cache = specialized_material_pipeline_cache
+            .entry(item.retained_view_entity)
+            .or_default();
+        view_specialized_material_pipeline_cache.insert(item.visible_entity, pipeline_id);
+    }
+
+    world
+        .resource_mut::<SpecializedMaterial2dPipelineCache>()
+        .retain(|view, _| all_views.contains(view));
+}
+
+/// An internal type that [`specialize_material2d_meshes`] uses to store
+/// specialization jobs.
+pub struct Specialization2dWorkItem {
+    visible_entity: MainEntity,
+    retained_view_entity: RetainedViewEntity,
+    mesh_key: Mesh2dPipelineKey,
+    layout: MeshVertexBufferLayoutRef,
+    properties: Arc<MaterialProperties>,
+    material_type_id: TypeId,
+}
+
+/// Iterates over all 2D mesh instances that have changed, adding and removing
+/// them from render batches and bins as appropriate.
+pub fn queue_material2d_meshes(
     (render_meshes, render_materials): (
         Res<RenderAssets<RenderMesh>>,
-        Res<RenderAssets<PreparedMaterial2d<M>>>,
+        Res<ErasedRenderAssets<PreparedMaterial2d>>,
     ),
     mut render_mesh_instances: ResMut<RenderMesh2dInstances>,
-    render_material_instances: Res<RenderMaterial2dInstances<M>>,
+    render_material_instances: Res<RenderMaterial2dInstances>,
     mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent2d>>,
     mut opaque_render_phases: ResMut<ViewBinnedRenderPhases<Opaque2d>>,
     mut alpha_mask_render_phases: ResMut<ViewBinnedRenderPhases<AlphaMask2d>>,
-    views: Query<(&MainEntity, &ExtractedView, &RenderVisibleEntities)>,
+    views: Query<(&ExtractedView, &RenderVisibleEntities)>,
     dirty_specializations: Res<DirtySpecializations>,
     mut pending_mesh_material2d_queues: ResMut<PendingMeshMaterial2dQueues>,
-    specialized_material_pipeline_cache: ResMut<SpecializedMaterial2dPipelineCache<M>>,
-) where
-    M::Data: PartialEq + Eq + Hash + Clone,
-{
+    specialized_material_pipeline_cache: ResMut<SpecializedMaterial2dPipelineCache>,
+) {
     if render_material_instances.is_empty() {
         return;
     }
 
-    for (view_entity, view, visible_entities) in &views {
+    for (view, visible_entities) in &views {
         let Some(view_specialized_material_pipeline_cache) =
-            specialized_material_pipeline_cache.get(view_entity)
+            specialized_material_pipeline_cache.get(&view.retained_view_entity)
         else {
             continue;
         };
@@ -973,7 +1061,6 @@ pub fn queue_material2d_meshes<M: Material2d>(
             opaque_phase.remove(*visible_entity);
             alpha_mask_phase.remove(*visible_entity);
 
-            mesh_instance.material_bind_group_id = material_2d.get_bind_group_id();
             let mesh_z = mesh_instance.transforms.world_from_local.translation.z;
 
             // We don't support multidraw yet for 2D meshes, so we use this
@@ -988,12 +1075,18 @@ pub fn queue_material2d_meshes<M: Material2d>(
             };
 
             match material_2d.properties.alpha_mode {
-                AlphaMode2d::Opaque => {
+                AlphaMode::Opaque => {
+                    let Some(draw_function) = material_2d
+                        .properties
+                        .get_draw_function(Pass2dOpaqueDrawFunction)
+                    else {
+                        continue;
+                    };
                     let bin_key = Opaque2dBinKey {
                         pipeline: pipeline_id,
-                        draw_function: material_2d.properties.draw_function_id,
+                        draw_function,
                         asset_id: mesh_instance.mesh_asset_id.into(),
-                        material_bind_group_id: material_2d.get_bind_group_id().0,
+                        material_bind_group_index: Some(material_2d.binding.group.0),
                     };
                     opaque_phase.add(
                         BatchSetKey2d {
@@ -1005,12 +1098,18 @@ pub fn queue_material2d_meshes<M: Material2d>(
                         binned_render_phase_type,
                     );
                 }
-                AlphaMode2d::Mask(_) => {
+                AlphaMode::Mask(_) => {
+                    let Some(draw_function) = material_2d
+                        .properties
+                        .get_draw_function(Pass2dAlphaMaskDrawFunction)
+                    else {
+                        continue;
+                    };
                     let bin_key = AlphaMask2dBinKey {
                         pipeline: pipeline_id,
-                        draw_function: material_2d.properties.draw_function_id,
+                        draw_function,
                         asset_id: mesh_instance.mesh_asset_id.into(),
-                        material_bind_group_id: material_2d.get_bind_group_id().0,
+                        material_bind_group_index: Some(material_2d.binding.group.0),
                     };
                     alpha_mask_phase.add(
                         BatchSetKey2d {
@@ -1022,7 +1121,13 @@ pub fn queue_material2d_meshes<M: Material2d>(
                         binned_render_phase_type,
                     );
                 }
-                AlphaMode2d::Blend => {
+                _ => {
+                    let Some(draw_function) = material_2d
+                        .properties
+                        .get_draw_function(Pass2dTransparentDrawFunction)
+                    else {
+                        continue;
+                    };
                     // We have to use `Entity::PLACEHOLDER` as the render entity
                     // so that we can dequeue the items later with
                     // `iter_to_dequeue` above.
@@ -1039,7 +1144,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
                     // entity in its sorted phases.
                     transparent_phase.add_retained(Transparent2d {
                         entity: (Entity::PLACEHOLDER, *visible_entity),
-                        draw_function: material_2d.properties.draw_function_id,
+                        draw_function,
                         pipeline: pipeline_id,
                         // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
                         // lowest sort key and getting closer should increase. As we have
@@ -1058,56 +1163,34 @@ pub fn queue_material2d_meshes<M: Material2d>(
     }
 }
 
+/// The bind group ID that a single 2D material has been assigned to.
 #[derive(Component, Clone, Copy, Default, PartialEq, Eq, Deref, DerefMut)]
 pub struct Material2dBindGroupId(pub Option<BindGroupId>);
 
-#[derive(Resource, Default, Deref, DerefMut)]
-pub struct RenderMaterial2dBindGroupIds(HashMap<UntypedAssetId, Material2dBindGroupId>);
-
-#[derive(Resource, Default, Deref, DerefMut)]
-pub struct RenderMaterial2dIds(MainEntityHashMap<UntypedAssetId>);
-
-/// Common [`Material2d`] properties, calculated for a specific material instance.
-pub struct Material2dProperties {
-    /// The [`AlphaMode2d`] of this material.
-    pub alpha_mode: AlphaMode2d,
-    /// Add a bias to the view depth of the mesh which can be used to force a specific render order
-    /// for meshes with equal depth, to avoid z-fighting.
-    /// The bias is in depth-texture units so large values may
-    pub depth_bias: f32,
-    /// The bits in the [`Mesh2dPipelineKey`] for this material.
-    ///
-    /// These are precalculated so that we can just "or" them together in
-    /// [`queue_material2d_meshes`].
-    pub mesh_pipeline_key_bits: Mesh2dPipelineKey,
-    pub draw_function_id: DrawFunctionId,
-}
-
 /// Data prepared for a [`Material2d`] instance.
-pub struct PreparedMaterial2d<T: Material2d> {
-    pub bindings: BindingResources,
-    pub bind_group: BindGroup,
-    pub key: T::Data,
-    pub properties: Material2dProperties,
+pub struct PreparedMaterial2d {
+    /// Where the material is stored in the bind group allocator.
+    pub binding: MaterialBindingId,
+    /// Common properties for the material.
+    pub properties: Arc<MaterialProperties>,
 }
 
-impl<T: Material2d> PreparedMaterial2d<T> {
-    pub fn get_bind_group_id(&self) -> Material2dBindGroupId {
-        Material2dBindGroupId(Some(self.bind_group.id()))
-    }
-}
-
-impl<M: Material2d> RenderAsset for PreparedMaterial2d<M> {
+impl<M: Material2d> ErasedRenderAsset for MeshMaterial2d<M>
+where
+    M::Data: PartialEq + Eq + Hash + Clone,
+{
     type SourceAsset = M;
+    type ErasedAsset = PreparedMaterial2d;
 
     type Param = (
         SRes<RenderDevice>,
         SRes<PipelineCache>,
-        SRes<Material2dPipeline<M>>,
+        SResMut<MaterialBindGroupAllocators>,
+        SResMut<RenderMaterialBindings>,
         SRes<DrawFunctions<Opaque2d>>,
         SRes<DrawFunctions<AlphaMask2d>>,
         SRes<DrawFunctions<Transparent2d>>,
-        SResMut<RenderMaterial2dBindGroupIds>,
+        SRes<Material2dShaders<M>>,
         M::Param,
     );
 
@@ -1117,57 +1200,205 @@ impl<M: Material2d> RenderAsset for PreparedMaterial2d<M> {
         (
             render_device,
             pipeline_cache,
-            pipeline,
+            bind_group_allocators,
+            render_material_bindings,
             opaque_draw_functions,
             alpha_mask_draw_functions,
             transparent_draw_functions,
-            render_material_2d_bind_group_ids,
+            material_shaders,
             material_param,
         ): &mut SystemParamItem<Self::Param>,
-        _: Option<&Self>,
-    ) -> Result<Self, PrepareAssetError<Self::SourceAsset>> {
-        let bind_group_data = material.bind_group_data();
-        match material.as_bind_group(
-            &pipeline.material2d_layout,
+    ) -> Result<Self::ErasedAsset, PrepareAssetError<Self::SourceAsset>> {
+        let material_layout = M::bind_group_layout_descriptor(render_device);
+
+        let material_binding_id = render_material_bindings.prepare_material(
+            &material,
+            material_id,
+            material_param,
+            &material_layout,
+            bind_group_allocators,
             render_device,
             pipeline_cache,
-            material_param,
-        ) {
-            Ok(prepared) => {
-                let mut mesh_pipeline_key_bits = Mesh2dPipelineKey::empty();
-                mesh_pipeline_key_bits.insert(alpha_mode_pipeline_key(material.alpha_mode()));
+        )?;
 
-                let draw_function_id = match material.alpha_mode() {
-                    AlphaMode2d::Opaque => opaque_draw_functions.read().id::<DrawMaterial2d<M>>(),
-                    AlphaMode2d::Mask(_) => {
-                        alpha_mask_draw_functions.read().id::<DrawMaterial2d<M>>()
-                    }
-                    AlphaMode2d::Blend => {
-                        transparent_draw_functions.read().id::<DrawMaterial2d<M>>()
-                    }
-                };
+        let mut mesh_pipeline_key_bits = Mesh2dPipelineKey::empty();
+        mesh_pipeline_key_bits.insert(alpha_mode_pipeline_key_2d(material.alpha_mode().into()));
+        let mesh_pipeline_key_bits = ErasedMeshPipelineKey::new(mesh_pipeline_key_bits);
 
-                render_material_2d_bind_group_ids.insert(
-                    material_id.into(),
-                    Material2dBindGroupId(Some(prepared.bind_group.id())),
-                );
+        let render_phase_type = match material.alpha_mode() {
+            AlphaMode2d::Opaque => RenderPhaseType::Opaque,
+            AlphaMode2d::Mask(_) => RenderPhaseType::AlphaMask,
+            AlphaMode2d::Blend => RenderPhaseType::Transparent,
+        };
 
-                Ok(PreparedMaterial2d {
-                    bindings: prepared.bindings,
-                    bind_group: prepared.bind_group,
-                    key: bind_group_data,
-                    properties: Material2dProperties {
-                        depth_bias: material.depth_bias(),
-                        alpha_mode: material.alpha_mode(),
-                        mesh_pipeline_key_bits,
-                        draw_function_id,
-                    },
-                })
-            }
-            Err(AsBindGroupError::RetryNextUpdate) => {
-                Err(PrepareAssetError::RetryNextUpdate(material))
-            }
-            Err(other) => Err(PrepareAssetError::AsBindGroupError(other)),
+        let draw_opaque_2d = opaque_draw_functions.read().id::<DrawMaterial2d>();
+        let draw_alpha_mask_2d = alpha_mask_draw_functions.read().id::<DrawMaterial2d>();
+        let draw_transparent_2d = transparent_draw_functions.read().id::<DrawMaterial2d>();
+
+        let draw_functions = SmallVec::from_iter([
+            (Pass2dOpaqueDrawFunction.intern(), draw_opaque_2d),
+            (Pass2dAlphaMaskDrawFunction.intern(), draw_alpha_mask_2d),
+            (Pass2dTransparentDrawFunction.intern(), draw_transparent_2d),
+        ]);
+
+        let shaders = material_shaders.shaders.clone();
+
+        let bindless = material_uses_bindless_resources::<M>(render_device);
+        let bind_group_data = material.bind_group_data();
+        let material_key = ErasedMaterialKey::new(bind_group_data);
+
+        Ok(PreparedMaterial2d {
+            binding: material_binding_id,
+            properties: Arc::new(MaterialProperties {
+                depth_bias: material.depth_bias(),
+                alpha_mode: material.alpha_mode().into(),
+                material_layout: Some(material_layout),
+                bindless,
+                base_specialize: Some(base_specialize),
+                user_specialize: Some(user_specialize::<M>),
+                mesh_pipeline_key_bits,
+                render_method: OpaqueRendererMethod::Forward,
+                material_key,
+                render_phase_type,
+                reads_view_transmission_texture: false,
+                draw_functions,
+                shaders,
+                prepass_specialize: None,
+                shadows_enabled: false,
+                prepass_enabled: false,
+            }),
+        })
+    }
+}
+
+/// Creates a [`Material2dPipelineSpecializer`] and uses it to specialize a
+/// single 2D material.
+pub fn base_specialize(
+    world: &mut World,
+    key: ErasedMaterialPipelineKey,
+    layout: &MeshVertexBufferLayoutRef,
+    properties: &Arc<MaterialProperties>,
+) -> Result<CachedRenderPipelineId, SpecializedMeshPipelineError> {
+    world.resource_scope(
+        |world, mut pipelines: Mut<SpecializedMeshPipelines<Material2dPipelineSpecializer>>| {
+            let mesh2d_pipeline = world.resource::<Mesh2dPipeline>().clone();
+            let pipeline_cache = world.resource::<PipelineCache>();
+
+            let specializer = Material2dPipelineSpecializer {
+                pipeline: Material2dPipeline { mesh2d_pipeline },
+                properties: properties.clone(),
+            };
+
+            pipelines.specialize(pipeline_cache, &specializer, key, layout)
+        },
+    )
+}
+
+/// Calls the [`Material2d::specialize`] function for a single material in order
+/// to do any custom specializations that the material wishes.
+fn user_specialize<M>(
+    pipeline: &dyn Any,
+    descriptor: &mut RenderPipelineDescriptor,
+    mesh_layout: &MeshVertexBufferLayoutRef,
+    erased_key: ErasedMaterialPipelineKey,
+) -> Result<(), SpecializedMeshPipelineError>
+where
+    M: Material2d,
+    M::Data: Hash + Clone,
+{
+    let pipeline = pipeline.downcast_ref::<Material2dPipeline>().unwrap();
+    let material_key = erased_key.material_key.to_key();
+    let mesh_key: Mesh2dPipelineKey = erased_key.mesh_key.downcast();
+    M::specialize(
+        pipeline,
+        descriptor,
+        mesh_layout,
+        Material2dKey {
+            mesh_key,
+            bind_group_data: material_key,
+        },
+    )
+}
+
+/// Identifies the vertex shader for a 2D material.
+#[derive(ShaderLabel, Debug, Hash, PartialEq, Eq, Clone, Default)]
+pub struct Material2dVertexShader;
+/// Identifies the fragment shader for a 2D material.
+#[derive(ShaderLabel, Debug, Hash, PartialEq, Eq, Clone, Default)]
+pub struct Material2dFragmentShader;
+
+/// The draw function that draws binned opaque 2D meshes.
+#[derive(DrawFunctionLabel, Debug, Hash, PartialEq, Eq, Clone, Default)]
+pub struct Pass2dOpaqueDrawFunction;
+/// The draw function that draws binned alpha masked 2D meshes.
+#[derive(DrawFunctionLabel, Debug, Hash, PartialEq, Eq, Clone, Default)]
+pub struct Pass2dAlphaMaskDrawFunction;
+/// The draw function that draws sorted 2D meshes with alpha-blended
+/// transparency.
+#[derive(DrawFunctionLabel, Debug, Hash, PartialEq, Eq, Clone, Default)]
+pub struct Pass2dTransparentDrawFunction;
+
+/// A resource that caches resolved shader handles for a specific material type.
+#[derive(Resource)]
+pub struct Material2dShaders<M>
+where
+    M: Material2d,
+{
+    shaders: SmallVec<[(InternedShaderLabel, Handle<Shader>); 6]>,
+    marker: PhantomData<M>,
+}
+
+impl<M> Default for Material2dShaders<M>
+where
+    M: Material2d,
+{
+    fn default() -> Self {
+        Material2dShaders {
+            shaders: SmallVec::new(),
+            marker: PhantomData,
         }
     }
+}
+
+impl<M> Material2dShaders<M>
+where
+    M: Material2d,
+{
+    /// Creates a [`Material2dShaders`] from the given vertex and fragment
+    /// shaders.
+    pub fn with_shader_cache(
+        shaders: SmallVec<[(InternedShaderLabel, Handle<Shader>); 6]>,
+    ) -> Material2dShaders<M> {
+        Material2dShaders {
+            shaders,
+            marker: PhantomData,
+        }
+    }
+}
+
+/// Initializes the vertex and fragment shaders for a single 2D material.
+fn initialize_material2d_shaders<M>(
+    render_world: &World,
+) -> SmallVec<[(InternedShaderLabel, Handle<Shader>); 6]>
+where
+    M: Material2d,
+{
+    let asset_server = render_world.resource::<AssetServer>();
+    let mut shaders = SmallVec::new();
+
+    let mut add_shader = |label: InternedShaderLabel, shader_ref: ShaderRef| {
+        let maybe_shader = match shader_ref {
+            ShaderRef::Default => None,
+            ShaderRef::Handle(handle) => Some(handle),
+            ShaderRef::Path(path) => Some(asset_server.load(path)),
+        };
+        if let Some(shader) = maybe_shader {
+            shaders.push((label, shader));
+        }
+    };
+
+    add_shader(Material2dVertexShader.intern(), M::vertex_shader());
+    add_shader(Material2dFragmentShader.intern(), M::fragment_shader());
+
+    shaders
 }

--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -250,7 +250,7 @@ impl<M: Material2d> AsAssetId for MeshMaterial2d<M> {
 /// Sets how a 2d material's base color alpha channel is used for transparency.
 /// Currently, this only works with [`Mesh2d`]. Sprites are always transparent.
 ///
-/// This is very similar to [`AlphaMode`](bevy_material::AlphaMode) but this only applies to 2d meshes.
+/// This is very similar to [`AlphaMode`] but this only applies to 2d meshes.
 /// We use a separate type because 2d doesn't support all the transparency modes that 3d does.
 #[derive(Debug, Default, Reflect, Copy, Clone, PartialEq)]
 #[reflect(Default, Debug, Clone)]

--- a/crates/bevy_sprite_render/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh.rs
@@ -243,7 +243,9 @@ pub struct Mesh2dUniform {
 }
 
 impl Mesh2dUniform {
-    fn from_components(
+    /// Creates a new [`Mesh2dUniform`] from the given transform, bind group
+    /// slot, tag, and optional metadata index.
+    pub fn from_components(
         mesh_transforms: &Mesh2dTransforms,
         material_bind_group_slot: MaterialBindGroupSlot,
         tag: u32,

--- a/crates/bevy_sprite_render/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh.rs
@@ -4,6 +4,9 @@ use bevy_camera::{visibility::ViewVisibility, Camera2d, CompositingSpace};
 use bevy_platform::collections::HashMap;
 use bevy_render::{
     camera::{DirtySpecializations, ExtractedCamera},
+    material_bind_groups::{
+        MaterialBindGroupIndex, MaterialBindGroupSlot, MaterialBindingId, RenderMaterialBindings,
+    },
     mesh::{allocator::MeshSlabId, MeshMetadata, MeshMetadataFallbackBuffer},
     render_resource::binding_types::{storage_buffer_read_only, uniform_buffer_sized},
     RenderStartup,
@@ -11,8 +14,8 @@ use bevy_render::{
 use bevy_shader::{load_shader_library, Shader, ShaderDefVal, ShaderSettings};
 
 use crate::{
-    prepare_pending_mesh_material2d_queues, tonemapping_pipeline_key, Material2dBindGroupId,
-    PendingMeshMaterial2dQueues, RenderMaterial2dBindGroupIds, RenderMaterial2dIds,
+    prepare_pending_mesh_material2d_queues, tonemapping_pipeline_key, PendingMeshMaterial2dQueues,
+    RenderMaterial2dInstances,
 };
 use bevy_core_pipeline::{
     core_2d::{AlphaMask2d, Opaque2d, Transparent2d, CORE_2D_DEPTH_FORMAT},
@@ -28,7 +31,10 @@ use bevy_ecs::{
     system::{lifetimeless::*, SystemParamItem},
 };
 use bevy_math::{Affine3, Affine3Ext, Vec4};
-use bevy_mesh::{Mesh, Mesh2d, MeshAttributeCompressionFlags, MeshTag, MeshVertexBufferLayoutRef};
+use bevy_mesh::{
+    BaseMeshPipelineKey, Mesh, Mesh2d, MeshAttributeCompressionFlags, MeshTag,
+    MeshVertexBufferLayoutRef,
+};
 use bevy_render::prelude::Msaa;
 use bevy_render::RenderSystems::PrepareAssets;
 use bevy_render::{
@@ -85,10 +91,6 @@ impl Plugin for Mesh2dRenderPlugin {
                 .init_resource::<ViewKeyCache>()
                 .init_resource::<RenderMesh2dInstances>()
                 .allow_ambiguous_resource::<RenderMesh2dInstances>()
-                .init_resource::<RenderMaterial2dBindGroupIds>()
-                .allow_ambiguous_resource::<RenderMaterial2dBindGroupIds>()
-                .init_resource::<RenderMaterial2dIds>()
-                .allow_ambiguous_resource::<RenderMaterial2dIds>()
                 .init_gpu_resource::<SpecializedMeshPipelines<Mesh2dPipeline>>()
                 .add_systems(
                     RenderStartup,
@@ -234,6 +236,7 @@ pub struct Mesh2dUniform {
     pub local_from_world_transpose_a: [Vec4; 2],
     pub local_from_world_transpose_b: f32,
     pub flags: u32,
+    pub material_bind_group_slot: u32,
     pub tag: u32,
     pub metadata_index: u32,
 }
@@ -241,6 +244,7 @@ pub struct Mesh2dUniform {
 impl Mesh2dUniform {
     fn from_components(
         mesh_transforms: &Mesh2dTransforms,
+        material_bind_group_slot: MaterialBindGroupSlot,
         tag: u32,
         metadata_index: Option<u32>,
     ) -> Self {
@@ -250,6 +254,7 @@ impl Mesh2dUniform {
             world_from_local: mesh_transforms.world_from_local.to_transpose(),
             local_from_world_transpose_a,
             local_from_world_transpose_b,
+            material_bind_group_slot: material_bind_group_slot.0,
             flags: mesh_transforms.flags,
             tag,
             metadata_index: metadata_index.unwrap_or(0),
@@ -268,8 +273,8 @@ bitflags::bitflags! {
 
 pub struct RenderMesh2dInstance {
     pub transforms: Mesh2dTransforms,
+    pub material_bindings_index: MaterialBindingId,
     pub mesh_asset_id: AssetId<Mesh>,
-    pub material_bind_group_id: Material2dBindGroupId,
     pub automatic_batching: bool,
     pub tag: u32,
 }
@@ -282,8 +287,8 @@ pub struct Mesh2dMarker;
 
 pub fn extract_mesh2d(
     mut render_mesh_instances: ResMut<RenderMesh2dInstances>,
-    render_material_2d_bind_group_ids: Res<RenderMaterial2dBindGroupIds>,
-    render_material_instances: Res<RenderMaterial2dIds>,
+    render_material_instances: Res<RenderMaterial2dInstances>,
+    render_material_bindings: Res<RenderMaterialBindings>,
     query: Extract<
         Query<(
             Entity,
@@ -302,11 +307,18 @@ pub fn extract_mesh2d(
             continue;
         }
         let main_entity = entity.into();
-        let material_bind_group_id = render_material_instances
-            .get(&main_entity)
-            .and_then(|material_id| render_material_2d_bind_group_ids.get(material_id))
-            .copied()
-            .unwrap_or_default();
+
+        // Look up the material index. If we couldn't fetch the material index,
+        // then the material hasn't been prepared yet, perhaps because it hasn't
+        // yet loaded.
+        let Some(mesh_material) = render_material_instances.get(&main_entity) else {
+            continue;
+        };
+        let Some(mesh_material_binding_id) = render_material_bindings.get(mesh_material).copied()
+        else {
+            continue;
+        };
+
         render_mesh_instances.insert(
             main_entity,
             RenderMesh2dInstance {
@@ -314,8 +326,8 @@ pub fn extract_mesh2d(
                     world_from_local: transform.affine().into(),
                     flags: MeshFlags::empty().bits(),
                 },
+                material_bindings_index: mesh_material_binding_id,
                 mesh_asset_id: handle.0.id(),
-                material_bind_group_id,
                 automatic_batching: !no_automatic_batching,
                 tag: tag.map_or(0, |i| **i),
             },
@@ -378,8 +390,8 @@ pub fn init_mesh_2d_pipeline(
 
 impl GetBatchData for Mesh2dPipeline {
     type Param = (SRes<RenderMesh2dInstances>, SRes<MeshAllocator>);
-    type BatchSetCompareData = (Material2dBindGroupId, AssetId<Mesh>);
-    type BatchCompareData = ();
+    type BatchSetCompareData = AssetId<Mesh>;
+    type BatchCompareData = MaterialBindGroupIndex;
     type BufferData = Mesh2dUniform;
 
     fn get_batch_data(
@@ -393,20 +405,18 @@ impl GetBatchData for Mesh2dPipeline {
         let metadata_index = mesh_allocator
             .mesh_metadata_slice(&mesh_instance.mesh_asset_id)
             .map(|mesh_metadata_slice| mesh_metadata_slice.range.start);
+        let material_bind_group_index = mesh_instance.material_bindings_index;
 
         Some((
             Mesh2dUniform::from_components(
                 &mesh_instance.transforms,
+                material_bind_group_index.slot,
                 mesh_instance.tag,
                 metadata_index,
             ),
-            mesh_instance.automatic_batching.then_some((
-                (
-                    mesh_instance.material_bind_group_id,
-                    mesh_instance.mesh_asset_id,
-                ),
-                (),
-            )),
+            mesh_instance
+                .automatic_batching
+                .then_some((mesh_instance.mesh_asset_id, material_bind_group_index.group)),
         ))
     }
 }
@@ -422,9 +432,11 @@ impl GetFullBatchData for Mesh2dPipeline {
         let metadata_index = mesh_allocator
             .mesh_metadata_slice(&mesh_instance.mesh_asset_id)
             .map(|mesh_metadata_slice| mesh_metadata_slice.range.start);
+        let material_bind_group_index = mesh_instance.material_bindings_index;
 
         Some(Mesh2dUniform::from_components(
             &mesh_instance.transforms,
+            material_bind_group_index.slot,
             mesh_instance.tag,
             metadata_index,
         ))
@@ -491,7 +503,8 @@ bitflags::bitflags! {
     // NOTE: Apparently quadro drivers support up to 64x MSAA.
     // MSAA uses the highest 3 bits for the MSAA log2(sample count) to support up to 128x MSAA.
     // FIXME: make normals optional?
-    pub struct Mesh2dPipelineKey: u32 {
+    // NB: This must be compatible with [`BaseMeshPipelineKey`].
+    pub struct Mesh2dPipelineKey: u64 {
         const NONE                              = 0;
         const TONEMAP_IN_SHADER                 = 1 << 0;
         const DEBAND_DITHER                     = 1 << 1;
@@ -501,7 +514,7 @@ bitflags::bitflags! {
         const OKLAB_COMPOSITING                 = 1 << 5;
         const COLOR_TARGET_FORMAT_RESERVED_BITS = Self::COLOR_TARGET_FORMAT_MASK_BITS << Self::COLOR_TARGET_FORMAT_SHIFT_BITS;
         const MSAA_RESERVED_BITS                = Self::MSAA_MASK_BITS << Self::MSAA_SHIFT_BITS;
-        const PRIMITIVE_TOPOLOGY_RESERVED_BITS  = Self::PRIMITIVE_TOPOLOGY_MASK_BITS << Self::PRIMITIVE_TOPOLOGY_SHIFT_BITS;
+        const PRIMITIVE_TOPOLOGY_RESERVED_BITS  = BaseMeshPipelineKey::PRIMITIVE_TOPOLOGY_MASK_BITS << BaseMeshPipelineKey::PRIMITIVE_TOPOLOGY_SHIFT_BITS;
         const TONEMAP_METHOD_RESERVED_BITS      = Self::TONEMAP_METHOD_MASK_BITS << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_NONE               = 0 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_REINHARD           = 1 << Self::TONEMAP_METHOD_SHIFT_BITS;
@@ -512,30 +525,26 @@ bitflags::bitflags! {
         const TONEMAP_METHOD_TONY_MC_MAPFACE    = 6 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_BLENDER_FILMIC     = 7 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_PBR_NEUTRAL        = 8 << Self::TONEMAP_METHOD_SHIFT_BITS;
-        const STRIP_INDEX_FORMAT_RESERVED_BITS        = Self::INDEX_FORMAT_MASK_BITS << Self::INDEX_FORMAT_SHIFT_BITS;
-        const STRIP_INDEX_FORMAT_NONE                 = 0 << Self::INDEX_FORMAT_SHIFT_BITS;
-        const STRIP_INDEX_FORMAT_U32                  = 1 << Self::INDEX_FORMAT_SHIFT_BITS;
-        const STRIP_INDEX_FORMAT_U16                  = 2 << Self::INDEX_FORMAT_SHIFT_BITS;
     }
 }
 
 impl Mesh2dPipelineKey {
-    const COLOR_TARGET_FORMAT_MASK_BITS: u32 = bevy_render::view::COLOR_TARGET_FORMAT_MASK_BITS;
+    const COLOR_TARGET_FORMAT_MASK_BITS: u64 =
+        bevy_render::view::COLOR_TARGET_FORMAT_MASK_BITS as u64;
     const COLOR_TARGET_FORMAT_SHIFT_BITS: u32 = 6;
-    const MSAA_MASK_BITS: u32 = 0b111;
-    const MSAA_SHIFT_BITS: u32 = 32 - Self::MSAA_MASK_BITS.count_ones();
-    const PRIMITIVE_TOPOLOGY_MASK_BITS: u32 = 0b111;
-    const PRIMITIVE_TOPOLOGY_SHIFT_BITS: u32 = Self::MSAA_SHIFT_BITS - 3;
-    const TONEMAP_METHOD_MASK_BITS: u32 = 0b1111;
-    const TONEMAP_METHOD_SHIFT_BITS: u32 =
-        Self::PRIMITIVE_TOPOLOGY_SHIFT_BITS - Self::TONEMAP_METHOD_MASK_BITS.count_ones();
-    pub const INDEX_FORMAT_MASK_BITS: u32 = 0b11;
-    pub const INDEX_FORMAT_SHIFT_BITS: u32 =
-        Self::TONEMAP_METHOD_SHIFT_BITS - Self::TONEMAP_METHOD_MASK_BITS.count_ones();
+    const MSAA_MASK_BITS: u64 = 0b111;
+    const MSAA_SHIFT_BITS: u64 = BaseMeshPipelineKey::STRIP_INDEX_FORMAT_SHIFT_BITS
+        - Self::MSAA_MASK_BITS.count_ones() as u64;
+    const TONEMAP_METHOD_MASK_BITS: u64 = 0b1111;
+    const TONEMAP_METHOD_SHIFT_BITS: u64 =
+        Self::MSAA_SHIFT_BITS - Self::TONEMAP_METHOD_MASK_BITS.count_ones() as u64;
+    pub const INDEX_FORMAT_MASK_BITS: u64 = 0b11;
+    pub const INDEX_FORMAT_SHIFT_BITS: u64 =
+        Self::TONEMAP_METHOD_SHIFT_BITS - Self::TONEMAP_METHOD_MASK_BITS.count_ones() as u64;
 
     pub fn from_msaa_samples(msaa_samples: u32) -> Self {
-        let msaa_bits =
-            (msaa_samples.trailing_zeros() & Self::MSAA_MASK_BITS) << Self::MSAA_SHIFT_BITS;
+        let msaa_bits = ((msaa_samples.trailing_zeros() as u64) & Self::MSAA_MASK_BITS)
+            << Self::MSAA_SHIFT_BITS;
         Self::from_bits_retain(msaa_bits)
     }
 
@@ -543,7 +552,7 @@ impl Mesh2dPipelineKey {
     #[inline]
     pub fn from_target_format(format: TextureFormat) -> Self {
         let code = texture_format_to_code(format)
-            .expect("Texture format is not supported by the pipeline") as u32;
+            .expect("Texture format is not supported by the pipeline") as u64;
         Self::from_bits_retain(
             (code & Self::COLOR_TARGET_FORMAT_MASK_BITS) << Self::COLOR_TARGET_FORMAT_SHIFT_BITS,
         )
@@ -562,52 +571,20 @@ impl Mesh2dPipelineKey {
         1 << ((self.bits() >> Self::MSAA_SHIFT_BITS) & Self::MSAA_MASK_BITS)
     }
 
-    /// Create a [`Mesh2dPipelineKey`] from mesh primitive topology and index format.
-    ///
-    /// For non-strip topologies, [`Self::STRIP_INDEX_FORMAT_NONE`] is set regardless of the `strip_index_format` argument.
-    pub fn from_primitive_topology_and_strip_index(
-        primitive_topology: PrimitiveTopology,
-        strip_index_format: Option<IndexFormat>,
-    ) -> Self {
-        let index_bits = if primitive_topology.is_strip() {
-            match strip_index_format {
-                None => Self::STRIP_INDEX_FORMAT_NONE,
-                Some(indices) => match indices {
-                    IndexFormat::Uint16 => Self::STRIP_INDEX_FORMAT_U16,
-                    IndexFormat::Uint32 => Self::STRIP_INDEX_FORMAT_U32,
-                },
-            }
-        } else {
-            Self::STRIP_INDEX_FORMAT_NONE
-        }
-        .bits();
-        let primitive_topology_bits = ((primitive_topology as u32)
-            & Self::PRIMITIVE_TOPOLOGY_MASK_BITS)
-            << Self::PRIMITIVE_TOPOLOGY_SHIFT_BITS;
-        Self::from_bits_retain(primitive_topology_bits | index_bits)
+    pub fn as_base_mesh_pipeline_key(&self) -> BaseMeshPipelineKey {
+        BaseMeshPipelineKey::from_bits_retain(self.bits())
     }
+}
 
-    pub fn primitive_topology(&self) -> PrimitiveTopology {
-        let primitive_topology_bits = (self.bits() >> Self::PRIMITIVE_TOPOLOGY_SHIFT_BITS)
-            & Self::PRIMITIVE_TOPOLOGY_MASK_BITS;
-        match primitive_topology_bits {
-            x if x == PrimitiveTopology::PointList as u32 => PrimitiveTopology::PointList,
-            x if x == PrimitiveTopology::LineList as u32 => PrimitiveTopology::LineList,
-            x if x == PrimitiveTopology::LineStrip as u32 => PrimitiveTopology::LineStrip,
-            x if x == PrimitiveTopology::TriangleList as u32 => PrimitiveTopology::TriangleList,
-            x if x == PrimitiveTopology::TriangleStrip as u32 => PrimitiveTopology::TriangleStrip,
-            _ => PrimitiveTopology::default(),
-        }
+impl From<u64> for Mesh2dPipelineKey {
+    fn from(value: u64) -> Self {
+        Mesh2dPipelineKey::from_bits_retain(value)
     }
+}
 
-    pub fn strip_index_format(&self) -> Option<IndexFormat> {
-        let index_bits = self.bits() & Self::STRIP_INDEX_FORMAT_RESERVED_BITS.bits();
-        match index_bits {
-            x if x == Self::STRIP_INDEX_FORMAT_U16.bits() => Some(IndexFormat::Uint16),
-            x if x == Self::STRIP_INDEX_FORMAT_U32.bits() => Some(IndexFormat::Uint32),
-            x if x == Self::STRIP_INDEX_FORMAT_NONE.bits() => None,
-            _ => unreachable!(),
-        }
+impl From<Mesh2dPipelineKey> for u64 {
+    fn from(value: Mesh2dPipelineKey) -> Self {
+        value.bits()
     }
 }
 
@@ -773,8 +750,8 @@ impl SpecializedMeshPipeline for Mesh2dPipeline {
                 unclipped_depth: false,
                 polygon_mode: PolygonMode::Fill,
                 conservative: false,
-                topology: key.primitive_topology(),
-                strip_index_format: key.strip_index_format(),
+                topology: key.as_base_mesh_pipeline_key().primitive_topology(),
+                strip_index_format: key.as_base_mesh_pipeline_key().strip_index_format(),
             },
             depth_stencil: Some(DepthStencilState {
                 format: CORE_2D_DEPTH_FORMAT,

--- a/crates/bevy_sprite_render/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh.rs
@@ -65,6 +65,7 @@ use bevy_render::{
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::default;
 use nonmax::NonMaxU32;
+use static_assertions::const_assert_eq;
 use tracing::error;
 
 #[derive(Default)]
@@ -512,9 +513,6 @@ bitflags::bitflags! {
         const MAY_DISCARD                       = 1 << 3;
         const SRGB_COMPOSITING                  = 1 << 4;
         const OKLAB_COMPOSITING                 = 1 << 5;
-        const COLOR_TARGET_FORMAT_RESERVED_BITS = Self::COLOR_TARGET_FORMAT_MASK_BITS << Self::COLOR_TARGET_FORMAT_SHIFT_BITS;
-        const MSAA_RESERVED_BITS                = Self::MSAA_MASK_BITS << Self::MSAA_SHIFT_BITS;
-        const PRIMITIVE_TOPOLOGY_RESERVED_BITS  = BaseMeshPipelineKey::PRIMITIVE_TOPOLOGY_MASK_BITS << BaseMeshPipelineKey::PRIMITIVE_TOPOLOGY_SHIFT_BITS;
         const TONEMAP_METHOD_RESERVED_BITS      = Self::TONEMAP_METHOD_MASK_BITS << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_NONE               = 0 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_REINHARD           = 1 << Self::TONEMAP_METHOD_SHIFT_BITS;
@@ -527,6 +525,13 @@ bitflags::bitflags! {
         const TONEMAP_METHOD_PBR_NEUTRAL        = 8 << Self::TONEMAP_METHOD_SHIFT_BITS;
     }
 }
+
+// Ensure that the bits of `BaseMeshPipelineKey` don't overlap with the bits of `MeshPipelineKey`
+// except the inherited bits.
+const_assert_eq!(
+    BaseMeshPipelineKey::all().bits() & Mesh2dPipelineKey::all().bits(),
+    0
+);
 
 impl Mesh2dPipelineKey {
     const COLOR_TARGET_FORMAT_MASK_BITS: u64 =

--- a/crates/bevy_sprite_render/src/mesh2d/mesh2d.wgsl
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh2d.wgsl
@@ -46,6 +46,9 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 #ifdef VERTEX_COLORS
     out.color = uncompressed_vertex.color;
 #endif
+
+    out.instance_index = vertex.instance_index;
+
     return out;
 }
 

--- a/crates/bevy_sprite_render/src/mesh2d/mesh2d_types.wgsl
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh2d_types.wgsl
@@ -13,6 +13,8 @@ struct Mesh2d {
     local_from_world_transpose_b: f32,
     // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32,
+    // Index of the material in the bind group data.
+    material_bind_group_slot: u32,
     tag: u32,
     /// The index of the mesh metadata buffer.
     metadata_index: u32,

--- a/crates/bevy_sprite_render/src/mesh2d/mesh2d_vertex_output.wgsl
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh2d_vertex_output.wgsl
@@ -13,4 +13,5 @@ struct VertexOutput {
     #ifdef VERTEX_COLORS
     @location(4) color: vec4<f32>,
     #endif
+    @location(5) @interpolate(flat) instance_index: u32,
 }

--- a/crates/bevy_sprite_render/src/mesh2d/wireframe2d.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/wireframe2d.rs
@@ -811,10 +811,7 @@ pub fn specialize_wireframes(
             };
 
             let mut mesh_key = *view_key;
-            mesh_key |= Mesh2dPipelineKey::from_primitive_topology_and_strip_index(
-                mesh.primitive_topology(),
-                mesh.index_format(),
-            );
+            mesh_key |= Mesh2dPipelineKey::from_bits_retain(mesh.key_bits.bits());
 
             let pipeline_id =
                 pipelines.specialize(&pipeline_cache, &pipeline, mesh_key, &mesh.layout);

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -8,37 +8,52 @@
 use bevy::{
     asset::RenderAssetUsages,
     color::palettes::basic::YELLOW,
-    core_pipeline::core_2d::{Transparent2d, CORE_2D_DEPTH_FORMAT},
+    core_pipeline::{core_2d::CORE_2D_DEPTH_FORMAT, Core2d, Core2dSystems},
+    ecs::{
+        entity::EntityHash,
+        system::{lifetimeless::SRes, SystemParamItem},
+    },
     math::{ops, FloatOrd},
     mesh::{BaseMeshPipelineKey, Indices, MeshVertexAttribute, VertexBufferLayout},
+    platform::collections::HashSet,
     prelude::*,
     render::{
-        material_bind_groups::RenderMaterialBindings,
-        mesh::RenderMesh,
+        batching::{no_gpu_preprocessing::batch_and_prepare_sorted_render_phase, GetBatchData},
+        camera::ExtractedCamera,
+        diagnostic::RecordDiagnostics as _,
+        material_bind_groups::{MaterialBindGroupIndex, MaterialBindGroupSlot},
+        mesh::{
+            allocator::MeshAllocator, MeshMetadataFallbackBuffer, RenderMesh, RenderMeshBufferInfo,
+        },
         render_asset::RenderAssets,
         render_phase::{
-            AddRenderCommand, DrawFunctions, PhaseItemExtraIndex, SetItemPipeline,
-            ViewSortedRenderPhases,
+            sort_phase_system, AddRenderCommand, CachedRenderPipelinePhaseItem, DrawFunctionId,
+            DrawFunctions, PhaseItem, PhaseItemExtraIndex, RenderCommand, RenderCommandResult,
+            SetItemPipeline, SortedPhaseItem, TrackedRenderPass, ViewSortedRenderPhases,
         },
         render_resource::{
-            BlendState, ColorTargetState, ColorWrites, CompareFunction, DepthBiasState,
-            DepthStencilState, Face, FragmentState, MultisampleState, PipelineCache,
-            PrimitiveState, PrimitiveTopology, RenderPipelineDescriptor, SpecializedRenderPipeline,
-            SpecializedRenderPipelines, StencilFaceState, StencilState, VertexFormat, VertexState,
-            VertexStepMode,
+            BlendState, CachedRenderPipelineId, ColorTargetState, ColorWrites, CompareFunction,
+            DepthBiasState, DepthStencilState, Face, FragmentState, MultisampleState,
+            PipelineCache, PrimitiveState, PrimitiveTopology, RenderPassDescriptor,
+            RenderPipelineDescriptor, SpecializedRenderPipeline, SpecializedRenderPipelines,
+            StencilFaceState, StencilState, StoreOp, VertexFormat, VertexState, VertexStepMode,
         },
+        renderer::{RenderContext, ViewQuery},
         sync_component::{SyncComponent, SyncComponentPlugin},
         sync_world::{MainEntity, MainEntityHashMap, RenderEntity},
-        view::{ExtractedView, RenderVisibleEntities},
+        view::{
+            ExtractedView, RenderVisibleEntities, RetainedViewEntity, ViewDepthTexture, ViewTarget,
+        },
         Extract, Render, RenderApp, RenderStartup, RenderSystems,
     },
     sprite_render::{
-        extract_mesh2d, init_mesh_2d_pipeline, DrawMesh2d, Mesh2dPipeline, Mesh2dPipelineKey,
-        Mesh2dTransforms, MeshFlags, RenderMaterial2dInstances, RenderMesh2dInstance,
-        SetMesh2dBindGroup, SetMesh2dViewBindGroup,
+        extract_mesh2d, init_mesh_2d_pipeline, Mesh2dBindGroup, Mesh2dPipeline, Mesh2dPipelineKey,
+        Mesh2dTransforms, Mesh2dUniform, MeshFlags, RenderMesh2dInstance, SetMesh2dViewBindGroup,
     },
 };
-use std::f32::consts::PI;
+use bevy_render::material_bind_groups::MaterialBindingId;
+use indexmap::IndexMap;
+use std::{f32::consts::PI, ops::Range};
 
 fn main() {
     App::new()
@@ -230,15 +245,15 @@ impl SpecializedRenderPipeline for ColoredMesh2dPipeline {
 }
 
 // This specifies how to render a colored 2d mesh
-type DrawColoredMesh2d = (
+type DrawTransparentColoredMesh2d = (
     // Set the pipeline
     SetItemPipeline,
     // Set the view uniform as bind group 0
     SetMesh2dViewBindGroup<0>,
     // Set the mesh uniform as bind group 1
-    SetMesh2dBindGroup<1>,
+    SetColoredMesh2dBindGroup<1>,
     // Draw the mesh
-    DrawMesh2d,
+    DrawColoredMesh2d,
 );
 
 // The custom shader can be inline like here, included from another file at build time
@@ -311,23 +326,190 @@ impl Plugin for ColoredMesh2dPlugin {
         // Register our custom draw function, and add our render systems
         app.get_sub_app_mut(RenderApp)
             .unwrap()
-            .insert_resource(ColoredMesh2dShader(shader))
-            .add_render_command::<Transparent2d, DrawColoredMesh2d>()
+            .init_resource::<DrawFunctions<TransparentColoredMesh2d>>()
+            // Declare a render phase, `TransparentColoredMesh2d`, to go with
+            // our pipeline.
+            .init_resource::<ViewSortedRenderPhases<TransparentColoredMesh2d>>()
+            // Declare the pipeline itself.
             .init_resource::<SpecializedRenderPipelines<ColoredMesh2dPipeline>>()
+            // Declare the render-world resource that will hold the instances.
             .init_resource::<RenderColoredMesh2dInstances>()
+            .insert_resource(ColoredMesh2dShader(shader))
+            // Declare a new render command.
+            .add_render_command::<TransparentColoredMesh2d, DrawTransparentColoredMesh2d>()
             .add_systems(
                 RenderStartup,
                 init_colored_mesh_2d_pipeline.after(init_mesh_2d_pipeline),
             )
             .add_systems(
                 ExtractSchedule,
-                extract_colored_mesh2d.after(extract_mesh2d),
+                (
+                    extract_colored_mesh2d.after(extract_mesh2d),
+                    extract_colored_mesh2d_camera_phases,
+                ),
             )
             .add_systems(
                 Render,
-                queue_colored_mesh2d.in_set(RenderSystems::QueueMeshes),
+                (
+                    sort_phase_system::<TransparentColoredMesh2d>.in_set(RenderSystems::PhaseSort),
+                    queue_colored_mesh2d.in_set(RenderSystems::QueueMeshes),
+                    // Make sure to prepare the render phase.
+                    batch_and_prepare_sorted_render_phase::<
+                        TransparentColoredMesh2d,
+                        ColoredMesh2dPipeline,
+                    >
+                        .in_set(RenderSystems::PrepareResources),
+                ),
+            )
+            .add_systems(
+                Core2d,
+                // Add the draw command to draw the items in our custom phase.
+                main_colored_transparent_pass_2d.in_set(Core2dSystems::MainPass),
             );
     }
+}
+
+/// Our own [`PhaseItem`].
+///
+/// Every render phase must be in 1:1 correspondence with a pipeline. Since we
+/// have our own custom pipeline, we must also declare a custom render phase to
+/// go with it.
+struct TransparentColoredMesh2d {
+    sort_key: FloatOrd,
+    entity: (Entity, MainEntity),
+    pipeline: CachedRenderPipelineId,
+    draw_function: DrawFunctionId,
+    batch_range: Range<u32>,
+    extra_index: PhaseItemExtraIndex,
+    /// Whether the mesh in question is indexed (uses an index buffer in
+    /// addition to its vertex buffer).
+    indexed: bool,
+}
+
+impl PhaseItem for TransparentColoredMesh2d {
+    #[inline]
+    fn entity(&self) -> Entity {
+        self.entity.0
+    }
+
+    #[inline]
+    fn main_entity(&self) -> MainEntity {
+        self.entity.1
+    }
+
+    #[inline]
+    fn draw_function(&self) -> DrawFunctionId {
+        self.draw_function
+    }
+
+    #[inline]
+    fn batch_range(&self) -> &Range<u32> {
+        &self.batch_range
+    }
+
+    #[inline]
+    fn batch_range_mut(&mut self) -> &mut Range<u32> {
+        &mut self.batch_range
+    }
+
+    #[inline]
+    fn extra_index(&self) -> PhaseItemExtraIndex {
+        self.extra_index.clone()
+    }
+
+    #[inline]
+    fn batch_range_and_extra_index_mut(&mut self) -> (&mut Range<u32>, &mut PhaseItemExtraIndex) {
+        (&mut self.batch_range, &mut self.extra_index)
+    }
+}
+
+impl SortedPhaseItem for TransparentColoredMesh2d {
+    type SortKey = FloatOrd;
+
+    #[inline]
+    fn sort_key(&self) -> Self::SortKey {
+        self.sort_key
+    }
+
+    #[inline]
+    fn sort(items: &mut IndexMap<(Entity, MainEntity), TransparentColoredMesh2d, EntityHash>) {
+        items.sort_by_key(|_, item| item.sort_key());
+    }
+
+    fn recalculate_sort_keys(
+        _: &mut IndexMap<(Entity, MainEntity), Self, EntityHash>,
+        _: &ExtractedView,
+    ) {
+        // Sort keys are precalculated for 2D phase items.
+    }
+
+    fn indexed(&self) -> bool {
+        self.indexed
+    }
+}
+
+impl CachedRenderPipelinePhaseItem for TransparentColoredMesh2d {
+    #[inline]
+    fn cached_pipeline(&self) -> CachedRenderPipelineId {
+        self.pipeline
+    }
+}
+
+impl GetBatchData for ColoredMesh2dPipeline {
+    type Param = (SRes<RenderColoredMesh2dInstances>, SRes<MeshAllocator>);
+    type BatchSetCompareData = AssetId<Mesh>;
+    type BatchCompareData = Option<MaterialBindGroupIndex>;
+    type BufferData = Mesh2dUniform;
+
+    fn get_batch_data(
+        (mesh_instances, mesh_allocator): &SystemParamItem<Self::Param>,
+        (_entity, main_entity): (Entity, MainEntity),
+    ) -> Option<(
+        Self::BufferData,
+        Option<(Self::BatchSetCompareData, Self::BatchCompareData)>,
+    )> {
+        let mesh_instance = mesh_instances.get(&main_entity)?;
+        let metadata_index = mesh_allocator
+            .mesh_metadata_slice(&mesh_instance.mesh_asset_id)
+            .map(|mesh_metadata_slice| mesh_metadata_slice.range.start);
+
+        Some((
+            Mesh2dUniform::from_components(
+                &mesh_instance.transforms,
+                MaterialBindGroupSlot(0),
+                mesh_instance.tag,
+                metadata_index,
+            ),
+            mesh_instance
+                .automatic_batching
+                .then_some((mesh_instance.mesh_asset_id, None)),
+        ))
+    }
+}
+
+/// Prepares our custom render phase for a new frame.
+fn extract_colored_mesh2d_camera_phases(
+    mut colored_mesh2d_render_phases: ResMut<ViewSortedRenderPhases<TransparentColoredMesh2d>>,
+    cameras_2d: Extract<Query<(Entity, &Camera), With<Camera2d>>>,
+    mut live_entities: Local<HashSet<RetainedViewEntity>>,
+) {
+    live_entities.clear();
+
+    for (main_entity, camera) in &cameras_2d {
+        if !camera.is_active {
+            continue;
+        }
+
+        // This is the main 2D camera, so we use the first subview index (0).
+        let retained_view_entity = RetainedViewEntity::new(main_entity.into(), None, 0);
+
+        colored_mesh2d_render_phases.prepare_for_new_frame(retained_view_entity);
+
+        live_entities.insert(retained_view_entity);
+    }
+
+    // Clear out all dead views.
+    colored_mesh2d_render_phases.retain(|camera_entity, _| live_entities.contains(camera_entity));
 }
 
 /// Extract the [`ColoredMesh2d`] marker component into the render app
@@ -349,8 +531,6 @@ pub fn extract_colored_mesh2d(
         >,
     >,
     mut render_mesh_instances: ResMut<RenderColoredMesh2dInstances>,
-    render_material_instances: Res<RenderMaterial2dInstances>,
-    render_material_bindings: Res<RenderMaterialBindings>,
 ) {
     let mut values = Vec::with_capacity(*previous_len);
     for (entity, render_entity, view_visibility, transform, handle) in &query {
@@ -363,24 +543,14 @@ pub fn extract_colored_mesh2d(
             flags: MeshFlags::empty().bits(),
         };
 
-        // Look up the material index. If we couldn't fetch the material index,
-        // then the material hasn't been prepared yet, perhaps because it hasn't
-        // yet loaded.
-        let Some(mesh_material) = render_material_instances.get(&MainEntity::from(entity)) else {
-            continue;
-        };
-        let Some(mesh_material_binding_id) = render_material_bindings.get(mesh_material).copied()
-        else {
-            continue;
-        };
-
         values.push((render_entity, ColoredMesh2d));
         render_mesh_instances.insert(
             entity.into(),
             RenderMesh2dInstance {
                 mesh_asset_id: handle.0.id(),
                 transforms,
-                material_bindings_index: mesh_material_binding_id,
+                // This is unused here.
+                material_bindings_index: MaterialBindingId::default(),
                 automatic_batching: false,
                 tag: 0,
             },
@@ -391,19 +561,20 @@ pub fn extract_colored_mesh2d(
 }
 
 /// Queue the 2d meshes marked with [`ColoredMesh2d`] using our custom pipeline and draw function
-pub fn queue_colored_mesh2d(
-    transparent_draw_functions: Res<DrawFunctions<Transparent2d>>,
+fn queue_colored_mesh2d(
+    transparent_draw_functions: Res<DrawFunctions<TransparentColoredMesh2d>>,
     colored_mesh2d_pipeline: Res<ColoredMesh2dPipeline>,
     mut pipelines: ResMut<SpecializedRenderPipelines<ColoredMesh2dPipeline>>,
     pipeline_cache: Res<PipelineCache>,
     render_meshes: Res<RenderAssets<RenderMesh>>,
     render_mesh_instances: Res<RenderColoredMesh2dInstances>,
-    mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent2d>>,
+    mut transparent_render_phases: ResMut<ViewSortedRenderPhases<TransparentColoredMesh2d>>,
     views: Query<(&RenderVisibleEntities, &ExtractedView, &Msaa)>,
 ) {
     if render_mesh_instances.is_empty() {
         return;
     }
+
     // Iterate each view (a camera is a view)
     for (visible_entities, view, msaa) in &views {
         let Some(transparent_phase) = transparent_render_phases.get_mut(&view.retained_view_entity)
@@ -411,7 +582,9 @@ pub fn queue_colored_mesh2d(
             continue;
         };
 
-        let draw_colored_mesh2d = transparent_draw_functions.read().id::<DrawColoredMesh2d>();
+        let draw_colored_mesh2d = transparent_draw_functions
+            .read()
+            .id::<DrawTransparentColoredMesh2d>();
 
         let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())
             | Mesh2dPipelineKey::from_target_format(view.target_format);
@@ -441,7 +614,7 @@ pub fn queue_colored_mesh2d(
                     pipelines.specialize(&pipeline_cache, &colored_mesh2d_pipeline, mesh2d_key);
 
                 let mesh_z = mesh2d_transforms.world_from_local.translation.z;
-                transparent_phase.add_retained(Transparent2d {
+                transparent_phase.add_retained(TransparentColoredMesh2d {
                     entity: (*render_entity, *visible_entity),
                     draw_function: draw_colored_mesh2d,
                     pipeline: pipeline_id,
@@ -451,10 +624,204 @@ pub fn queue_colored_mesh2d(
                     // This material is not batched
                     batch_range: 0..1,
                     extra_index: PhaseItemExtraIndex::None,
-                    extracted_index: usize::MAX,
                     indexed: mesh.indexed(),
                 });
             }
         }
+    }
+}
+
+/// The render node system that draws all items in the
+/// [`TransparentColoredMesh2d`] phase.
+fn main_colored_transparent_pass_2d(
+    world: &World,
+    view: ViewQuery<(
+        &ExtractedCamera,
+        &ExtractedView,
+        &ViewTarget,
+        &ViewDepthTexture,
+    )>,
+    transparent_phases: Res<ViewSortedRenderPhases<TransparentColoredMesh2d>>,
+    mut ctx: RenderContext,
+) {
+    let view_entity = view.entity();
+    let (camera, extracted_view, target, depth) = view.into_inner();
+
+    let Some(transparent_phase) = transparent_phases.get(&extracted_view.retained_view_entity)
+    else {
+        return;
+    };
+
+    #[cfg(feature = "trace")]
+    let _span = info_span!("main_colored_transparent_pass_2d").entered();
+
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+
+    let color_attachments = [Some(target.get_color_attachment())];
+    // NOTE: For the transparent pass we load the depth buffer. There should be no
+    // need to write to it, but store is set to `true` as a workaround for issue #3776,
+    // https://github.com/bevyengine/bevy/issues/3776
+    // so that wgpu does not clear the depth buffer.
+    // As the opaque and alpha mask passes run first, opaque meshes can occlude
+    // transparent ones.
+    let depth_stencil_attachment = Some(depth.get_attachment(StoreOp::Store));
+
+    {
+        let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
+            label: Some("main_colored_transparent_pass_2d"),
+            color_attachments: &color_attachments,
+            depth_stencil_attachment,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        let pass_span = diagnostics.pass_span(&mut render_pass, "main_colored_transparent_pass_2d");
+
+        if let Some(viewport) = camera.viewport.as_ref() {
+            render_pass.set_camera_viewport(viewport);
+        }
+
+        if !transparent_phase.items.is_empty() {
+            #[cfg(feature = "trace")]
+            let _transparent_span = info_span!("colored_transparent_main_pass_2d").entered();
+            if let Err(err) = transparent_phase.render(&mut render_pass, world, view_entity) {
+                error!(
+                    "Error encountered while rendering the colored transparent 2D phase {err:?}"
+                );
+            }
+        }
+
+        pass_span.end(&mut render_pass);
+    }
+}
+
+/// The render command that sets the right bind group.
+///
+/// Since the normal `SetMesh2dBindGroup` render command is hardwired to use
+/// `RenderMesh2dInstances`, we need to replace it with our own render command.
+struct SetColoredMesh2dBindGroup<const I: usize>;
+
+impl<P, const I: usize> RenderCommand<P> for SetColoredMesh2dBindGroup<I>
+where
+    P: PhaseItem,
+{
+    type Param = (
+        SRes<Mesh2dBindGroup>,
+        SRes<RenderColoredMesh2dInstances>,
+        SRes<MeshAllocator>,
+        SRes<MeshMetadataFallbackBuffer>,
+    );
+    type ViewQuery = ();
+    type ItemQuery = ();
+
+    #[inline]
+    fn render<'w>(
+        item: &P,
+        _view: (),
+        _item_query: Option<()>,
+        (mesh2d_bind_group, render_mesh2d_instances, mesh_allocator,metadata_fallback_buffer): SystemParamItem<
+            'w,
+            '_,
+            Self::Param,
+        >,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let render_mesh2d_instances = render_mesh2d_instances.into_inner();
+        let mesh_allocator = mesh_allocator.into_inner();
+        let mesh2d_bind_group = mesh2d_bind_group.into_inner();
+
+        let Some(RenderMesh2dInstance { mesh_asset_id, .. }) =
+            render_mesh2d_instances.get(&item.main_entity())
+        else {
+            return RenderCommandResult::Skip;
+        };
+        let metadata_slab_id = mesh_allocator
+            .key_to_slab
+            .get(&bevy_render::mesh::allocator::MeshAllocationKey::new(
+                *mesh_asset_id,
+                bevy_render::mesh::allocator::ElementClass::Metadata,
+            ))
+            .cloned()
+            .unwrap_or(metadata_fallback_buffer.slab_id);
+        let Some(bind_group) = &mesh2d_bind_group.value.get(&metadata_slab_id) else {
+            return RenderCommandResult::Failure(
+                "The mesh2d bind group wasn't set in the render phase.",
+            );
+        };
+
+        let mut dynamic_offsets: [u32; 1] = Default::default();
+        let mut offset_count = 0;
+        if let PhaseItemExtraIndex::DynamicOffset(dynamic_offset) = item.extra_index() {
+            dynamic_offsets[offset_count] = dynamic_offset;
+            offset_count += 1;
+        }
+        pass.set_bind_group(I, bind_group, &dynamic_offsets[..offset_count]);
+        RenderCommandResult::Success
+    }
+}
+
+/// The render command that draws all the meshes in our custom render phase.
+struct DrawColoredMesh2d;
+
+impl<P: PhaseItem> RenderCommand<P> for DrawColoredMesh2d {
+    type Param = (
+        SRes<RenderAssets<RenderMesh>>,
+        SRes<RenderColoredMesh2dInstances>,
+        SRes<MeshAllocator>,
+    );
+    type ViewQuery = ();
+    type ItemQuery = ();
+
+    #[inline]
+    fn render<'w>(
+        item: &P,
+        _view: (),
+        _item_query: Option<()>,
+        (meshes, render_mesh2d_instances, mesh_allocator): SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let meshes = meshes.into_inner();
+        let render_mesh2d_instances = render_mesh2d_instances.into_inner();
+        let mesh_allocator = mesh_allocator.into_inner();
+
+        let Some(RenderMesh2dInstance { mesh_asset_id, .. }) =
+            render_mesh2d_instances.get(&item.main_entity())
+        else {
+            return RenderCommandResult::Skip;
+        };
+        let Some(gpu_mesh) = meshes.get(*mesh_asset_id) else {
+            return RenderCommandResult::Skip;
+        };
+        let Some(vertex_buffer_slice) = mesh_allocator.mesh_vertex_slice(mesh_asset_id) else {
+            return RenderCommandResult::Skip;
+        };
+
+        pass.set_vertex_buffer(0, vertex_buffer_slice.buffer.slice(..));
+
+        let batch_range = item.batch_range();
+        match &gpu_mesh.buffer_info {
+            RenderMeshBufferInfo::Indexed {
+                index_format,
+                count,
+            } => {
+                let Some(index_buffer_slice) = mesh_allocator.mesh_index_slice(mesh_asset_id)
+                else {
+                    return RenderCommandResult::Skip;
+                };
+
+                pass.set_index_buffer(index_buffer_slice.buffer.slice(..), *index_format);
+
+                pass.draw_indexed(
+                    index_buffer_slice.range.start..(index_buffer_slice.range.start + count),
+                    vertex_buffer_slice.range.start as i32,
+                    batch_range.clone(),
+                );
+            }
+            RenderMeshBufferInfo::NonIndexed => {
+                pass.draw(vertex_buffer_slice.range, batch_range.clone());
+            }
+        }
+        RenderCommandResult::Success
     }
 }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -21,7 +21,7 @@ use bevy::{
         batching::{no_gpu_preprocessing::batch_and_prepare_sorted_render_phase, GetBatchData},
         camera::ExtractedCamera,
         diagnostic::RecordDiagnostics as _,
-        material_bind_groups::{MaterialBindGroupIndex, MaterialBindGroupSlot},
+        material_bind_groups::{MaterialBindGroupIndex, MaterialBindGroupSlot, MaterialBindingId},
         mesh::{
             allocator::MeshAllocator, MeshMetadataFallbackBuffer, RenderMesh, RenderMeshBufferInfo,
         },
@@ -51,7 +51,6 @@ use bevy::{
         Mesh2dTransforms, Mesh2dUniform, MeshFlags, RenderMesh2dInstance, SetMesh2dViewBindGroup,
     },
 };
-use bevy_render::material_bind_groups::MaterialBindingId;
 use indexmap::IndexMap;
 use std::{f32::consts::PI, ops::Range};
 

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -10,9 +10,10 @@ use bevy::{
     color::palettes::basic::YELLOW,
     core_pipeline::core_2d::{Transparent2d, CORE_2D_DEPTH_FORMAT},
     math::{ops, FloatOrd},
-    mesh::{Indices, MeshVertexAttribute, VertexBufferLayout},
+    mesh::{BaseMeshPipelineKey, Indices, MeshVertexAttribute, VertexBufferLayout},
     prelude::*,
     render::{
+        material_bind_groups::RenderMaterialBindings,
         mesh::RenderMesh,
         render_asset::RenderAssets,
         render_phase::{
@@ -27,14 +28,14 @@ use bevy::{
             VertexStepMode,
         },
         sync_component::{SyncComponent, SyncComponentPlugin},
-        sync_world::{MainEntityHashMap, RenderEntity},
+        sync_world::{MainEntity, MainEntityHashMap, RenderEntity},
         view::{ExtractedView, RenderVisibleEntities},
         Extract, Render, RenderApp, RenderStartup, RenderSystems,
     },
     sprite_render::{
-        extract_mesh2d, init_mesh_2d_pipeline, DrawMesh2d, Material2dBindGroupId, Mesh2dPipeline,
-        Mesh2dPipelineKey, Mesh2dTransforms, MeshFlags, RenderMesh2dInstance, SetMesh2dBindGroup,
-        SetMesh2dViewBindGroup,
+        extract_mesh2d, init_mesh_2d_pipeline, DrawMesh2d, Mesh2dPipeline, Mesh2dPipelineKey,
+        Mesh2dTransforms, MeshFlags, RenderMaterial2dInstances, RenderMesh2dInstance,
+        SetMesh2dBindGroup, SetMesh2dViewBindGroup,
     },
 };
 use std::f32::consts::PI;
@@ -196,8 +197,9 @@ impl SpecializedRenderPipeline for ColoredMesh2dPipeline {
             ],
             primitive: PrimitiveState {
                 cull_mode: Some(Face::Back),
-                topology: key.primitive_topology(),
-                strip_index_format: key.strip_index_format(),
+                topology: BaseMeshPipelineKey::from_bits_retain(key.bits()).primitive_topology(),
+                strip_index_format: BaseMeshPipelineKey::from_bits_retain(key.bits())
+                    .strip_index_format(),
                 ..default()
             },
             depth_stencil: Some(DepthStencilState {
@@ -347,6 +349,8 @@ pub fn extract_colored_mesh2d(
         >,
     >,
     mut render_mesh_instances: ResMut<RenderColoredMesh2dInstances>,
+    render_material_instances: Res<RenderMaterial2dInstances>,
+    render_material_bindings: Res<RenderMaterialBindings>,
 ) {
     let mut values = Vec::with_capacity(*previous_len);
     for (entity, render_entity, view_visibility, transform, handle) in &query {
@@ -359,13 +363,24 @@ pub fn extract_colored_mesh2d(
             flags: MeshFlags::empty().bits(),
         };
 
+        // Look up the material index. If we couldn't fetch the material index,
+        // then the material hasn't been prepared yet, perhaps because it hasn't
+        // yet loaded.
+        let Some(mesh_material) = render_material_instances.get(&MainEntity::from(entity)) else {
+            continue;
+        };
+        let Some(mesh_material_binding_id) = render_material_bindings.get(mesh_material).copied()
+        else {
+            continue;
+        };
+
         values.push((render_entity, ColoredMesh2d));
         render_mesh_instances.insert(
             entity.into(),
             RenderMesh2dInstance {
                 mesh_asset_id: handle.0.id(),
                 transforms,
-                material_bind_group_id: Material2dBindGroupId::default(),
+                material_bindings_index: mesh_material_binding_id,
                 automatic_batching: false,
                 tag: 0,
             },
@@ -414,9 +429,12 @@ pub fn queue_colored_mesh2d(
                 let Some(mesh) = render_meshes.get(mesh2d_handle) else {
                     continue;
                 };
-                mesh2d_key |= Mesh2dPipelineKey::from_primitive_topology_and_strip_index(
-                    mesh.primitive_topology(),
-                    mesh.index_format(),
+                mesh2d_key |= Mesh2dPipelineKey::from(
+                    BaseMeshPipelineKey::from_primitive_topology_and_strip_index(
+                        mesh.primitive_topology(),
+                        mesh.index_format(),
+                    )
+                    .bits(),
                 );
 
                 let pipeline_id =

--- a/examples/README.md
+++ b/examples/README.md
@@ -499,6 +499,7 @@ Example | Description
 [Instancing](../examples/shader_advanced/custom_shader_instancing.rs) | A shader that renders a mesh multiple times in one draw call using low level rendering api
 [Material](../examples/shader/shader_material.rs) | A shader and a material that uses it
 [Material](../examples/shader/shader_material_2d.rs) | A shader and a material that uses it on a 2d mesh
+[Material - 2D Bindless](../examples/shader/shader_material_2d_bindless.rs) | Demonstrates bindless materials in 2D
 [Material - Bindless](../examples/shader/shader_material_bindless.rs) | Demonstrates how to make materials that use bindless textures
 [Material - GLSL](../examples/shader/shader_material_glsl.rs) | A shader that uses the GLSL shading language
 [Material - Screenspace Texture](../examples/shader/shader_material_screenspace_texture.rs) | A shader that samples a texture with view-independent UV coordinates

--- a/examples/gltf/custom_gltf_vertex_attribute.rs
+++ b/examples/gltf/custom_gltf_vertex_attribute.rs
@@ -7,7 +7,7 @@ use bevy::{
     reflect::TypePath,
     render::render_resource::*,
     shader::ShaderRef,
-    sprite_render::{Material2d, Material2dKey, Material2dPlugin},
+    sprite_render::{Material2d, Material2dKey, Material2dPipeline, Material2dPlugin},
 };
 
 /// This example uses a shader source file from the assets subdirectory
@@ -80,6 +80,7 @@ impl Material2d for CustomMaterial {
     }
 
     fn specialize(
+        _pipeline: &Material2dPipeline,
         descriptor: &mut RenderPipelineDescriptor,
         layout: &MeshVertexBufferLayoutRef,
         _key: Material2dKey<Self>,

--- a/examples/gltf/gltf_extension_mesh_2d.rs
+++ b/examples/gltf/gltf_extension_mesh_2d.rs
@@ -12,7 +12,7 @@ use bevy::{
     reflect::TypePath,
     render::render_resource::*,
     shader::ShaderRef,
-    sprite_render::{Material2d, Material2dKey, Material2dPlugin},
+    sprite_render::{Material2d, Material2dKey, Material2dPipeline, Material2dPlugin},
 };
 
 /// This example uses a shader source file from the assets subdirectory
@@ -131,6 +131,7 @@ impl Material2d for CustomMaterial {
     }
 
     fn specialize(
+        _pipeline: &Material2dPipeline,
         descriptor: &mut RenderPipelineDescriptor,
         layout: &MeshVertexBufferLayoutRef,
         _key: Material2dKey<Self>,

--- a/examples/shader/pipeline_constants.rs
+++ b/examples/shader/pipeline_constants.rs
@@ -16,7 +16,7 @@ use bevy::{
         AsBindGroup, RenderPipelineDescriptor, SpecializedMeshPipelineError,
     },
     shader::ShaderRef,
-    sprite_render::{Material2d, Material2dKey, Material2dPlugin},
+    sprite_render::{Material2d, Material2dKey, Material2dPipeline, Material2dPlugin},
 };
 
 const SHADER_ASSET_PATH: &str = "shaders/pipeline_constants.wgsl";
@@ -83,6 +83,7 @@ impl Material2d for PosterizeMaterial {
     }
 
     fn specialize(
+        _pipeline: &Material2dPipeline,
         descriptor: &mut RenderPipelineDescriptor,
         _layout: &MeshVertexBufferLayoutRef,
         key: Material2dKey<Self>,

--- a/examples/shader/shader_material_2d_bindless.rs
+++ b/examples/shader/shader_material_2d_bindless.rs
@@ -1,0 +1,103 @@
+//! Demonstrates bindless materials in 2D.
+
+use bevy::{
+    prelude::*,
+    reflect::TypePath,
+    render::render_resource::{AsBindGroup, ShaderType},
+    shader::ShaderRef,
+    sprite_render::{AlphaMode2d, Material2d, Material2dPlugin},
+};
+
+/// This example uses a shader source file from the `assets` subdirectory.
+const SHADER_ASSET_PATH: &str = "shaders/custom_material_2d_bindless.wgsl";
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            Material2dPlugin::<BindlessMaterial>::default(),
+        ))
+        .add_systems(Startup, setup)
+        .run();
+}
+
+// Setup a simple 2D scene.
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<BindlessMaterial>>,
+    asset_server: Res<AssetServer>,
+) {
+    // Spawn the camera.
+    commands.spawn(Camera2d);
+
+    // Create the shared assets that the bindless material will use.
+    let dark_icon = asset_server.load("branding/bevy_logo_dark.png");
+    let light_icon = asset_server.load("branding/bevy_logo_light.png");
+    let mesh = meshes.add(Rectangle::default());
+
+    // Spawn the quads.
+    for (offset, color, image) in [
+        (vec2(-1.0, -1.0), LinearRgba::RED, dark_icon.clone()),
+        (
+            vec2(1.0, -1.0),
+            LinearRgba::new(1.0, 1.0, 0.0, 1.0),
+            light_icon.clone(),
+        ),
+        (vec2(-1.0, 1.0), LinearRgba::GREEN, dark_icon.clone()),
+        (vec2(1.0, 1.0), LinearRgba::BLUE, light_icon.clone()),
+    ] {
+        commands.spawn((
+            Mesh2d(mesh.clone()),
+            MeshMaterial2d(materials.add(BindlessMaterial {
+                color,
+                color_texture: Some(image),
+            })),
+            Transform::default()
+                .with_scale(vec3(128.0, 32.0, 1.0))
+                .with_translation((offset * 128.0).extend(0.0)),
+        ));
+    }
+}
+
+/// The CPU-side structure that's passed to the shader.
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+#[uniform(0, BindlessMaterialUniform, binding_array(10))]
+#[bindless]
+struct BindlessMaterial {
+    color: LinearRgba,
+    #[texture(1)]
+    #[sampler(2)]
+    color_texture: Option<Handle<Image>>,
+}
+
+/// The GPU-side structure that's passed to the shader.
+#[derive(ShaderType)]
+struct BindlessMaterialUniform {
+    color: LinearRgba,
+}
+
+// The conversion function that Bevy calls to convert from the CPU-side material
+// structure to the GPU-side material structure.
+impl<'a> From<&'a BindlessMaterial> for BindlessMaterialUniform {
+    fn from(material: &'a BindlessMaterial) -> Self {
+        BindlessMaterialUniform {
+            color: material.color,
+        }
+    }
+}
+
+// The `Material2d`` trait is very configurable, but comes with sensible defaults
+// for all methods.
+//
+// You only need to implement functions for features that need non-default
+// behavior. See the `Material2d` API documentation for details.
+impl Material2d for BindlessMaterial {
+    fn fragment_shader() -> ShaderRef {
+        SHADER_ASSET_PATH.into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode2d {
+        AlphaMode2d::Mask(0.5)
+    }
+}

--- a/examples/shader_advanced/manual_material.rs
+++ b/examples/shader_advanced/manual_material.rs
@@ -10,8 +10,7 @@ use bevy::{
     material::{key::ErasedMeshPipelineKey, MaterialProperties},
     pbr::{
         base_specialize, DrawMaterial, EntitiesNeedingSpecialization, MainPassOpaqueDrawFunction,
-        MaterialBindGroupAllocator, MaterialBindGroupAllocators, MaterialFragmentShader,
-        MeshPipelineKey, PreparedMaterial, RenderMaterialBindings, RenderMaterialInstance,
+        MaterialFragmentShader, MeshPipelineKey, PreparedMaterial, RenderMaterialInstance,
         RenderMaterialInstances,
     },
     platform::collections::hash_map::Entry,
@@ -19,6 +18,9 @@ use bevy::{
     render::{
         camera::{DirtySpecializationSystems, DirtySpecializations},
         erased_render_asset::{ErasedRenderAsset, ErasedRenderAssetPlugin, PrepareAssetError},
+        material_bind_groups::{
+            MaterialBindGroupAllocator, MaterialBindGroupAllocators, RenderMaterialBindings,
+        },
         render_asset::RenderAssets,
         render_phase::DrawFunctions,
         render_resource::{


### PR DESCRIPTION
At the moment, Bevy must issue a separate drawcall and bind group switch for each 2D object with a different texture, incurring significant `wgpu` and driver overhead. To address this problem, this commit ports the bindless support that the 3D PBR pipeline has long enjoyed to the 2D pipeline as well. Bindless allows Bevy to batch 2D meshes into single drawcalls as long as they share the same mesh, even if their materials (including textures) differ.

To implement bindless, this patch moves the efficient material bind group allocator from `bevy_pbr` to `bevy_render`. Like the 3D PBR pipeline, the code in this PR checks to see whether bindless is supported on the current platform and automatically falls back to non-bindless if it isn't.

Because the logic needed to support bindless is tightly intertwined with the logic needed to prepare pipelines, this PR also overhauls `specialize_material2d_meshes`. That function is now very similar to the one in the 3D pipeline. At some point, it'd probably be best to merge the core logic of this function for the 2D and 3D pipelines together. However, I opted to leave that to a follow-up for two reasons: (1) it's easier to verify in review that the 2D and 3D functions are the same than to verify that any added layers of abstraction are correct; (2) it might (or might not) be best to wait until multi-draw indirect is added to the 2D pipeline to do the refactoring.

Per review request, I've left the migration of `ColorMaterial` and `SpriteMaterial` over to bindless to a follow-up. With this follow-up (*not in this PR*), on the `bevymark` example with `--waves 1 --per-wave 10000 --vary-per-instance --material-texture-count 1000`, I observed:

* With the dedicated sprite rendering path, which doesn't use bindless, I get 21.5 ms/frame, or 47 FPS.

* With the `SpriteMaterial` path, with the follow-up patch that adds bindless support to that material, I get 17.4 ms/frame, or 67 FPS.

* With the `SpriteMaterial` path on `main`, I get 29.7 ms/frame, or 38.2 FPS.

The follow-up patch is therefore a 1.71× speedup on that workload for `SpriteMaterial` and a 1.24× speedup over the dedicated sprite rendering path.

Note that, in that follow-up patch, order to see the changes in action, I had to change `bevymark` to avoid using the same seed for all its parallel RNGs. Without that change, the fact that each RNG uses the same seed means that each texture effectively gets its own Z layer, causing the benchmark to degenerate into the optimal scenario for batching in the non-bindless case. The follow-up PR scrambles the RNG seeds to avoid this pathological, unrealistic behavior.