### PR TITLE
Expose `bevy::pbr::gltf` module.

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -28,7 +28,7 @@ mod atmosphere;
 mod cluster;
 pub mod contact_shadows;
 #[cfg(feature = "bevy_gltf")]
-mod gltf;
+pub mod gltf;
 use bevy_light::cluster::GlobalClusterSettings;
 use bevy_render::{
     sync_component::SyncComponent,


### PR DESCRIPTION
# Objective

This allows users to reuse `standard_material_from_gltf_material` given the 0.19 changes to expose GltfMaterial instead of StandardMaterial.

Clients that iterate `Gltf` and `GltfMesh` to reclaim the ability to manually instantiate the materials from `GltfMaterial` as in 0.18.

See https://discord.com/channels/691052431525675048/749332104487108618/1521606712623235082

## Solution

- Expose `bevy::pbr::gltf` as `pub`. It only exposes the given function as `pub`.

(An alternative is to provide `pub use standard_material_from_gltf_material` from `bevy::pbr`, but that makes the client `use bevy::pbr::standard_material_from_gltf_material` which might be confusing.

## Testing

- Tested with my code that can now use `use bevy::pbr::gltf::standard_material_from_gltf_material;`.