### PR TITLE
Remove webgl2 render pass viewport workaround

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_transparent_pass_2d_node.rs
@@ -71,21 +71,4 @@ pub fn main_transparent_pass_2d(
 
         pass_span.end(&mut render_pass);
     }
-
-    // WebGL2 quirk: if ending with a render pass with a custom viewport, the viewport isn't
-    // reset for the next render pass so add an empty render pass without a custom viewport
-    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    if camera.viewport.is_some() {
-        #[cfg(feature = "trace")]
-        let _reset_viewport_pass_2d = info_span!("reset_viewport_pass_2d").entered();
-
-        let _reset_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
-            label: Some("reset_viewport_pass_2d"),
-            color_attachments: &[Some(target.get_color_attachment())],
-            depth_stencil_attachment: None,
-            timestamp_writes: None,
-            occlusion_query_set: None,
-            multiview_mask: None,
-        });
-    }
 }

--- a/crates/bevy_core_pipeline/src/core_3d/main_transparent_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_transparent_pass_3d_node.rs
@@ -98,22 +98,4 @@ pub fn main_transparent_pass_3d(
 
         pass_span.end(&mut render_pass);
     }
-
-    // WebGL2 quirk: if ending with a render pass with a custom viewport, the viewport isn't
-    // reset for the next render pass so add an empty render pass without a custom viewport
-    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    if camera.viewport.is_some() {
-        #[cfg(feature = "trace")]
-        let _reset_viewport_pass_3d = info_span!("reset_viewport_pass_3d").entered();
-        let pass_descriptor = RenderPassDescriptor {
-            label: Some("reset_viewport_pass_3d"),
-            color_attachments: &[Some(target.get_color_attachment())],
-            depth_stencil_attachment: None,
-            timestamp_writes: None,
-            occlusion_query_set: None,
-            multiview_mask: None,
-        };
-
-        ctx.command_encoder().begin_render_pass(&pass_descriptor);
-    }
 }

--- a/crates/bevy_core_pipeline/src/core_3d/main_transparent_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_transparent_pass_3d_node.rs
@@ -47,55 +47,57 @@ pub fn main_transparent_pass_3d(
         return;
     };
 
-    if !transparent_phase.items.is_empty() {
-        #[cfg(feature = "trace")]
-        let _main_transparent_pass_3d_span = info_span!("main_transparent_pass_3d").entered();
-
-        let diagnostics = ctx.diagnostic_recorder();
-        let diagnostics = diagnostics.as_deref();
-
-        if has_oit {
-            // We can't run transparent phase if OitResolvePipelineId is not ready
-            // Otherwise we will write to `oit_atomic_counter` and `oit_heads` buffer without resetting them
-            // which causes corrupted linked list(can have circular references) on the next pass
-            let Some(oit_resolve_pipeline_id) = oit_resolve_pipeline_id else {
-                return;
-            };
-            let pipeline_cache = world.resource::<PipelineCache>();
-            if pipeline_cache
-                .get_render_pipeline(oit_resolve_pipeline_id.0)
-                .is_none()
-            {
-                return;
-            }
-        }
-
-        let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
-            label: Some("main_transparent_pass_3d"),
-            color_attachments: &[Some(target.get_color_attachment())],
-            // NOTE: For the transparent pass we load the depth buffer. There should be no
-            // need to write to it, but store is set to `true` as a workaround for issue #3776,
-            // https://github.com/bevyengine/bevy/issues/3776
-            // so that wgpu does not clear the depth buffer.
-            // As the opaque and alpha mask passes run first, opaque meshes can occlude
-            // transparent ones.
-            depth_stencil_attachment: Some(depth.get_attachment(StoreOp::Store)),
-            timestamp_writes: None,
-            occlusion_query_set: None,
-            multiview_mask: None,
-        });
-        let pass_span = diagnostics.pass_span(&mut render_pass, "main_transparent_pass_3d");
-
-        if let Some(viewport) =
-            Viewport::from_viewport_and_override(camera.viewport.as_ref(), resolution_override)
-        {
-            render_pass.set_camera_viewport(&viewport);
-        }
-
-        if let Err(err) = transparent_phase.render(&mut render_pass, world, view_entity) {
-            error!("Error encountered while rendering the transparent phase {err:?}");
-        }
-
-        pass_span.end(&mut render_pass);
+    if transparent_phase.items.is_empty() {
+        return;
     }
+
+    #[cfg(feature = "trace")]
+    let _main_transparent_pass_3d_span = info_span!("main_transparent_pass_3d").entered();
+
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+
+    if has_oit {
+        // We can't run transparent phase if OitResolvePipelineId is not ready
+        // Otherwise we will write to `oit_atomic_counter` and `oit_heads` buffer without resetting them
+        // which causes corrupted linked list(can have circular references) on the next pass
+        let Some(oit_resolve_pipeline_id) = oit_resolve_pipeline_id else {
+            return;
+        };
+        let pipeline_cache = world.resource::<PipelineCache>();
+        if pipeline_cache
+            .get_render_pipeline(oit_resolve_pipeline_id.0)
+            .is_none()
+        {
+            return;
+        }
+    }
+
+    let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
+        label: Some("main_transparent_pass_3d"),
+        color_attachments: &[Some(target.get_color_attachment())],
+        // NOTE: For the transparent pass we load the depth buffer. There should be no
+        // need to write to it, but store is set to `true` as a workaround for issue #3776,
+        // https://github.com/bevyengine/bevy/issues/3776
+        // so that wgpu does not clear the depth buffer.
+        // As the opaque and alpha mask passes run first, opaque meshes can occlude
+        // transparent ones.
+        depth_stencil_attachment: Some(depth.get_attachment(StoreOp::Store)),
+        timestamp_writes: None,
+        occlusion_query_set: None,
+        multiview_mask: None,
+    });
+    let pass_span = diagnostics.pass_span(&mut render_pass, "main_transparent_pass_3d");
+
+    if let Some(viewport) =
+        Viewport::from_viewport_and_override(camera.viewport.as_ref(), resolution_override)
+    {
+        render_pass.set_camera_viewport(&viewport);
+    }
+
+    if let Err(err) = transparent_phase.render(&mut render_pass, world, view_entity) {
+        error!("Error encountered while rendering the transparent phase {err:?}");
+    }
+
+    pass_span.end(&mut render_pass);
 }


### PR DESCRIPTION
# Objective

The webgl2 workaround is added in #4967. It's old, and I didn't find any issues with the `split_screen` example on webgl2 after removing the workaround.

## Solution

Remove the webgl2 workaround

## Testing

```
cargo r -p build-wasm-example split_screen
```

<img width="480" height="258" alt="屏幕截图_20260703_131252" src="https://github.com/user-attachments/assets/3774b5fa-cb92-4f70-a8fe-5e81c277d0a7" />
