### PR TITLE
forward custom trait methods to entity set types

### DIFF
--- a/crates/bevy_ecs/src/entity/entity_set.rs
+++ b/crates/bevy_ecs/src/entity/entity_set.rs
@@ -7,9 +7,10 @@ use bevy_platform::collections::HashSet;
 
 use core::{
     array,
+    cmp::Ordering,
     fmt::{Debug, Formatter},
     hash::{BuildHasher, Hash},
-    iter::{self, FusedIterator},
+    iter::{self, FusedIterator, Product, Sum},
     option, ptr, result,
 };
 
@@ -427,6 +428,16 @@ impl<I: Iterator<Item: EntityEquivalent>> UniqueEntityIter<I> {
     }
 }
 
+// The following methods are not forwarded:
+// `try_fold` and `try_for_each` are dependent on the nightly `Try` trait.
+//
+// `chain`, `zip`, `map`, `filter`, `filter_map`, `enumerate`, `peekable`,
+// `skip_while`, `take_while`, `map_while`, `skip`, take, `scan`, `flat_map`,
+// `flatten`, `inspect`, `rev`, `copied`, `cloned` and `cycle`
+// return combinator iterator types with no public construction methods.
+//
+// `unzip` because no tuples implement `EntityEquivalent`.
+// `rposition`, given that the compiler cannot infer the implied bounds for I.
 impl<I: Iterator<Item: EntityEquivalent>> Iterator for UniqueEntityIter<I> {
     type Item = I::Item;
 
@@ -437,14 +448,279 @@ impl<I: Iterator<Item: EntityEquivalent>> Iterator for UniqueEntityIter<I> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.iter.last()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth(n)
+    }
+
+    fn for_each<F>(self, f: F)
+    where
+        Self: Sized,
+        F: FnMut(Self::Item),
+    {
+        self.iter.for_each(f);
+    }
+
+    fn collect<B: FromIterator<Self::Item>>(self) -> B
+    where
+        Self: Sized,
+    {
+        self.iter.collect()
+    }
+
+    fn partition<B, F>(self, f: F) -> (B, B)
+    where
+        Self: Sized,
+        B: Default + Extend<Self::Item>,
+        F: FnMut(&Self::Item) -> bool,
+    {
+        self.iter.partition(f)
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, f)
+    }
+
+    fn reduce<F>(self, f: F) -> Option<Self::Item>
+    where
+        Self: Sized,
+        F: FnMut(Self::Item, Self::Item) -> Self::Item,
+    {
+        self.iter.reduce(f)
+    }
+
+    fn all<F>(&mut self, f: F) -> bool
+    where
+        Self: Sized,
+        F: FnMut(Self::Item) -> bool,
+    {
+        self.iter.all(f)
+    }
+
+    fn any<F>(&mut self, f: F) -> bool
+    where
+        Self: Sized,
+        F: FnMut(Self::Item) -> bool,
+    {
+        self.iter.any(f)
+    }
+
+    fn find<P>(&mut self, predicate: P) -> Option<Self::Item>
+    where
+        Self: Sized,
+        P: FnMut(&Self::Item) -> bool,
+    {
+        self.iter.find(predicate)
+    }
+
+    fn find_map<B, F>(&mut self, f: F) -> Option<B>
+    where
+        Self: Sized,
+        F: FnMut(Self::Item) -> Option<B>,
+    {
+        self.iter.find_map(f)
+    }
+
+    fn position<P>(&mut self, predicate: P) -> Option<usize>
+    where
+        Self: Sized,
+        P: FnMut(Self::Item) -> bool,
+    {
+        self.iter.position(predicate)
+    }
+
+    fn max(self) -> Option<Self::Item>
+    where
+        Self: Sized,
+        Self::Item: Ord,
+    {
+        self.iter.max()
+    }
+
+    fn min(self) -> Option<Self::Item>
+    where
+        Self: Sized,
+        Self::Item: Ord,
+    {
+        self.iter.min()
+    }
+
+    fn max_by_key<B: Ord, F>(self, f: F) -> Option<Self::Item>
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item) -> B,
+    {
+        self.iter.max_by_key(f)
+    }
+
+    fn max_by<F>(self, compare: F) -> Option<Self::Item>
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
+    {
+        self.iter.max_by(compare)
+    }
+
+    fn min_by_key<B: Ord, F>(self, f: F) -> Option<Self::Item>
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item) -> B,
+    {
+        self.iter.min_by_key(f)
+    }
+
+    fn min_by<F>(self, compare: F) -> Option<Self::Item>
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
+    {
+        self.iter.min_by(compare)
+    }
+
+    fn sum<S>(self) -> S
+    where
+        Self: Sized,
+        S: Sum<Self::Item>,
+    {
+        self.iter.sum()
+    }
+
+    fn product<P>(self) -> P
+    where
+        Self: Sized,
+        P: Product<Self::Item>,
+    {
+        self.iter.product()
+    }
+
+    fn cmp<O>(self, other: O) -> Ordering
+    where
+        O: IntoIterator<Item = Self::Item>,
+        Self::Item: Ord,
+        Self: Sized,
+    {
+        self.iter.cmp(other)
+    }
+
+    fn partial_cmp<O>(self, other: O) -> Option<Ordering>
+    where
+        O: IntoIterator,
+        Self::Item: PartialOrd<O::Item>,
+        Self: Sized,
+    {
+        self.iter.partial_cmp(other)
+    }
+
+    fn eq<O>(self, other: O) -> bool
+    where
+        O: IntoIterator,
+        Self::Item: PartialEq<O::Item>,
+        Self: Sized,
+    {
+        self.iter.eq(other)
+    }
+
+    fn lt<O>(self, other: O) -> bool
+    where
+        O: IntoIterator,
+        Self::Item: PartialOrd<O::Item>,
+        Self: Sized,
+    {
+        self.iter.lt(other)
+    }
+
+    fn le<O>(self, other: O) -> bool
+    where
+        O: IntoIterator,
+        Self::Item: PartialOrd<O::Item>,
+        Self: Sized,
+    {
+        self.iter.le(other)
+    }
+
+    fn gt<O>(self, other: O) -> bool
+    where
+        O: IntoIterator,
+        Self::Item: PartialOrd<O::Item>,
+        Self: Sized,
+    {
+        self.iter.gt(other)
+    }
+
+    fn ge<O>(self, other: O) -> bool
+    where
+        O: IntoIterator,
+        Self::Item: PartialOrd<O::Item>,
+        Self: Sized,
+    {
+        self.iter.ge(other)
+    }
+
+    fn is_sorted(self) -> bool
+    where
+        Self: Sized,
+        Self::Item: PartialOrd,
+    {
+        self.iter.is_sorted()
+    }
+
+    fn is_sorted_by<F>(self, compare: F) -> bool
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> bool,
+    {
+        self.iter.is_sorted_by(compare)
+    }
+
+    fn is_sorted_by_key<F, K>(self, f: F) -> bool
+    where
+        Self: Sized,
+        F: FnMut(Self::Item) -> K,
+        K: PartialOrd,
+    {
+        self.iter.is_sorted_by_key(f)
+    }
 }
 
 impl<I: ExactSizeIterator<Item: EntityEquivalent>> ExactSizeIterator for UniqueEntityIter<I> {}
 
