### PR TITLE
Fix SubApp::add_message does not schedule `message_update_system`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -407,8 +407,7 @@ impl App {
         self
     }
 
-    /// Initializes [`Message`] handling for `T` by inserting a message queue resource ([`Messages::<T>`])
-    /// and scheduling an [`message_update_system`] in [`First`].
+    /// Initializes [`Message`] handling for `T` by inserting a message queue resource ([`Messages::<T>`]).
     ///
     /// See [`Messages`] for information on how to define messages.
     ///

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1,6 +1,5 @@
 use crate::{
-    First, Main, MainSchedulePlugin, PlaceholderPlugin, Plugin, Plugins, PluginsState, SubApp,
-    SubApps,
+    Main, MainSchedulePlugin, PlaceholderPlugin, Plugin, Plugins, PluginsState, SubApp, SubApps,
 };
 use alloc::{
     boxed::Box,
@@ -12,7 +11,7 @@ use bevy_ecs::{
     component::RequiredComponentsError,
     error::{ErrorHandler, FallbackErrorHandler},
     intern::Interned,
-    message::{message_update_system, MessageCursor},
+    message::MessageCursor,
     observer::IntoObserver,
     prelude::*,
     schedule::{
@@ -123,12 +122,6 @@ impl Default for App {
         app.init_resource::<AppFunctionRegistry>();
 
         app.add_plugins(MainSchedulePlugin);
-        app.add_systems(
-            First,
-            message_update_system
-                .in_set(bevy_ecs::message::MessageUpdateSystems)
-                .run_if(bevy_ecs::message::message_update_condition),
-        );
         app.add_systems(
             crate::Last,
             bevy_ecs::system::despawn_unused_registered_systems,

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -1,7 +1,7 @@
-use crate::{App, AppLabel, InternedAppLabel, Plugin, Plugins, PluginsState};
+use crate::{App, AppLabel, First, InternedAppLabel, Plugin, Plugins, PluginsState};
 use alloc::{boxed::Box, string::String, vec::Vec};
 use bevy_ecs::{
-    message::MessageRegistry,
+    message::{message_update_system, MessageRegistry},
     observer::IntoObserver,
     prelude::*,
     schedule::{
@@ -384,6 +384,14 @@ impl SubApp {
     where
         T: Message,
     {
+        if !self.world.contains_resource::<MessageRegistry>() {
+            self.add_systems(
+                First,
+                message_update_system
+                    .in_set(bevy_ecs::message::MessageUpdateSystems)
+                    .run_if(bevy_ecs::message::message_update_condition),
+            );
+        }
         if !self.world.contains_resource::<Messages<T>>() {
             MessageRegistry::register_message::<T>(self.world_mut());
         }
@@ -598,5 +606,47 @@ impl SubApps {
             sub_app.extract(&mut self.main.world);
             sub_app.update();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn sub_app_add_message_schedules_update_system() {
+        use crate::{First, SubApp};
+        use bevy_ecs::message::Messages;
+        use bevy_ecs::prelude::Message;
+        use bevy_ecs::schedule::{Schedule, ScheduleLabel, Schedules};
+
+        #[derive(Message, Clone, Copy)]
+        struct TestMsg;
+
+        let mut sub_app = SubApp::new();
+
+        // Wire the sub-app to actually run `First` each update so the test
+        // does not silently pass simply because nothing in the schedule runs.
+        sub_app.update_schedule = Some(First.intern());
+        sub_app
+            .world_mut()
+            .resource_mut::<Schedules>()
+            .insert(Schedule::new(First));
+
+        sub_app.add_message::<TestMsg>();
+
+        {
+            let mut msgs = sub_app.world_mut().resource_mut::<Messages<TestMsg>>();
+            msgs.write(TestMsg);
+            msgs.write(TestMsg);
+        }
+
+        assert_eq!(sub_app.world().resource::<Messages<TestMsg>>().len(), 2);
+
+        // Two updates will let the double buffer rotate twice and drop
+        // the events. As long as a `message_update_system` is set up,
+        // the following assertion should pass.
+        sub_app.update();
+        sub_app.update();
+
+        assert_eq!(sub_app.world().resource::<Messages<TestMsg>>().len(), 0);
     }
 }

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -88,6 +88,8 @@ impl Debug for SubApp {
 }
 
 impl Default for SubApp {
+    /// As part of default initialization, we schedule a [`message_update_system`] in [`First`].
+    /// We expect all [`SubApp`] implementations to schedule [`First`] regularly.
     fn default() -> Self {
         let mut world = World::new();
         world.init_resource::<Schedules>();

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -91,6 +91,12 @@ impl Default for SubApp {
     fn default() -> Self {
         let mut world = World::new();
         world.init_resource::<Schedules>();
+        world.resource_mut::<Schedules>().add_systems(
+            First,
+            message_update_system
+                .in_set(bevy_ecs::message::MessageUpdateSystems)
+                .run_if(bevy_ecs::message::message_update_condition),
+        );
         Self {
             world,
             plugin_registry: Vec::default(),
@@ -384,14 +390,6 @@ impl SubApp {
     where
         T: Message,
     {
-        if !self.world.contains_resource::<MessageRegistry>() {
-            self.add_systems(
-                First,
-                message_update_system
-                    .in_set(bevy_ecs::message::MessageUpdateSystems)
-                    .run_if(bevy_ecs::message::message_update_condition),
-            );
-        }
         if !self.world.contains_resource::<Messages<T>>() {
             MessageRegistry::register_message::<T>(self.world_mut());
         }
@@ -616,20 +614,17 @@ mod tests {
         use crate::{First, SubApp};
         use bevy_ecs::message::Messages;
         use bevy_ecs::prelude::Message;
-        use bevy_ecs::schedule::{Schedule, ScheduleLabel, Schedules};
+        use bevy_ecs::schedule::ScheduleLabel;
 
         #[derive(Message, Clone, Copy)]
         struct TestMsg;
 
-        let mut sub_app = SubApp::new();
-
         // Wire the sub-app to actually run `First` each update so the test
         // does not silently pass simply because nothing in the schedule runs.
-        sub_app.update_schedule = Some(First.intern());
-        sub_app
-            .world_mut()
-            .resource_mut::<Schedules>()
-            .insert(Schedule::new(First));
+        let mut sub_app = SubApp {
+            update_schedule: Some(First.intern()),
+            ..Default::default()
+        };
 
         sub_app.add_message::<TestMsg>();
 

--- a/crates/bevy_dev_tools/src/schedule_data/plugin.rs
+++ b/crates/bevy_dev_tools/src/schedule_data/plugin.rs
@@ -139,9 +139,8 @@ mod tests {
 
     use crate::schedule_data::{
         plugin::collect_system_data_inner,
-        serde::{
-            tests::{remove_module_paths, simple_system, sort_app_data},
-            SystemData,
+        serde::tests::{
+            remove_module_paths, simple_system, sort_app_data, validate_message_update_system,
         },
     };
 
@@ -164,17 +163,7 @@ mod tests {
 
         assert_eq!(app_data.schedules.len(), 3);
         let first = &app_data.schedules[0];
-        assert_eq!(first.name, "First");
-        assert_eq!(
-            first.systems,
-            [SystemData {
-                name: "message_update_system".into(),
-                apply_deferred: false,
-                exclusive: true,
-                deferred: false,
-                filtered_accesses: vec![],
-            }]
-        );
+        validate_message_update_system(first);
         let post_update = &app_data.schedules[1];
         assert_eq!(post_update.name, "PostUpdate");
         assert_eq!(post_update.systems, [simple_system("c")]);

--- a/crates/bevy_dev_tools/src/schedule_data/plugin.rs
+++ b/crates/bevy_dev_tools/src/schedule_data/plugin.rs
@@ -139,7 +139,10 @@ mod tests {
 
     use crate::schedule_data::{
         plugin::collect_system_data_inner,
-        serde::tests::{remove_module_paths, simple_system, sort_app_data},
+        serde::{
+            tests::{remove_module_paths, simple_system, sort_app_data},
+            SystemData,
+        },
     };
 
     #[test]
@@ -159,11 +162,23 @@ mod tests {
         remove_module_paths(&mut app_data);
         sort_app_data(&mut app_data);
 
-        assert_eq!(app_data.schedules.len(), 2);
-        let post_update = &app_data.schedules[0];
+        assert_eq!(app_data.schedules.len(), 3);
+        let first = &app_data.schedules[0];
+        assert_eq!(first.name, "First");
+        assert_eq!(
+            first.systems,
+            [SystemData {
+                name: "message_update_system".into(),
+                apply_deferred: false,
+                exclusive: true,
+                deferred: false,
+                filtered_accesses: vec![],
+            }]
+        );
+        let post_update = &app_data.schedules[1];
         assert_eq!(post_update.name, "PostUpdate");
         assert_eq!(post_update.systems, [simple_system("c")]);
-        let update = &app_data.schedules[1];
+        let update = &app_data.schedules[2];
         assert_eq!(update.name, "Update");
         assert_eq!(update.systems, [simple_system("a"), simple_system("b")]);
     }

--- a/crates/bevy_dev_tools/src/schedule_data/serde.rs
+++ b/crates/bevy_dev_tools/src/schedule_data/serde.rs
@@ -793,16 +793,37 @@ pub mod tests {
         app.add_systems(Update, (a, b, c).chain());
 
         let data = app_data_from_app(&mut app).unwrap();
-        assert_eq!(data.schedules.len(), 1);
-        let schedule = &data.schedules[0];
-        assert_eq!(schedule.name, "Update");
+        // SubApps start with the First schedule by default.
+        assert_eq!(data.schedules.len(), 2);
+        let first = &data.schedules[0];
+        assert_eq!(first.name, "First");
         assert_eq!(
-            schedule.systems,
+            first.systems,
+            [SystemData {
+                name: "message_update_system".into(),
+                apply_deferred: false,
+                exclusive: true,
+                deferred: false,
+                filtered_accesses: vec![],
+            }]
+        );
+        assert_eq!(
+            first.system_sets,
+            [
+                simple_system_set("MessageUpdateSystems"),
+                simple_system_set("SystemTypeSet:message_update_system"),
+            ]
+        );
+
+        let update = &data.schedules[1];
+        assert_eq!(update.name, "Update");
+        assert_eq!(
+            update.systems,
             [simple_system("a"), simple_system("b"), simple_system("c"),]
         );
         // Each system is also a system set.
         assert_eq!(
-            schedule.system_sets,
+            update.system_sets,
             [
                 simple_system_set("SystemTypeSet:a"),
                 simple_system_set("SystemTypeSet:b"),
@@ -811,7 +832,7 @@ pub mod tests {
         );
         // Every system is in its own system set.
         assert_eq!(
-            schedule.hierarchy,
+            update.hierarchy,
             [
                 (SystemSetIndex(0), ScheduleIndex::System(0)),
                 (SystemSetIndex(1), ScheduleIndex::System(1)),
@@ -820,14 +841,14 @@ pub mod tests {
         );
         // There are 2 dependency edges to connect a-b and b-c.
         assert_eq!(
-            schedule.dependency,
+            update.dependency,
             [
                 (ScheduleIndex::System(0), ScheduleIndex::System(1)),
                 (ScheduleIndex::System(1), ScheduleIndex::System(2)),
             ]
         );
-        assert_eq!(schedule.components.len(), 0);
-        assert_eq!(schedule.conflicts.len(), 0);
+        assert_eq!(update.components.len(), 0);
+        assert_eq!(update.conflicts.len(), 0);
     }
 
     #[test]
@@ -837,29 +858,50 @@ pub mod tests {
         app.configure_sets(Update, (MySet::<0>, MySet::<1>, MySet::<2>).chain());
 
         let data = app_data_from_app(&mut app).unwrap();
-        assert_eq!(data.schedules.len(), 1);
-        let schedule = &data.schedules[0];
-        assert_eq!(schedule.name, "Update");
-        assert_eq!(schedule.systems, []);
+        // SubApps start with the First schedule by default.
+        assert_eq!(data.schedules.len(), 2);
+        let first = &data.schedules[0];
+        assert_eq!(first.name, "First");
         assert_eq!(
-            schedule.system_sets,
+            first.systems,
+            [SystemData {
+                name: "message_update_system".into(),
+                apply_deferred: false,
+                exclusive: true,
+                deferred: false,
+                filtered_accesses: vec![],
+            }]
+        );
+        assert_eq!(
+            first.system_sets,
+            [
+                simple_system_set("MessageUpdateSystems"),
+                simple_system_set("SystemTypeSet:message_update_system"),
+            ]
+        );
+
+        let update = &data.schedules[1];
+        assert_eq!(update.name, "Update");
+        assert_eq!(update.systems, []);
+        assert_eq!(
+            update.system_sets,
             [
                 simple_system_set("MySet<0>"),
                 simple_system_set("MySet<1>"),
                 simple_system_set("MySet<2>"),
             ]
         );
-        assert_eq!(schedule.hierarchy, []);
+        assert_eq!(update.hierarchy, []);
         // There are 2 dependency edges to connect 0-1 and 1-2.
         assert_eq!(
-            schedule.dependency,
+            update.dependency,
             [
                 (ScheduleIndex::SystemSet(0), ScheduleIndex::SystemSet(1)),
                 (ScheduleIndex::SystemSet(1), ScheduleIndex::SystemSet(2)),
             ]
         );
-        assert_eq!(schedule.components.len(), 0);
-        assert_eq!(schedule.conflicts.len(), 0);
+        assert_eq!(update.components.len(), 0);
+        assert_eq!(update.conflicts.len(), 0);
     }
 
     #[test]
@@ -873,12 +915,33 @@ pub mod tests {
             .configure_sets(Update, MySet::<1>.in_set(MySet::<2>));
 
         let data = app_data_from_app(&mut app).unwrap();
-        assert_eq!(data.schedules.len(), 1);
-        let schedule = &data.schedules[0];
-        assert_eq!(schedule.name, "Update");
-        assert_eq!(schedule.systems, [simple_system("a")]);
+        // SubApps start with the First schedule by default.
+        assert_eq!(data.schedules.len(), 2);
+        let first = &data.schedules[0];
+        assert_eq!(first.name, "First");
         assert_eq!(
-            schedule.system_sets,
+            first.systems,
+            [SystemData {
+                name: "message_update_system".into(),
+                apply_deferred: false,
+                exclusive: true,
+                deferred: false,
+                filtered_accesses: vec![],
+            }]
+        );
+        assert_eq!(
+            first.system_sets,
+            [
+                simple_system_set("MessageUpdateSystems"),
+                simple_system_set("SystemTypeSet:message_update_system"),
+            ]
+        );
+
+        let update = &data.schedules[1];
+        assert_eq!(update.name, "Update");
+        assert_eq!(update.systems, [simple_system("a")]);
+        assert_eq!(
+            update.system_sets,
             [
                 simple_system_set("MySet<0>"),
                 simple_system_set("MySet<1>"),
@@ -887,7 +950,7 @@ pub mod tests {
             ]
         );
         assert_eq!(
-            schedule.hierarchy,
+            update.hierarchy,
             [
                 (SystemSetIndex(0), ScheduleIndex::System(0)),
                 (SystemSetIndex(1), ScheduleIndex::SystemSet(0)),
@@ -895,9 +958,9 @@ pub mod tests {
                 (SystemSetIndex(3), ScheduleIndex::System(0)),
             ]
         );
-        assert_eq!(schedule.dependency, []);
-        assert_eq!(schedule.components.len(), 0);
-        assert_eq!(schedule.conflicts.len(), 0);
+        assert_eq!(update.dependency, []);
+        assert_eq!(update.components.len(), 0);
+        assert_eq!(update.conflicts.len(), 0);
     }
 
     #[test]
@@ -915,11 +978,32 @@ pub mod tests {
         app.add_systems(Update, (((a0, a1), (b0, b1)).chain(), (c0, c1).chain()));
 
         let data = app_data_from_app(&mut app).unwrap();
-        assert_eq!(data.schedules.len(), 1);
-        let schedule = &data.schedules[0];
-        assert_eq!(schedule.name, "Update");
+        // SubApps start with the First schedule by default.
+        assert_eq!(data.schedules.len(), 2);
+        let first = &data.schedules[0];
+        assert_eq!(first.name, "First");
         assert_eq!(
-            schedule.systems,
+            first.systems,
+            [SystemData {
+                name: "message_update_system".into(),
+                apply_deferred: false,
+                exclusive: true,
+                deferred: false,
+                filtered_accesses: vec![],
+            }]
+        );
+        assert_eq!(
+            first.system_sets,
+            [
+                simple_system_set("MessageUpdateSystems"),
+                simple_system_set("SystemTypeSet:message_update_system"),
+            ]
+        );
+
+        let update = &data.schedules[1];
+        assert_eq!(update.name, "Update");
+        assert_eq!(
+            update.systems,
             [
                 SystemData {
                     name: "a0".into(),
@@ -949,7 +1033,7 @@ pub mod tests {
             ]
         );
         assert_eq!(
-            schedule.system_sets,
+            update.system_sets,
             [
                 simple_system_set("SystemTypeSet:a0"),
                 simple_system_set("SystemTypeSet:a1"),
@@ -960,7 +1044,7 @@ pub mod tests {
             ]
         );
         assert_eq!(
-            schedule.hierarchy,
+            update.hierarchy,
             [
                 (SystemSetIndex(0), ScheduleIndex::System(0)),
                 (SystemSetIndex(1), ScheduleIndex::System(1)),
@@ -971,7 +1055,7 @@ pub mod tests {
             ]
         );
         assert_eq!(
-            schedule.dependency,
+            update.dependency,
             [
                 // a->sync and a->b
                 (ScheduleIndex::System(0), ScheduleIndex::System(2)),
@@ -987,8 +1071,8 @@ pub mod tests {
                 (ScheduleIndex::System(5), ScheduleIndex::System(6)),
             ]
         );
-        assert_eq!(schedule.components.len(), 0);
-        assert_eq!(schedule.conflicts.len(), 0);
+        assert_eq!(update.components.len(), 0);
+        assert_eq!(update.conflicts.len(), 0);
     }
 
     #[test]
@@ -1034,11 +1118,32 @@ pub mod tests {
         app.add_systems(Update, (a0, a1, b0, b1, c0, c1, d0, d1, (e0, e1).chain()));
 
         let data = app_data_from_app(&mut app).unwrap();
-        assert_eq!(data.schedules.len(), 1);
-        let schedule = &data.schedules[0];
-        assert_eq!(schedule.name, "Update");
+        // SubApps start with the First schedule by default.
+        assert_eq!(data.schedules.len(), 2);
+        let first = &data.schedules[0];
+        assert_eq!(first.name, "First");
         assert_eq!(
-            schedule.components,
+            first.systems,
+            [SystemData {
+                name: "message_update_system".into(),
+                apply_deferred: false,
+                exclusive: true,
+                deferred: false,
+                filtered_accesses: vec![],
+            }]
+        );
+        assert_eq!(
+            first.system_sets,
+            [
+                simple_system_set("MessageUpdateSystems"),
+                simple_system_set("SystemTypeSet:message_update_system"),
+            ]
+        );
+
+        let update = &data.schedules[1];
+        assert_eq!(update.name, "Update");
+        assert_eq!(
+            update.components,
             [
                 simple_component("Disabled"),
                 simple_component("MyComponent<0>"),
@@ -1055,7 +1160,7 @@ pub mod tests {
         );
 
         assert_eq!(
-            schedule.systems,
+            update.systems,
             [
                 full_system("a0", vec![0], vec![], None, None),
                 full_system("a1", vec![0], vec![], None, None),
@@ -1071,7 +1176,7 @@ pub mod tests {
         );
 
         assert_eq!(
-            schedule.system_sets,
+            update.system_sets,
             [
                 simple_system_set("SystemTypeSet:a0"),
                 simple_system_set("SystemTypeSet:a1"),
@@ -1086,7 +1191,7 @@ pub mod tests {
             ]
         );
         assert_eq!(
-            schedule.hierarchy,
+            update.hierarchy,
             [
                 (SystemSetIndex(0), ScheduleIndex::System(0)),
                 (SystemSetIndex(1), ScheduleIndex::System(1)),
@@ -1101,14 +1206,14 @@ pub mod tests {
             ]
         );
         assert_eq!(
-            schedule.dependency,
+            update.dependency,
             [
                 // e0 -> e1
                 (ScheduleIndex::System(8), ScheduleIndex::System(9)),
             ]
         );
         assert_eq!(
-            schedule.conflicts,
+            update.conflicts,
             [
                 // +1 on components for 0 = Disabled
 

--- a/crates/bevy_dev_tools/src/schedule_data/serde.rs
+++ b/crates/bevy_dev_tools/src/schedule_data/serde.rs
@@ -768,6 +768,29 @@ pub mod tests {
         }
     }
 
+    /// Convenience to check the structure of the first schedule in an [`App`], which should always
+    /// be [`First`] containing [`message_update_system`].
+    pub fn validate_message_update_system(schedule: &ScheduleData) {
+        assert_eq!(schedule.name, "First");
+        assert_eq!(
+            schedule.systems,
+            [SystemData {
+                name: "message_update_system".into(),
+                apply_deferred: false,
+                exclusive: true,
+                deferred: false,
+                filtered_accesses: vec![],
+            }]
+        );
+        assert_eq!(
+            schedule.system_sets,
+            [
+                simple_system_set("MessageUpdateSystems"),
+                simple_system_set("SystemTypeSet:message_update_system"),
+            ]
+        );
+    }
+
     /// A convenience system set that is generic allowing us to make many of these quickly.
     #[derive(SystemSet, Hash, PartialEq, Eq, Clone)]
     struct MySet<const NUM: u32>;
@@ -795,25 +818,7 @@ pub mod tests {
         let data = app_data_from_app(&mut app).unwrap();
         // SubApps start with the First schedule by default.
         assert_eq!(data.schedules.len(), 2);
-        let first = &data.schedules[0];
-        assert_eq!(first.name, "First");
-        assert_eq!(
-            first.systems,
-            [SystemData {
-                name: "message_update_system".into(),
-                apply_deferred: false,
-                exclusive: true,
-                deferred: false,
-                filtered_accesses: vec![],
-            }]
-        );
-        assert_eq!(
-            first.system_sets,
-            [
-                simple_system_set("MessageUpdateSystems"),
-                simple_system_set("SystemTypeSet:message_update_system"),
-            ]
-        );
+        validate_message_update_system(&data.schedules[0]);
 
         let update = &data.schedules[1];
         assert_eq!(update.name, "Update");
@@ -860,26 +865,7 @@ pub mod tests {
         let data = app_data_from_app(&mut app).unwrap();
         // SubApps start with the First schedule by default.
         assert_eq!(data.schedules.len(), 2);
-        let first = &data.schedules[0];
-        assert_eq!(first.name, "First");
-        assert_eq!(
-            first.systems,
-            [SystemData {
-                name: "message_update_system".into(),
-                apply_deferred: false,
-                exclusive: true,
-                deferred: false,
-                filtered_accesses: vec![],
-            }]
-        );
-        assert_eq!(
-            first.system_sets,
-            [
-                simple_system_set("MessageUpdateSystems"),
-                simple_system_set("SystemTypeSet:message_update_system"),
-            ]
-        );
-
+        validate_message_update_system(&data.schedules[0]);
         let update = &data.schedules[1];
         assert_eq!(update.name, "Update");
         assert_eq!(update.systems, []);
@@ -917,26 +903,7 @@ pub mod tests {
         let data = app_data_from_app(&mut app).unwrap();
         // SubApps start with the First schedule by default.
         assert_eq!(data.schedules.len(), 2);
-        let first = &data.schedules[0];
-        assert_eq!(first.name, "First");
-        assert_eq!(
-            first.systems,
-            [SystemData {
-                name: "message_update_system".into(),
-                apply_deferred: false,
-                exclusive: true,
-                deferred: false,
-                filtered_accesses: vec![],
-            }]
-        );
-        assert_eq!(
-            first.system_sets,
-            [
-                simple_system_set("MessageUpdateSystems"),
-                simple_system_set("SystemTypeSet:message_update_system"),
-            ]
-        );
-
+        validate_message_update_system(&data.schedules[0]);
         let update = &data.schedules[1];
         assert_eq!(update.name, "Update");
         assert_eq!(update.systems, [simple_system("a")]);
@@ -980,26 +947,7 @@ pub mod tests {
         let data = app_data_from_app(&mut app).unwrap();
         // SubApps start with the First schedule by default.
         assert_eq!(data.schedules.len(), 2);
-        let first = &data.schedules[0];
-        assert_eq!(first.name, "First");
-        assert_eq!(
-            first.systems,
-            [SystemData {
-                name: "message_update_system".into(),
-                apply_deferred: false,
-                exclusive: true,
-                deferred: false,
-                filtered_accesses: vec![],
-            }]
-        );
-        assert_eq!(
-            first.system_sets,
-            [
-                simple_system_set("MessageUpdateSystems"),
-                simple_system_set("SystemTypeSet:message_update_system"),
-            ]
-        );
-
+        validate_message_update_system(&data.schedules[0]);
         let update = &data.schedules[1];
         assert_eq!(update.name, "Update");
         assert_eq!(
@@ -1120,26 +1068,7 @@ pub mod tests {
         let data = app_data_from_app(&mut app).unwrap();
         // SubApps start with the First schedule by default.
         assert_eq!(data.schedules.len(), 2);
-        let first = &data.schedules[0];
-        assert_eq!(first.name, "First");
-        assert_eq!(
-            first.systems,
-            [SystemData {
-                name: "message_update_system".into(),
-                apply_deferred: false,
-                exclusive: true,
-                deferred: false,
-                filtered_accesses: vec![],
-            }]
-        );
-        assert_eq!(
-            first.system_sets,
-            [
-                simple_system_set("MessageUpdateSystems"),
-                simple_system_set("SystemTypeSet:message_update_system"),
-            ]
-        );
-
+        validate_message_update_system(&data.schedules[0]);
         let update = &data.schedules[1];
         assert_eq!(update.name, "Update");
         assert_eq!(

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -258,7 +258,7 @@ pub struct RenderScheduleOrder {
 impl Default for RenderScheduleOrder {
     fn default() -> Self {
         Self {
-            labels: vec![Render.intern()],
+            labels: vec![First.intern(), Render.intern()],
         }
     }
 }
@@ -392,11 +392,6 @@ impl Plugin for RenderPlugin {
             .init_resource::<RenderErrorHandler>();
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.init_resource::<RenderScheduleOrder>();
-            render_app
-                .init_schedule(First)
-                .world_mut()
-                .resource_mut::<RenderScheduleOrder>()
-                .insert_before(Render, First);
             render_app.init_resource::<RenderAssetBytesPerFrameLimiter>();
             render_app.init_gpu_resource::<renderer::PendingCommandBuffers>();
             render_app.insert_resource(sender);

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -98,7 +98,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 use batching::gpu_preprocessing::BatchingPlugin;
-use bevy_app::{App, AppLabel, Plugin, SubApp};
+use bevy_app::{App, AppLabel, First, Plugin, SubApp};
 use bevy_asset::{AssetApp, AssetServer};
 use bevy_derive::Deref;
 use bevy_ecs::{
@@ -392,6 +392,11 @@ impl Plugin for RenderPlugin {
             .init_resource::<RenderErrorHandler>();
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.init_resource::<RenderScheduleOrder>();
+            render_app
+                .init_schedule(First)
+                .world_mut()
+                .resource_mut::<RenderScheduleOrder>()
+                .insert_before(Render, First);
             render_app.init_resource::<RenderAssetBytesPerFrameLimiter>();
             render_app.init_gpu_resource::<renderer::PendingCommandBuffers>();
             render_app.insert_resource(sender);


### PR DESCRIPTION
# Objective
Fixes #23780.

Previously App::default() scheduled `message_update_system`, which registered it for main apps only. Other sub-apps that tried to call `add_message` would result in a message buffer that never rotated, and that would grow unbounded.

## Solution

This change moves this logic into SubApp::add_message so that sub-apps can call `add_message` and get more reasonable behavior, minus the memory leak.

## Testing

Added the test from the issue discussion.

---