### PR TITLE
Clear stale atmosphere components when AtmosphereSettings or Atmosphere components are removed.

### DIFF
--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -89,7 +89,8 @@ use crate::resources::prepare_atmosphere_buffers;
 
 use self::resources::{
     prepare_atmosphere_bind_groups, prepare_atmosphere_textures, AtmosphereBindGroupLayouts,
-    AtmosphereLutPipelines, AtmosphereSampler,
+    AtmosphereBindGroups, AtmosphereLutPipelines, AtmosphereSampler, AtmosphereTextures,
+    AtmosphereTransformsOffset, RenderSkyPipelineId,
 };
 
 #[doc(hidden)]
@@ -205,24 +206,28 @@ impl Plugin for AtmospherePlugin {
 pub fn extract_atmosphere(
     mut commands: Commands,
     atmosphere_entities: Extract<Query<(Entity, &Atmosphere, &GlobalTransform)>>,
-    cameras: Extract<Query<(RenderEntity, &AtmosphereSettings, &GlobalTransform), With<Camera3d>>>,
+    cameras: Extract<
+        Query<(RenderEntity, Option<&AtmosphereSettings>, &GlobalTransform), With<Camera3d>>,
+    >,
 ) {
     let candidates: Vec<(Entity, &Atmosphere, &GlobalTransform)> =
         atmosphere_entities.iter().collect();
 
-    if candidates.is_empty() {
-        for (render_entity, ..) in &cameras {
-            commands
-                .entity(render_entity)
-                .remove::<ExtractedAtmosphere>();
-            commands
-                .entity(render_entity)
-                .remove::<GpuAtmosphereSettings>();
-        }
-        return;
-    }
-
     for (render_entity, settings, cam_global) in &cameras {
+        // Remove any stale render-world state when AtmosphereSettings is removed or candidates is empty
+        let (Some(settings), false) = (settings, candidates.is_empty()) else {
+            commands.entity(render_entity).remove::<(
+                ExtractedAtmosphere,
+                GpuAtmosphereSettings,
+                GpuAtmosphere,
+                AtmosphereTextures,
+                AtmosphereTransformsOffset,
+                RenderSkyPipelineId,
+                AtmosphereBindGroups,
+            )>();
+            continue;
+        };
+
         let cam_world = cam_global.translation();
         let selected = candidates
             .iter()

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -216,7 +216,7 @@ pub fn extract_atmosphere(
     for (render_entity, settings, cam_global) in &cameras {
         // Remove any stale render-world state when AtmosphereSettings is removed or candidates is empty
         let (Some(settings), false) = (settings, candidates.is_empty()) else {
-            commands.entity(render_entity).remove::<(
+            commands.entity(render_entity).try_remove::<(
                 ExtractedAtmosphere,
                 GpuAtmosphereSettings,
                 GpuAtmosphere,


### PR DESCRIPTION
# Objective

- Fixes #24808 

## Solution

- The extract system in the atmosphere module now correctly removes the components that cause sky rendering for each camera when either the camera has no AtmosphereSettings or there are no entities with Atmosphere components. 

## Testing

- I tested using the example provided by the issue, [here](https://github.com/Novakasa/bevy/tree/explore-atmosphere-disabling)

I am not sure about the correct praxis for extract systems. I made it so the system now completely clears related components, but to disable unwanted rendering it would be enough to only remove AtmosphereBindGroups in addition to the two that were removed previously.