+// `try_rfold` is dependent on the nightly `Try` trait, and can thus not be forwarded here.
 impl<I: DoubleEndedIterator<Item: EntityEquivalent>> DoubleEndedIterator for UniqueEntityIter<I> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.iter.next_back()
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.iter.nth_back(n)
+    }
+
+    fn rfold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.rfold(init, f)
+    }
+
+    fn rfind<P>(&mut self, predicate: P) -> Option<Self::Item>
+    where
+        Self: Sized,
+        P: FnMut(&Self::Item) -> bool,
+    {
+        self.iter.rfind(predicate)
     }
 }
 
@@ -492,6 +768,10 @@ impl<I: EntitySetIterator + Clone> Clone for UniqueEntityIter<I> {
         Self {
             iter: self.iter.clone(),
         }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.iter.clone_from(&source.iter);
     }
 }
 

--- a/crates/bevy_ecs/src/entity/hash_map.rs
+++ b/crates/bevy_ecs/src/entity/hash_map.rs
@@ -221,6 +221,14 @@ impl<'a, K: EntityEquivalent + Hash, V> Iterator for Keys<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
+    }
 }
 
 impl<K: EntityEquivalent + Hash, V> ExactSizeIterator for Keys<'_, K, V> {}
@@ -299,6 +307,14 @@ impl<K: EntityEquivalent + Hash, V> Iterator for IntoKeys<K, V> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
     }
 }
 

--- a/crates/bevy_ecs/src/entity/hash_set.rs
+++ b/crates/bevy_ecs/src/entity/hash_set.rs
@@ -281,6 +281,14 @@ impl<'a, K: EntityEquivalent + Hash> Iterator for Iter<'a, K> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
+    }
 }
 
 impl<K: EntityEquivalent + Hash> ExactSizeIterator for Iter<'_, K> {}
