### PR TITLE
Fix mismatch in UI color conversions

### DIFF
--- a/crates/bevy_ui_render/src/gradient.wgsl
+++ b/crates/bevy_ui_render/src/gradient.wgsl
@@ -16,6 +16,7 @@
     hsv_to_linear_rgb,
     hsl_to_linear_rgb,
     oklab_to_linear_rgb,
+    srgb_to_linear,
 }
 
 #import bevy_render::maths::PI
@@ -205,7 +206,7 @@ fn convert_to_linear_rgba(
 #else ifdef IN_OKLAB
     let rgb = oklab_to_linear_rgb(color.xyz);
 #else ifdef IN_SRGB
-    let rgb = pow(color.xyz, vec3(2.2));
+    let rgb = srgb_to_linear(color.xyz);
 #else
     // Color is already in linear rgba space
     let rgb = color.rgb;


### PR DESCRIPTION
# Objective
Fixes #24857.

## Solution

The UI shader code for gradients uses a `pow(color, 2.2)` approximation to convert srgb to linear rgb, while the rust side uses a more complex conversion to go from linear to srgb. Since the two aren't exact inverses, colors were slightly off after a round-trip through both functions.

## Testing

- Ran the feathers gallery example and used an eyedropper, the slider colors now match the rest of the UI.

