### PR TITLE
Increase `MaterialProperties::draw_functions` inline capacity

### DIFF
--- a/crates/bevy_material/src/lib.rs
+++ b/crates/bevy_material/src/lib.rs
@@ -74,9 +74,9 @@ pub struct MaterialProperties {
     pub reads_view_transmission_texture: bool,
     pub render_phase_type: RenderPhaseType,
     pub material_layout: Option<BindGroupLayoutDescriptor>,
-    /// Backing array is a size of 4 because the [`StandardMaterial`](https://docs.rs/bevy/latest/bevy/pbr/struct.StandardMaterial.html)
-    /// needs 4 draw functions by default
-    pub draw_functions: SmallVec<[(InternedDrawFunctionLabel, DrawFunctionId); 4]>,
+    /// Backing array is a size of 11 because the [`StandardMaterial`](https://docs.rs/bevy/latest/bevy/pbr/struct.StandardMaterial.html)
+    /// needs 11 draw functions by default
+    pub draw_functions: SmallVec<[(InternedDrawFunctionLabel, DrawFunctionId); 11]>,
     /// Backing array is a size of 6 because the [`StandardMaterial`](https://docs.rs/bevy/latest/bevy/pbr/struct.StandardMaterial.html)
     /// has 6 custom shaders (`frag`, `prepass_frag`, `deferred_frag`, `vertex`, `prepass_vertex`,
     /// `deferred vertex`) which is the most common use case

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1707,7 +1707,7 @@ where
         let draw_shadows = shadow_draw_functions.read().id::<DrawPrepass>();
         let draw_shadows_depth_only = shadow_draw_functions.read().id::<DrawDepthOnlyPrepass>();
 
-        let draw_functions = SmallVec::from_iter([
+        let draw_functions = SmallVec::from_const([
             (MainPassOpaqueDrawFunction.intern(), draw_opaque_pbr),
             (MainPassAlphaMaskDrawFunction.intern(), draw_alpha_mask_pbr),
             (


### PR DESCRIPTION
# Objective

We have 11 draw functions but `MaterialProperties::draw_functions` SmallVec only inlines 4 on the stack, which means currently it offers no benefit over `Vec`.

## Solution

Increases its capacity to 11. The size of `PreparedMaterial` doesn't matter, because it's stored on the heap anyway (inside `ErasedRenderAssets<PreparedMaterial>`).

## Testing

CI
