### PR TITLE
FeathersSlider / bevy_ui_widgets/slider fixes

### DIFF
--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -56,8 +56,6 @@ pub struct FeathersSlider;
 
 /// Props used to construct the [`FeathersSlider`] scene.
 pub struct FeathersSliderProps {
-    /// Slider current value
-    pub value: f32,
     /// Slider minimum value
     pub min: f32,
     /// Slider maximum value
@@ -67,7 +65,6 @@ pub struct FeathersSliderProps {
 impl Default for FeathersSliderProps {
     fn default() -> Self {
         Self {
-            value: 0.0,
             min: 0.0,
             max: 1.0,
         }
@@ -91,7 +88,7 @@ impl FeathersSlider {
                 orientation: SliderOrientation::Horizontal,
             }
             FeathersSlider
-            SliderValue({props.value})
+            SliderValue({props.min})
             SliderRange::new(props.min, props.max)
             EntityCursor::System(bevy_window::SystemCursorIcon::EwResize)
             TabIndex(0)
@@ -163,7 +160,7 @@ pub fn slider_bundle<B: Bundle>(props: FeathersSliderProps, overrides: B) -> imp
             orientation: SliderOrientation::Horizontal,
         },
         FeathersSlider,
-        SliderValue(props.value),
+        SliderValue(props.min),
         SliderRange::new(props.min, props.max),
         EntityCursor::System(bevy_window::SystemCursorIcon::EwResize),
         TabIndex(0),
@@ -356,7 +353,7 @@ fn update_slider_pos(
             Entity,
             &SliderValue,
             &SliderRange,
-            &SliderPrecision,
+            Option<&SliderPrecision>,
             &mut BackgroundGradient,
         ),
         (
@@ -379,17 +376,19 @@ fn update_slider_pos(
         }
 
         // Find slider text child entity and update its text with the formatted value
+        let precision = precision.cloned().unwrap_or_default().0;
+
         q_children.iter_descendants(slider_ent).for_each(|child| {
             if let Ok(mut text) = q_slider_text.get_mut(child) {
                 let label = format!("{}", value.0);
                 let decimals_len = label
                     .split_once('.')
                     .map(|(_, decimals)| decimals.len() as i32)
-                    .unwrap_or(precision.0);
+                    .unwrap_or(precision);
 
                 // Don't format with precision if the value has more decimals than the precision
-                text.0 = if precision.0 >= 0 && decimals_len <= precision.0 {
-                    format!("{:.precision$}", value.0, precision = precision.0 as usize)
+                text.0 = if precision >= 0 && decimals_len <= precision {
+                    format!("{:.precision$}", value.0, precision = precision as usize)
                 } else {
                     label
                 };

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -64,10 +64,7 @@ pub struct FeathersSliderProps {
 
 impl Default for FeathersSliderProps {
     fn default() -> Self {
-        Self {
-            min: 0.0,
-            max: 1.0,
-        }
+        Self { min: 0.0, max: 1.0 }
     }
 }
 

--- a/crates/bevy_ui_widgets/src/slider.rs
+++ b/crates/bevy_ui_widgets/src/slider.rs
@@ -703,11 +703,13 @@ fn slider_on_set_value(
                 range.clamp(value.0 + delta * step.map(|s| s.0).unwrap_or_default())
             }
         };
-        commands.trigger(ValueChange {
-            source: set_slider_value.entity,
-            value: new_value,
-            is_final: true,
-        });
+        if new_value != value.0 {
+            commands.trigger(ValueChange {
+                source: set_slider_value.entity,
+                value: new_value,
+                is_final: true,
+            });
+        }
     }
 }
 

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -423,8 +423,8 @@ fn demo_column_1() -> impl Scene {
             (
                 @FeathersSlider {
                     @max: 100.0,
-                    @value: 20.0,
                 }
+                SliderValue(20.0)
                 SliderStep(10.)
                 SliderPrecision(2)
                 on(slider_self_update)


### PR DESCRIPTION
: Removed value from `FeathersSliderProps` as it doesn't exist in other controls (use `SliderValue` component instead) and made `SliderPrecision` be correctly optional as it is in underlying UI widget rather than silently not updating sliders if not present, in underlying UI widget only send `ValueChange` if value genuinely changes (matches other controls) rather than every time a `SetSliderValue` is added

*note: slider may end up deprecated in favour of number input, but thought it best to leave it in working state*

# Objective

- Working way through feathers constructing minimal UIs from the controls I noticed some differences between the slider and other controls (such as `FeathersCheckbox`) that would confuse users.

## Testing

- Feathers Gallery and local testing

---

## Showcase

### Missing SliderPrecision

```
(
    @FeathersSlider {
        @min: 0.0,
        @max: 1.0,
    }
    on(slider_self_update)
    on(|change: On<ValueChange<f32>>, mut values: ResMut<TestValues>| {
        info!("value changed {}", change.value);
    })
)
```

Silently failed to update the slider, now it works.

### value property (*note: breaking change*)

```
@FeathersSlider {
    @min: 0.0,
    @max: 1.0,
    @value: 0.5,
}
```

The above is different from other controls which use a component for value

```
@FeathersSlider {
    @min: 0.0,
    @max: 1.0,
}
SliderValue(0.5)
```

Is the correct way of setting initial value

### SetSliderValue

```
commands.trigger(SetSliderValue {
     entity,
     change: some_value,
});
```

Would trigger ValueChange<f32> every time, even when some_value is the same as the existing value. Now it doesn't. This is the same as `SetChecked`

