### PR TITLE
Fix Atmosphere Space View affecting directional light transmittance.

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_lighting.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wgsl
@@ -924,15 +924,16 @@ color *= (*light).color.rgb * texture_sample;
     ).xyz;
     let P_clamped = clamp_to_surface(atmosphere, P_as);
     let r = length(P_clamped);
-    let local_up = normalize(P_clamped);
-    let mu_light = dot(L, local_up);
 
     // Sample atmosphere
-    let transmittance = sample_transmittance_lut(r, mu_light);
-    let sun_visibility = calculate_visible_sun_ratio(atmosphere, r, mu_light, (*light).sun_disk_angular_size);
-
-    // Apply atmospheric effects
-    color *= transmittance * sun_visibility;
+    if r < atmosphere.outer_radius {
+        let local_up = normalize(P_clamped);
+        let mu_light = dot(L, local_up);
+        let transmittance = sample_transmittance_lut(r, mu_light);
+        let sun_visibility = calculate_visible_sun_ratio(atmosphere, r, mu_light, (*light).sun_disk_angular_size);
+        // Apply atmospheric effects
+        color *= transmittance * sun_visibility;
+    }
 #endif
 
     return color;

--- a/crates/bevy_pbr/src/render/pbr_lighting.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wgsl
@@ -925,7 +925,8 @@ color *= (*light).color.rgb * texture_sample;
     let P_clamped = clamp_to_surface(atmosphere, P_as);
     let r = length(P_clamped);
 
-    // Sample atmosphere
+    // The transmittance LUT is only valid within the atmosphere. Do not change directional light
+    // for surfaces sampled outside the currently rendered atmosphere.
     if r < atmosphere.outer_radius {
         let local_up = normalize(P_clamped);
         let mu_light = dot(L, local_up);


### PR DESCRIPTION
# Objective

- Currently when an atmosphere component exists in the scene all directional lights will be dimmed by the distance from the atmosphere. The expected behavior is that this transmittance change is only applied when within the atmosphere and not for the space view.

## Solution

- Only apply transmittance and sun visibility when radius is within the atmosphere. An alternative solution would be to avoid the branch by modifying sample_transmittance_lut and calculate_visible_sun_ratio.

## Testing

- In my current game project I have atmospheres on Venus, Earth, Mars and Titan (real scale). Without this fix every object appears dim when not close to an atmosphere, with this fix everything looks as expected.
- Reproduction https://github.com/bevyengine/bevy/pull/24888#issuecomment-4918498611
