### PR TITLE
Avoid creating a pass for main_transparent_pass_2d when unecessary

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
@@ -31,6 +31,10 @@ pub fn main_transparent_pass_2d(
         return;
     };
 
+    if transparent_phase.items.is_empty() {
+        return;
+    }
+
     #[cfg(feature = "trace")]
     let _span = info_span!("main_transparent_pass_2d").entered();
 
@@ -61,12 +65,10 @@ pub fn main_transparent_pass_2d(
             render_pass.set_camera_viewport(viewport);
         }
 
-        if !transparent_phase.items.is_empty() {
-            #[cfg(feature = "trace")]
-            let _transparent_span = info_span!("transparent_main_pass_2d").entered();
-            if let Err(err) = transparent_phase.render(&mut render_pass, world, view_entity) {
-                error!("Error encountered while rendering the transparent 2D phase {err:?}");
-            }
+        #[cfg(feature = "trace")]
+        let _transparent_span = info_span!("transparent_main_pass_2d").entered();
+        if let Err(err) = transparent_phase.render(&mut render_pass, world, view_entity) {
+            error!("Error encountered while rendering the transparent 2D phase {err:?}");
         }
 
         pass_span.end(&mut render_pass);


### PR DESCRIPTION
# Objective

- Less CPU & GPU usage from an empty render pass

## Solution

- Move the if condition to earlier

## Testing

- Ran `2d_shapes` and `transparency_2d` examples and it looks fine. 

---

## Showcase

<img width="1299" height="239" alt="tracy-profiler_iW4FEIsKxw" src="https://github.com/user-attachments/assets/4b8558ef-aa14-43af-8dff-8d862871f71b" />
