### PR TITLE
Very simple fix for where linear gradient is used as a border between…

### DIFF
--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -192,7 +192,7 @@ impl FeathersNumberInput {
                             ColorStop::new(Color::NONE, percent(50)),
                             ColorStop::new(Color::NONE, percent(100)),
                         ],
-                        color_space: InterpolationColorSpace::Srgba,
+                        color_space: InterpolationColorSpace::LinearRgba,
                     })])
                     EntityCursor::System(bevy_window::SystemCursorIcon::ColResize)
                     on(number_input_init)

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -105,7 +105,7 @@ impl FeathersSlider {
                     ColorStop::new(Color::NONE, percent(50)),
                     ColorStop::new(Color::NONE, percent(100)),
                 ],
-                color_space: InterpolationColorSpace::Srgba,
+                color_space: InterpolationColorSpace::LinearRgba,
             })])
             Children [(
                 // Text container
@@ -177,7 +177,7 @@ pub fn slider_bundle<B: Bundle>(props: FeathersSliderProps, overrides: B) -> imp
                 ColorStop::new(Color::NONE, percent(50)),
                 ColorStop::new(Color::NONE, percent(100)),
             ],
-            color_space: InterpolationColorSpace::Srgba,
+            color_space: InterpolationColorSpace::LinearRgba,
         })]),
         overrides,
         children![(


### PR DESCRIPTION
…, say, a slider and its background. Interpolating as SRGB involves a conversion in rust and conversion back in shader using different maths leading to slightly off colors, interpolating as linear is clean and produces exact results

# Objective

- Noticed that a slider with same BG color as the surrounding area still appeared slightly different, fixed by tracing through where the colors were coming from.

## Solution

- Changed interpolation to linear, which basically means there is no two way conversion

## Showcase

### Before (annotation text added afterwards, difference is probably only visible with an eyedropper tool)

<img width="250" height="182" alt="image" src="https://github.com/user-attachments/assets/7e4a6810-056c-4f9e-b228-2335bb3b1150" />
