### PR TITLE
Pass command panics to the fallback error handler

### DIFF
--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -6,7 +6,6 @@ use crate::{
 
 use alloc::{boxed::Box, vec::Vec};
 use bevy_ptr::{OwningPtr, Unaligned};
-use bevy_utils::DebugName;
 use core::{
     fmt::Debug,
     mem::{size_of, MaybeUninit},
@@ -196,7 +195,10 @@ impl RawCommandQueue {
         let meta = CommandMeta {
             consume_command_and_get_size: |command, world, runner| {
                 runner.local_cursor += size_of::<C>();
-                runner.current_command_name = DebugName::type_name::<C>();
+                #[cfg(all(feature = "debug", feature = "std"))]
+                {
+                    runner.current_command_name = core::any::type_name::<C>();
+                }
 
                 // Putting the command onto the stack is necessary not just for alignment and to be able to consume it,
                 // but also because applying the command may cause the command queue to reallocate.
@@ -300,7 +302,13 @@ struct CommandQueueRunner<'a> {
     /// This is assigned by [`CommandMeta::consume_command_and_get_size`]
     /// before running a command so that it is available
     /// in the error handler if the command panics.
-    current_command_name: DebugName,
+    ///
+    /// This is not stored as [`DebugName`](bevy_utils::DebugName)
+    /// because that uses [`Cow`](alloc::borrow::Cow) internally,
+    /// so assignments would have to emit code to check the
+    /// variant and deallocate a [`String`](alloc::string::String).
+    #[cfg(all(feature = "debug", feature = "std"))]
+    current_command_name: &'static str,
     command_queue: &'a mut RawCommandQueue,
     start: usize,
     stop: usize,
@@ -321,7 +329,8 @@ impl<'a> CommandQueueRunner<'a> {
 
         Self {
             local_cursor: start,
-            current_command_name: DebugName::borrowed("Unknown command"),
+            #[cfg(all(feature = "debug", feature = "std"))]
+            current_command_name: "Unknown command",
             command_queue,
             start,
             stop,
@@ -380,6 +389,7 @@ impl<'a> CommandQueueRunner<'a> {
                 use crate::error::{
                     BevyError, ErrorContext, Severity, PANIC_ORIGINATES_FROM_ERROR_HANDLER,
                 };
+                use bevy_utils::DebugName;
                 use std::{
                     backtrace::Backtrace,
                     panic::{catch_unwind, resume_unwind},
@@ -403,7 +413,12 @@ impl<'a> CommandQueueRunner<'a> {
                     world.fallback_error_handler()(
                         error,
                         ErrorContext::Command {
-                            name: self.current_command_name.clone(),
+                            #[cfg(feature = "debug")]
+                            name: DebugName::borrowed(self.current_command_name),
+                            // `DebugName` is empty when the feature is disabled,
+                            // so it does not matter what string we pass here.
+                            #[cfg(not(feature = "debug"))]
+                            name: DebugName::borrowed(""),
                         },
                     );
                 }

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -20,12 +20,9 @@ struct CommandMeta {
     ///
     /// `world` is optional to allow this one function pointer to perform double-duty as a drop.
     ///
-    /// Advances `runner.local_cursor` by the size of `T` in bytes.
-    consume_command_and_get_size: unsafe fn(
-        value: OwningPtr<Unaligned>,
-        world: Option<&mut World>,
-        runner: &mut CommandQueueRunner,
-    ),
+    /// Advances `cursor` by the size of `T` in bytes.
+    consume_command_and_get_size:
+        unsafe fn(value: OwningPtr<Unaligned>, world: Option<&mut World>, cursor: &mut usize),
 }
 
 /// Densely and efficiently stores a queue of heterogenous types implementing [`Command`].
@@ -193,12 +190,8 @@ impl RawCommandQueue {
         }
 
         let meta = CommandMeta {
-            consume_command_and_get_size: |command, world, runner| {
-                runner.local_cursor += size_of::<C>();
-                #[cfg(all(feature = "debug", feature = "std"))]
-                {
-                    runner.current_command_name = core::any::type_name::<C>();
-                }
+            consume_command_and_get_size: |command, world, cursor| {
+                *cursor += size_of::<C>();
 
                 // Putting the command onto the stack is necessary not just for alignment and to be able to consume it,
                 // but also because applying the command may cause the command queue to reallocate.
@@ -296,20 +289,8 @@ impl SystemBuffer for CommandQueue {
 /// A RAII guard used while running commands to ensure
 /// that unapplied commands are dropped during unwind.
 struct CommandQueueRunner<'a> {
-    local_cursor: usize,
-    /// The type name of the last command to be applied.
-    ///
-    /// This is assigned by [`CommandMeta::consume_command_and_get_size`]
-    /// before running a command so that it is available
-    /// in the error handler if the command panics.
-    ///
-    /// This is not stored as [`DebugName`](bevy_utils::DebugName)
-    /// because that uses [`Cow`](alloc::borrow::Cow) internally,
-    /// so assignments would have to emit code to check the
-    /// variant and deallocate a [`String`](alloc::string::String).
-    #[cfg(all(feature = "debug", feature = "std"))]
-    current_command_name: &'static str,
     command_queue: &'a mut RawCommandQueue,
+    local_cursor: usize,
     start: usize,
     stop: usize,
 }
@@ -328,10 +309,8 @@ impl<'a> CommandQueueRunner<'a> {
         unsafe { command_queue.cursor.write(stop) };
 
         Self {
-            local_cursor: start,
-            #[cfg(all(feature = "debug", feature = "std"))]
-            current_command_name: "Unknown command",
             command_queue,
+            local_cursor: start,
             start,
             stop,
         }
@@ -381,7 +360,7 @@ impl<'a> CommandQueueRunner<'a> {
                 // This also advances the cursor past the command. For ZSTs, the cursor will not move.
                 // At this point, it will either point to the next `CommandMeta`,
                 // or the cursor will be out of bounds and the loop will end.
-                unsafe { (meta.consume_command_and_get_size)(cmd, world.as_deref_mut(), self) };
+                unsafe { (meta.consume_command_and_get_size)(cmd, world.as_deref_mut(), &mut self.local_cursor) };
             });
 
             #[cfg(feature = "std")]
@@ -413,12 +392,7 @@ impl<'a> CommandQueueRunner<'a> {
                     world.fallback_error_handler()(
                         error,
                         ErrorContext::Command {
-                            #[cfg(feature = "debug")]
-                            name: DebugName::borrowed(self.current_command_name),
-                            // `DebugName` is empty when the feature is disabled,
-                            // so it does not matter what string we pass here.
-                            #[cfg(not(feature = "debug"))]
-                            name: DebugName::borrowed(""),
+                            name: DebugName::type_name::<CommandQueue>(),
                         },
                     );
                 }

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -24,7 +24,7 @@ struct CommandMeta {
     /// Advances `runner.local_cursor` by the size of `T` in bytes.
     consume_command_and_get_size: unsafe fn(
         value: OwningPtr<Unaligned>,
-        world: Option<NonNull<World>>,
+        world: Option<&mut World>,
         runner: &mut CommandQueueRunner,
     ),
 }
@@ -123,7 +123,7 @@ impl CommandQueue {
 
         // SAFETY: A reference is always a valid pointer
         unsafe {
-            self.get_raw().apply_or_drop_queued(Some(world.into()));
+            self.get_raw().apply_or_drop_queued(Some(world));
         }
     }
 
@@ -205,9 +205,7 @@ impl RawCommandQueue {
                 let command: C = unsafe { command.read_unaligned() };
                 match world {
                     // Apply command to the provided world...
-                    Some(mut world) => {
-                        // SAFETY: Caller ensures pointer is not null
-                        let world = unsafe { world.as_mut() };
+                    Some(world) => {
                         command.apply(world);
                         // The command may have queued up world commands, which we flush here to ensure they are also picked up.
                         // If the current command queue already the World Command queue, this will still behave appropriately because the global cursor
@@ -257,12 +255,10 @@ impl RawCommandQueue {
     /// # Safety
     /// - `self` has not outlived the underlying queue
     /// - there is no other unsynchonized access to the same underlying queue
-    /// - If `world` is `Some`, then it must be valid to use as `&mut World`.
     #[inline]
-    pub(crate) unsafe fn apply_or_drop_queued(&mut self, world: Option<NonNull<World>>) {
+    pub(crate) unsafe fn apply_or_drop_queued(&mut self, world: Option<&mut World>) {
         // SAFETY: Caller ensures `self` has not outlived the queue.
-        // that there is no other unsynchronized access,
-        // and that `world` is valid.
+        // and that there is no other unsynchronized access.
         unsafe { CommandQueueRunner::new(self).run(world) };
     }
 }
@@ -332,8 +328,7 @@ impl<'a> CommandQueueRunner<'a> {
         }
     }
 
-    /// SAFETY: If `world` is `Some`, then it must be valid to use as `&mut World`.
-    unsafe fn run(&mut self, world: Option<NonNull<World>>) {
+    fn run(&mut self, mut world: Option<&mut World>) {
         #[cfg(feature = "std")]
         {
             crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
@@ -377,7 +372,7 @@ impl<'a> CommandQueueRunner<'a> {
                 // This also advances the cursor past the command. For ZSTs, the cursor will not move.
                 // At this point, it will either point to the next `CommandMeta`,
                 // or the cursor will be out of bounds and the loop will end.
-                unsafe { (meta.consume_command_and_get_size)(cmd, world, self) };
+                unsafe { (meta.consume_command_and_get_size)(cmd, world.as_deref_mut(), self) };
             });
 
             #[cfg(feature = "std")]
@@ -397,11 +392,9 @@ impl<'a> CommandQueueRunner<'a> {
                     if panic_originates_from_error_handler {
                         resume_unwind(payload)
                     }
-                    let Some(mut world) = world else {
+                    let Some(world) = world.as_deref_mut() else {
                         resume_unwind(payload)
                     };
-                    // SAFETY: Caller ensures pointer is not null
-                    let world = unsafe { world.as_mut() };
                     let error = BevyError::new_with_backtrace(
                         Severity::Panic,
                         "Command panicked",
@@ -426,8 +419,7 @@ impl Drop for CommandQueueRunner<'_> {
     fn drop(&mut self) {
         // Drop any unapplied commands before resetting the length.
         // If `run` completed successfully then this will do nothing.
-        // SAFETY: `world` is `None`
-        unsafe { self.run(None) };
+        self.run(None);
 
         // Reset the buffer: all commands past the original `start` cursor have been applied.
         // SAFETY: we are setting the length of bytes to the original length, minus the length of the original

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -9,10 +9,19 @@ use bevy_ptr::{OwningPtr, Unaligned};
 use core::{
     fmt::Debug,
     mem::{size_of, MaybeUninit},
-    panic::AssertUnwindSafe,
     ptr::{addr_of_mut, NonNull},
 };
 use log::warn;
+
+#[cfg(feature = "std")]
+use crate::error::{BevyError, ErrorContext, Severity, PANIC_ORIGINATES_FROM_ERROR_HANDLER};
+#[cfg(feature = "std")]
+use bevy_utils::DebugName;
+#[cfg(feature = "std")]
+use std::{
+    backtrace::Backtrace,
+    panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
+};
 
 struct CommandMeta {
     /// SAFETY: The `value` must point to a value of type `T: Command`,
@@ -190,7 +199,7 @@ impl RawCommandQueue {
         }
 
         let meta = CommandMeta {
-            consume_command_and_get_size: |command, world, cursor| {
+            consume_command_and_get_size: |command, mut world, cursor| {
                 *cursor += size_of::<C>();
 
                 // Putting the command onto the stack is necessary not just for alignment and to be able to consume it,
@@ -198,18 +207,33 @@ impl RawCommandQueue {
                 // SAFETY: According to the invariants of `CommandMeta.consume_command_and_get_size`,
                 // `command` must point to a value of type `C`.
                 let command: C = unsafe { command.read_unaligned() };
-                match world {
-                    // Apply command to the provided world...
-                    Some(world) => {
-                        command.apply(world);
-                        // The command may have queued up world commands, which we flush here to ensure they are also picked up.
-                        // If the current command queue already the World Command queue, this will still behave appropriately because the global cursor
-                        // is still at the current `stop`, ensuring only the newly queued Commands will be applied.
-                        world.flush();
+
+                let f = || {
+                    match world.as_deref_mut() {
+                        // Apply command to the provided world...
+                        Some(world) => {
+                            command.apply(world);
+                            // The command may have queued up world commands, which we flush here to ensure they are also picked up.
+                            // If the current command queue already the World Command queue, this will still behave appropriately because the global cursor
+                            // is still at the current `stop`, ensuring only the newly queued Commands will be applied.
+                            world.flush();
+                        }
+                        // ...or discard it.
+                        None => drop(command),
                     }
-                    // ...or discard it.
-                    None => drop(command),
+                };
+
+                #[cfg(feature = "std")]
+                {
+                    let result = catch_unwind(AssertUnwindSafe(f));
+                    if let Err(payload) = result {
+                        let name = DebugName::type_name::<C>();
+                        handle_panic_payload(world, payload, name);
+                    }
                 }
+
+                #[cfg(not(feature = "std"))]
+                (f)();
             },
         };
 
@@ -319,7 +343,7 @@ impl<'a> CommandQueueRunner<'a> {
     fn run(&mut self, mut world: Option<&mut World>) {
         #[cfg(feature = "std")]
         {
-            crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
+            PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
         }
 
         while self.local_cursor < self.stop {
@@ -353,55 +377,44 @@ impl<'a> CommandQueueRunner<'a> {
                         .cast(),
                 ))
             };
-            let f = AssertUnwindSafe(|| {
-                // SAFETY: The data underneath the cursor must correspond to the type erased in metadata,
-                // since they were stored next to each other by `.push()`.
-                // For ZSTs, the type doesn't matter as long as the pointer is non-null.
-                // This also advances the cursor past the command. For ZSTs, the cursor will not move.
-                // At this point, it will either point to the next `CommandMeta`,
-                // or the cursor will be out of bounds and the loop will end.
-                unsafe { (meta.consume_command_and_get_size)(cmd, world.as_deref_mut(), &mut self.local_cursor) };
-            });
-
-            #[cfg(feature = "std")]
-            {
-                use crate::error::{
-                    BevyError, ErrorContext, Severity, PANIC_ORIGINATES_FROM_ERROR_HANDLER,
-                };
-                use bevy_utils::DebugName;
-                use std::{
-                    backtrace::Backtrace,
-                    panic::{catch_unwind, resume_unwind},
-                };
-
-                let result = catch_unwind(f);
-                let panic_originates_from_error_handler =
-                    PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false);
-                if let Err(payload) = result {
-                    if panic_originates_from_error_handler {
-                        resume_unwind(payload)
-                    }
-                    let Some(world) = world.as_deref_mut() else {
-                        resume_unwind(payload)
-                    };
-                    let error = BevyError::new_with_backtrace(
-                        Severity::Panic,
-                        "Command panicked",
-                        Backtrace::disabled(),
-                    );
-                    world.fallback_error_handler()(
-                        error,
-                        ErrorContext::Command {
-                            name: DebugName::type_name::<CommandQueue>(),
-                        },
-                    );
-                }
-            }
-
-            #[cfg(not(feature = "std"))]
-            (f)();
+            // SAFETY: The data underneath the cursor must correspond to the type erased in metadata,
+            // since they were stored next to each other by `.push()`.
+            // For ZSTs, the type doesn't matter as long as the pointer is non-null.
+            // This also advances the cursor past the command. For ZSTs, the cursor will not move.
+            // At this point, it will either point to the next `CommandMeta`,
+            // or the cursor will be out of bounds and the loop will end.
+            unsafe {
+                (meta.consume_command_and_get_size)(
+                    cmd,
+                    world.as_deref_mut(),
+                    &mut self.local_cursor,
+                )
+            };
         }
     }
+}
+
+/// Handle a panic thrown within a command.
+///
+/// This is a separate non-generic function so that the panic handling code
+/// is not monomorphized separately for each command type.
+#[cfg(feature = "std")]
+#[cold]
+fn handle_panic_payload(
+    world: Option<&mut World>,
+    payload: Box<dyn core::any::Any + Send>,
+    name: DebugName,
+) {
+    let panic_originates_from_error_handler = PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false);
+    if panic_originates_from_error_handler {
+        resume_unwind(payload)
+    }
+    let Some(world) = world else {
+        resume_unwind(payload)
+    };
+    let error =
+        BevyError::new_with_backtrace(Severity::Panic, "Command panicked", Backtrace::disabled());
+    world.fallback_error_handler()(error, ErrorContext::Command { name });
 }
 
 impl Drop for CommandQueueRunner<'_> {
@@ -553,7 +566,7 @@ mod test {
 
         let mut world = World::new();
 
-        let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let _ = catch_unwind(AssertUnwindSafe(|| {
             queue.apply(&mut world);
         }));
 
@@ -608,7 +621,7 @@ mod test {
         });
         world.commands().queue(add_index(4));
 
-        let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let _ = catch_unwind(AssertUnwindSafe(|| {
             world.flush_commands();
         }));
 

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -438,7 +438,7 @@ mod test {
     use super::*;
     use crate::{
         component::Component,
-        error::{warn, FallbackErrorHandler},
+        error::{BevyError, ErrorContext, FallbackErrorHandler},
         resource::Resource,
     };
     use alloc::{borrow::ToOwned, string::String, sync::Arc};
@@ -446,6 +446,7 @@ mod test {
         panic::AssertUnwindSafe,
         sync::atomic::{AtomicU32, Ordering},
     };
+    use std::{string::ToString, sync::Mutex};
 
     #[cfg(miri)]
     use alloc::format;
@@ -579,7 +580,7 @@ mod test {
     }
 
     #[test]
-    fn test_command_queue_inner_panic_safe_warn() {
+    fn test_command_queue_inner_panic_safe_handled() {
         let mut queue = CommandQueue::default();
 
         queue.push(PanicCommand("I panic!".to_owned()));
@@ -587,8 +588,14 @@ mod test {
         // handles the panicking command.
         queue.push(SpawnCommand);
 
+        fn record_last_error(error: BevyError, context: ErrorContext) {
+            *LAST_ERROR.lock().unwrap() = Some((error, context));
+        }
+        static LAST_ERROR: Mutex<Option<(BevyError, ErrorContext)>> = Mutex::new(None);
+        *LAST_ERROR.lock().unwrap() = None;
+
         let mut world = World::new();
-        world.insert_resource(FallbackErrorHandler(warn));
+        world.insert_resource(FallbackErrorHandler(record_last_error));
 
         queue.apply(&mut world);
 
@@ -598,6 +605,11 @@ mod test {
         queue.push(SpawnCommand);
         queue.apply(&mut world);
         assert_eq!(world.query::<&A>().query(&world).count(), 3);
+
+        let (error, context) = LAST_ERROR.lock().unwrap().take().unwrap();
+        assert!(error.to_string().contains("Command panicked"));
+        let name = DebugName::type_name::<PanicCommand>();
+        assert_eq!(context, ErrorContext::Command { name });
     }
 
     #[test]
@@ -631,13 +643,19 @@ mod test {
     }
 
     #[test]
-    fn test_command_queue_inner_nested_panic_safe_warn() {
+    fn test_command_queue_inner_nested_panic_safe_handled() {
         #[derive(Resource, Default)]
         struct Order(Vec<usize>);
 
+        fn record_last_error(error: BevyError, context: ErrorContext) {
+            *LAST_ERROR.lock().unwrap() = Some((error, context));
+        }
+        static LAST_ERROR: Mutex<Option<(BevyError, ErrorContext)>> = Mutex::new(None);
+        *LAST_ERROR.lock().unwrap() = None;
+
         let mut world = World::new();
         world.init_resource::<Order>();
-        world.insert_resource(FallbackErrorHandler(warn));
+        world.insert_resource(FallbackErrorHandler(record_last_error));
 
         fn add_index(index: usize) -> impl Command {
             move |world: &mut World| world.resource_mut::<Order>().0.push(index)
@@ -658,6 +676,11 @@ mod test {
         world.commands().queue(add_index(5));
         world.flush_commands();
         assert_eq!(&world.resource::<Order>().0, &[1, 2, 3, 4, 5]);
+
+        let (error, context) = LAST_ERROR.lock().unwrap().take().unwrap();
+        assert!(error.to_string().contains("Command panicked"));
+        let name = DebugName::type_name_of_val(&PanicCommand(String::new()).handle_error());
+        assert_eq!(context, ErrorContext::Command { name });
     }
 
     // NOTE: `CommandQueue` is `Send` because `Command` is send.

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -40,9 +40,6 @@ pub struct CommandQueue {
     pub(crate) bytes: Vec<MaybeUninit<u8>>,
     /// Index into `bytes` at which unapplied commands start.
     pub(crate) cursor: usize,
-    /// Commands that have not yet been applied because a previous command has panicked.
-    /// Only contains data during a panic.
-    pub(crate) panic_recovery: Vec<MaybeUninit<u8>>,
     pub(crate) caller: MaybeLocation,
     /// Always emit a warning if a command is dropped before it is applied.
     /// Defaults to `true`.
@@ -58,7 +55,6 @@ impl Default for CommandQueue {
         Self {
             bytes: Default::default(),
             cursor: Default::default(),
-            panic_recovery: Default::default(),
             caller: MaybeLocation::caller(),
             warn_on_unapplied: true,
         }
@@ -71,7 +67,6 @@ impl Default for CommandQueue {
 pub(crate) struct RawCommandQueue {
     pub(crate) bytes: NonNull<Vec<MaybeUninit<u8>>>,
     pub(crate) cursor: NonNull<usize>,
-    pub(crate) panic_recovery: NonNull<Vec<MaybeUninit<u8>>>,
 }
 
 // CommandQueue needs to implement Debug manually, rather than deriving it, because the derived impl just prints
@@ -101,7 +96,6 @@ impl CommandQueue {
         CommandQueue {
             bytes: Default::default(),
             cursor: Default::default(),
-            panic_recovery: Default::default(),
             caller: MaybeLocation::caller(),
             warn_on_unapplied: false,
         }
@@ -147,7 +141,6 @@ impl CommandQueue {
             RawCommandQueue {
                 bytes: NonNull::new_unchecked(addr_of_mut!(self.bytes)),
                 cursor: NonNull::new_unchecked(addr_of_mut!(self.cursor)),
-                panic_recovery: NonNull::new_unchecked(addr_of_mut!(self.panic_recovery)),
             }
         }
     }
@@ -166,7 +159,6 @@ impl RawCommandQueue {
             Self {
                 bytes: NonNull::new_unchecked(Box::into_raw(Box::default())),
                 cursor: NonNull::new_unchecked(Box::into_raw(Box::new(0usize))),
-                panic_recovery: NonNull::new_unchecked(Box::into_raw(Box::default())),
             }
         }
     }
@@ -271,6 +263,11 @@ impl RawCommandQueue {
             self.cursor.write(stop);
         }
 
+        #[cfg(feature = "std")]
+        {
+            crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
+        }
+
         while local_cursor < stop {
             // We must re-read the pointer to the allocation before each command
             // as the previous might have cause a reallocation.
@@ -308,35 +305,38 @@ impl RawCommandQueue {
 
             #[cfg(feature = "std")]
             {
-                let result = std::panic::catch_unwind(f);
+                use crate::error::{
+                    BevyError, ErrorContext, Severity, PANIC_ORIGINATES_FROM_ERROR_HANDLER,
+                };
+                use bevy_utils::DebugName;
+                use std::{
+                    backtrace::Backtrace,
+                    panic::{catch_unwind, resume_unwind},
+                };
 
+                let result = catch_unwind(f);
+                let panic_originates_from_error_handler =
+                    PANIC_ORIGINATES_FROM_ERROR_HANDLER.replace(false);
                 if let Err(payload) = result {
-                    // SAFETY: Queue is life & there is no other unsynchronized access
-                    unsafe {
-                        // local_cursor now points to the location _after_ the panicked command.
-                        // Add the remaining commands that _would have_ been applied to the
-                        // panic_recovery queue.
-                        //
-                        // This uses `current_stop` instead of `stop` to account for any commands
-                        // that were queued _during_ this panic.
-                        //
-                        // This is implemented in such a way that if apply_or_drop_queued() are nested recursively in,
-                        // an applied Command, the correct command order will be retained.
-                        let panic_recovery = self.panic_recovery.as_mut();
-                        let bytes = self.bytes.as_mut();
-                        let current_stop = bytes.len();
-                        panic_recovery.extend_from_slice(&bytes[local_cursor..current_stop]);
-                        bytes.set_len(start);
-                        self.cursor.write(start);
-
-                        // This was the "top of the apply stack". If we are _not_ at the top of the apply stack,
-                        // when we call`resume_unwind" the caller "closer to the top" will catch the unwind and do this check,
-                        // until we reach the top.
-                        if start == 0 {
-                            bytes.append(panic_recovery);
-                        }
+                    if panic_originates_from_error_handler {
+                        resume_unwind(payload)
                     }
-                    std::panic::resume_unwind(payload);
+                    let Some(mut world) = world else {
+                        resume_unwind(payload)
+                    };
+                    // SAFETY: Caller ensures pointer is not null
+                    let world = unsafe { world.as_mut() };
+                    let error = BevyError::new_with_backtrace(
+                        Severity::Panic,
+                        "Command panicked",
+                        Backtrace::disabled(),
+                    );
+                    world.fallback_error_handler()(
+                        error,
+                        ErrorContext::Command {
+                            name: DebugName::type_name::<CommandQueue>(),
+                        },
+                    );
                 }
             }
 
@@ -385,7 +385,11 @@ impl SystemBuffer for CommandQueue {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{component::Component, resource::Resource};
+    use crate::{
+        component::Component,
+        error::{warn, FallbackErrorHandler},
+        resource::Resource,
+    };
     use alloc::{borrow::ToOwned, string::String, sync::Arc};
     use core::{
         panic::AssertUnwindSafe,
@@ -502,12 +506,11 @@ mod test {
     }
 
     #[test]
-    fn test_command_queue_inner_panic_safe() {
-        std::panic::set_hook(Box::new(|_| {}));
-
+    fn test_command_queue_inner_panic_safe_panic() {
         let mut queue = CommandQueue::default();
 
         queue.push(PanicCommand("I panic!".to_owned()));
+        // This will get skipped due to the panic
         queue.push(SpawnCommand);
 
         let mut world = World::new();
@@ -521,13 +524,33 @@ mod test {
         queue.push(SpawnCommand);
         queue.push(SpawnCommand);
         queue.apply(&mut world);
+        assert_eq!(world.query::<&A>().query(&world).count(), 2);
+    }
+
+    #[test]
+    fn test_command_queue_inner_panic_safe_warn() {
+        let mut queue = CommandQueue::default();
+
+        queue.push(PanicCommand("I panic!".to_owned()));
+        // This will get run because the fallback error handler
+        // handles the panicking command.
+        queue.push(SpawnCommand);
+
+        let mut world = World::new();
+        world.insert_resource(FallbackErrorHandler(warn));
+
+        queue.apply(&mut world);
+
+        // Even though the first command panicked, it's still ok to push
+        // more commands.
+        queue.push(SpawnCommand);
+        queue.push(SpawnCommand);
+        queue.apply(&mut world);
         assert_eq!(world.query::<&A>().query(&world).count(), 3);
     }
 
     #[test]
-    fn test_command_queue_inner_nested_panic_safe() {
-        std::panic::set_hook(Box::new(|_| {}));
-
+    fn test_command_queue_inner_nested_panic_safe_panic() {
         #[derive(Resource, Default)]
         struct Order(Vec<usize>);
 
@@ -541,6 +564,7 @@ mod test {
         world.commands().queue(|world: &mut World| {
             world.commands().queue(add_index(2));
             world.commands().queue(PanicCommand("I panic!".to_owned()));
+            // Everything after here will get skipped due to the panic
             world.commands().queue(add_index(3));
             world.flush_commands();
         });
@@ -549,6 +573,36 @@ mod test {
         let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
             world.flush_commands();
         }));
+
+        world.commands().queue(add_index(5));
+        world.flush_commands();
+        assert_eq!(&world.resource::<Order>().0, &[1, 2, 5]);
+    }
+
+    #[test]
+    fn test_command_queue_inner_nested_panic_safe_warn() {
+        #[derive(Resource, Default)]
+        struct Order(Vec<usize>);
+
+        let mut world = World::new();
+        world.init_resource::<Order>();
+        world.insert_resource(FallbackErrorHandler(warn));
+
+        fn add_index(index: usize) -> impl Command {
+            move |world: &mut World| world.resource_mut::<Order>().0.push(index)
+        }
+        world.commands().queue(add_index(1));
+        world.commands().queue(|world: &mut World| {
+            world.commands().queue(add_index(2));
+            world.commands().queue(PanicCommand("I panic!".to_owned()));
+            // Everything after here will get run because the
+            // fallback error handler handles the panicking command.
+            world.commands().queue(add_index(3));
+            world.flush_commands();
+        });
+        world.commands().queue(add_index(4));
+
+        world.flush_commands();
 
         world.commands().queue(add_index(5));
         world.flush_commands();

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -6,6 +6,7 @@ use crate::{
 
 use alloc::{boxed::Box, vec::Vec};
 use bevy_ptr::{OwningPtr, Unaligned};
+use bevy_utils::DebugName;
 use core::{
     fmt::Debug,
     mem::{size_of, MaybeUninit},
@@ -20,9 +21,12 @@ struct CommandMeta {
     ///
     /// `world` is optional to allow this one function pointer to perform double-duty as a drop.
     ///
-    /// Advances `cursor` by the size of `T` in bytes.
-    consume_command_and_get_size:
-        unsafe fn(value: OwningPtr<Unaligned>, world: Option<NonNull<World>>, cursor: &mut usize),
+    /// Advances `runner.local_cursor` by the size of `T` in bytes.
+    consume_command_and_get_size: unsafe fn(
+        value: OwningPtr<Unaligned>,
+        world: Option<NonNull<World>>,
+        runner: &mut CommandQueueRunner,
+    ),
 }
 
 /// Densely and efficiently stores a queue of heterogenous types implementing [`Command`].
@@ -190,8 +194,9 @@ impl RawCommandQueue {
         }
 
         let meta = CommandMeta {
-            consume_command_and_get_size: |command, world, cursor| {
-                *cursor += size_of::<C>();
+            consume_command_and_get_size: |command, world, runner| {
+                runner.local_cursor += size_of::<C>();
+                runner.current_command_name = DebugName::type_name::<C>();
 
                 // Putting the command onto the stack is necessary not just for alignment and to be able to consume it,
                 // but also because applying the command may cause the command queue to reallocate.
@@ -293,8 +298,14 @@ impl SystemBuffer for CommandQueue {
 /// A RAII guard used while running commands to ensure
 /// that unapplied commands are dropped during unwind.
 struct CommandQueueRunner<'a> {
-    command_queue: &'a mut RawCommandQueue,
     local_cursor: usize,
+    /// The type name of the last command to be applied.
+    ///
+    /// This is assigned by [`CommandMeta::consume_command_and_get_size`]
+    /// before running a command so that it is available
+    /// in the error handler if the command panics.
+    current_command_name: DebugName,
+    command_queue: &'a mut RawCommandQueue,
     start: usize,
     stop: usize,
 }
@@ -313,8 +324,9 @@ impl<'a> CommandQueueRunner<'a> {
         unsafe { command_queue.cursor.write(stop) };
 
         Self {
-            command_queue,
             local_cursor: start,
+            current_command_name: DebugName::borrowed("Unknown command"),
+            command_queue,
             start,
             stop,
         }
@@ -365,7 +377,7 @@ impl<'a> CommandQueueRunner<'a> {
                 // This also advances the cursor past the command. For ZSTs, the cursor will not move.
                 // At this point, it will either point to the next `CommandMeta`,
                 // or the cursor will be out of bounds and the loop will end.
-                unsafe { (meta.consume_command_and_get_size)(cmd, world, &mut self.local_cursor) };
+                unsafe { (meta.consume_command_and_get_size)(cmd, world, self) };
             });
 
             #[cfg(feature = "std")]
@@ -373,7 +385,6 @@ impl<'a> CommandQueueRunner<'a> {
                 use crate::error::{
                     BevyError, ErrorContext, Severity, PANIC_ORIGINATES_FROM_ERROR_HANDLER,
                 };
-                use bevy_utils::DebugName;
                 use std::{
                     backtrace::Backtrace,
                     panic::{catch_unwind, resume_unwind},
@@ -399,7 +410,7 @@ impl<'a> CommandQueueRunner<'a> {
                     world.fallback_error_handler()(
                         error,
                         ErrorContext::Command {
-                            name: DebugName::type_name::<CommandQueue>(),
+                            name: self.current_command_name.clone(),
                         },
                     );
                 }

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -6,6 +6,7 @@ use crate::{
 
 use alloc::{boxed::Box, vec::Vec};
 use bevy_ptr::{OwningPtr, Unaligned};
+use bevy_utils::DebugName;
 use core::{
     fmt::Debug,
     mem::{size_of, MaybeUninit},
@@ -14,6 +15,7 @@ use core::{
 };
 use log::warn;
 
+/// Metadata about a type-erased command.
 struct CommandMeta {
     /// SAFETY: The `value` must point to a value of type `T: Command`,
     /// where `T` is some specific type that was used to produce this metadata.
@@ -23,6 +25,43 @@ struct CommandMeta {
     /// Advances `cursor` by the size of `T` in bytes.
     consume_command_and_get_size:
         unsafe fn(value: OwningPtr<Unaligned>, world: Option<NonNull<World>>, cursor: &mut usize),
+    /// Returns the name of the command, for use in [`ErrorContext`].
+    name: fn() -> DebugName,
+}
+
+/// A trait that provides a `const` [`CommandMeta`]
+/// in order to provide a `&'static CommandMeta` for a type.
+trait CommandMetaProvider {
+    const META: CommandMeta;
+}
+
+impl<C: Command> CommandMetaProvider for C {
+    const META: CommandMeta = CommandMeta {
+        consume_command_and_get_size: |command, world, cursor| {
+            *cursor += size_of::<C>();
+
+            // Putting the command onto the stack is necessary not just for alignment and to be able to consume it,
+            // but also because applying the command may cause the command queue to reallocate.
+            // SAFETY: According to the invariants of `CommandMeta.consume_command_and_get_size`,
+            // `command` must point to a value of type `C`.
+            let command: C = unsafe { command.read_unaligned() };
+            match world {
+                // Apply command to the provided world...
+                Some(mut world) => {
+                    // SAFETY: Caller ensures pointer is not null
+                    let world = unsafe { world.as_mut() };
+                    command.apply(world);
+                    // The command may have queued up world commands, which we flush here to ensure they are also picked up.
+                    // If the current command queue already the World Command queue, this will still behave appropriately because the global cursor
+                    // is still at the current `stop`, ensuring only the newly queued Commands will be applied.
+                    world.flush();
+                }
+                // ...or discard it.
+                None => drop(command),
+            }
+        },
+        name: DebugName::type_name::<C>,
+    };
 }
 
 /// Densely and efficiently stores a queue of heterogenous types implementing [`Command`].
@@ -185,35 +224,11 @@ impl RawCommandQueue {
         // while `repr(packed)` prevents the compiler from inserting padding bytes.
         #[repr(C, packed)]
         struct Packed<C: Command<Out = ()>> {
-            meta: CommandMeta,
+            meta: &'static CommandMeta,
             command: C,
         }
 
-        let meta = CommandMeta {
-            consume_command_and_get_size: |command, world, cursor| {
-                *cursor += size_of::<C>();
-
-                // Putting the command onto the stack is necessary not just for alignment and to be able to consume it,
-                // but also because applying the command may cause the command queue to reallocate.
-                // SAFETY: According to the invariants of `CommandMeta.consume_command_and_get_size`,
-                // `command` must point to a value of type `C`.
-                let command: C = unsafe { command.read_unaligned() };
-                match world {
-                    // Apply command to the provided world...
-                    Some(mut world) => {
-                        // SAFETY: Caller ensures pointer is not null
-                        let world = unsafe { world.as_mut() };
-                        command.apply(world);
-                        // The command may have queued up world commands, which we flush here to ensure they are also picked up.
-                        // If the current command queue already the World Command queue, this will still behave appropriately because the global cursor
-                        // is still at the current `stop`, ensuring only the newly queued Commands will be applied.
-                        world.flush();
-                    }
-                    // ...or discard it.
-                    None => drop(command),
-                }
-            },
-        };
+        let meta = const { &C::META };
 
         // SAFETY: There are no outstanding references to self.bytes
         let bytes = unsafe { self.bytes.as_mut() };
@@ -338,12 +353,12 @@ impl<'a> CommandQueueRunner<'a> {
                     .as_mut()
                     .as_mut_ptr()
                     .add(self.local_cursor)
-                    .cast::<CommandMeta>()
+                    .cast::<&'static CommandMeta>()
                     .read_unaligned()
             };
 
             // Advance to the bytes just after `meta`, which represent a type-erased command.
-            self.local_cursor += size_of::<CommandMeta>();
+            self.local_cursor += size_of::<&'static CommandMeta>();
             // Construct an owned pointer to the command.
             // SAFETY: It is safe to transfer ownership out of `self.bytes`, since the increment of `cursor` above
             // guarantees that nothing stored in the buffer will get observed after this function ends.
@@ -373,7 +388,6 @@ impl<'a> CommandQueueRunner<'a> {
                 use crate::error::{
                     BevyError, ErrorContext, Severity, PANIC_ORIGINATES_FROM_ERROR_HANDLER,
                 };
-                use bevy_utils::DebugName;
                 use std::{
                     backtrace::Backtrace,
                     panic::{catch_unwind, resume_unwind},
@@ -399,7 +413,7 @@ impl<'a> CommandQueueRunner<'a> {
                     world.fallback_error_handler()(
                         error,
                         ErrorContext::Command {
-                            name: DebugName::type_name::<CommandQueue>(),
+                            name: (meta.name)(),
                         },
                     );
                 }

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -388,8 +388,8 @@ impl<'a> CommandQueueRunner<'a> {
                     cmd,
                     world.as_deref_mut(),
                     &mut self.local_cursor,
-                )
-            };
+                );
+            }
         }
     }
 }
@@ -441,12 +441,16 @@ mod test {
         error::{BevyError, ErrorContext, FallbackErrorHandler},
         resource::Resource,
     };
-    use alloc::{borrow::ToOwned, string::String, sync::Arc};
+    use alloc::{
+        borrow::ToOwned,
+        string::{String, ToString},
+        sync::Arc,
+    };
     use core::{
         panic::AssertUnwindSafe,
         sync::atomic::{AtomicU32, Ordering},
     };
-    use std::{string::ToString, sync::Mutex};
+    use std::sync::Mutex;
 
     #[cfg(miri)]
     use alloc::format;

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -6,8 +6,6 @@ use crate::{
 
 use alloc::{boxed::Box, vec::Vec};
 use bevy_ptr::{OwningPtr, Unaligned};
-#[cfg(feature = "std")]
-use bevy_utils::DebugName;
 use core::{
     fmt::Debug,
     mem::{size_of, MaybeUninit},
@@ -16,7 +14,6 @@ use core::{
 };
 use log::warn;
 
-/// Metadata about a type-erased command.
 struct CommandMeta {
     /// SAFETY: The `value` must point to a value of type `T: Command`,
     /// where `T` is some specific type that was used to produce this metadata.
@@ -26,45 +23,6 @@ struct CommandMeta {
     /// Advances `cursor` by the size of `T` in bytes.
     consume_command_and_get_size:
         unsafe fn(value: OwningPtr<Unaligned>, world: Option<NonNull<World>>, cursor: &mut usize),
-    /// Returns the name of the command, for use in [`ErrorContext`].
-    #[cfg(feature = "std")]
-    name: fn() -> DebugName,
-}
-
-/// A trait that provides a `const` [`CommandMeta`]
-/// in order to provide a `&'static CommandMeta` for a type.
-trait CommandMetaProvider {
-    const META: CommandMeta;
-}
-
-impl<C: Command> CommandMetaProvider for C {
-    const META: CommandMeta = CommandMeta {
-        consume_command_and_get_size: |command, world, cursor| {
-            *cursor += size_of::<C>();
-
-            // Putting the command onto the stack is necessary not just for alignment and to be able to consume it,
-            // but also because applying the command may cause the command queue to reallocate.
-            // SAFETY: According to the invariants of `CommandMeta.consume_command_and_get_size`,
-            // `command` must point to a value of type `C`.
-            let command: C = unsafe { command.read_unaligned() };
-            match world {
-                // Apply command to the provided world...
-                Some(mut world) => {
-                    // SAFETY: Caller ensures pointer is not null
-                    let world = unsafe { world.as_mut() };
-                    command.apply(world);
-                    // The command may have queued up world commands, which we flush here to ensure they are also picked up.
-                    // If the current command queue already the World Command queue, this will still behave appropriately because the global cursor
-                    // is still at the current `stop`, ensuring only the newly queued Commands will be applied.
-                    world.flush();
-                }
-                // ...or discard it.
-                None => drop(command),
-            }
-        },
-        #[cfg(feature = "std")]
-        name: DebugName::type_name::<C>,
-    };
 }
 
 /// Densely and efficiently stores a queue of heterogenous types implementing [`Command`].
@@ -227,11 +185,35 @@ impl RawCommandQueue {
         // while `repr(packed)` prevents the compiler from inserting padding bytes.
         #[repr(C, packed)]
         struct Packed<C: Command<Out = ()>> {
-            meta: &'static CommandMeta,
+            meta: CommandMeta,
             command: C,
         }
 
-        let meta = const { &C::META };
+        let meta = CommandMeta {
+            consume_command_and_get_size: |command, world, cursor| {
+                *cursor += size_of::<C>();
+
+                // Putting the command onto the stack is necessary not just for alignment and to be able to consume it,
+                // but also because applying the command may cause the command queue to reallocate.
+                // SAFETY: According to the invariants of `CommandMeta.consume_command_and_get_size`,
+                // `command` must point to a value of type `C`.
+                let command: C = unsafe { command.read_unaligned() };
+                match world {
+                    // Apply command to the provided world...
+                    Some(mut world) => {
+                        // SAFETY: Caller ensures pointer is not null
+                        let world = unsafe { world.as_mut() };
+                        command.apply(world);
+                        // The command may have queued up world commands, which we flush here to ensure they are also picked up.
+                        // If the current command queue already the World Command queue, this will still behave appropriately because the global cursor
+                        // is still at the current `stop`, ensuring only the newly queued Commands will be applied.
+                        world.flush();
+                    }
+                    // ...or discard it.
+                    None => drop(command),
+                }
+            },
+        };
 
         // SAFETY: There are no outstanding references to self.bytes
         let bytes = unsafe { self.bytes.as_mut() };
@@ -356,12 +338,12 @@ impl<'a> CommandQueueRunner<'a> {
                     .as_mut()
                     .as_mut_ptr()
                     .add(self.local_cursor)
-                    .cast::<&'static CommandMeta>()
+                    .cast::<CommandMeta>()
                     .read_unaligned()
             };
 
             // Advance to the bytes just after `meta`, which represent a type-erased command.
-            self.local_cursor += size_of::<&'static CommandMeta>();
+            self.local_cursor += size_of::<CommandMeta>();
             // Construct an owned pointer to the command.
             // SAFETY: It is safe to transfer ownership out of `self.bytes`, since the increment of `cursor` above
             // guarantees that nothing stored in the buffer will get observed after this function ends.
@@ -391,6 +373,7 @@ impl<'a> CommandQueueRunner<'a> {
                 use crate::error::{
                     BevyError, ErrorContext, Severity, PANIC_ORIGINATES_FROM_ERROR_HANDLER,
                 };
+                use bevy_utils::DebugName;
                 use std::{
                     backtrace::Backtrace,
                     panic::{catch_unwind, resume_unwind},
@@ -416,7 +399,7 @@ impl<'a> CommandQueueRunner<'a> {
                     world.fallback_error_handler()(
                         error,
                         ErrorContext::Command {
-                            name: (meta.name)(),
+                            name: DebugName::type_name::<CommandQueue>(),
                         },
                     );
                 }

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -6,6 +6,7 @@ use crate::{
 
 use alloc::{boxed::Box, vec::Vec};
 use bevy_ptr::{OwningPtr, Unaligned};
+#[cfg(feature = "std")]
 use bevy_utils::DebugName;
 use core::{
     fmt::Debug,
@@ -26,6 +27,7 @@ struct CommandMeta {
     consume_command_and_get_size:
         unsafe fn(value: OwningPtr<Unaligned>, world: Option<NonNull<World>>, cursor: &mut usize),
     /// Returns the name of the command, for use in [`ErrorContext`].
+    #[cfg(feature = "std")]
     name: fn() -> DebugName,
 }
 
@@ -60,6 +62,7 @@ impl<C: Command> CommandMetaProvider for C {
                 None => drop(command),
             }
         },
+        #[cfg(feature = "std")]
         name: DebugName::type_name::<C>,
     };
 }

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -252,45 +252,110 @@ impl RawCommandQueue {
     /// # Safety
     /// - `self` has not outlived the underlying queue
     /// - there is no other unsynchonized access to the same underlying queue
+    /// - If `world` is `Some`, then it must be valid to use as `&mut World`.
     #[inline]
     pub(crate) unsafe fn apply_or_drop_queued(&mut self, world: Option<NonNull<World>>) {
+        // SAFETY: Caller ensures `self` has not outlived the queue.
+        // that there is no other unsynchronized access,
+        // and that `world` is valid.
+        unsafe { CommandQueueRunner::new(self).run(world) };
+    }
+}
+
+impl Drop for CommandQueue {
+    fn drop(&mut self) {
+        if !self.bytes.is_empty() && self.warn_on_unapplied {
+            if let Some(caller) = self.caller.into_option() {
+                warn!("CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply? caller:{caller:?}");
+            } else {
+                warn!("CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply?");
+            }
+        }
+        // SAFETY: A reference is always a valid pointer
+        unsafe { self.get_raw().apply_or_drop_queued(None) };
+    }
+}
+
+impl SystemBuffer for CommandQueue {
+    #[inline]
+    fn apply(&mut self, _system_meta: &SystemMeta, world: &mut World) {
+        #[cfg(feature = "trace")]
+        let _span_guard = _system_meta.commands_span.enter();
+        self.apply(world);
+    }
+
+    #[inline]
+    fn queue(&mut self, _system_meta: &SystemMeta, mut world: DeferredWorld) {
+        world.commands().append(self);
+    }
+}
+
+/// A RAII guard used while running commands to ensure
+/// that unapplied commands are dropped during unwind.
+struct CommandQueueRunner<'a> {
+    command_queue: &'a mut RawCommandQueue,
+    local_cursor: usize,
+    start: usize,
+    stop: usize,
+}
+
+impl<'a> CommandQueueRunner<'a> {
+    /// # Safety
+    /// - `self` has not outlived the underlying queue
+    /// - there is no other unsynchonized access to the same underlying queue
+    unsafe fn new(command_queue: &'a mut RawCommandQueue) -> Self {
         // SAFETY: Queue is life & there is no other unsynchronized access
-        let (start, stop) = unsafe { (self.cursor.read(), self.bytes.as_ref().len()) };
-        let mut local_cursor = start;
+        let start = unsafe { command_queue.cursor.read() };
+        // SAFETY: Queue is life & there is no other unsynchronized access
+        let stop = unsafe { command_queue.bytes.as_ref().len() };
         // SAFETY: we are setting the global cursor to the current length to prevent the executing commands from applying
         // the remaining commands currently in this list. This is safe.
-        unsafe {
-            self.cursor.write(stop);
-        }
+        unsafe { command_queue.cursor.write(stop) };
 
+        Self {
+            command_queue,
+            local_cursor: start,
+            start,
+            stop,
+        }
+    }
+
+    /// SAFETY: If `world` is `Some`, then it must be valid to use as `&mut World`.
+    unsafe fn run(&mut self, world: Option<NonNull<World>>) {
         #[cfg(feature = "std")]
         {
             crate::error::PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
         }
 
-        while local_cursor < stop {
+        while self.local_cursor < self.stop {
             // We must re-read the pointer to the allocation before each command
             // as the previous might have cause a reallocation.
             // SAFETY: The cursor is either at the start of the buffer, or just after the previous command.
             // Since we know that the cursor is in bounds, it must point to the start of a new command.
             let meta = unsafe {
-                self.bytes
+                self.command_queue
+                    .bytes
                     .as_mut()
                     .as_mut_ptr()
-                    .add(local_cursor)
+                    .add(self.local_cursor)
                     .cast::<CommandMeta>()
                     .read_unaligned()
             };
 
             // Advance to the bytes just after `meta`, which represent a type-erased command.
-            local_cursor += size_of::<CommandMeta>();
+            self.local_cursor += size_of::<CommandMeta>();
             // Construct an owned pointer to the command.
             // SAFETY: It is safe to transfer ownership out of `self.bytes`, since the increment of `cursor` above
             // guarantees that nothing stored in the buffer will get observed after this function ends.
             // `cmd` points to a valid address of a stored command, so it must be non-null.
             let cmd = unsafe {
                 OwningPtr::<Unaligned>::new(NonNull::new_unchecked(
-                    self.bytes.as_mut().as_mut_ptr().add(local_cursor).cast(),
+                    self.command_queue
+                        .bytes
+                        .as_mut()
+                        .as_mut_ptr()
+                        .add(self.local_cursor)
+                        .cast(),
                 ))
             };
             let f = AssertUnwindSafe(|| {
@@ -300,7 +365,7 @@ impl RawCommandQueue {
                 // This also advances the cursor past the command. For ZSTs, the cursor will not move.
                 // At this point, it will either point to the next `CommandMeta`,
                 // or the cursor will be out of bounds and the loop will end.
-                unsafe { (meta.consume_command_and_get_size)(cmd, world, &mut local_cursor) };
+                unsafe { (meta.consume_command_and_get_size)(cmd, world, &mut self.local_cursor) };
             });
 
             #[cfg(feature = "std")]
@@ -343,42 +408,23 @@ impl RawCommandQueue {
             #[cfg(not(feature = "std"))]
             (f)();
         }
+    }
+}
+
+impl Drop for CommandQueueRunner<'_> {
+    fn drop(&mut self) {
+        // Drop any unapplied commands before resetting the length.
+        // If `run` completed successfully then this will do nothing.
+        // SAFETY: `world` is `None`
+        unsafe { self.run(None) };
 
         // Reset the buffer: all commands past the original `start` cursor have been applied.
         // SAFETY: we are setting the length of bytes to the original length, minus the length of the original
         // list of commands being considered. All bytes remaining in the Vec are still valid, unapplied commands.
         unsafe {
-            self.bytes.as_mut().set_len(start);
-            *self.cursor.as_mut() = start;
-        };
-    }
-}
-
-impl Drop for CommandQueue {
-    fn drop(&mut self) {
-        if !self.bytes.is_empty() && self.warn_on_unapplied {
-            if let Some(caller) = self.caller.into_option() {
-                warn!("CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply? caller:{caller:?}");
-            } else {
-                warn!("CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply?");
-            }
+            self.command_queue.bytes.as_mut().set_len(self.start);
+            *self.command_queue.cursor.as_mut() = self.start;
         }
-        // SAFETY: A reference is always a valid pointer
-        unsafe { self.get_raw().apply_or_drop_queued(None) };
-    }
-}
-
-impl SystemBuffer for CommandQueue {
-    #[inline]
-    fn apply(&mut self, _system_meta: &SystemMeta, world: &mut World) {
-        #[cfg(feature = "trace")]
-        let _span_guard = _system_meta.commands_span.enter();
-        self.apply(world);
-    }
-
-    #[inline]
-    fn queue(&mut self, _system_meta: &SystemMeta, mut world: DeferredWorld) {
-        world.commands().append(self);
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -144,8 +144,6 @@ impl Drop for World {
         drop(unsafe { Box::from_raw(self.command_queue.bytes.as_ptr()) });
         // SAFETY: Pointers in internal command queue are only invalidated here
         drop(unsafe { Box::from_raw(self.command_queue.cursor.as_ptr()) });
-        // SAFETY: Pointers in internal command queue are only invalidated here
-        drop(unsafe { Box::from_raw(self.command_queue.panic_recovery.as_ptr()) });
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -3056,9 +3056,7 @@ impl World {
         if !unsafe { self.command_queue.is_empty() } {
             // SAFETY: `self.command_queue` is only de-allocated in `World`'s `Drop`
             unsafe {
-                self.command_queue
-                    .clone()
-                    .apply_or_drop_queued(Some(self.into()));
+                self.command_queue.clone().apply_or_drop_queued(Some(self));
             };
         }
     }

--- a/crates/bevy_utils/src/debug_info.rs
+++ b/crates/bevy_utils/src/debug_info.rs
@@ -83,6 +83,19 @@ impl DebugName {
         }
     }
 
+    /// Create a new `DebugName` from a type by using its [`core::any::type_name`]
+    ///
+    /// This is the same as `type_name::<T>()`, but can be used where the type of a
+    /// variable is not easily available.
+    ///
+    /// The value will be ignored if the `debug` feature is not enabled
+    pub fn type_name_of_val<T>(_val: &T) -> Self {
+        DebugName {
+            #[cfg(feature = "debug")]
+            name: Cow::Borrowed(type_name::<T>()),
+        }
+    }
+
     /// Get the [`ShortName`] corresponding to this debug name
     ///
     /// The value will be a static string if the `debug` feature is not enabled


### PR DESCRIPTION
# Objective

Improve the handling of commands that panic.  

Currently, if a command panics, any unapplied commands are left in the command queue.  This means they will get run, but at an unpredictable time in the future.  

And when running in `no_std`, cleanup is not run at all and the commands simply leak.  

## Solution

Catch panics from commands and pass them to the fallback error handler, just as we now do for systems from #24240.  This means if the error handler is set to something non-panicking like `warn`, then `flush_commands()` will never panic and all commands in the queue will be applied.  

Introduce a RAII guard during command application that will drop any commands still in the queue and perform cleanup during unwinding, even on `no_std`.  

To make the command's type name available in the error handler, add a field to the RAII guard that gets written by `consume_command_and_get_size` before applying the command.