### PR TITLE
Solari: Fix normal maps and support two-channel maps

### DIFF
--- a/crates/bevy_solari/src/scene/raytracing_scene_bindings.wgsl
+++ b/crates/bevy_solari/src/scene/raytracing_scene_bindings.wgsl
@@ -215,7 +215,8 @@ fn resolve_triangle_data_full(instance_id: u32, triangle_id: u32, barycentrics: 
         let T = TBN[0];
         let B = TBN[1];
         let N = TBN[2];
-        let Nt = sample_texture(material.normal_map_texture_id, uv);
+        var Nt = sample_texture(material.normal_map_texture_id, uv) * 2.0 - 1.0;
+        Nt.z = sqrt(max(1.0 - dot(Nt.xy, Nt.xy), 0.0)); // Reconstruct Z to support two-channel normal maps
         world_normal = normalize(Nt.x * T + Nt.y * B + Nt.z * N);
     }
 


### PR DESCRIPTION
I was missing the `* 2.0 - 1.0` before. See: https://github.com/bevyengine/bevy/blob/0eac08ae5da33f39d64ad148740c34c14b38c481/crates/bevy_pbr/src/render/pbr_functions.wgsl#L204-L210

Also now we reconstruct Z so that two-channel normal maps (e.g. from the texture compressor plugin) are supported. 