### PR TITLE
Allow users to filter messages 

### DIFF
--- a/crates/bevy_ecs/src/message/iterators.rs
+++ b/crates/bevy_ecs/src/message/iterators.rs
@@ -61,17 +61,21 @@ impl<'a, M: Message> MessageIteratorWithId<'a, M> {
         let a = messages.messages_a.get(a_index..).unwrap_or_default();
         let b = messages.messages_b.get(b_index..).unwrap_or_default();
 
-        let unread_count = a.len() + b.len();
+        let unread_positional = a.len() + b.len();
         // Ensure `len` is implemented correctly
-        debug_assert_eq!(unread_count, reader.len(messages));
-        reader.last_message_count = messages.message_count - unread_count;
+        debug_assert_eq!(unread_positional, reader.len(messages));
+        reader.last_message_count = messages.message_count - unread_positional;
+
+        let unread_live =
+            a.iter().filter(|i| !i.deleted).count() + b.iter().filter(|i| !i.deleted).count();
+
         // Iterate the oldest first, then the newer messages
         let chain = a.iter().chain(b.iter());
 
         Self {
             reader,
             chain,
-            unread: unread_count,
+            unread: unread_live,
         }
     }
 
@@ -84,57 +88,21 @@ impl<'a, M: Message> MessageIteratorWithId<'a, M> {
 impl<'a, M: Message> Iterator for MessageIteratorWithId<'a, M> {
     type Item = (&'a M, MessageId<M>);
     fn next(&mut self) -> Option<Self::Item> {
-        match self
-            .chain
-            .next()
-            .map(|instance| (&instance.message, instance.message_id))
-        {
-            Some(item) => {
-                #[cfg(feature = "detailed_trace")]
-                tracing::trace!("MessageReader::iter() -> {}", item.1);
-                self.reader.last_message_count += 1;
-                self.unread -= 1;
-                Some(item)
+        loop {
+            let instance = self.chain.next()?;
+            self.reader.last_message_count += 1;
+            if instance.deleted {
+                continue;
             }
-            None => None,
+            self.unread -= 1;
+            #[cfg(feature = "detailed_trace")]
+            tracing::trace!("MessageReader::iter() -> {}", instance.message_id);
+            return Some((&instance.message, instance.message_id));
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.chain.size_hint()
-    }
-
-    fn count(self) -> usize {
-        self.reader.last_message_count += self.unread;
-        self.unread
-    }
-
-    fn last(self) -> Option<Self::Item>
-    where
-        Self: Sized,
-    {
-        let MessageInstance {
-            message_id,
-            message,
-        } = self.chain.last()?;
-        self.reader.last_message_count += self.unread;
-        Some((message, *message_id))
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        if let Some(MessageInstance {
-            message_id,
-            message,
-        }) = self.chain.nth(n)
-        {
-            self.reader.last_message_count += n + 1;
-            self.unread -= n + 1;
-            Some((message, *message_id))
-        } else {
-            self.reader.last_message_count += self.unread;
-            self.unread = 0;
-            None
-        }
+        (self.unread, Some(self.unread))
     }
 }
 
@@ -243,6 +211,9 @@ impl<'a, M: Message> MessageParIter<'a, M> {
                     let func = func.clone();
                     scope.spawn(async move {
                         for message_instance in batch {
+                            if message_instance.deleted {
+                                continue;
+                            }
                             func(&message_instance.message, message_instance.message_id);
                         }
                     });
@@ -277,7 +248,8 @@ impl<'a, M: Message> IntoIterator for MessageParIter<'a, M> {
             slices: [a, b],
             ..
         } = self;
-        let unread = a.len() + b.len();
+        let unread =
+            a.iter().filter(|i| !i.deleted).count() + b.iter().filter(|i| !i.deleted).count();
         let chain = a.iter().chain(b);
         MessageIteratorWithId {
             reader,

--- a/crates/bevy_ecs/src/message/message_mutator.rs
+++ b/crates/bevy_ecs/src/message/message_mutator.rs
@@ -183,4 +183,10 @@ impl<'w, 's, M: Message> MessageMutator<'w, 's, M> {
     {
         self.messages.write_default()
     }
+
+    /// Retain messages for which the predicate returns 'true', removing all others so that
+    /// downstream readers never see them.
+    pub fn retain(&mut self, f: impl FnMut(&M) -> bool) {
+        self.messages.retain(f);
+    }
 }

--- a/crates/bevy_ecs/src/message/message_mutator.rs
+++ b/crates/bevy_ecs/src/message/message_mutator.rs
@@ -186,7 +186,7 @@ impl<'w, 's, M: Message> MessageMutator<'w, 's, M> {
 
     /// Retain messages for which the predicate returns 'true', removing all others so that
     /// downstream readers never see them.
-    pub fn retain(&mut self, f: impl FnMut(&M) -> bool) {
+    pub fn filter(&mut self, f: impl FnMut(&M) -> bool) {
         self.messages.filter(f);
     }
 }

--- a/crates/bevy_ecs/src/message/message_mutator.rs
+++ b/crates/bevy_ecs/src/message/message_mutator.rs
@@ -184,7 +184,7 @@ impl<'w, 's, M: Message> MessageMutator<'w, 's, M> {
         self.messages.write_default()
     }
 
-    /// Retain messages for which the predicate returns 'true', removing all others so that
+    /// Filter messages for which the predicate returns 'false', flagging the messages so that
     /// downstream readers never see them.
     pub fn filter(&mut self, f: impl FnMut(&M) -> bool) {
         self.messages.filter(f);

--- a/crates/bevy_ecs/src/message/message_mutator.rs
+++ b/crates/bevy_ecs/src/message/message_mutator.rs
@@ -187,6 +187,6 @@ impl<'w, 's, M: Message> MessageMutator<'w, 's, M> {
     /// Retain messages for which the predicate returns 'true', removing all others so that
     /// downstream readers never see them.
     pub fn retain(&mut self, f: impl FnMut(&M) -> bool) {
-        self.messages.retain(f);
+        self.messages.filter(f);
     }
 }

--- a/crates/bevy_ecs/src/message/messages.rs
+++ b/crates/bevy_ecs/src/message/messages.rs
@@ -138,6 +138,7 @@ impl<M: Message> Messages<M> {
         let message_instance = MessageInstance {
             message_id,
             message,
+            deleted: false,
         };
 
         self.messages_b.push(message_instance);
@@ -214,7 +215,7 @@ impl<M: Message> Messages<M> {
             self.messages_b.start_message_count
         );
 
-        iter.map(|e| e.message)
+        iter.filter(|e| !e.deleted).map(|e| e.message)
     }
 
     #[inline]
@@ -251,6 +252,7 @@ impl<M: Message> Messages<M> {
         self.messages_a
             .drain(..)
             .chain(self.messages_b.drain(..))
+            .filter(|i| !i.deleted)
             .map(|i| i.message)
     }
 
@@ -277,16 +279,26 @@ impl<M: Message> Messages<M> {
 
         sequence
             .get(index)
+            .filter(|instance| !instance.deleted)
             .map(|instance| (&instance.message, instance.message_id))
     }
 
-    /// Retains messages for which the predicate returns `true`, removing all others from both
-    /// internal buffers.
-    pub fn retain(&mut self, mut f: impl FnMut(&M) -> bool) {
-        self.messages_b
+    /// Filters every message for which `f` returns `false`, so that [`MessageReader`]s and
+    /// [`MessageMutator`]s never observe them. 
+    ///
+    /// [`MessageReader`]: super::MessageReader
+    /// [`MessageMutator`]: super::MessageMutator
+    pub fn filter(&mut self, mut f: impl FnMut(&M) -> bool) {
+        for instance in self
+            .messages_a
             .messages
-            .retain(|instance| f(&instance.message));
-        self.message_count = self.messages_b.start_message_count + self.messages_b.len();
+            .iter_mut()
+            .chain(self.messages_b.messages.iter_mut())
+        {
+            if !instance.deleted && !f(&instance.message) {
+                instance.deleted = true;
+            }
+        }
     }
 
     /// Which message buffer is this message id a part of.
@@ -317,6 +329,7 @@ impl<M: Message> Extend<M> for Messages<M> {
             MessageInstance {
                 message_id,
                 message,
+                deleted: false,
             }
         });
 

--- a/crates/bevy_ecs/src/message/messages.rs
+++ b/crates/bevy_ecs/src/message/messages.rs
@@ -282,29 +282,6 @@ impl<M: Message> Messages<M> {
 
     /// Retains messages for which the predicate returns `true`, removing all others from both
     /// internal buffers.
-    ///
-    /// In order for this functionality to be useful, users need to order their systems so that
-    /// systems which produce messages come before systems that filter them, which come before
-    /// systems that consume them.
-    /// 
-    /// # Example
-    /// 
-    /// ```
-    /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::message::{Message, Messages};
-    /// #
-    /// #[derive(Message, Clone, Debug)]
-    /// struct DealDamage { amount: i32 }
-    /// 
-    /// fn block_zero_damage(mut mutator: MessageMutator<DealDamage>) {
-    ///     mutator.retain(|msg| msg.amount > 0);
-    /// }
-    /// # bevy_ecs::system::assert_is_system(block_zero_damage);
-    /// ```
-    /// 
-    /// [`MessageMutator`]: super::MessageMutator
-    /// [`MessageReader`]: super::MessageReader
-    /// [`MessageCursor`]: super::MessageCursor
     pub fn retain(&mut self, mut f: impl FnMut(&M) -> bool) {
         self.messages_b
             .messages

--- a/crates/bevy_ecs/src/message/messages.rs
+++ b/crates/bevy_ecs/src/message/messages.rs
@@ -280,6 +280,39 @@ impl<M: Message> Messages<M> {
             .map(|instance| (&instance.message, instance.message_id))
     }
 
+    /// Retains messages for which the predicate returns `true`, removing all others from both
+    /// internal buffers.
+    ///
+    /// In order for this functionality to be useful, users need to order their systems so that
+    /// systems which produce messages come before systems that filter them, which come before
+    /// systems that consume them.
+    /// 
+    /// # Example
+    /// 
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::message::{Message, Messages};
+    /// #
+    /// #[derive(Message, Clone, Debug)]
+    /// struct DealDamage { amount: i32 }
+    /// 
+    /// fn block_zero_damage(mut mutator: MessageMutator<DealDamage>) {
+    ///     mutator.retain(|msg| msg.amount > 0);
+    /// }
+    /// # bevy_ecs::system::assert_is_system(block_zero_damage);
+    /// ```
+    /// 
+    /// [`MessageMutator`]: super::MessageMutator
+    /// [`MessageReader`]: super::MessageReader
+    /// [`MessageCursor`]: super::MessageCursor
+    pub fn retain(&mut self, mut f: impl FnMut(&M) -> bool) {
+        self.messages_b
+            .messages
+            .retain(|instance| f(&instance.message));
+        self.message_count =
+            self.messages_b.start_message_count + self.messages_b.len();
+    }
+
     /// Which message buffer is this message id a part of.
     fn sequence(&self, id: usize) -> &MessageSequence<M> {
         if id < self.messages_b.start_message_count {

--- a/crates/bevy_ecs/src/message/messages.rs
+++ b/crates/bevy_ecs/src/message/messages.rs
@@ -286,8 +286,7 @@ impl<M: Message> Messages<M> {
         self.messages_b
             .messages
             .retain(|instance| f(&instance.message));
-        self.message_count =
-            self.messages_b.start_message_count + self.messages_b.len();
+        self.message_count = self.messages_b.start_message_count + self.messages_b.len();
     }
 
     /// Which message buffer is this message id a part of.

--- a/crates/bevy_ecs/src/message/mod.rs
+++ b/crates/bevy_ecs/src/message/mod.rs
@@ -104,6 +104,7 @@ pub trait Message: Send + Sync + 'static {}
 pub(crate) struct MessageInstance<M: Message> {
     pub message_id: MessageId<M>,
     pub message: M,
+    pub deleted: bool,
 }
 
 /// A [`MessageId`] uniquely identifies a message stored in a specific [`World`].

--- a/crates/bevy_ecs/src/message/mut_iterators.rs
+++ b/crates/bevy_ecs/src/message/mut_iterators.rs
@@ -65,16 +65,19 @@ impl<'a, M: Message> MessageMutIteratorWithId<'a, M> {
         let a = messages.messages_a.get_mut(a_index..).unwrap_or_default();
         let b = messages.messages_b.get_mut(b_index..).unwrap_or_default();
 
-        let unread_count = a.len() + b.len();
+        let unread_positional = a.len() + b.len();
+        mutator.last_message_count = messages.message_count - unread_positional;
 
-        mutator.last_message_count = messages.message_count - unread_count;
+        let unread_live =
+            a.iter().filter(|i| !i.deleted).count() + b.iter().filter(|i| !i.deleted).count();
+
         // Iterate the oldest first, then the newer messages
         let chain = a.iter_mut().chain(b.iter_mut());
 
         Self {
             mutator,
             chain,
-            unread: unread_count,
+            unread: unread_live,
         }
     }
 
@@ -87,57 +90,22 @@ impl<'a, M: Message> MessageMutIteratorWithId<'a, M> {
 impl<'a, M: Message> Iterator for MessageMutIteratorWithId<'a, M> {
     type Item = (&'a mut M, MessageId<M>);
     fn next(&mut self) -> Option<Self::Item> {
-        match self
-            .chain
-            .next()
-            .map(|instance| (&mut instance.message, instance.message_id))
-        {
-            Some(item) => {
-                #[cfg(feature = "detailed_trace")]
-                tracing::trace!("MessageMutator::iter() -> {}", item.1);
-                self.mutator.last_message_count += 1;
-                self.unread -= 1;
-                Some(item)
+        loop {
+            let instance = self.chain.next()?;
+            self.mutator.last_message_count += 1;
+            if instance.deleted {
+                continue;
             }
-            None => None,
+            self.unread -= 1;
+            let message_id = instance.message_id;
+            #[cfg(feature = "detailed_trace")]
+            tracing::trace!("MessageMutator::iter() -> {}", message_id);
+            return Some((&mut instance.message, message_id));
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.chain.size_hint()
-    }
-
-    fn count(self) -> usize {
-        self.mutator.last_message_count += self.unread;
-        self.unread
-    }
-
-    fn last(self) -> Option<Self::Item>
-    where
-        Self: Sized,
-    {
-        let MessageInstance {
-            message_id,
-            message,
-        } = self.chain.last()?;
-        self.mutator.last_message_count += self.unread;
-        Some((message, *message_id))
-    }
-
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        if let Some(MessageInstance {
-            message_id,
-            message,
-        }) = self.chain.nth(n)
-        {
-            self.mutator.last_message_count += n + 1;
-            self.unread -= n + 1;
-            Some((message, *message_id))
-        } else {
-            self.mutator.last_message_count += self.unread;
-            self.unread = 0;
-            None
-        }
+        (self.unread, Some(self.unread))
     }
 }
 
@@ -246,6 +214,9 @@ impl<'a, M: Message> MessageMutParIter<'a, M> {
                     let func = func.clone();
                     scope.spawn(async move {
                         for message_instance in batch {
+                            if message_instance.deleted {
+                                continue;
+                            }
                             func(&mut message_instance.message, message_instance.message_id);
                         }
                     });
@@ -280,7 +251,8 @@ impl<'a, M: Message> IntoIterator for MessageMutParIter<'a, M> {
             slices: [a, b],
             ..
         } = self;
-        let unread = a.len() + b.len();
+        let unread =
+            a.iter().filter(|i| !i.deleted).count() + b.iter().filter(|i| !i.deleted).count();
         let chain = a.iter_mut().chain(b);
         MessageMutIteratorWithId {
             mutator: reader,


### PR DESCRIPTION
# Objective

Allow users to filter messages instead of only being able to mutate them.

## Solution

Added a .retain() function to the `Messages` impl accessible through the `MessageMutator`

## Testing

I tested the changes by vendoring bevy_ecs and using the changes in my own project.
I do not believe it needs additional testing.
Other reviewers can test my changes by pulling the code and making a simple toy project. Something like this should be good to start:

```rust
use bevy_ecs::{message::MessageRegistry, prelude::*};

fn main() {
    let mut world = World::new();
    MessageRegistry::register_message::<Number>(&mut world);
    let mut schedule = Schedule::default();
    #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
    struct FlushMessages;
    schedule.add_systems(bevy_ecs::message::message_update_system.in_set(FlushMessages));

    // producer -> filter -> consumer, strictly ordered.
    schedule.add_systems(
        (write_numbers, retain_odd, read_numbers)
            .chain()
            .after(FlushMessages),
    );

    schedule.run(&mut world);
}

#[derive(Message, Debug)]
struct Number(u32);

fn write_numbers(mut writer: MessageWriter<Number>) {
    for n in 1..10 {
        writer.write(Number(n));
    }
    println!("wrote 1..10");
}

fn retain_odd(mut mutator: MessageMutator<Number>) {
    mutator.retain(|Number(n)| n % 2 == 1);
    println!("retained odd numbers");
}

fn read_numbers(mut reader: MessageReader<Number>) {
    for Number(n) in reader.read() {
        println!("    read {n}");
    }
}
```

I tested these changes on Windows 10. I do not believe this is relevant to the changes. 
