### PR TITLE
Fix MP4 Audio Playback Failure in Bevy 0.19.0

### DIFF
--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -94,7 +94,11 @@ impl Decodable for AudioSource {
     type Decoder = rodio::Decoder<Cursor<AudioSource>>;
 
     fn decoder(&self) -> Self::Decoder {
-        rodio::Decoder::new(Cursor::new(self.clone())).unwrap()
+        rodio::Decoder::builder()
+            .with_byte_len(self.bytes.len() as u64)
+            .with_data(Cursor::new(self.clone()))
+            .build()
+            .unwrap()
     }
 }
 


### PR DESCRIPTION
# Objective

Fix https://github.com/bevyengine/bevy/issues/24878

# Solution
Refactor audio decoder method to use rodio builder pattern

# Testing

```rust
use bevy::prelude::*;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .run();
}

fn setup(asset_server: Res<AssetServer>, mut commands: Commands) {
    commands.spawn(AudioPlayer::new(
        asset_server.load("something.mp4"),
    ));
}
```
