### PR TITLE
Added a shell.nix for easy development using Nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,35 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+  ];
+
+  buildInputs = with pkgs; [
+    alsa-lib
+    libudev-zero
+    libx11
+    libxcursor
+    libxi
+    libxrandr
+    libxkbcommon
+    vulkan-loader
+    wayland
+  ];
+
+  env = {
+    LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (
+      with pkgs;
+      [
+        libx11
+        libxcursor
+        libxi
+        libxkbcommon
+        vulkan-loader
+        wayland
+      ]
+    );
+  };
+}


### PR DESCRIPTION
# Objective

Support using nix-shell for Nix-based environments.

## Solution

Add a shell.nix with the required dependencies for bevy. This only assumes a working Rust-development environment to be already present.

## Testing

- cargo build --all
- cargo test --all

---

## Showcase

```bash
$ nix-shell
$ cargo build --all
```