### PR TITLE
Fix split screen + transparent material rendering

### DIFF
--- a/crates/bevy_pbr/src/transmission/transmission.wgsl
+++ b/crates/bevy_pbr/src/transmission/transmission.wgsl
@@ -42,7 +42,11 @@ fn specular_transmissive_light(world_position: vec4<f32>, frag_coord: vec3<f32>,
     let clip_exit_position = view_bindings::view.clip_from_world * vec4<f32>(exit_position, 1.0);
 
     // Scale / offset position so that coordinate is in right space for sampling transmissive background texture
-    let offset_position = (clip_exit_position.xy / clip_exit_position.w) * vec2<f32>(0.5, -0.5) + 0.5;
+    let subview_position = (clip_exit_position.xy / clip_exit_position.w) * vec2<f32>(0.5, -0.5) + 0.5;
+    let origin = view_bindings::view.viewport.xy;
+    let size = view_bindings::view.viewport.zw;
+    let full_size = textureDimensions(view_bindings::view_transmission_texture);
+    let offset_position = (subview_position * size + origin) / vec2f(f32(full_size.x), f32(full_size.y));
 
     // Fetch background color
     var background_color: vec4<f32>;

--- a/crates/bevy_pbr/src/transmission/transmission.wgsl
+++ b/crates/bevy_pbr/src/transmission/transmission.wgsl
@@ -43,10 +43,10 @@ fn specular_transmissive_light(world_position: vec4<f32>, frag_coord: vec3<f32>,
 
     // Scale / offset position so that coordinate is in right space for sampling transmissive background texture
     let subview_position = (clip_exit_position.xy / clip_exit_position.w) * vec2<f32>(0.5, -0.5) + 0.5;
-    let origin = view_bindings::view.viewport.xy;
-    let size = view_bindings::view.viewport.zw;
-    let full_size = textureDimensions(view_bindings::view_transmission_texture);
-    let offset_position = (subview_position * size + origin) / vec2f(f32(full_size.x), f32(full_size.y));
+    let viewport_origin = view_bindings::view.viewport.xy;
+    let viewport_size = view_bindings::view.viewport.zw;
+    let full_size = vec2<f32>(textureDimensions(view_bindings::view_transmission_texture));
+    let offset_position = (subview_position * viewport_size + viewport_origin) / full_size;
 
     // Fetch background color
     var background_color: vec4<f32>;


### PR DESCRIPTION
# Objective

Fixes #20405 

## Solution

Use the subview viewport and whole-texture size to properly offset the background image sampling to just the section that the viewport is actually referencing.

I would appreciate some more experienced rendering dev input on whether this is the right way to get the `full_size`, and on any code organization conventions.

## Testing

Tested against a modified split screen example which clearly demonstrates the broken before and fixed after (see showcase)

I also ran the 3d_scene example (unmodifed) to make sure that normal rendering hasn't completely broken, and I didn't notice any difference.

---

## Showcase

Before:
<img width="1920" height="1080" alt="screenshot" src="https://github.com/user-attachments/assets/fa1ae334-f949-456c-a0a9-bf0363b1cf78" />

After:
<img width="2176" height="1224" alt="screenshot" src="https://github.com/user-attachments/assets/5c23534e-85ab-4d34-b1a2-24e71eb761e0" />

Code compared to split screen example:
```diff
@@ -56,6 +56,18 @@ fn setup(
         .build(),
     ));
 
+    let material = StandardMaterial {
+        perceptual_roughness: 0.0,
+        specular_transmission: 1.0,
+        cull_mode: None,
+        ..default()
+    };
+    let material = materials.add(material);
+
+    let cuboid = meshes.add(Cuboid {
+        half_size: Vec3::splat(0.5),
+    });
+
     // Cameras and their dedicated UI
     for (index, (camera_name, camera_pos)) in [
         ("Player 1", Vec3::new(0.0, 200.0, -150.0)),
@@ -78,6 +90,12 @@ fn setup(
                 CameraPosition {
                     pos: UVec2::new((index % 2) as u32, (index / 2) as u32),
                 },
+                children![(
+                    Transform::from_translation(Vec3::new(-0.5, 0.0, -1.8))
+                        .with_rotation(Quat::from_rotation_y(1.0)),
+                    Mesh3d(cuboid.clone()),
+                    MeshMaterial3d(material.clone())
+                )],
             ))
             .id();
```

<details>
<summary>Full code</summary>

```rust
//! Renders four cameras to the same window to accomplish "split screen".

use std::f32::consts::PI;

use bevy::{
    camera::Viewport, light::CascadeShadowConfigBuilder, prelude::*, window::WindowResized,
};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .add_systems(Update, (set_camera_viewports, button_system))
        .run();
}

/// set up a simple 3D scene
fn setup(
    mut commands: Commands,
    asset_server: Res<AssetServer>,
    mut meshes: ResMut<Assets<Mesh>>,
    mut materials: ResMut<Assets<StandardMaterial>>,
) {
    // plane
    commands.spawn((
        Mesh3d(meshes.add(Plane3d::default().mesh().size(100.0, 100.0))),
        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
    ));

    commands.spawn(WorldAssetRoot(
        asset_server.load(GltfAssetLabel::Scene(0).from_asset("models/animated/Fox.glb")),
    ));

    // Light
    commands.spawn((
        Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, 1.0, -PI / 4.)),
        DirectionalLight {
            shadow_maps_enabled: true,
            ..default()
        },
        CascadeShadowConfigBuilder {
            num_cascades: if cfg!(all(
                feature = "webgl2",
                target_arch = "wasm32",
                not(feature = "webgpu")
            )) {
                // Limited to 1 cascade in WebGL
                1
            } else {
                2
            },
            first_cascade_far_bound: 200.0,
            maximum_distance: 280.0,
            ..default()
        }
        .build(),
    ));

    let material = StandardMaterial {
        perceptual_roughness: 0.0,
        specular_transmission: 1.0,
        cull_mode: None,
        ..default()
    };
    let material = materials.add(material);

    let cuboid = meshes.add(Cuboid {
        half_size: Vec3::splat(0.5),
    });

    // Cameras and their dedicated UI
    for (index, (camera_name, camera_pos)) in [
        ("Player 1", Vec3::new(0.0, 200.0, -150.0)),
        ("Player 2", Vec3::new(150.0, 150., 50.0)),
        ("Player 3", Vec3::new(100.0, 150., -150.0)),
        ("Player 4", Vec3::new(-100.0, 80., 150.0)),
    ]
    .iter()
    .enumerate()
    {
        let camera = commands
            .spawn((
                Camera3d::default(),
                Transform::from_translation(*camera_pos).looking_at(Vec3::ZERO, Vec3::Y),
                Camera {
                    // Renders cameras with different priorities to prevent ambiguities
                    order: index as isize,
                    ..default()
                },
                CameraPosition {
                    pos: UVec2::new((index % 2) as u32, (index / 2) as u32),
                },
                children![(
                    Transform::from_translation(Vec3::new(-0.5, 0.0, -1.8))
                        .with_rotation(Quat::from_rotation_y(1.0)),
                    Mesh3d(cuboid.clone()),
                    MeshMaterial3d(material.clone())
                )],
            ))
            .id();

        // Set up UI
        commands.spawn((
            UiTargetCamera(camera),
            Node {
                width: percent(100),
                height: percent(100),
                ..default()
            },
            children![
                (
                    Text::new(*camera_name),
                    Node {
                        position_type: PositionType::Absolute,
                        top: px(12),
                        left: px(12),
                        ..default()
                    },
                ),
                buttons_panel(),
            ],
        ));
    }

    fn buttons_panel() -> impl Bundle {
        (
            Node {
                position_type: PositionType::Absolute,
                width: percent(100),
                height: percent(100),
                display: Display::Flex,
                flex_direction: FlexDirection::Row,
                justify_content: JustifyContent::SpaceBetween,
                align_items: AlignItems::Center,
                padding: UiRect::all(px(20)),
                ..default()
            },
            children![
                rotate_button("<", Direction::Left),
                rotate_button(">", Direction::Right),
            ],
        )
    }

    fn rotate_button(caption: &str, direction: Direction) -> impl Bundle {
        (
            RotateCamera(direction),
            Button,
            Node {
                width: px(40),
                height: px(40),
                border: UiRect::all(px(2)),
                justify_content: JustifyContent::Center,
                align_items: AlignItems::Center,
                ..default()
            },
            BorderColor::all(Color::WHITE),
            BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
            children![Text::new(caption)],
        )
    }
}

#[derive(Component)]
struct CameraPosition {
    pos: UVec2,
}

#[derive(Component)]
struct RotateCamera(Direction);

enum Direction {
    Left,
    Right,
}

fn set_camera_viewports(
    windows: Query<&Window>,
    mut window_resized_reader: MessageReader<WindowResized>,
    mut query: Query<(&CameraPosition, &mut Camera)>,
) {
    // We need to dynamically resize the camera's viewports whenever the window size changes
    // so then each camera always takes up half the screen.
    // A resize_event is sent when the window is first created, allowing us to reuse this system for initial setup.
    for window_resized in window_resized_reader.read() {
        let window = windows.get(window_resized.window).unwrap();
        let size = window.physical_size() / 2;

        for (camera_position, mut camera) in &mut query {
            camera.viewport = Some(Viewport {
                physical_position: camera_position.pos * size,
                physical_size: size,
                ..default()
            });
        }
    }
}

fn button_system(
    interaction_query: Query<
        (&Interaction, &ComputedUiTargetCamera, &RotateCamera),
        (Changed<Interaction>, With<Button>),
    >,
    mut camera_query: Query<&mut Transform, With<Camera>>,
) {
    for (interaction, computed_target, RotateCamera(direction)) in &interaction_query {
        if let Interaction::Pressed = *interaction {
            // Since TargetCamera propagates to the children, we can use it to find
            // which side of the screen the button is on.
            if let Some(mut camera_transform) = computed_target
                .get()
                .and_then(|camera| camera_query.get_mut(camera).ok())
            {
                let angle = match direction {
                    Direction::Left => -0.1,
                    Direction::Right => 0.1,
                };
                camera_transform.rotate_around(Vec3::ZERO, Quat::from_axis_angle(Vec3::Y, angle));
            }
        }
    }
}
```

</details>
