### PR TITLE
Allow overriding the default compressed image processor extensions

### DIFF
--- a/_release-content/migration-guides/compressed_image_saver.md
+++ b/_release-content/migration-guides/compressed_image_saver.md
@@ -18,3 +18,14 @@ bevy = { version = "0.20", features = ["compressed_image_saver_universal"] }
 Alternatively, keep using `compressed_image_saver` to get the new BCn/ASTC compression backend. This produces higher-quality output and supports a wider range of input formats, but does not support all platforms in a single file like UASTC does. We recommend sticking to `compressed_image_saver_universal` when targeting the web.
 
 `CompressedImageSaverError` has a new variant `CompressionFailed`. If you were matching exhaustively on this enum, add a branch for it.
+
+In Bevy 0.19, `ImagePlugin` registered a default compressed image processor for PNG files. This meant PNG files were automatically compressed if asset processing was enabled, and the processor wasn't overridden by a `.meta` file. In Bevy 0.20, JPEG files have been added to the default processor. The extensions that the default processor uses can also be overridden by `ImagePlugin::default_compressed_image_processor_extensions` -  to revert back to the Bevy 0.19 PNG-only behavior:
+
+```rust
+App::new().add_plugins(
+	DefaultPlugins.set(ImagePlugin {
+		default_compressed_image_processor_extensions: ["png".into()].into(),
+		..Default::default()
+	}),
+)
+```

--- a/_release-content/migration-guides/compressed_image_saver.md
+++ b/_release-content/migration-guides/compressed_image_saver.md
@@ -23,9 +23,9 @@ In Bevy 0.19, `ImagePlugin` registered a default compressed image processor for 
 
 ```rust
 App::new().add_plugins(
-	DefaultPlugins.set(ImagePlugin {
-		default_compressed_image_processor_extensions: ["png".into()].into(),
-		..Default::default()
-	}),
+    DefaultPlugins.set(ImagePlugin {
+        default_compressed_image_processor_extensions: ["png".into()].into(),
+        ..Default::default()
+    }),
 )
 ```

--- a/_release-content/migration-guides/compressed_image_saver.md
+++ b/_release-content/migration-guides/compressed_image_saver.md
@@ -1,6 +1,6 @@
 ---
 title: "`CompressedImageSaver` improvements"
-pull_requests: [24223]
+pull_requests: [24223, 24904]
 ---
 
 The `compressed_image_saver` Cargo feature has been reworked. The old behavior (Basis Universal UASTC compression) has been moved to a new feature called `compressed_image_saver_universal`, and the `compressed_image_saver` feature now uses the `ctt` library to compress textures into BCn (desktop) or ASTC (mobile) formats instead.

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -180,27 +180,51 @@ pub const TRANSPARENT_IMAGE_HANDLE: Handle<Image> =
 pub struct ImagePlugin {
     /// The default image sampler to use when [`ImageSampler`] is set to `Default`.
     pub default_sampler: ImageSamplerDescriptor,
+    /// The file extensions that will be assigned a default compressed image
+    /// processor. This means they will be automatically compressed unless
+    /// overridden with a `.meta` file.
+    ///
+    /// Defaults to `["png", "jpeg", "jpg"]`.
+    #[cfg(any(
+        feature = "compressed_image_saver",
+        feature = "compressed_image_saver_universal"
+    ))]
+    pub default_compressed_image_processor_extensions: Vec<String>,
 }
 
 impl Default for ImagePlugin {
     fn default() -> Self {
-        ImagePlugin::default_linear()
+        ImagePlugin {
+            default_sampler: ImageSamplerDescriptor::linear(),
+            #[cfg(any(
+                feature = "compressed_image_saver",
+                feature = "compressed_image_saver_universal"
+            ))]
+            default_compressed_image_processor_extensions: [
+                "png".into(),
+                "jpeg".into(),
+                "jpg".into(),
+            ]
+            .into(),
+        }
     }
 }
 
 impl ImagePlugin {
+    /// Sets [`ImagePlugin::default_sampler`].
+    pub fn with_default_sampler(mut self, value: ImageSamplerDescriptor) -> ImagePlugin {
+        self.default_sampler = value;
+        self
+    }
+
     /// Creates image settings with linear sampling by default.
     pub fn default_linear() -> ImagePlugin {
-        ImagePlugin {
-            default_sampler: ImageSamplerDescriptor::linear(),
-        }
+        Default::default()
     }
 
     /// Creates image settings with nearest sampling by default.
     pub fn default_nearest() -> ImagePlugin {
-        ImagePlugin {
-            default_sampler: ImageSamplerDescriptor::nearest(),
-        }
+        ImagePlugin::default().with_default_sampler(ImageSamplerDescriptor::nearest())
     }
 }
 
@@ -239,7 +263,7 @@ impl Plugin for ImagePlugin {
                 crate::CompressedImageSaver,
             >>(crate::CompressedImageSaver::default().into());
 
-            for file_extension in ["png", "jpeg", "jpg"] {
+            for file_extension in &self.default_compressed_image_processor_extensions {
                 processor.set_default_processor::<bevy_asset::processor::LoadTransformAndSave<
                     ImageLoader,
                     bevy_asset::transformer::IdentityAssetTransformer<Image>,


### PR DESCRIPTION
## Objective

Progress #24903 by adding an option to choose the extensions for the default compressed image processor. This will help users who might not want compression by default, or want to include other extensions by default (e.g. `.tga`).

## Solution

```diff
 pub struct ImagePlugin {
     /// The default image sampler to use when [`ImageSampler`] is set to `Default`.
     pub default_sampler: ImageSamplerDescriptor,
+    /// The file extensions that will be assigned a default compressed image
+    /// processor. This means they will be automatically compressed unless
+    /// overridden with a `.meta` file.
+    ///
+    /// Defaults to `["png", "jpeg", "jpg"]`.
+    #[cfg(any(
+        feature = "compressed_image_saver",
+        feature = "compressed_image_saver_universal"
+    ))]
+    pub default_compressed_image_processor_extensions: Vec<String>,
 }
```

## Testing

Locally modified the `compressed_image_saver` example to try a few different cases.
