### PR TITLE
Give render thread an explicit name

### DIFF
--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -146,36 +146,39 @@ impl Plugin for PipelinedRenderingPlugin {
             render_to_app_receiver,
         ));
 
-        std::thread::spawn(move || {
-            #[cfg(feature = "trace")]
-            let _span = bevy_log::info_span!("render thread").entered();
+        std::thread::Builder::new()
+            .name("render thread".into())
+            .spawn(move || {
+                #[cfg(feature = "trace")]
+                let _span = bevy_log::info_span!("render thread").entered();
 
-            let compute_task_pool = ComputeTaskPool::get();
-            loop {
-                // run a scope here to allow main world to use this thread while it's waiting for the render app
-                let sent_app = compute_task_pool
-                    .scope(|s| {
-                        s.spawn(async { app_to_render_receiver.recv().await });
-                    })
-                    .pop();
-                let Some(Ok(mut render_app)) = sent_app else {
-                    break;
-                };
+                let compute_task_pool = ComputeTaskPool::get();
+                loop {
+                    // run a scope here to allow main world to use this thread while it's waiting for the render app
+                    let sent_app = compute_task_pool
+                        .scope(|s| {
+                            s.spawn(async { app_to_render_receiver.recv().await });
+                        })
+                        .pop();
+                    let Some(Ok(mut render_app)) = sent_app else {
+                        break;
+                    };
 
-                {
-                    #[cfg(feature = "trace")]
-                    let _sub_app_span =
-                        bevy_log::info_span!("sub app", name = ?RenderApp).entered();
-                    render_app.update();
+                    {
+                        #[cfg(feature = "trace")]
+                        let _sub_app_span =
+                            bevy_log::info_span!("sub app", name = ?RenderApp).entered();
+                        render_app.update();
+                    }
+
+                    if render_to_app_sender.send_blocking(render_app).is_err() {
+                        break;
+                    }
                 }
 
-                if render_to_app_sender.send_blocking(render_app).is_err() {
-                    break;
-                }
-            }
-
-            bevy_log::debug!("exiting pipelined rendering thread");
-        });
+                bevy_log::debug!("exiting pipelined rendering thread");
+            })
+            .expect("Failed to create render thread");
     }
 }
 

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -147,7 +147,7 @@ impl Plugin for PipelinedRenderingPlugin {
         ));
 
         std::thread::Builder::new()
-            .name("render thread".into())
+            .name("Render thread".into())
             .spawn(move || {
                 #[cfg(feature = "trace")]
                 let _span = bevy_log::info_span!("render thread").entered();


### PR DESCRIPTION
# Objective

- Makes it show up nicer in tools like Tracy

## Solution

- `std::thread::Builder::name()`

## Testing

- Did you test these changes? If so, how? 
    - Shows up in Tracy and System Informer.
- Are there any parts that need more testing?
    - No
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
    - Check if the thread name shows up in Tracy ig 
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?
    - Windows

---

## Showcase

<img width="246" height="197" alt="image" src="https://github.com/user-attachments/assets/a27a34bb-74fe-4ac5-9967-50bfd3b860dc" />