@@ -357,6 +365,14 @@ impl<K: EntityEquivalent + Hash> Iterator for IntoIter<K> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
+    }
 }
 
 impl<K: EntityEquivalent + Hash> ExactSizeIterator for IntoIter<K> {}
@@ -426,6 +442,14 @@ impl<'a, K: EntityEquivalent + Hash> Iterator for Drain<'a, K> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
     }
 }
 

--- a/crates/bevy_ecs/src/entity/index_map.rs
+++ b/crates/bevy_ecs/src/entity/index_map.rs
@@ -927,11 +927,34 @@ impl<'a, K: EntityEquivalent + Hash, V> Iterator for Iter<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.0.last()
+    }
+
+    fn collect<C>(self) -> C
+    where
+        C: FromIterator<Self::Item>,
+    {
+        self.0.collect()
+    }
 }
 
 impl<K: EntityEquivalent + Hash, V> DoubleEndedIterator for Iter<'_, K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n)
     }
 }
 
@@ -1021,11 +1044,34 @@ impl<'a, K: EntityEquivalent + Hash, V> Iterator for IterMut<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.0.last()
+    }
+
+    fn collect<C>(self) -> C
+    where
+        C: FromIterator<Self::Item>,
+    {
+        self.0.collect()
+    }
 }
 
 impl<K: EntityEquivalent + Hash, V> DoubleEndedIterator for IterMut<'_, K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n)
     }
 }
 
@@ -1111,11 +1157,34 @@ impl<K: EntityEquivalent + Hash, V> Iterator for IntoIter<K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.0.last()
+    }
+
+    fn collect<C>(self) -> C
+    where
+        C: FromIterator<Self::Item>,
+    {
+        self.0.collect()
+    }
 }
 
 impl<K: EntityEquivalent + Hash, V> DoubleEndedIterator for IntoIter<K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n)
     }
 }
 
@@ -1198,11 +1267,34 @@ impl<K: EntityEquivalent + Hash, V> Iterator for Drain<'_, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.0.last()
+    }
+
+    fn collect<C>(self) -> C
+    where
+        C: FromIterator<Self::Item>,
+    {
+        self.0.collect()
+    }
 }
 
 impl<K: EntityEquivalent + Hash, V> DoubleEndedIterator for Drain<'_, K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n)
     }
 }
 
@@ -1263,11 +1355,34 @@ impl<'a, K: EntityEquivalent + Hash, V> Iterator for Keys<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.0.last()
+    }
+
+    fn collect<C>(self) -> C
+    where
+        C: FromIterator<Self::Item>,
+    {
+        self.0.collect()
+    }
 }
 
 impl<K: EntityEquivalent + Hash, V> DoubleEndedIterator for Keys<'_, K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n)
     }
 }
 
@@ -1352,11 +1467,34 @@ impl<K: EntityEquivalent + Hash, V> Iterator for IntoKeys<K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.0.last()
+    }
+
+    fn collect<C>(self) -> C
+    where
+        C: FromIterator<Self::Item>,
+    {
+        self.0.collect()
+    }
 }
 
 impl<K: EntityEquivalent + Hash, V> DoubleEndedIterator for IntoKeys<K, V> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n)
     }
 }
 

--- a/crates/bevy_ecs/src/entity/index_set.rs
+++ b/crates/bevy_ecs/src/entity/index_set.rs
@@ -626,11 +626,34 @@ impl<'a, K: EntityEquivalent + Hash> Iterator for Iter<'a, K> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.0.last()
+    }
+
+    fn collect<C>(self) -> C
+    where
+        C: FromIterator<Self::Item>,
+    {
+        self.0.collect()
+    }
 }
 
 impl<K: EntityEquivalent + Hash> DoubleEndedIterator for Iter<'_, K> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n)
     }
 }
 
@@ -711,11 +734,34 @@ impl<K: EntityEquivalent + Hash> Iterator for IntoIter<K> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.0.last()
+    }
+
+    fn collect<C>(self) -> C
+    where
+        C: FromIterator<Self::Item>,
+    {
+        self.0.collect()
+    }
 }
 
 impl<K: EntityEquivalent + Hash> DoubleEndedIterator for IntoIter<K> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n)
     }
 }
 
