### PR TITLE
Text measurement min-content fix

### DIFF
--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -243,23 +243,26 @@ impl UiSurface {
                  -> taffy::Size<f32> {
                     context
                         .map(|ctx| {
-                            let buffer = get_text_buffer(
-                                crate::widget::TextMeasure::needs_buffer(
-                                    known_dimensions.height,
-                                    available_space.width,
-                                ),
-                                ctx,
-                                buffer_query,
-                            );
-                            let size = ctx.measure(MeasureArgs {
+                            let mut measure_args = MeasureArgs {
                                 known_width: known_dimensions.width,
                                 known_height: known_dimensions.height,
                                 available_width: available_space.width,
                                 available_height: available_space.height,
                                 font_system,
-                                buffer,
+                                buffer: None,
                                 style,
-                            });
+                            };
+                            let buffer = get_text_buffer(
+                                crate::widget::TextMeasure::needs_buffer(
+                                    measure_args.resolve_width().effective,
+                                    measure_args.resolve_height().effective,
+                                    available_space.width,
+                                ),
+                                ctx,
+                                buffer_query,
+                            );
+                            measure_args.buffer = buffer;
+                            let size = ctx.measure(measure_args);
                             taffy::Size {
                                 width: size.x,
                                 height: size.y,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -174,8 +174,13 @@ pub struct TextMeasure {
 impl TextMeasure {
     /// Checks if the Parley text layout is needed for measuring the text.
     #[inline]
-    pub const fn needs_buffer(height: Option<f32>, available_width: AvailableSpace) -> bool {
-        height.is_none() && matches!(available_width, AvailableSpace::Definite(_))
+    pub const fn needs_buffer(
+        width: Option<f32>,
+        height: Option<f32>,
+        available_width: AvailableSpace,
+    ) -> bool {
+        height.is_none()
+            && (width.is_some() || matches!(available_width, AvailableSpace::Definite(_)))
     }
 }
 
@@ -225,8 +230,8 @@ impl Measure for TextMeasure {
             .maybe_clamp(width.min, width.max);
 
         let size = height.effective.map_or_else(
-            || match available_width {
-                AvailableSpace::Definite(_) => {
+            || {
+                if width.effective.is_some() || available_width.is_definite() {
                     if let Some(buffer) = buffer {
                         self.info
                             .compute_size(TextBounds::new_horizontal(x), buffer, font_system)
@@ -234,9 +239,13 @@ impl Measure for TextMeasure {
                         error!("text measure failed, buffer is missing");
                         Vec2::default()
                     }
+                } else {
+                    match available_width {
+                        AvailableSpace::MinContent => Vec2::new(x, self.info.min.y),
+                        AvailableSpace::MaxContent => Vec2::new(x, self.info.max.y),
+                        _ => unreachable!(),
+                    }
                 }
-                AvailableSpace::MinContent => Vec2::new(x, self.info.min.y),
-                AvailableSpace::MaxContent => Vec2::new(x, self.info.max.y),
             },
             |y| Vec2::new(x, y),
         );

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -35,6 +35,7 @@ fn main() {
     }))
     .add_systems(OnEnter(Scene::Image), image::setup)
     .add_systems(OnEnter(Scene::Text), text::setup)
+    .add_systems(OnEnter(Scene::TextMeasurement), text_measurement::setup)
     .add_systems(OnEnter(Scene::Grid), grid::setup)
     .add_systems(OnEnter(Scene::Borders), borders::setup)
     .add_systems(OnEnter(Scene::BoxShadow), box_shadow::setup)
@@ -74,6 +75,7 @@ enum Scene {
     #[default]
     Image,
     Text,
+    TextMeasurement,
     Grid,
     Borders,
     BoxShadow,
@@ -111,7 +113,8 @@ impl Next for Scene {
     fn next(&self) -> Self {
         match self {
             Scene::Image => Scene::Text,
-            Scene::Text => Scene::Grid,
+            Scene::Text => Scene::TextMeasurement,
+            Scene::TextMeasurement => Scene::Grid,
             Scene::Grid => Scene::Borders,
             Scene::Borders => Scene::BoxShadow,
             Scene::BoxShadow => Scene::TextWrap,
@@ -675,6 +678,127 @@ mod text {
                 }
             });
         });
+    }
+}
+
+mod text_measurement {
+    use bevy::prelude::*;
+
+    pub fn setup(mut commands: Commands) {
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::TextMeasurement)));
+
+        commands
+            .spawn((
+                Node {
+                    width: percent(100),
+                    height: percent(100),
+                    flex_direction: FlexDirection::Row,
+                    column_gap: px(8),
+                    padding: px(8).horizontal(),
+                    ..default()
+                },
+                DespawnOnExit(super::Scene::TextMeasurement),
+            ))
+            .with_children(|parent| {
+                let width = px(102);
+                for (flex_direction, boxed) in [
+                    (FlexDirection::Row, true),
+                    (FlexDirection::Row, false),
+                    (FlexDirection::Column, true),
+                    (FlexDirection::Column, false),
+                ] {
+                    parent
+                        .spawn(Node {
+                            flex_direction: FlexDirection::Column,
+                            ..default()
+                        })
+                        .with_children(|parent| {
+                            for align_items in [
+                                AlignItems::Baseline,
+                                AlignItems::Center,
+                                AlignItems::Stretch,
+                                AlignItems::FlexStart,
+                                AlignItems::FlexEnd,
+                            ] {
+                                parent.spawn((
+                                    Node {
+                                        margin: px(8).top(),
+                                        ..default()
+                                    },
+                                    Text::new(format!("AlignItems::{align_items:?}")),
+                                    TextFont::from_font_size(10.),
+                                ));
+                                if boxed {
+                                    parent.spawn((
+                                        Node {
+                                            align_items,
+                                            border: px(2).all(),
+                                            padding: px(2).all(),
+                                            flex_direction,
+                                            ..default()
+                                        },
+                                        BorderColor::all(Color::WHITE),
+                                        children![
+                                            (
+                                                Node {
+                                                    width: px(32),
+                                                    height: px(32),
+                                                    ..default()
+                                                },
+                                                BackgroundColor(Color::WHITE),
+                                            ),
+                                            (
+                                                Node { width, ..default() },
+                                                children![(
+                                                    Text::new("+300 Some Long Item Title"),
+                                                    TextFont {
+                                                        font_size: FontSize::Px(10.),
+                                                        ..default()
+                                                    },
+                                                    BackgroundColor(Color::srgba(
+                                                        0.95, 0.85, 0.2, 0.35
+                                                    )),
+                                                )]
+                                            )
+                                        ],
+                                    ));
+                                } else {
+                                    parent.spawn((
+                                        Node {
+                                            align_items,
+                                            border: px(2).all(),
+                                            padding: px(2).all(),
+                                            flex_direction,
+                                            ..default()
+                                        },
+                                        BorderColor::all(Color::WHITE),
+                                        children![
+                                            (
+                                                Node {
+                                                    width: px(32),
+                                                    height: px(32),
+                                                    ..default()
+                                                },
+                                                BackgroundColor(Color::WHITE),
+                                            ),
+                                            (
+                                                Node { width, ..default() },
+                                                Text::new("+300 Some Long Item Title"),
+                                                TextFont {
+                                                    font_size: FontSize::Px(10.),
+                                                    ..default()
+                                                },
+                                                BackgroundColor(Color::srgba(
+                                                    0.95, 0.85, 0.2, 0.35
+                                                )),
+                                            )
+                                        ],
+                                    ));
+                                }
+                            }
+                        });
+                }
+            });
     }
 }
 


### PR DESCRIPTION
# Objective

`TextMeasure` returns the cached min-content height even when a width is supplied and the size should be recomputed:

<img width="589" alt="measurement-bad" src="https://github.com/user-attachments/assets/1cab9402-b3e7-4228-9eec-a64bd7a9a8ce" />

Fixes #24858

## Solution

When the height is unknown and the width is supplied, request the text buffer and recompute the text layout size.

## Testing

New testbed scene based on the issue's replication example:

```
cargo run --example testbed_ui -- textmeasurement
```

<img width="864" height="646" alt="text-measure-good" src="https://github.com/user-attachments/assets/65bf2fb5-c5b7-45bc-8624-0b2d19be750e" />
