### PR TITLE
fix: fps_overlay graph shader reads one element past its storage buffer

### DIFF
--- a/crates/bevy_dev_tools/src/frame_time_graph/frame_time_graph.wgsl
+++ b/crates/bevy_dev_tools/src/frame_time_graph/frame_time_graph.wgsl
@@ -40,7 +40,7 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
 
     let len = arrayLength(&values);
     var graph_width = 0.0;
-    for (var i = 0u; i <= len; i += 1u) {
+    for (var i = 1u; i <= len; i += 1u) {
         let dt = values[len - i];
 
         var frame_width: f32;


### PR DESCRIPTION
`frame_time_graph.wgsl` has an off-by-one:

```wgsl
let len = arrayLength(&values);
var graph_width = 0.0;
for (var i = 0u; i <= len; i += 1u) {
    let dt = values[len - i];        // i == 0 reads values[len], one past the end
```

The loop runs `len + 1` times and its first iteration always reads `values[len]`. This is UB on every backend; it goes unnoticed on desktop (maaybe draws one bogus bar) but Metal Shader Validation on iOS flags every UI draw:

```
Invalid metal usage: Invalid load in 'device' or 'constant' address space at offset 12,
executing fragment function: "fragment_"
MTLBuffer: <no label>, length:12  (then 16, 20, 24, ... — grows 4 bytes per frame
as the frame-time history fills; the bad load is always at offset == length)
pipeline: "ui_material_pipeline", encoder "ui"
MTLBuffer allocated here: ... <GpuShaderBuffer as RenderAsset>::prepare_asset
```

## Testing

- Did you test these changes? **Yes, on my iPhone under Xcode's Metal Shader Validation**