@@ -799,11 +845,34 @@ impl<'a, K: EntityEquivalent + Hash> Iterator for Drain<'a, K> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.0.count()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth(n)
+    }
+
+    fn last(self) -> Option<Self::Item> {
+        self.0.last()
+    }
+
+    fn collect<C>(self) -> C
+    where
+        C: FromIterator<Self::Item>,
+    {
+        self.0.collect()
+    }
 }
 
 impl<K: EntityEquivalent + Hash> DoubleEndedIterator for Drain<'_, K> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n)
     }
 }
 

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -96,10 +96,6 @@ impl<T: EntityEquivalent> UniqueEntityEquivalentSlice<T> {
     /// # Safety
     ///
     /// The returned slice must only ever contain unique elements.
-    #[expect(
-        clippy::borrowed_box,
-        reason = "We wish to access the Box API of the inner type, without consuming it."
-    )]
     const unsafe fn as_mut_boxed_inner(self: &mut Box<Self>) -> &mut Box<[T]> {
         // SAFETY: UniqueEntityEquivalentSlice is a transparent wrapper around [T].
         unsafe { &mut *(ptr::from_mut(self).cast::<Box<[T]>>()) }

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -1031,7 +1031,7 @@ impl<T: EntityEquivalent + Clone> Clone for Box<UniqueEntityEquivalentSlice<T>> 
         // SAFETY: This is a clone of a valid slice.
         unsafe {
             self.as_mut_boxed_inner()
-                .clone_from(source.as_boxed_inner())
+                .clone_from(source.as_boxed_inner());
         };
     }
 }

--- a/crates/bevy_ecs/src/entity/unique_slice.rs
+++ b/crates/bevy_ecs/src/entity/unique_slice.rs
@@ -80,6 +80,31 @@ impl<T: EntityEquivalent> UniqueEntityEquivalentSlice<T> {
         unsafe { Box::from_raw(Box::into_raw(slice) as *mut Self) }
     }
 
+    /// Casts a reference to `self` to the inner slice.
+    #[expect(
+        clippy::borrowed_box,
+        reason = "We wish to access the Box API of the inner type, without consuming it."
+    )]
+    pub const fn as_boxed_inner(self: &Box<Self>) -> &Box<[T]> {
+        // SAFETY: UniqueEntityEquivalentSlice is a transparent wrapper around [T].
+        unsafe { &*(ptr::from_ref(self).cast::<Box<[T]>>()) }
+    }
+
+    // Do not publicize until mutable slice functionality is added, safety comment may need expansion.
+    /// Casts a mutable reference to `self` to the inner slice.
+    ///
+    /// # Safety
+    ///
+    /// The returned slice must only ever contain unique elements.
+    #[expect(
+        clippy::borrowed_box,
+        reason = "We wish to access the Box API of the inner type, without consuming it."
+    )]
+    const unsafe fn as_mut_boxed_inner(self: &mut Box<Self>) -> &mut Box<[T]> {
+        // SAFETY: UniqueEntityEquivalentSlice is a transparent wrapper around [T].
+        unsafe { &mut *(ptr::from_mut(self).cast::<Box<[T]>>()) }
+    }
+
     /// Casts `self` to the inner slice.
     pub fn into_boxed_inner(self: Box<Self>) -> Box<[T]> {
         // SAFETY: UniqueEntityEquivalentSlice is a transparent wrapper around [T].
@@ -996,7 +1021,18 @@ impl<T: EntityEquivalent> Borrow<[T]> for UniqueEntityEquivalentSlice<T> {
 
 impl<T: EntityEquivalent + Clone> Clone for Box<UniqueEntityEquivalentSlice<T>> {
     fn clone(&self) -> Self {
-        self.to_vec().into_boxed_slice()
+        // SAFETY: This is a clone of a valid slice.
+        unsafe {
+            UniqueEntityEquivalentSlice::from_boxed_slice_unchecked(self.as_boxed_inner().clone())
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        // SAFETY: This is a clone of a valid slice.
+        unsafe {
+            self.as_mut_boxed_inner()
+                .clone_from(source.as_boxed_inner())
+        };
     }
 }
 


### PR DESCRIPTION
# Objective

The entity set wrappers, especially the iterators, wrap types that sometimes have custom trait implementations.
Right now, these are for the most part not forwarded, and the original behavior is lost. 
In most cases, this means a performance hit for the affected methods.

## Solution

Forward custom trait implementations.
Because `UniqueEntityIter` is generic over the iterator it wraps, we forward all methods where custom impls are possible.
The missing ones are documented.
Everywhere else, we only forward methods that were customized by the original type.

For reference, `indexmap` does the same thing. Most notably, they forward `collect` to the base `std` iterators, so they can benefit from `TrustedLen`. We now do as well.

This PR also introduces a public `as_boxed_inner` for slices, and a for now private `as_mut_boxed_inner`. (They are used in the `Clone` impl)