### PR TITLE
Documents and regression tests apply scene replace and orphan behavior.

### DIFF
--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -870,7 +870,7 @@ impl QueuedScenes {
 #[cfg(test)]
 mod tests {
     use super::EntityWorldMutSceneExt;
-    use crate::{bsn, ScenePlugin};
+    use crate::{self as bevy_scene, bsn, ScenePlugin};
     use bevy_app::{App, TaskPoolPlugin};
     use bevy_asset::AssetPlugin;
     use bevy_ecs::{name::Name, prelude::*, template::FromTemplate};

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -469,7 +469,7 @@ pub trait EntityWorldMutSceneExt {
     /// Queues the `scene` to be applied. This will evaluate the `scene`'s dependencies (via [`Scene::register_dependencies`]) and queue it to be resolved and spawned
     /// after all of the dependencies have been loaded. If a [`SpawnSceneError`] occurs, it will be logged as an error.
     ///
-    /// See [EntityWorldMutSceneExt::apply_scene] for more information on what happens when a scene is resolved.
+    /// See [`EntityWorldMutSceneExt::apply_scene`] for more information on what happens when a scene is resolved.
     ///
     /// If the dependencies are already loaded (or there are no dependencies), then the scene will be spawned this frame.
     /// This will write directly on top of any existing components on the entity. [`Scene`] is generally used as a spawning mechanism, so for most things, prefer using [`World::queue_spawn_scene`].

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -866,3 +866,62 @@ impl QueuedScenes {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::EntityWorldMutSceneExt;
+    use crate::{bsn, ScenePlugin};
+    use bevy_app::{App, TaskPoolPlugin};
+    use bevy_asset::AssetPlugin;
+    use bevy_ecs::{
+        name::Name,
+        prelude::*,
+        template::FromTemplate,
+    };
+
+    fn test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins((
+            TaskPoolPlugin::default(),
+            AssetPlugin::default(),
+            ScenePlugin,
+        ));
+        app
+    }
+
+    #[derive(Component, Default, FromTemplate)]
+    struct SceneChild;
+
+    #[derive(Component)]
+    struct PreExistingChild;
+
+    #[test]
+    fn apply_scene_replaces_and_orphans_children() {
+        let mut app = test_app();
+        let world = app.world_mut();
+
+        let pre_existing = world.spawn(PreExistingChild).id();
+        let root = world.spawn(Name::new("root")).add_child(pre_existing).id();
+
+        assert_eq!(world.entity(root).get::<Children>().map(|c| c.len()), Some(1));
+
+        let scene = bsn! {
+            Children [ #SceneChild SceneChild ]
+        };
+        world.entity_mut(root).apply_scene(scene).unwrap();
+
+        let children: Vec<Entity> = world
+            .entity(root)
+            .get::<Children>()
+            .map(|c| c.iter().collect())
+            .unwrap_or_default();
+
+        // Scene child is spawned and linked.
+        assert_eq!(children.len(), 1);
+        assert!(world.entity(children[0]).contains::<SceneChild>());
+
+        // Pre-existing child entity still exists, but is no longer listed under root.
+        assert!(world.get_entity(pre_existing).is_ok());
+        assert!(!children.contains(&pre_existing));
+    }
+}

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -891,7 +891,7 @@ mod tests {
     #[derive(Component)]
     struct PreExistingChild;
 
-    /// Tests that documented behaviour of [`EntityWorldMutSceneExt::apply_scene`] is correct.
+    /// Tests that documented behavior of [`EntityWorldMutSceneExt::apply_scene`] is correct.
     #[test]
     fn apply_scene_replaces_and_orphans_children() {
         let mut app = test_app();

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -873,11 +873,7 @@ mod tests {
     use crate::{bsn, ScenePlugin};
     use bevy_app::{App, TaskPoolPlugin};
     use bevy_asset::AssetPlugin;
-    use bevy_ecs::{
-        name::Name,
-        prelude::*,
-        template::FromTemplate,
-    };
+    use bevy_ecs::{name::Name, prelude::*, template::FromTemplate};
 
     fn test_app() -> App {
         let mut app = App::new();
@@ -895,6 +891,7 @@ mod tests {
     #[derive(Component)]
     struct PreExistingChild;
 
+    /// Tests that documented behaviour of [`EntityWorldMutSceneExt::apply_scene`] is correct.
     #[test]
     fn apply_scene_replaces_and_orphans_children() {
         let mut app = test_app();
@@ -903,7 +900,10 @@ mod tests {
         let pre_existing = world.spawn(PreExistingChild).id();
         let root = world.spawn(Name::new("root")).add_child(pre_existing).id();
 
-        assert_eq!(world.entity(root).get::<Children>().map(|c| c.len()), Some(1));
+        assert_eq!(
+            world.entity(root).get::<Children>().map(|c| c.len()),
+            Some(1)
+        );
 
         let scene = bsn! {
             Children [ #SceneChild SceneChild ]

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -901,7 +901,7 @@ mod tests {
         let root = world.spawn(Name::new("root")).add_child(pre_existing).id();
 
         assert_eq!(
-            world.entity(root).get::<Children>().map(|c| c.len()),
+            world.entity(root).get::<Children>().map(Children::len),
             Some(1)
         );
 

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -454,6 +454,8 @@ pub trait EntityWorldMutSceneExt {
     /// Applies the given [`Scene`] to the current entity immediately. This will resolve the Scene (using [`Scene::resolve`]). If that fails (for example, if there are dependencies that have not been
     /// loaded yet), it will return a [`SpawnSceneError`]. If resolving the [`Scene`] is successful, the scene will be spawned.
     ///
+    /// When a scene is resolved, it will replace and orphan the current entity's children.
+    ///
     /// If resolving and spawning is successful, the entity will contain the full contents of the spawned scene.
     ///
     /// This will write directly on top of any existing components on the entity. [`Scene`] is generally used as a spawning mechanism, so for most things, prefer using [`World::spawn_scene`].
@@ -466,6 +468,8 @@ pub trait EntityWorldMutSceneExt {
 
     /// Queues the `scene` to be applied. This will evaluate the `scene`'s dependencies (via [`Scene::register_dependencies`]) and queue it to be resolved and spawned
     /// after all of the dependencies have been loaded. If a [`SpawnSceneError`] occurs, it will be logged as an error.
+    ///
+    /// See [EntityWorldMutSceneExt::apply_scene] for more information on what happens when a scene is resolved.
     ///
     /// If the dependencies are already loaded (or there are no dependencies), then the scene will be spawned this frame.
     /// This will write directly on top of any existing components on the entity. [`Scene`] is generally used as a spawning mechanism, so for most things, prefer using [`World::queue_spawn_scene`].


### PR DESCRIPTION
# Objective

- The behavior of https://docs.rs/bevy_scene/0.19.0/src/bevy_scene/resolved_scene.rs.html#60-63 means that `apply_scene` will replace and orphan pre-existing entity children. 
- Adds doc comment explaining this behavior.
- Adds regression test validating the doc comment; helps ensure comment is up to date. 

## Solution

- Adds docs and corresponding regression test. 

## Testing

- See test at bottom of `spawn.rs` called `apply_scene_replaces_and_orphans_children`
