### PR TITLE
`bsn!` `if`/`else` blocks MVP ⚖️

### DIFF
--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -1,7 +1,7 @@
 use crate::bsn::types::{
-    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot,
-    BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn, BsnSceneListItem, BsnSceneListItems,
-    BsnType, BsnValue,
+    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot, BsnPatchEntry,
+    BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneEntry, BsnSceneFn, BsnSceneListItem,
+    BsnSceneListItems, BsnType, BsnValue,
 };
 use bevy_macro_utils::{fq_std::FQDefault, path_to_string};
 use proc_macro2::TokenStream;
@@ -201,7 +201,14 @@ impl BsnEntry {
         let (bevy_scene, bevy_ecs) = (ctx.bevy_scene, ctx.bevy_ecs);
 
         Ok(match self {
-            BsnEntry::TemplatePatch(ty) => {
+            BsnEntry::Patch(BsnPatchEntry::Name(ident)) => {
+                let (name, index) = ctx.fixed_entity_ref(ident);
+                let invocation = ctx.invocation_index.clone();
+                EntryResult::CombinedSceneFunction(quote! {
+                    #bevy_scene::NameEntityReference { name: #bevy_ecs::name::Name(#name.into()), reference: #bevy_ecs::template::SceneEntityReference::new(#invocation, #index, _call_id,) }.resolve_inline(_context, _scene);
+                })
+            }
+            BsnEntry::Patch(BsnPatchEntry::Template(ty)) => {
                 let mut assigns = Vec::new();
                 let target = PatchTarget {
                     path: &[Member::Named(Ident::new(
@@ -223,7 +230,7 @@ impl BsnEntry {
                     }
                 })
             }
-            BsnEntry::FromTemplatePatch(ty) => {
+            BsnEntry::Patch(BsnPatchEntry::FromTemplate(ty)) => {
                 let mut assigns = Vec::new();
                 let target = PatchTarget {
                     path: &[Member::Named(Ident::new(
@@ -245,53 +252,50 @@ impl BsnEntry {
                     }
                 })
             }
-            BsnEntry::TemplateConst {
+            BsnEntry::Patch(BsnPatchEntry::TemplateConst {
                 type_path,
                 const_ident,
-            } => EntryResult::CombinedSceneFunction(quote! {
+            }) => EntryResult::CombinedSceneFunction(quote! {
                 let __value = _scene.get_or_insert_template::<#type_path>(_context);
                 *__value = #type_path::#const_ident;
             }),
-            BsnEntry::TemplateConstructor(BsnConstructor {
+            BsnEntry::Patch(BsnPatchEntry::TemplateConstructor(BsnConstructor {
                 type_path,
                 function,
                 args,
-            }) => EntryResult::CombinedSceneFunction({
+            })) => EntryResult::CombinedSceneFunction({
                 let args = args.to_tokens(ctx);
                 quote! {
                     let __value = _scene.get_or_insert_template::<#type_path>(_context);
                     *__value = #type_path::#function #args;
                 }
             }),
-            BsnEntry::FromTemplateConstructor(BsnConstructor {
+            BsnEntry::Patch(BsnPatchEntry::FromTemplateConstructor(BsnConstructor {
                 type_path,
                 function,
                 args,
-            }) => EntryResult::CombinedSceneFunction({
+            })) => EntryResult::CombinedSceneFunction({
                 let args = args.to_tokens(ctx);
                 quote! {
                     let __value = _scene.get_or_insert_template::<<#type_path as #bevy_ecs::template::FromTemplate>::Template>(_context);
                     *__value = <#type_path as #bevy_ecs::template::FromTemplate>::Template::#function #args;
                 }
             }),
-            BsnEntry::RelatedSceneList(BsnRelatedSceneList {
+            BsnEntry::Scene(BsnSceneEntry::RelatedList(BsnRelatedSceneList {
                 scene_list,
                 relationship_path,
-            }) => {
+            })) => {
                 let scenes = scene_list.0.to_tokens(ctx);
                 EntryResult::NewSceneImpl(quote! {
                     #bevy_scene::RelatedScenes::<<#relationship_path as #bevy_ecs::relationship::RelationshipTarget>
                     ::Relationship, _>::new(#scenes)
                 })
             }
-            BsnEntry::UncachedScene(s) => EntryResult::NewSceneImpl(s.to_tokens(ctx)?),
-            BsnEntry::CachedScene(s) => EntryResult::NewSceneImpl(s.to_tokens(ctx)?),
-            BsnEntry::Name(ident) => {
-                let (name, index) = ctx.fixed_entity_ref(ident);
-                let invocation = ctx.invocation_index.clone();
-                EntryResult::CombinedSceneFunction(quote! {
-                    #bevy_scene::NameEntityReference { name: #bevy_ecs::name::Name(#name.into()), reference: #bevy_ecs::template::SceneEntityReference::new(#invocation, #index, _call_id,) }.resolve_inline(_context, _scene);
-                })
+            BsnEntry::Scene(BsnSceneEntry::Uncached(s)) => {
+                EntryResult::NewSceneImpl(s.to_tokens(ctx)?)
+            }
+            BsnEntry::Scene(BsnSceneEntry::Cached(s)) => {
+                EntryResult::NewSceneImpl(s.to_tokens(ctx)?)
             }
         })
     }

--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -1,9 +1,12 @@
 use crate::bsn::types::{
-    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot, BsnPatchEntry,
-    BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneEntry, BsnSceneFn, BsnSceneListItem,
-    BsnSceneListItems, BsnType, BsnValue,
+    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnIf, BsnListRoot,
+    BsnPatchEntry, BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneEntry, BsnSceneFn,
+    BsnSceneListItem, BsnSceneListItems, BsnType, BsnValue,
 };
-use bevy_macro_utils::{fq_std::FQDefault, path_to_string};
+use bevy_macro_utils::{
+    fq_std::{FQBox, FQDefault},
+    path_to_string,
+};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use std::collections::{hash_map::Entry, HashMap, HashSet};
@@ -159,8 +162,8 @@ impl<const ALLOW_FLAT: bool> Bsn<ALLOW_FLAT> {
         let mut scene_impls = Vec::new();
         for entry in &self.entries {
             match entry.try_to_tokens(ctx) {
-                Ok(EntryResult::CombinedSceneFunction(patch)) => combined_patches.push(patch),
-                Ok(EntryResult::NewSceneImpl(scene_impl)) => {
+                Ok(Some(EntryResult::CombinedSceneFunction(patch))) => combined_patches.push(patch),
+                Ok(Some(EntryResult::NewSceneImpl(scene_impl))) => {
                     if !combined_patches.is_empty() {
                         let patches = combined_patches.drain(..);
                         scene_impls.push(quote! {
@@ -171,6 +174,7 @@ impl<const ALLOW_FLAT: bool> Bsn<ALLOW_FLAT> {
                     }
                     scene_impls.push(scene_impl)
                 }
+                Ok(None) => {}
                 Err(err) => scene_impls.push(err.to_compile_error()),
             }
         }
@@ -197,18 +201,30 @@ enum EntryResult {
 }
 
 impl BsnEntry {
-    fn try_to_tokens(&self, ctx: &mut BsnCodegenCtx) -> syn::Result<EntryResult> {
+    fn try_to_tokens(&self, ctx: &mut BsnCodegenCtx) -> syn::Result<Option<EntryResult>> {
+        Ok(match self {
+            BsnEntry::Patch(patch) => Some(EntryResult::CombinedSceneFunction(
+                patch.try_to_tokens(ctx)?,
+            )),
+            BsnEntry::Scene(scene) => Some(EntryResult::NewSceneImpl(scene.try_to_tokens(ctx)?)),
+            BsnEntry::If(conditional) => conditional.try_to_tokens(ctx)?,
+        })
+    }
+}
+
+impl BsnPatchEntry {
+    fn try_to_tokens(&self, ctx: &mut BsnCodegenCtx) -> syn::Result<TokenStream> {
         let (bevy_scene, bevy_ecs) = (ctx.bevy_scene, ctx.bevy_ecs);
 
         Ok(match self {
-            BsnEntry::Patch(BsnPatchEntry::Name(ident)) => {
+            BsnPatchEntry::Name(ident) => {
                 let (name, index) = ctx.fixed_entity_ref(ident);
                 let invocation = ctx.invocation_index.clone();
-                EntryResult::CombinedSceneFunction(quote! {
+                quote! {
                     #bevy_scene::NameEntityReference { name: #bevy_ecs::name::Name(#name.into()), reference: #bevy_ecs::template::SceneEntityReference::new(#invocation, #index, _call_id,) }.resolve_inline(_context, _scene);
-                })
+                }
             }
-            BsnEntry::Patch(BsnPatchEntry::Template(ty)) => {
+            BsnPatchEntry::Template(ty) => {
                 let mut assigns = Vec::new();
                 let target = PatchTarget {
                     path: &[Member::Named(Ident::new(
@@ -219,7 +235,7 @@ impl BsnEntry {
                 };
                 ty.to_patch_tokens(ctx, &mut assigns, true, false, true, target)?;
                 let path = &ty.path;
-                EntryResult::CombinedSceneFunction(if assigns.is_empty() {
+                if assigns.is_empty() {
                     quote! {
                         let _ = _scene.get_or_insert_template::<#path>(_context);
                     }
@@ -228,9 +244,9 @@ impl BsnEntry {
                         let __value = _scene.get_or_insert_template::<#path>(_context);
                         #(#assigns)*
                     }
-                })
+                }
             }
-            BsnEntry::Patch(BsnPatchEntry::FromTemplate(ty)) => {
+            BsnPatchEntry::FromTemplate(ty) => {
                 let mut assigns = Vec::new();
                 let target = PatchTarget {
                     path: &[Member::Named(Ident::new(
@@ -241,7 +257,7 @@ impl BsnEntry {
                 };
                 ty.to_patch_tokens(ctx, &mut assigns, true, false, false, target)?;
                 let path = &ty.path;
-                EntryResult::CombinedSceneFunction(if assigns.is_empty() {
+                if assigns.is_empty() {
                     quote! {
                         let _ = _scene.get_or_insert_template::<<#path as #bevy_ecs::template::FromTemplate>::Template>(_context);
                     }
@@ -250,54 +266,194 @@ impl BsnEntry {
                         let __value = _scene.get_or_insert_template::<<#path as #bevy_ecs::template::FromTemplate>::Template>(_context);
                         #(#assigns)*
                     }
-                })
+                }
             }
-            BsnEntry::Patch(BsnPatchEntry::TemplateConst {
+            BsnPatchEntry::TemplateConst {
                 type_path,
                 const_ident,
-            }) => EntryResult::CombinedSceneFunction(quote! {
+            } => quote! {
                 let __value = _scene.get_or_insert_template::<#type_path>(_context);
                 *__value = #type_path::#const_ident;
-            }),
-            BsnEntry::Patch(BsnPatchEntry::TemplateConstructor(BsnConstructor {
+            },
+            BsnPatchEntry::TemplateConstructor(BsnConstructor {
                 type_path,
                 function,
                 args,
-            })) => EntryResult::CombinedSceneFunction({
+            }) => {
                 let args = args.to_tokens(ctx);
                 quote! {
                     let __value = _scene.get_or_insert_template::<#type_path>(_context);
                     *__value = #type_path::#function #args;
                 }
-            }),
-            BsnEntry::Patch(BsnPatchEntry::FromTemplateConstructor(BsnConstructor {
+            }
+            BsnPatchEntry::FromTemplateConstructor(BsnConstructor {
                 type_path,
                 function,
                 args,
-            })) => EntryResult::CombinedSceneFunction({
+            }) => {
                 let args = args.to_tokens(ctx);
                 quote! {
                     let __value = _scene.get_or_insert_template::<<#type_path as #bevy_ecs::template::FromTemplate>::Template>(_context);
                     *__value = <#type_path as #bevy_ecs::template::FromTemplate>::Template::#function #args;
                 }
-            }),
-            BsnEntry::Scene(BsnSceneEntry::RelatedList(BsnRelatedSceneList {
+            }
+        })
+    }
+}
+
+impl BsnSceneEntry {
+    fn try_to_tokens(&self, ctx: &mut BsnCodegenCtx) -> syn::Result<TokenStream> {
+        let (bevy_scene, bevy_ecs) = (ctx.bevy_scene, ctx.bevy_ecs);
+
+        match self {
+            BsnSceneEntry::RelatedList(BsnRelatedSceneList {
                 scene_list,
                 relationship_path,
-            })) => {
+            }) => {
                 let scenes = scene_list.0.to_tokens(ctx);
-                EntryResult::NewSceneImpl(quote! {
+                Ok(quote! {
                     #bevy_scene::RelatedScenes::<<#relationship_path as #bevy_ecs::relationship::RelationshipTarget>
                     ::Relationship, _>::new(#scenes)
                 })
             }
-            BsnEntry::Scene(BsnSceneEntry::Uncached(s)) => {
-                EntryResult::NewSceneImpl(s.to_tokens(ctx)?)
-            }
-            BsnEntry::Scene(BsnSceneEntry::Cached(s)) => {
-                EntryResult::NewSceneImpl(s.to_tokens(ctx)?)
-            }
-        })
+            BsnSceneEntry::Uncached(scene) => Ok(scene.to_tokens(ctx)?),
+            BsnSceneEntry::Cached(scene) => Ok(scene.to_tokens(ctx)?),
+        }
+    }
+}
+
+impl BsnIf {
+    fn try_to_tokens(&self, ctx: &mut BsnCodegenCtx) -> syn::Result<Option<EntryResult>> {
+        let Self {
+            condition,
+            success,
+            failure,
+        } = self;
+        let bevy_scene: &Path = ctx.bevy_scene;
+
+        let success_empty = success.entries.is_empty();
+        let failure_empty = failure.as_ref().is_none_or(|f| f.entries.is_empty());
+
+        if success_empty && failure_empty {
+            // If both branches are empty, we don't generate any if/else blocks at all.
+            return Ok(None);
+        }
+
+        // We need to check that both branches produce either only template patches, or only new scene entries.
+        // This is because if/else blocks for either need to be placed in different contexts
+        // (e.g. inside a `SceneFunction` for patches, or wrapping whole scene declarations for new scene entries).
+        let (success_is_patch_compatible, success_is_scene_compatible) = success
+            .entries
+            .iter()
+            .fold((true, true), |(is_patch, is_scene), e| match e {
+                BsnEntry::Scene(_) => (false, is_scene),
+                BsnEntry::Patch(_) => (is_patch, false),
+                BsnEntry::If(_) => (is_patch, is_scene),
+            });
+        let (failure_is_patch_compatible, failure_is_scene_compatible) = failure
+            .as_ref()
+            .map(|f| {
+                f.entries
+                    .iter()
+                    .fold((true, true), |(is_patch, is_scene), e| match e {
+                        BsnEntry::Scene(_) => (false, is_scene),
+                        BsnEntry::Patch(_) => (is_patch, false),
+                        BsnEntry::If(_) => (is_patch, is_scene),
+                    })
+            })
+            .unwrap_or((true, true));
+
+        if success_is_patch_compatible && failure_is_patch_compatible {
+            // Both branches can be placed inside a `SceneFunction` (one may optionally be entirely empty).
+
+            let mut entry_to_tokens = |e: &BsnEntry| match e.try_to_tokens(ctx)? {
+                Some(EntryResult::CombinedSceneFunction(tokens)) => Ok(tokens),
+                Some(EntryResult::NewSceneImpl(_)) => {
+                    // Nested conditionals whose parent branch is a patch cannot produce new scene entries,
+                    // because the parent branch will already produce a patch inside a `SceneFunction`.
+                    ctx.errors.push(syn::Error::new_spanned(
+                        condition,
+                        "A single `if`/`else` block must use only one of: \
+                        conditional patching or conditional scene inclusion. They cannot \
+                        be mixed, even if they are in different branches.",
+                    ));
+                    Ok(quote! {})
+                }
+                None => {
+                    // Branch is empty, so we will generate an empty block for it.
+                    Ok(quote! {})
+                }
+            };
+
+            let success_tokens = success
+                .entries
+                .iter()
+                .map(&mut entry_to_tokens)
+                .collect::<syn::Result<Vec<_>>>()?;
+            let failure_tokens = failure
+                .as_ref()
+                .into_iter()
+                .flat_map(|f| &f.entries)
+                .map(&mut entry_to_tokens)
+                .collect::<syn::Result<Vec<_>>>()?;
+
+            Ok(Some(EntryResult::CombinedSceneFunction(quote! {
+                if #condition {
+                    #(#success_tokens)*
+                } else {
+                    #(#failure_tokens)*
+                }
+            })))
+        } else if success_is_scene_compatible && failure_is_scene_compatible {
+            // Both branches can wrap scene declarations (one may optionally be entirely empty).
+
+            let mut entry_to_tokens = |e: &BsnEntry| match e.try_to_tokens(ctx)? {
+                Some(EntryResult::NewSceneImpl(tokens)) => Ok(tokens),
+                Some(EntryResult::CombinedSceneFunction(patch)) => {
+                    // Conditional patches can be nested inside conditional scene inclusion,
+                    // so we need to wrap them in a `SceneFunction` so they can
+                    // be combined with sibling scene entries at a higher level.
+                    Ok(quote! {
+                        #bevy_scene::SceneFunction(move |_context, _scene| { #patch })
+                    })
+                }
+                None => {
+                    // Branch is empty, so we will generate an empty scene to satisfy the type checker.
+                    Ok(quote! {})
+                }
+            };
+
+            let success_tokens = success
+                .entries
+                .iter()
+                .map(&mut entry_to_tokens)
+                .collect::<syn::Result<Vec<_>>>()?;
+            let failure_tokens = failure
+                .as_ref()
+                .into_iter()
+                .flat_map(|f| &f.entries)
+                .map(&mut entry_to_tokens)
+                .collect::<syn::Result<Vec<_>>>()?;
+
+            let success_scene = quote! { #bevy_scene::auto_nest_tuple!(#(#success_tokens),*) };
+            let failure_scene = quote! { #bevy_scene::auto_nest_tuple!(#(#failure_tokens),*) };
+            Ok(Some(EntryResult::NewSceneImpl(quote! {
+                if #condition {
+                    #FQBox::new(#success_scene) as #FQBox<dyn #bevy_scene::Scene>
+                } else {
+                    #FQBox::new(#failure_scene) as #FQBox<dyn #bevy_scene::Scene>
+                }
+            })))
+        } else {
+            // The branches are mixed: one is a patch and the other is a scene.
+            ctx.errors.push(syn::Error::new_spanned(
+                condition,
+                "A single `if`/`else` block must use only one of: \
+                conditional patching or conditional scene inclusion. They cannot \
+                be mixed, even if they are in different branches.",
+            ));
+            Ok(None)
+        }
     }
 }
 
@@ -1020,6 +1176,211 @@ mod tests {
 
         // Assert
         assert_eq!(res, expected,);
+    }
+
+    #[test]
+    fn empty_conditional_is_ignored() {
+        // Arrange
+        let mut refs = EntityRefs::default();
+        let paths = TestPaths::new();
+        let mut exprs = HoistedExpressions::default();
+        let mut ctx = paths.ctx(&mut refs, &mut exprs);
+        let entry = BsnEntry::If(BsnIf {
+            condition: parse_quote!(condition),
+            success: Bsn::<true> { entries: vec![] },
+            failure: Some(Bsn::<true> { entries: vec![] }),
+        });
+
+        // Act
+        let result = entry.try_to_tokens(&mut ctx).unwrap();
+
+        // Assert
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn conditional_patch_is_never_boxed() {
+        // Arrange
+        let mut refs = EntityRefs::default();
+        let paths = TestPaths::new();
+        let mut exprs = HoistedExpressions::default();
+        let mut ctx = paths.ctx(&mut refs, &mut exprs);
+        let entry = BsnEntry::If(BsnIf {
+            condition: parse_quote!(condition),
+            success: Bsn::<true> {
+                entries: vec![BsnEntry::Patch(BsnPatchEntry::TemplateConst {
+                    type_path: parse_quote!(Foo),
+                    const_ident: parse_quote!(BAR),
+                })],
+            },
+            failure: Some(Bsn::<true> {
+                entries: vec![BsnEntry::Patch(BsnPatchEntry::TemplateConst {
+                    type_path: parse_quote!(Foo),
+                    const_ident: parse_quote!(BAZ),
+                })],
+            }),
+        });
+
+        // Act
+        let result = entry.try_to_tokens(&mut ctx).unwrap().unwrap();
+
+        // Assert
+        let EntryResult::CombinedSceneFunction(tokens) = &result else {
+            panic!("expected a `CombinedSceneFunction`, not a boxed `NewSceneImpl`");
+        };
+        let tokens = tokens.to_string();
+        assert!(
+            !tokens.contains("Box"),
+            "conditional patches should not be boxed"
+        );
+        assert!(tokens.contains("if condition"));
+        assert!(tokens.contains("else"));
+    }
+
+    #[test]
+    fn conditional_scene_is_boxed() {
+        // Arrange
+        let mut refs = EntityRefs::default();
+        let paths = TestPaths::new();
+        let mut exprs = HoistedExpressions::default();
+        let mut ctx = paths.ctx(&mut refs, &mut exprs);
+        let entry = BsnEntry::If(BsnIf {
+            condition: parse_quote!(condition),
+            success: Bsn::<true> {
+                entries: vec![BsnEntry::Scene(BsnSceneEntry::Uncached(
+                    BsnScene::Expression(quote!(some_scene())),
+                ))],
+            },
+            failure: Some(Bsn::<true> {
+                entries: vec![BsnEntry::Scene(BsnSceneEntry::Uncached(
+                    BsnScene::Expression(quote!(some_other_scene())),
+                ))],
+            }),
+        });
+
+        // Act
+        let result = entry.try_to_tokens(&mut ctx).unwrap().unwrap();
+
+        // Assert
+        let EntryResult::NewSceneImpl(tokens) = &result else {
+            panic!("expected a `NewSceneImpl`, not a `CombinedSceneFunction`");
+        };
+        let tokens = tokens.to_string();
+        assert!(tokens.contains("Box"), "conditional scenes should be boxed");
+        assert!(tokens.contains("if condition"));
+        assert!(tokens.contains("else"));
+    }
+
+    #[test]
+    fn conditional_patch_nested_in_conditional_scene_works() {
+        // Arrange
+        let mut refs = EntityRefs::default();
+        let paths = TestPaths::new();
+        let mut exprs = HoistedExpressions::default();
+        let mut ctx = paths.ctx(&mut refs, &mut exprs);
+        let entry = BsnEntry::If(BsnIf {
+            condition: parse_quote!(condition),
+            success: Bsn::<true> {
+                entries: vec![BsnEntry::Scene(BsnSceneEntry::Uncached(
+                    BsnScene::Expression(quote!(some_scene())),
+                ))],
+            },
+            failure: Some(Bsn::<true> {
+                entries: vec![BsnEntry::If(BsnIf {
+                    condition: parse_quote!(nested_condition),
+                    success: Bsn::<true> {
+                        entries: vec![BsnEntry::Patch(BsnPatchEntry::TemplateConst {
+                            type_path: parse_quote!(Foo),
+                            const_ident: parse_quote!(BAR),
+                        })],
+                    },
+                    failure: Some(Bsn::<true> {
+                        entries: vec![BsnEntry::Patch(BsnPatchEntry::TemplateConst {
+                            type_path: parse_quote!(Foo),
+                            const_ident: parse_quote!(BAZ),
+                        })],
+                    }),
+                })],
+            }),
+        });
+
+        // Act
+        let result = entry.try_to_tokens(&mut ctx).unwrap().unwrap();
+
+        // Assert
+        let EntryResult::NewSceneImpl(tokens) = &result else {
+            panic!("expected a `NewSceneImpl`, not a `CombinedSceneFunction`");
+        };
+        let tokens = tokens.to_string();
+        assert!(tokens.contains("Box"), "conditional scenes should be boxed");
+        assert!(tokens.contains("if condition"));
+        assert!(tokens.contains("if nested_condition"));
+        assert!(tokens.contains("else"));
+    }
+
+    #[test]
+    fn conditional_mixed_if_branch_errors() {
+        // Arrange
+        let mut refs = EntityRefs::default();
+        let paths = TestPaths::new();
+        let mut exprs = HoistedExpressions::default();
+        let mut ctx = paths.ctx(&mut refs, &mut exprs);
+        let entry = BsnEntry::If(BsnIf {
+            condition: parse_quote!(condition),
+            success: Bsn::<true> {
+                entries: vec![
+                    BsnEntry::Patch(BsnPatchEntry::TemplateConst {
+                        type_path: parse_quote!(Foo),
+                        const_ident: parse_quote!(BAR),
+                    }),
+                    BsnEntry::Scene(BsnSceneEntry::Uncached(BsnScene::Expression(quote!(
+                        some_scene()
+                    )))),
+                ],
+            },
+            failure: None,
+        });
+
+        // Act
+        let res = entry.try_to_tokens(&mut ctx);
+
+        // Assert
+        assert!(res.is_ok());
+        assert_eq!(ctx.errors.len(), 1);
+        assert_eq!(ctx.errors[0].to_string(),
+            "A single `if`/`else` block must use only one of: conditional patching or conditional scene inclusion. They cannot be mixed, even if they are in different branches.");
+    }
+
+    #[test]
+    fn conditional_mixed_across_branches_errors() {
+        // Arrange
+        let mut refs = EntityRefs::default();
+        let paths = TestPaths::new();
+        let mut exprs = HoistedExpressions::default();
+        let mut ctx = paths.ctx(&mut refs, &mut exprs);
+        let entry = BsnEntry::If(BsnIf {
+            condition: parse_quote!(condition),
+            success: Bsn::<true> {
+                entries: vec![BsnEntry::Scene(BsnSceneEntry::Uncached(
+                    BsnScene::Expression(quote!(some_scene())),
+                ))],
+            },
+            failure: Some(Bsn::<true> {
+                entries: vec![BsnEntry::Patch(BsnPatchEntry::TemplateConst {
+                    type_path: parse_quote!(Foo),
+                    const_ident: parse_quote!(BAR),
+                })],
+            }),
+        });
+
+        // Act
+        let res = entry.try_to_tokens(&mut ctx);
+
+        // Assert
+        assert!(res.is_ok());
+        assert_eq!(ctx.errors.len(), 1);
+        assert_eq!(ctx.errors[0].to_string(),
+            "A single `if`/`else` block must use only one of: conditional patching or conditional scene inclusion. They cannot be mixed, even if they are in different branches.");
     }
 
     #[test]

--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -1,7 +1,8 @@
 use crate::bsn::types::{
-    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot, BsnNamedField,
-    BsnPatchEntry, BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneEntry, BsnSceneFn, BsnSceneList,
-    BsnSceneListItem, BsnSceneListItems, BsnTuple, BsnType, BsnUnnamedField, BsnValue,
+    Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnIf, BsnListRoot,
+    BsnNamedField, BsnPatchEntry, BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneEntry,
+    BsnSceneFn, BsnSceneList, BsnSceneListItem, BsnSceneListItems, BsnTuple, BsnType,
+    BsnUnnamedField, BsnValue,
 };
 use bevy_macro_utils::{path_to_string, PathType};
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
@@ -12,8 +13,8 @@ use syn::{
     parenthesized,
     parse::{discouraged::Speculative, Parse, ParseBuffer, ParseStream},
     spanned::Spanned,
-    token::{At, Brace, Bracket, Colon, Comma, Paren, Tilde},
-    Block, Ident, Lit, LitStr, Path, Result, Token,
+    token::{At, Brace, Bracket, Colon, Comma, Else, If, Paren, Tilde},
+    Block, Expr, Ident, Lit, LitStr, Path, Result, Token,
 };
 
 /// Functionally identical to [`Punctuated`](syn::punctuated::Punctuated), but fills the given `$list` Vec instead
@@ -107,6 +108,8 @@ impl Parse for BsnEntry {
             BsnEntry::Patch(BsnPatchEntry::Name(input.parse::<Ident>()?))
         } else if input.peek(Brace) || input.peek(At) {
             BsnEntry::Scene(BsnSceneEntry::Uncached(BsnScene::parse(input)?))
+        } else if input.peek(If) {
+            BsnEntry::If(BsnIf::parse(input)?)
         } else {
             let is_template = input.peek(Tilde);
             if is_template {
@@ -290,6 +293,35 @@ impl Parse for BsnScene {
                     ))
                 }
             }
+        })
+    }
+}
+
+impl Parse for BsnIf {
+    fn parse(input: ParseStream) -> Result<Self> {
+        input.parse::<If>()?;
+
+        // parsing Expr normally would greedily consume the following `{ }` block,
+        // so we use `parse_without_eager_brace` to avoid that.
+        let condition = Expr::parse_without_eager_brace(input)?;
+
+        let success_content;
+        braced!(success_content in input);
+        let success = success_content.parse::<Bsn<true>>()?;
+
+        let failure = if input.peek(Else) {
+            input.parse::<Else>()?;
+            let failure_content;
+            braced!(failure_content in input);
+            Some(failure_content.parse::<Bsn<true>>()?)
+        } else {
+            None
+        };
+
+        Ok(BsnIf {
+            condition,
+            success,
+            failure,
         })
     }
 }

--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -1,7 +1,7 @@
 use crate::bsn::types::{
     Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnListRoot, BsnNamedField,
-    BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn, BsnSceneList, BsnSceneListItem,
-    BsnSceneListItems, BsnTuple, BsnType, BsnUnnamedField, BsnValue,
+    BsnPatchEntry, BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneEntry, BsnSceneFn, BsnSceneList,
+    BsnSceneListItem, BsnSceneListItems, BsnTuple, BsnType, BsnUnnamedField, BsnValue,
 };
 use bevy_macro_utils::{path_to_string, PathType};
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
@@ -64,7 +64,8 @@ impl<const ALLOW_FLAT: bool> Parse for Bsn<ALLOW_FLAT> {
             parenthesized![content in input];
             while !content.is_empty() {
                 let entry = BsnEntry::parse(&content)?;
-                if matches!(entry, BsnEntry::CachedScene(_)) && !entries.is_empty() {
+                if matches!(entry, BsnEntry::Scene(BsnSceneEntry::Cached(_))) && !entries.is_empty()
+                {
                     return Err(syn::Error::new(
                         content.span(),
                         "Caching entries after the first is not supported, remove the ':' prefix or make this the first entry.",
@@ -75,7 +76,8 @@ impl<const ALLOW_FLAT: bool> Parse for Bsn<ALLOW_FLAT> {
         } else if ALLOW_FLAT {
             while !input.is_empty() {
                 let entry = BsnEntry::parse(input)?;
-                if matches!(entry, BsnEntry::CachedScene(_)) && !entries.is_empty() {
+                if matches!(entry, BsnEntry::Scene(BsnSceneEntry::Cached(_))) && !entries.is_empty()
+                {
                     return Err(syn::Error::new(
                         input.span(),
                         "Caching entries after the first is not supported, remove the ':' prefix or make this the first entry.",
@@ -96,15 +98,15 @@ impl<const ALLOW_FLAT: bool> Parse for Bsn<ALLOW_FLAT> {
     }
 }
 
-impl BsnEntry {
+impl Parse for BsnEntry {
     fn parse(input: ParseStream) -> Result<Self> {
         Ok(if input.peek(Token![:]) {
-            BsnEntry::CachedScene(BsnScene::parse(input)?)
+            BsnEntry::Scene(BsnSceneEntry::Cached(BsnScene::parse(input)?))
         } else if input.peek(Token![#]) {
             input.parse::<Token![#]>()?;
-            BsnEntry::Name(input.parse::<Ident>()?)
+            BsnEntry::Patch(BsnPatchEntry::Name(input.parse::<Ident>()?))
         } else if input.peek(Brace) || input.peek(At) {
-            BsnEntry::UncachedScene(BsnScene::parse(input)?)
+            BsnEntry::Scene(BsnSceneEntry::Uncached(BsnScene::parse(input)?))
         } else {
             let is_template = input.peek(Tilde);
             if is_template {
@@ -121,10 +123,10 @@ impl BsnEntry {
                     };
                     if input.peek(Bracket) {
                         // TODO: fail if this is an enum variant
-                        BsnEntry::RelatedSceneList(BsnRelatedSceneList {
+                        BsnEntry::Scene(BsnSceneEntry::RelatedList(BsnRelatedSceneList {
                             relationship_path: path,
                             scene_list: input.parse::<BsnSceneList>()?,
-                        })
+                        }))
                     } else {
                         let fields = input.parse::<BsnFields>()?;
                         let bsn_type = BsnType {
@@ -133,18 +135,18 @@ impl BsnEntry {
                             fields,
                         };
                         if is_template {
-                            BsnEntry::TemplatePatch(bsn_type)
+                            BsnEntry::Patch(BsnPatchEntry::Template(bsn_type))
                         } else {
-                            BsnEntry::FromTemplatePatch(bsn_type)
+                            BsnEntry::Patch(BsnPatchEntry::FromTemplate(bsn_type))
                         }
                     }
                 }
                 PathType::TypeConst => {
                     let const_ident = take_last_path_ident(&mut path).unwrap();
-                    BsnEntry::TemplateConst {
+                    BsnEntry::Patch(BsnPatchEntry::TemplateConst {
                         type_path: path,
                         const_ident,
-                    }
+                    })
                 }
                 PathType::Const => {
                     return Err(syn::Error::new(
@@ -161,17 +163,22 @@ impl BsnEntry {
                         args,
                     };
                     if is_template {
-                        BsnEntry::TemplateConstructor(bsn_constructor)
+                        BsnEntry::Patch(BsnPatchEntry::TemplateConstructor(bsn_constructor))
                     } else {
-                        BsnEntry::FromTemplateConstructor(bsn_constructor)
+                        BsnEntry::Patch(BsnPatchEntry::FromTemplateConstructor(bsn_constructor))
                     }
                 }
                 PathType::Function => {
                     if input.peek(Paren) {
                         let args = input.parse::<BsnFnArgs>()?;
-                        BsnEntry::UncachedScene(BsnScene::Fn(BsnSceneFn { path, args }))
+                        BsnEntry::Scene(BsnSceneEntry::Uncached(BsnScene::Fn(BsnSceneFn {
+                            path,
+                            args,
+                        })))
                     } else {
-                        BsnEntry::UncachedScene(BsnScene::Expression(quote! {#path}))
+                        BsnEntry::Scene(BsnSceneEntry::Uncached(BsnScene::Expression(
+                            quote! {#path},
+                        )))
                     }
                 }
             }
@@ -205,7 +212,7 @@ impl Parse for BsnSceneListItem {
     }
 }
 
-impl BsnScene {
+impl Parse for BsnScene {
     fn parse(input: ParseStream) -> Result<Self> {
         let cached = if input.peek(Token![:]) {
             Some(input.parse::<Token![:]>()?)

--- a/crates/bevy_scene/macros/src/bsn/types.rs
+++ b/crates/bevy_scene/macros/src/bsn/types.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use syn::{Ident, Lit, LitStr, Path, Stmt};
+use syn::{Expr, Ident, Lit, LitStr, Path, Stmt};
 
 #[derive(Debug)]
 pub struct BsnRoot(pub Bsn<true>);
@@ -16,6 +16,7 @@ pub struct Bsn<const ALLOW_FLAT: bool> {
 pub enum BsnEntry {
     Patch(BsnPatchEntry),
     Scene(BsnSceneEntry),
+    If(BsnIf),
 }
 
 /// Entries that patch scenes.
@@ -81,6 +82,22 @@ pub struct BsnConstructor {
     pub type_path: Path,
     pub function: Ident,
     pub args: BsnFnArgs,
+}
+
+/// ```rust,ignore
+/// bsn! {
+///     if condition {
+///         Success
+///     } else {
+///         Failure
+///     }
+/// }
+/// ```
+#[derive(Debug)]
+pub struct BsnIf {
+    pub condition: Expr,
+    pub success: Bsn<true>,
+    pub failure: Option<Bsn<true>>,
 }
 
 #[derive(Debug)]

--- a/crates/bevy_scene/macros/src/bsn/types.rs
+++ b/crates/bevy_scene/macros/src/bsn/types.rs
@@ -14,15 +14,27 @@ pub struct Bsn<const ALLOW_FLAT: bool> {
 
 #[derive(Debug)]
 pub enum BsnEntry {
+    Patch(BsnPatchEntry),
+    Scene(BsnSceneEntry),
+}
+
+/// Entries that patch scenes.
+#[derive(Debug)]
+pub enum BsnPatchEntry {
     Name(Ident),
-    FromTemplatePatch(BsnType),
-    TemplatePatch(BsnType),
+    FromTemplate(BsnType),
+    Template(BsnType),
     FromTemplateConstructor(BsnConstructor),
     TemplateConstructor(BsnConstructor),
     TemplateConst { type_path: Path, const_ident: Ident },
-    UncachedScene(BsnScene),
-    CachedScene(BsnScene),
-    RelatedSceneList(BsnRelatedSceneList),
+}
+
+/// Entries that create scenes.
+#[derive(Debug)]
+pub enum BsnSceneEntry {
+    Uncached(BsnScene),
+    Cached(BsnScene),
+    RelatedList(BsnRelatedSceneList),
 }
 
 #[derive(Debug)]

--- a/crates/bevy_scene/macros/src/lib.rs
+++ b/crates/bevy_scene/macros/src/lib.rs
@@ -41,6 +41,19 @@ use syn::{parse_macro_input, DeriveInput};
 ///             }
 ///         }
 ///     ]
+///     if condition {
+///         // conditional patching
+///         ComponentB(1.0)
+///     } else { // else block optional
+///         ComponentB(2.0)
+///     }
+///     if condition {
+///         // conditional scene inclusion (works with any relation type)
+///         Children [
+///             #ConditionalChild ComponentA
+///         ],
+///         #ConditionalScene other_scene()
+///     }
 /// }
 /// ```
 #[doc(hidden)]

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -555,39 +555,77 @@
 //! commands.spawn_scene(container(items));
 //! ```
 //!
-//! ### Conditional values
+//! ### Conditional patching
 //!
-//! There is no `if`/`match` syntax inside the [`bsn!`] grammar (yet!), but you can embed
-//! conditionals via `{...}` blocks or handle them outside the macro:
+//! You can use `if`/`else` blocks to conditionally patch a scene:
 //!
 //! ```ignore
 //! fn unit(is_boss: bool) -> impl Scene {
-//!     let hp = if is_boss { 500 } else { 100 };
-//!     bsn! { Health { current: hp, max: hp } }
-//! }
-//! ```
-//! One way to achieve conditional scenes is using a [`Box<dyn Scene>`] to store different scenes in one variable.
-//! ```ignore
-//! fn unit(is_boss: bool, level: u32) -> impl Scene {
-//!     let scene: Box<dyn Scene> = if is_boss {
-//!         Box::new(bsn! {
-//!             Boss
-//!             Followers [ // the boss is followed by some grunts
-//!                 :unit(false, level - 1) #Grunt1,
-//!                 :unit(false, level - 2) #Grunt2
-//!             ]
-//!         })
-//!     } else {
-//!         Box::new(bsn! { Grunt })
-//!     };
 //!     bsn! {
-//!         Level(level)
-//!         {scene}
+//!         if is_boss {
+//!             Health { current: 500, max: 500 }
+//!         } else {
+//!             Health { current: 100, max: 100 }
+//!         }
 //!     }
 //! }
 //! ```
 //!
-//! We plan on making "conditional scenes" easier to define in future releases.
+//! ### Conditional scene inclusion
+//!
+//! Additionally, you can use `if`/`else` blocks to conditionally include a
+//! scene in another scene, or optional children (and other relation types):
+//!
+//! ```ignore
+//! fn dungeon(is_boss: bool, is_dragon: bool) -> impl Scene {
+//!     bsn! {
+//!         #Dungeon
+//!         Room { size: 100 }
+//!         if is_boss {
+//!             Children [
+//!                 if is_dragon {
+//!                     #Dragon
+//!                 } else {
+//!                     #GoblinKing
+//!                 }
+//!                 Health { current: 1000, max: 1000 }
+//!             ]
+//!         } else {
+//!             random_dungeon_enemies()
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! You can't combine conditional patching and conditional scene inclusion at
+//! the same level of depth in an `if`/`else` block:
+//!
+//! ```ignore
+//! bsn! {
+//!     // ❌ ERROR: cannot mix conditional patching and conditional scene inclusion in the same block
+//!     if is_boss {
+//!         #Dragon                           // conditional patching
+//!         Health { current: 500, max: 500 } // ^^^^^
+//!         Children [ Rider ] // conditional scene inclusion
+//!     }
+//! }
+//! ```
+//!
+//! This may be supported in a future release, but for now you can work around
+//! it by splitting the conditional into two separate `if` blocks:
+//!
+//! ```ignore
+//! bsn! {
+//!     // ✅ OK: separate conditional blocks
+//!     if is_boss {
+//!         #Dragon
+//!         Health { current: 500, max: 500 } // conditional patching
+//!     }
+//!     if is_boss {
+//!         Children [ Rider ] // conditional scene inclusion
+//!     }
+//! }
+//! ```
 //!
 //! ## Scene Components
 //!
@@ -1447,6 +1485,122 @@ mod tests {
 
         let entity = world.spawn_scene(xaxis()).unwrap();
         assert_eq!(entity.get::<Value>().unwrap().0, 2);
+    }
+
+    #[test]
+    fn bsn_conditional_patches() {
+        let mut app = test_app();
+        let world = app.world_mut();
+
+        #[derive(Component, FromTemplate)]
+        struct Value(usize);
+
+        fn value(condition: bool) -> impl Scene {
+            bsn! {
+                if condition {
+                    Value(1)
+                } else {
+                    Value(2)
+                }
+            }
+        }
+
+        let entity = world.spawn_scene(value(true)).unwrap();
+        assert_eq!(entity.get::<Value>().unwrap().0, 1);
+
+        let entity = world.spawn_scene(value(false)).unwrap();
+        assert_eq!(entity.get::<Value>().unwrap().0, 2);
+    }
+
+    #[test]
+    fn bsn_conditional_children() {
+        let mut app = test_app();
+        let world = app.world_mut();
+
+        #[derive(Component, FromTemplate)]
+        struct Value(usize);
+
+        fn value(condition: bool) -> impl Scene {
+            bsn! {
+                if condition {
+                    Children [Value(1)]
+                } else {
+                    Children [Value(2), Value(3)]
+                }
+            }
+        }
+
+        let id = world.spawn_scene(value(true)).unwrap().id();
+        let children = world.entity(id).get::<Children>().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(world.entity(children[0]).get::<Value>().unwrap().0, 1);
+
+        let id = world.spawn_scene(value(false)).unwrap().id();
+        let children = world.entity(id).get::<Children>().unwrap();
+        assert_eq!(children.len(), 2);
+        assert_eq!(world.entity(children[0]).get::<Value>().unwrap().0, 2);
+        assert_eq!(world.entity(children[1]).get::<Value>().unwrap().0, 3);
+    }
+
+    #[test]
+    fn bsn_conditional_complex() {
+        let mut app = test_app();
+        let world = app.world_mut();
+
+        #[derive(Component, FromTemplate)]
+        struct Foo(usize);
+
+        #[derive(Component, FromTemplate)]
+        struct Bar(usize);
+
+        #[derive(Component, FromTemplate)]
+        struct Baz(usize);
+
+        fn value(condition: bool, condition2: bool) -> impl Scene {
+            bsn! {
+                if condition {
+                    Children [
+                        Foo(1) Bar(2) Baz(3)
+                    ]
+                } else {
+                    Children [
+                        Foo(2) Bar(3) Baz(4),
+
+                        if condition2 {
+                            Foo(3) Baz(5)
+                        } else {
+                            Foo(4) Baz(6)
+                        }
+                        if condition2 {
+                            Children [
+                                Foo(5) Bar(7) Baz(8)
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+
+        let id = world.spawn_scene(value(true, false)).unwrap().id();
+        let children = world.entity(id).get::<Children>().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(world.entity(children[0]).get::<Foo>().unwrap().0, 1);
+        assert_eq!(world.entity(children[0]).get::<Bar>().unwrap().0, 2);
+        assert_eq!(world.entity(children[0]).get::<Baz>().unwrap().0, 3);
+
+        let id = world.spawn_scene(value(false, true)).unwrap().id();
+        let children = world.entity(id).get::<Children>().unwrap();
+        assert_eq!(children.len(), 2);
+        assert_eq!(world.entity(children[0]).get::<Foo>().unwrap().0, 2);
+        assert_eq!(world.entity(children[0]).get::<Bar>().unwrap().0, 3);
+        assert_eq!(world.entity(children[0]).get::<Baz>().unwrap().0, 4);
+        assert_eq!(world.entity(children[1]).get::<Foo>().unwrap().0, 3);
+        assert_eq!(world.entity(children[1]).get::<Baz>().unwrap().0, 5);
+        let children2 = world.entity(children[1]).get::<Children>().unwrap();
+        assert_eq!(children2.len(), 1);
+        assert_eq!(world.entity(children2[0]).get::<Foo>().unwrap().0, 5);
+        assert_eq!(world.entity(children2[0]).get::<Bar>().unwrap().0, 7);
+        assert_eq!(world.entity(children2[0]).get::<Baz>().unwrap().0, 8);
     }
 
     #[derive(Component, FromTemplate)]


### PR DESCRIPTION
# Objective

Ergonomic conditional component insertion has long been a sought-after capability in Bevy:

- #2157 (May 2021!)
- https://github.com/bevyengine/bevy-website/issues/759
- #19491
- #19568

With the introduction of scenes and the `bsn!` macro in #23413, we finally have a good pathway to that.

# Solution

> **Note for reviewers: I recommend reviewing commit-by-commit. The first commit does some infrastructural setup for the main feature commit.**

This PR adds support for **conditional patching**:

```rust
bsn! {
    if is_boss {
        Health { current: 500, max: 500 }
    } else { // else blocks are optional
        Health { current: 100, max: 100 }
    }
}
```

as well as **conditional scene inclusion**:

```rust
bsn! {
    if is_boss {
        dragon()
    } else {
        Children [
            MoonlightGreatsword,
            PlateArmor
        ]
    }
}
```

However, due to the complex nature of their implementation, as well as the implementation of `bsn` in general, there are some tradeoffs to be aware of, and some concessions made as an MVP.

## A tale of tradeoffs

This PR is already a bit chunky, so to avoid further complexity I've reduced it to a minimal but still useful feature set. That means:

### You cannot mix conditional patching and conditional scene inclusion within the same `if`/`else` block, be that in the same branch or in separate branches.

The macro makes patching and scene inclusion look the same in code, but they work very differently under the hood. I recommend using the `Inline macro` code action in VSCode (or other IDEs) to see what's generated.

This is something we *could* support in a follow up, but even then it would have the following caveats:

- You wouldn't be able to use `if let` in a mixed conditional because the condition would be hoisted outside the generated scene itself.
- You wouldn't be able to access the (currently undocumented) `_context` variable for templating context, whereas you can currently when conditionally patching.

### There is not a (documented) way to easily access templating context for conditional patching.

I think the discussion on how to surface that in the macro syntax will lead to some bike-shedding, so I'd like to avoid that here.

### IDE autocomplete-ability was not a core focus of mine

If you have any ideas for improving that, let me know! If it's too much work we can save it for a follow up PR.

# Testing

Added macro syntax tests, as well as tests for generated scene outputs. If you have additional test case recommendations, let me know!

---

# Showcase

```rust
bsn! {
    // conditional patching
    if is_boss {
        Health { current: 500, max: 500 }
    } else { // else blocks are optional
        Health { current: 100, max: 100 }
    }
    
    // conditional scene inclusion
    if is_dragon {
        dragon()
    }

    // conditional children (or any other relation type)
    if is_dragon {
        Children [
            DragonRider
        ]
    }
}
```