### PR TITLE
Improve clarity of condition.rs doc examples

### DIFF
--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -64,13 +64,13 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 /// }
 ///
 /// # fn always_true() -> bool { true }
-/// # let mut app = Schedule::default();
+/// # let mut schedule = Schedule::default();
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
-/// app.add_systems(my_system.run_if(always_true.pipe(identity())));
+/// schedule.add_systems(my_system.run_if(always_true.pipe(identity())));
 /// # let mut world = World::new();
 /// # world.insert_resource(DidRun(false));
-/// # app.run(&mut world);
+/// # schedule.run(&mut world);
 /// # assert!(world.resource::<DidRun>().0);
 pub trait SystemCondition<Marker, In: SystemInput = ()>:
     IntoSystem<In, bool, Marker, System: ReadOnlySystem>
@@ -368,23 +368,23 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     NotFertilized,
     /// }
     ///
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # fn slow_plant_growth() {}
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // The slow_plant_growth system will only execute if both the `in_state(WeatherState::Sunny)`
     ///     // run condition and `in_state(SoilState::Fertilized)` run condition evaluate to `false`.
     ///     slow_plant_growth.run_if(
     ///         in_state(WeatherState::Sunny).nor_else(in_state(SoilState::Fertilized)),
     ///     ),
     /// );
-    /// # app.run(&mut world);
+    /// # schedule.run(&mut world);
     /// ```
     ///
     /// Equivalent logic can be achieved by using `not` in concert with `or`:
     ///
     /// ```compile_fail
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     slow_plant_growth.run_if(
     ///         not(in_state(WeatherState::Sunny).or_else(in_state(SoilState::Fertilized))),
     ///     ),
@@ -449,27 +449,27 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #[derive(Resource, PartialEq)]
     /// struct B(u32);
     ///
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # #[derive(Resource)] struct C(bool);
     /// # fn my_system(mut c: ResMut<C>) { c.0 = true; }
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // Only run the system if either `A` or else `B` exist.
     ///     my_system.run_if(resource_exists::<A>.or_else(resource_exists::<B>)),
     /// );
     /// #
     /// # world.insert_resource(C(false));
-    /// # app.run(&mut world);
+    /// # schedule.run(&mut world);
     /// # assert!(!world.resource::<C>().0);
     /// #
     /// # world.insert_resource(A(0));
-    /// # app.run(&mut world);
+    /// # schedule.run(&mut world);
     /// # assert!(world.resource::<C>().0);
     /// #
     /// # world.remove_resource::<A>();
     /// # world.insert_resource(B(0));
     /// # world.insert_resource(C(false));
-    /// # app.run(&mut world);
+    /// # schedule.run(&mut world);
     /// # assert!(world.resource::<C>().0);
     /// ```
     fn or_else<M, C: SystemCondition<M, In>>(self, else_run: C) -> OrElse<Self::System, C::System> {
@@ -521,10 +521,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # fn take_drink_orders() {}
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // The take_drink_orders system will only execute if the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition and `in_state(TeaKettleState::Inactive)` run conditions both evaluate to `false`,
     ///     // or both evaluate to `true`.
@@ -532,13 +532,13 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xnor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
-    /// # app.run(&mut world);
+    /// # schedule.run(&mut world);
     /// ```
     ///
     /// Equivalent logic can be achieved by using `not` in concert with `xor`:
     ///
     /// ```compile_fail
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     take_drink_orders.run_if(
     ///         not(in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive)))
     ///     ),
@@ -576,10 +576,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # fn prepare_beverage() {}
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // The prepare_beverage system will only execute if either the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition or `in_state(TeaKettleState::Inactive)` run condition evaluates to `true`,
     ///     // but not both.
@@ -587,7 +587,7 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
-    /// # app.run(&mut world);
+    /// # schedule.run(&mut world);
     /// ```
     fn xor<M, C: SystemCondition<M, In>>(self, other: C) -> Xor<Self::System, C::System> {
         let a = IntoSystem::into_system(self);
@@ -625,10 +625,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // `run_once` will only return true the first time it's evaluated
     ///     my_system.run_if(run_once),
     /// );
@@ -638,11 +638,11 @@ pub mod common_conditions {
     /// }
     ///
     /// // This is the first time the condition will be evaluated so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // This is the seconds time the condition will be evaluated so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn run_once(mut has_run: Local<bool>) -> bool {
@@ -666,9 +666,9 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // `resource_exists` will only return true if the given resource exists in the world
     ///     my_system.run_if(resource_exists::<Counter>),
     /// );
@@ -678,11 +678,11 @@ pub mod common_conditions {
     /// }
     ///
     /// // `Counter` hasn't been added so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// world.init_resource::<Counter>();
     ///
     /// // `Counter` has now been added so `my_system` can run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_exists<T>(res: Option<Res<T>>) -> bool
@@ -705,10 +705,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // `resource_equals` will only return true if the given resource equals the given value
     ///     my_system.run_if(resource_equals(Counter(0))),
     /// );
@@ -718,11 +718,11 @@ pub mod common_conditions {
     /// }
     ///
     /// // `Counter` is `0` so `my_system` can run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // `Counter` is no longer `0` so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_equals<T>(value: T) -> impl FnMut(Res<T>) -> bool
@@ -743,9 +743,9 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // `resource_exists_and_equals` will only return true
     ///     // if the given resource exists and equals the given value
     ///     my_system.run_if(resource_exists_and_equals(Counter(0))),
@@ -756,15 +756,15 @@ pub mod common_conditions {
     /// }
     ///
     /// // `Counter` hasn't been added so `my_system` can't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// world.init_resource::<Counter>();
     ///
     /// // `Counter` is `0` so `my_system` can run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // `Counter` is no longer `0` so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_exists_and_equals<T>(value: T) -> impl FnMut(Option<Res<T>>) -> bool
@@ -790,9 +790,9 @@ pub mod common_conditions {
     /// # struct Counter(i16);
     /// # #[derive(Resource)]
     /// # struct ShouldRun(String);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // `resource_exists_and` will only return true
     ///     // if the given resource exists and satisfies the given condition
     ///     increment.run_if(resource_exists_and(|should_run: &ShouldRun| should_run.0.is_ascii())),
@@ -805,18 +805,18 @@ pub mod common_conditions {
     /// world.insert_resource(Counter(0));
     ///
     /// // `ShouldRun` hasn't been added, so `increment` can't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     /// world.insert_resource(ShouldRun(String::from("bevy")));
     ///
     /// // `ShouldRun` exists and satisfies the run conditions, so `increment` can run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// world.get_resource_mut::<ShouldRun>().unwrap().0 = String::from("bevy ❤");
     ///
     /// // `ShouldRun` exists but has non-ASCII characters and thus
     /// // does not satisfy the run conditions, so `increment` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_exists_and<T>(
@@ -840,9 +840,9 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // `resource_added` will only return true if the
     ///     // given resource was just added
     ///     my_system.run_if(resource_added::<Counter>),
@@ -855,11 +855,11 @@ pub mod common_conditions {
     /// world.init_resource::<Counter>();
     ///
     /// // `Counter` was just added so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // `Counter` was not just added so `my_system` will not run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_added<T>(res: Option<Res<T>>) -> bool
@@ -889,10 +889,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // `resource_changed` will only return true if the
     ///     // given resource was just changed (or added)
     ///     my_system.run_if(
@@ -909,13 +909,13 @@ pub mod common_conditions {
     /// }
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.resource_mut::<Counter>().0 = 50;
     ///
     /// // `Counter` was just changed so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 51);
     /// ```
     pub fn resource_changed<T>(res: Res<T>) -> bool
@@ -940,9 +940,9 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // `resource_exists_and_changed` will only return true if the
     ///     // given resource exists and was just changed (or added)
     ///     my_system.run_if(
@@ -959,17 +959,17 @@ pub mod common_conditions {
     /// }
     ///
     /// // `Counter` doesn't exist so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// world.init_resource::<Counter>();
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.resource_mut::<Counter>().0 = 50;
     ///
     /// // `Counter` was just changed so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 51);
     /// ```
     pub fn resource_exists_and_changed<T>(res: Option<Res<T>>) -> bool
@@ -997,10 +997,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // `resource_changed_or_removed` will only return true if the
     ///     // given resource was just changed or removed (or added)
     ///     my_system.run_if(
@@ -1025,19 +1025,19 @@ pub mod common_conditions {
     /// }
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.resource_mut::<Counter>().0 = 50;
     ///
     /// // `Counter` was just changed so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 51);
     ///
     /// world.remove_resource::<Counter>();
     ///
     /// // `Counter` was just removed so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.contains_resource::<MyResource>(), true);
     /// ```
     pub fn resource_changed_or_removed<T>(res: Option<Res<T>>, mut existed: Local<bool>) -> bool
@@ -1064,10 +1064,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // `resource_removed` will only return true if the
     ///     // given resource was just removed
     ///     my_system.run_if(resource_removed::<MyResource>),
@@ -1083,13 +1083,13 @@ pub mod common_conditions {
     /// world.init_resource::<MyResource>();
     ///
     /// // `MyResource` hasn't just been removed so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.remove_resource::<MyResource>();
     ///
     /// // `MyResource` was just removed so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_removed<T>(res: Option<Res<T>>, mut existed: Local<bool>) -> bool
@@ -1118,13 +1118,13 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// # world.init_resource::<Messages<MyMessage>>();
-    /// # app.add_systems(bevy_ecs::message::message_update_system.before(my_system));
+    /// # schedule.add_systems(bevy_ecs::message::message_update_system.before(my_system));
     ///
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     my_system.run_if(on_message::<MyMessage>),
     /// );
     ///
@@ -1136,13 +1136,13 @@ pub mod common_conditions {
     /// }
     ///
     /// // No new `MyMessage` messages have been pushed so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.resource_mut::<Messages<MyMessage>>().write(MyMessage);
     ///
     /// // A `MyMessage` message has been pushed so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn on_message<M: Message>(mut reader: MessageReader<M>) -> bool {
@@ -1168,10 +1168,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     my_system.run_if(any_with_component::<MyComponent>),
     /// );
     ///
@@ -1183,13 +1183,13 @@ pub mod common_conditions {
     /// }
     ///
     /// // No entities exist yet with a `MyComponent` component so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.spawn(MyComponent);
     ///
     /// // An entities with `MyComponent` now exists so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn any_with_component<T: Component>(query: Query<(), With<T>>) -> bool {
@@ -1227,10 +1227,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     // `not` will inverse any condition you pass in.
     ///     // Since the condition we choose always returns true
     ///     // this system will never run
@@ -1245,7 +1245,7 @@ pub mod common_conditions {
     ///     true
     /// }
     ///
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     /// ```
     pub fn not<Marker, TOut, T>(condition: T) -> NotSystem<T::System>
@@ -1268,10 +1268,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     my_system.run_if(condition_changed(resource_exists::<MyResource>)),
     /// );
     ///
@@ -1284,16 +1284,16 @@ pub mod common_conditions {
     ///
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // We remove `MyResource`, the inner condition is now false, the system runs one more time.
     /// world.remove_resource::<MyResource>();
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
     /// ```
     pub fn condition_changed<Marker, CIn, C>(condition: C) -> impl SystemCondition<(), CIn>
@@ -1319,10 +1319,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedule.add_systems(
     ///     my_system.run_if(condition_changed_to(true, resource_exists::<MyResource>)),
     /// );
     ///
@@ -1335,21 +1335,21 @@ pub mod common_conditions {
     ///
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // We remove `MyResource`, the inner condition is now false, the system doesn't run.
     /// world.remove_resource::<MyResource>();
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // We reinsert `MyResource` again, so the system will run one more time
     /// world.insert_resource(MyResource);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
     /// ```
     pub fn condition_changed_to<Marker, CIn, C>(

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -35,6 +35,9 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 /// A condition that returns true every other time it's called.
 /// ```
 /// # use bevy_ecs::prelude::*;
+/// # use bevy_ecs::schedule::ScheduleLabel;
+/// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+/// # struct Update;
 /// fn every_other_time() -> impl SystemCondition<()> {
 ///     IntoSystem::into_system(|mut flag: Local<bool>| {
 ///         *flag = !*flag;
@@ -44,15 +47,15 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 ///
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
-/// # let mut schedules = Schedules::default();
-/// schedules.add_systems(Update, my_system.run_if(every_other_time()));
+/// # let mut app = Schedules::default();
+/// app.add_systems(Update, my_system.run_if(every_other_time()));
 /// # let mut world = World::new();
-/// # let schedule = schedules.get_mut(Update).unwrap();
+/// # let app = app.get_mut(Update).unwrap();
 /// # world.insert_resource(DidRun(false));
-/// # schedule.run(&mut world);
+/// # app.run(&mut world);
 /// # assert!(world.resource::<DidRun>().0);
 /// # world.insert_resource(DidRun(false));
-/// # schedule.run(&mut world);
+/// # app.run(&mut world);
 /// # assert!(!world.resource::<DidRun>().0);
 /// ```
 ///
@@ -60,19 +63,22 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
+/// # use bevy_ecs::schedule::ScheduleLabel;
+/// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+/// # struct Update;
 /// fn identity() -> impl SystemCondition<(), In<bool>> {
 ///     IntoSystem::into_system(|In(x): In<bool>| x)
 /// }
 ///
 /// # fn always_true() -> bool { true }
-/// # let mut schedules = Schedules::default();
+/// # let mut app = Schedules::default();
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
-/// schedules.add_systems(Update, my_system.run_if(always_true.pipe(identity())));
+/// app.add_systems(Update, my_system.run_if(always_true.pipe(identity())));
 /// # let mut world = World::new();
 /// # world.insert_resource(DidRun(false));
-/// # let schedule = schedules.get_mut(Update).unwrap();
-/// # schedule.run(&mut world);
+/// # let app = app.get_mut(Update).unwrap();
+/// # app.run(&mut world);
 /// # assert!(world.resource::<DidRun>().0);
 pub trait SystemCondition<Marker, In: SystemInput = ()>:
     IntoSystem<In, bool, Marker, System: ReadOnlySystem>
@@ -100,39 +106,45 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```should_panic
     /// use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     ///
     /// #[derive(Resource, PartialEq)]
     /// struct R(u32);
     ///
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # fn my_system() {}
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // The `resource_equals` run condition will panic since we don't initialize `R`,
     ///     // just like if we used `Res<R>` in a system.
     ///     my_system.run_if(resource_equals(R(0))),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
-    /// # schedule.run(&mut world);
+    /// # let app = app.get_mut(Update).unwrap();
+    /// # app.run(&mut world);
     /// ```
     ///
     /// Use `.and_then()` to avoid checking the condition.
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, PartialEq)]
     /// # struct R(u32);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # fn my_system() { unreachable!() }
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // `resource_equals` will only get run if the resource `R` exists.
     ///     my_system.run_if(resource_exists::<R>.and_then(resource_equals(R(0)))),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
-    /// # schedule.run(&mut world);
+    /// # let app = app.get_mut(Update).unwrap();
+    /// # app.run(&mut world);
     /// ```
     ///
     /// Note that in this specific case, it's better to just use the run condition [`resource_exists_and_equals`].
@@ -169,11 +181,14 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
     /// # use std::sync::atomic::AtomicBool;
     /// # use std::sync::atomic::Ordering;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, PartialEq)]
     /// # struct R(u32);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # fn my_system() { unreachable!() }
     /// # static CONDITION_A_RAN: AtomicBool = AtomicBool::new(false);
@@ -186,13 +201,13 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #   CONDITION_B_RAN.store(true, Ordering::Relaxed);
     /// #   true
     /// # }
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // both conditions will execute, even though the first one returned false
     ///     my_system.run_if(returns_false.and_eager(returns_true)),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
-    /// # schedule.run(&mut world);
+    /// # let app = app.get_mut(Update).unwrap();
+    /// # app.run(&mut world);
     /// # assert!(CONDITION_A_RAN.load(Ordering::Relaxed));
     /// # assert!(CONDITION_B_RAN.load(Ordering::Relaxed));
     /// ```
@@ -229,6 +244,9 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// #
     /// # #[derive(Resource, Debug, Clone, PartialEq, Eq, Hash)]
     /// # pub enum PlayerState {
@@ -254,10 +272,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// # #[derive(Resource)]
     /// # struct RanGameOver(bool);
     /// # fn game_over_credits(mut commands: Commands) { commands.insert_resource(RanGameOver(true)); }
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # world.insert_resource(PlayerState::Dead);
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // The game_over_credits system will only execute if either the `in_state(PlayerState::Alive)`
     ///     // run condition or `in_state(EnemyState::Alive)` run condition evaluates to `false`.
@@ -265,21 +283,21 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(PlayerState::Alive).nand_then(in_state(EnemyState::Alive)),
     ///     ),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
-    /// # schedule.run(&mut world);
+    /// # let app = app.get_mut(Update).unwrap();
+    /// # app.run(&mut world);
     /// # assert_eq!(IN_STATE_RUN_COUNT.load(Ordering::Relaxed), 1);
     /// # assert!(world.resource::<RanGameOver>().0);
     /// # IN_STATE_RUN_COUNT.store(0, Ordering::Relaxed);
     /// # world.insert_resource(RanGameOver(false));
     /// # world.insert_resource(PlayerState::Alive);
     /// # world.insert_resource(EnemyState::Dead);
-    /// # schedule.run(&mut world);
+    /// # app.run(&mut world);
     /// # assert_eq!(IN_STATE_RUN_COUNT.load(Ordering::Relaxed), 2);
     /// # assert!(world.resource::<RanGameOver>().0);
     /// # IN_STATE_RUN_COUNT.store(0, Ordering::Relaxed);
     /// # world.insert_resource(RanGameOver(false));
     /// # world.insert_resource(EnemyState::Alive);
-    /// # schedule.run(&mut world);
+    /// # app.run(&mut world);
     /// # assert_eq!(IN_STATE_RUN_COUNT.load(Ordering::Relaxed), 2);
     /// # assert!(!world.resource::<RanGameOver>().0);
     /// ```
@@ -288,6 +306,9 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Debug, Clone, PartialEq, Eq, Hash)]
     /// # pub enum PlayerState {
     /// #     Alive,
@@ -302,18 +323,18 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #   move |current_state| state == *current_state
     /// # }
     /// # fn game_over_credits() { unreachable!() }
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # world.insert_resource(PlayerState::Alive);
     /// # world.insert_resource(EnemyState::Alive);
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     game_over_credits.run_if(
     ///         not(in_state(PlayerState::Alive).and_then(in_state(EnemyState::Alive))),
     ///     ),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
-    /// # schedule.run(&mut world);
+    /// # let app = app.get_mut(Update).unwrap();
+    /// # app.run(&mut world);
     /// ```
     fn nand_then<M, C: SystemCondition<M, In>>(
         self,
@@ -380,10 +401,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     NotFertilized,
     /// }
     ///
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # fn slow_plant_growth() {}
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // The slow_plant_growth system will only execute if both the `in_state(WeatherState::Sunny)`
     ///     // run condition and `in_state(SoilState::Fertilized)` run condition evaluate to `false`.
@@ -391,14 +412,13 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(WeatherState::Sunny).nor_else(in_state(SoilState::Fertilized)),
     ///     ),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
-    /// # schedule.run(&mut world);
+    /// # app.run(&mut world);
     /// ```
     ///
     /// Equivalent logic can be achieved by using `not` in concert with `or`:
     ///
     /// ```compile_fail
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     slow_plant_growth.run_if(
     ///         not(in_state(WeatherState::Sunny).or_else(in_state(SoilState::Fertilized))),
@@ -457,6 +477,9 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```
     /// use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     ///
     /// #[derive(Resource, PartialEq)]
     /// struct A(u32);
@@ -464,29 +487,29 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #[derive(Resource, PartialEq)]
     /// struct B(u32);
     ///
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # #[derive(Resource)] struct C(bool);
     /// # fn my_system(mut c: ResMut<C>) { c.0 = true; }
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // Only run the system if either `A` or else `B` exist.
     ///     my_system.run_if(resource_exists::<A>.or_else(resource_exists::<B>)),
     /// );
     /// #
-    /// # let schedule = schedules.get_mut(Update).unwrap();
+    /// # let app = app.get_mut(Update).unwrap();
     /// # world.insert_resource(C(false));
-    /// # schedule.run(&mut world);
+    /// # app.run(&mut world);
     /// # assert!(!world.resource::<C>().0);
     /// #
     /// # world.insert_resource(A(0));
-    /// # schedule.run(&mut world);
+    /// # app.run(&mut world);
     /// # assert!(world.resource::<C>().0);
     /// #
     /// # world.remove_resource::<A>();
     /// # world.insert_resource(B(0));
     /// # world.insert_resource(C(false));
-    /// # schedule.run(&mut world);
+    /// # app.run(&mut world);
     /// # assert!(world.resource::<C>().0);
     /// ```
     fn or_else<M, C: SystemCondition<M, In>>(self, else_run: C) -> OrElse<Self::System, C::System> {
@@ -538,10 +561,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # fn take_drink_orders() {}
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // The take_drink_orders system will only execute if the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition and `in_state(TeaKettleState::Inactive)` run conditions both evaluate to `false`,
@@ -550,14 +573,14 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xnor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
-    /// # schedule.run(&mut world);
+    /// # let app = app.get_mut(Update).unwrap();
+    /// # app.run(&mut world);
     /// ```
     ///
     /// Equivalent logic can be achieved by using `not` in concert with `xor`:
     ///
     /// ```compile_fail
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     take_drink_orders.run_if(
     ///         not(in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive)))
@@ -596,10 +619,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # fn prepare_beverage() {}
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // The prepare_beverage system will only execute if either the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition or `in_state(TeaKettleState::Inactive)` run condition evaluates to `true`,
@@ -608,8 +631,8 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
-    /// # schedule.run(&mut world);
+    /// # let app = app.get_mut(Update).unwrap();
+    /// # app.run(&mut world);
     /// ```
     fn xor<M, C: SystemCondition<M, In>>(self, other: C) -> Xor<Self::System, C::System> {
         let a = IntoSystem::into_system(self);
@@ -645,12 +668,15 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // `run_once` will only return true the first time it's evaluated
     ///     my_system.run_if(run_once),
@@ -660,14 +686,14 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // This is the first time the condition will be evaluated so `my_system` will run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // This is the seconds time the condition will be evaluated so `my_system` won't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn run_once(mut has_run: Local<bool>) -> bool {
@@ -689,11 +715,14 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // `resource_exists` will only return true if the given resource exists in the world
     ///     my_system.run_if(resource_exists::<Counter>),
@@ -703,14 +732,14 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been added so `my_system` won't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// world.init_resource::<Counter>();
     ///
     /// // `Counter` has now been added so `my_system` can run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_exists<T>(res: Option<Res<T>>) -> bool
@@ -731,12 +760,15 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // `resource_equals` will only return true if the given resource equals the given value
     ///     my_system.run_if(resource_equals(Counter(0))),
@@ -746,14 +778,14 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // `Counter` is `0` so `my_system` can run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // `Counter` is no longer `0` so `my_system` won't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_equals<T>(value: T) -> impl FnMut(Res<T>) -> bool
@@ -772,11 +804,14 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // `resource_exists_and_equals` will only return true
     ///     // if the given resource exists and equals the given value
@@ -787,18 +822,18 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been added so `my_system` can't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// world.init_resource::<Counter>();
     ///
     /// // `Counter` is `0` so `my_system` can run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // `Counter` is no longer `0` so `my_system` won't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_exists_and_equals<T>(value: T) -> impl FnMut(Option<Res<T>>) -> bool
@@ -820,13 +855,16 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, PartialEq)]
     /// # struct Counter(i16);
     /// # #[derive(Resource)]
     /// # struct ShouldRun(String);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // `resource_exists_and` will only return true
     ///     // if the given resource exists and satisfies the given condition
@@ -839,21 +877,21 @@ pub mod common_conditions {
     ///
     /// world.insert_resource(Counter(0));
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // `ShouldRun` hasn't been added, so `increment` can't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     /// world.insert_resource(ShouldRun(String::from("bevy")));
     ///
     /// // `ShouldRun` exists and satisfies the run conditions, so `increment` can run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// world.get_resource_mut::<ShouldRun>().unwrap().0 = String::from("bevy ❤");
     ///
     /// // `ShouldRun` exists but has non-ASCII characters and thus
     /// // does not satisfy the run conditions, so `increment` won't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_exists_and<T>(
@@ -875,11 +913,14 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // `resource_added` will only return true if the
     ///     // given resource was just added
@@ -892,14 +933,14 @@ pub mod common_conditions {
     ///
     /// world.init_resource::<Counter>();
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // `Counter` was just added so `my_system` will run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // `Counter` was not just added so `my_system` will not run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_added<T>(res: Option<Res<T>>) -> bool
@@ -927,12 +968,15 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // `resource_changed` will only return true if the
     ///     // given resource was just changed (or added)
@@ -949,16 +993,16 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.resource_mut::<Counter>().0 = 50;
     ///
     /// // `Counter` was just changed so `my_system` will run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 51);
     /// ```
     pub fn resource_changed<T>(res: Res<T>) -> bool
@@ -981,11 +1025,14 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // `resource_exists_and_changed` will only return true if the
     ///     // given resource exists and was just changed (or added)
@@ -1002,20 +1049,20 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // `Counter` doesn't exist so `my_system` won't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// world.init_resource::<Counter>();
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.resource_mut::<Counter>().0 = 50;
     ///
     /// // `Counter` was just changed so `my_system` will run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 51);
     /// ```
     pub fn resource_exists_and_changed<T>(res: Option<Res<T>>) -> bool
@@ -1041,12 +1088,15 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // `resource_changed_or_removed` will only return true if the
     ///     // given resource was just changed or removed (or added)
@@ -1071,22 +1121,22 @@ pub mod common_conditions {
     ///     }
     /// }
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.resource_mut::<Counter>().0 = 50;
     ///
     /// // `Counter` was just changed so `my_system` will run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 51);
     ///
     /// world.remove_resource::<Counter>();
     ///
     /// // `Counter` was just removed so `my_system` will run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.contains_resource::<MyResource>(), true);
     /// ```
     pub fn resource_changed_or_removed<T>(res: Option<Res<T>>, mut existed: Local<bool>) -> bool
@@ -1111,12 +1161,15 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // `resource_removed` will only return true if the
     ///     // given resource was just removed
@@ -1132,16 +1185,16 @@ pub mod common_conditions {
     ///
     /// world.init_resource::<MyResource>();
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // `MyResource` hasn't just been removed so `my_system` won't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.remove_resource::<MyResource>();
     ///
     /// // `MyResource` was just removed so `my_system` will run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_removed<T>(res: Option<Res<T>>, mut existed: Local<bool>) -> bool
@@ -1168,15 +1221,18 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// # world.init_resource::<Messages<MyMessage>>();
-    /// # schedules.add_systems(Update, bevy_ecs::message::message_update_system.before(my_system));
+    /// # app.add_systems(Update, bevy_ecs::message::message_update_system.before(my_system));
     ///
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     my_system.run_if(on_message::<MyMessage>),
     /// );
@@ -1188,16 +1244,16 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // No new `MyMessage` messages have been pushed so `my_system` won't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.resource_mut::<Messages<MyMessage>>().write(MyMessage);
     ///
     /// // A `MyMessage` message has been pushed so `my_system` will run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn on_message<M: Message>(mut reader: MessageReader<M>) -> bool {
@@ -1221,12 +1277,15 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     my_system.run_if(any_with_component::<MyComponent>),
     /// );
@@ -1238,16 +1297,16 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // No entities exist yet with a `MyComponent` component so `my_system` won't run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.spawn(MyComponent);
     ///
     /// // An entities with `MyComponent` now exists so `my_system` will run
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn any_with_component<T: Component>(query: Query<(), With<T>>) -> bool {
@@ -1283,12 +1342,15 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     // `not` will inverse any condition you pass in.
     ///     // Since the condition we choose always returns true
@@ -1296,7 +1358,7 @@ pub mod common_conditions {
     ///     my_system.run_if(not(always)),
     /// );
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
@@ -1306,7 +1368,7 @@ pub mod common_conditions {
     ///     true
     /// }
     ///
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     /// ```
     pub fn not<Marker, TOut, T>(condition: T) -> NotSystem<T::System>
@@ -1327,12 +1389,15 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     my_system.run_if(condition_changed(resource_exists::<MyResource>)),
     /// );
@@ -1344,20 +1409,20 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // We remove `MyResource`, the inner condition is now false, the system runs one more time.
     /// world.remove_resource::<MyResource>();
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
     /// ```
     pub fn condition_changed<Marker, CIn, C>(condition: C) -> impl SystemCondition<(), CIn>
@@ -1381,12 +1446,15 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::ScheduleLabel;
+    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
+    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
+    /// app.add_systems(
     ///     Update,
     ///     my_system.run_if(condition_changed_to(true, resource_exists::<MyResource>)),
     /// );
@@ -1398,25 +1466,25 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
     ///
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // We remove `MyResource`, the inner condition is now false, the system doesn't run.
     /// world.remove_resource::<MyResource>();
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // We reinsert `MyResource` again, so the system will run one more time
     /// world.insert_resource(MyResource);
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
-    /// schedule.run(&mut world);
+    /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
     /// ```
     pub fn condition_changed_to<Marker, CIn, C>(

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -105,7 +105,7 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// # Examples
     ///
     /// ```should_panic
-    /// # use bevy_ecs::prelude::*;
+    /// use bevy_ecs::prelude::*;
     /// # use bevy_ecs::schedule::ScheduleLabel;
     /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
     /// # struct Update;
@@ -401,10 +401,11 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     NotFertilized,
     /// }
     ///
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # fn slow_plant_growth() {}
     /// app.add_systems(
+    ///     Update,
     ///     // The slow_plant_growth system will only execute if both the `in_state(WeatherState::Sunny)`
     ///     // run condition and `in_state(SoilState::Fertilized)` run condition evaluate to `false`.
     ///     slow_plant_growth.run_if(
@@ -418,6 +419,7 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```compile_fail
     /// app.add_systems(
+    ///     Update,
     ///     slow_plant_growth.run_if(
     ///         not(in_state(WeatherState::Sunny).or_else(in_state(SoilState::Fertilized))),
     ///     ),
@@ -474,7 +476,7 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// # Examples
     ///
     /// ```
-    /// # use bevy_ecs::prelude::*;
+    /// use bevy_ecs::prelude::*;
     /// # use bevy_ecs::schedule::ScheduleLabel;
     /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
     /// # struct Update;
@@ -559,10 +561,11 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # fn take_drink_orders() {}
     /// app.add_systems(
+    ///     Update,
     ///     // The take_drink_orders system will only execute if the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition and `in_state(TeaKettleState::Inactive)` run conditions both evaluate to `false`,
     ///     // or both evaluate to `true`.
@@ -570,6 +573,7 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xnor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
+    /// # let app = app.get_mut(Update).unwrap();
     /// # app.run(&mut world);
     /// ```
     ///
@@ -577,6 +581,7 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```compile_fail
     /// app.add_systems(
+    ///     Update,
     ///     take_drink_orders.run_if(
     ///         not(in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive)))
     ///     ),
@@ -614,10 +619,11 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedules::default();
     /// # let mut world = World::new();
     /// # fn prepare_beverage() {}
     /// app.add_systems(
+    ///     Update,
     ///     // The prepare_beverage system will only execute if either the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition or `in_state(TeaKettleState::Inactive)` run condition evaluates to `true`,
     ///     // but not both.
@@ -625,6 +631,7 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
+    /// # let app = app.get_mut(Update).unwrap();
     /// # app.run(&mut world);
     /// ```
     fn xor<M, C: SystemCondition<M, In>>(self, other: C) -> Xor<Self::System, C::System> {
@@ -679,7 +686,8 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // This is the first time the condition will be evaluated so `my_system` will run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
@@ -724,7 +732,8 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // `Counter` hasn't been added so `my_system` won't run
     /// app.run(&mut world);
     /// world.init_resource::<Counter>();
@@ -769,7 +778,8 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // `Counter` is `0` so `my_system` can run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
@@ -812,7 +822,8 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // `Counter` hasn't been added so `my_system` can't run
     /// app.run(&mut world);
     /// world.init_resource::<Counter>();
@@ -866,7 +877,8 @@ pub mod common_conditions {
     ///
     /// world.insert_resource(Counter(0));
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // `ShouldRun` hasn't been added, so `increment` can't run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
@@ -921,7 +933,8 @@ pub mod common_conditions {
     ///
     /// world.init_resource::<Counter>();
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // `Counter` was just added so `my_system` will run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
@@ -980,7 +993,8 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // `Counter` hasn't been changed so `my_system` won't run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
@@ -1035,7 +1049,8 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // `Counter` doesn't exist so `my_system` won't run
     /// app.run(&mut world);
     /// world.init_resource::<Counter>();
@@ -1106,7 +1121,8 @@ pub mod common_conditions {
     ///     }
     /// }
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // `Counter` hasn't been changed so `my_system` won't run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
@@ -1169,7 +1185,8 @@ pub mod common_conditions {
     ///
     /// world.init_resource::<MyResource>();
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // `MyResource` hasn't just been removed so `my_system` won't run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
@@ -1227,7 +1244,8 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // No new `MyMessage` messages have been pushed so `my_system` won't run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
@@ -1279,7 +1297,8 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // No entities exist yet with a `MyComponent` component so `my_system` won't run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
@@ -1339,7 +1358,8 @@ pub mod common_conditions {
     ///     my_system.run_if(not(always)),
     /// );
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
@@ -1389,7 +1409,8 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);
     /// app.run(&mut world);
@@ -1445,7 +1466,8 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// # let app = app.get_mut(Update).unwrap();
+    /// let app = app.get_mut(Update).unwrap();
+    ///
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);
     /// app.run(&mut world);

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -44,10 +44,9 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 ///
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
-/// # let mut schedules = Schedules::default();
-/// schedules.add_systems(Update, my_system.run_if(every_other_time()));
+/// # let mut schedule = Schedule::default();
+/// schedule.add_systems(my_system.run_if(every_other_time()));
 /// # let mut world = World::new();
-/// # let schedule = schedules.get_mut(Update).unwrap();
 /// # world.insert_resource(DidRun(false));
 /// # schedule.run(&mut world);
 /// # assert!(world.resource::<DidRun>().0);
@@ -65,13 +64,12 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 /// }
 ///
 /// # fn always_true() -> bool { true }
-/// # let mut schedules = Schedules::default();
+/// # let mut schedule = Schedule::default();
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
-/// schedules.add_systems(Update, my_system.run_if(always_true.pipe(identity())));
+/// schedule.add_systems(my_system.run_if(always_true.pipe(identity())));
 /// # let mut world = World::new();
 /// # world.insert_resource(DidRun(false));
-/// # let schedule = schedules.get_mut(Update).unwrap();
 /// # schedule.run(&mut world);
 /// # assert!(world.resource::<DidRun>().0);
 pub trait SystemCondition<Marker, In: SystemInput = ()>:
@@ -104,16 +102,14 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #[derive(Resource, PartialEq)]
     /// struct R(u32);
     ///
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # fn my_system() {}
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // The `resource_equals` run condition will panic since we don't initialize `R`,
     ///     // just like if we used `Res<R>` in a system.
     ///     my_system.run_if(resource_equals(R(0))),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// ```
     ///
@@ -123,15 +119,13 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, PartialEq)]
     /// # struct R(u32);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # fn my_system() { unreachable!() }
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // `resource_equals` will only get run if the resource `R` exists.
     ///     my_system.run_if(resource_exists::<R>.and_then(resource_equals(R(0)))),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// ```
     ///
@@ -173,7 +167,7 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// # use std::sync::atomic::Ordering;
     /// # #[derive(Resource, PartialEq)]
     /// # struct R(u32);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # fn my_system() { unreachable!() }
     /// # static CONDITION_A_RAN: AtomicBool = AtomicBool::new(false);
@@ -186,12 +180,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #   CONDITION_B_RAN.store(true, Ordering::Relaxed);
     /// #   true
     /// # }
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // both conditions will execute, even though the first one returned false
     ///     my_system.run_if(returns_false.and_eager(returns_true)),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// # assert!(CONDITION_A_RAN.load(Ordering::Relaxed));
     /// # assert!(CONDITION_B_RAN.load(Ordering::Relaxed));
@@ -254,18 +246,16 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// # #[derive(Resource)]
     /// # struct RanGameOver(bool);
     /// # fn game_over_credits(mut commands: Commands) { commands.insert_resource(RanGameOver(true)); }
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.insert_resource(PlayerState::Dead);
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // The game_over_credits system will only execute if either the `in_state(PlayerState::Alive)`
     ///     // run condition or `in_state(EnemyState::Alive)` run condition evaluates to `false`.
     ///     game_over_credits.run_if(
     ///         in_state(PlayerState::Alive).nand_then(in_state(EnemyState::Alive)),
     ///     ),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// # assert_eq!(IN_STATE_RUN_COUNT.load(Ordering::Relaxed), 1);
     /// # assert!(world.resource::<RanGameOver>().0);
@@ -302,17 +292,15 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #   move |current_state| state == *current_state
     /// # }
     /// # fn game_over_credits() { unreachable!() }
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.insert_resource(PlayerState::Alive);
     /// # world.insert_resource(EnemyState::Alive);
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     game_over_credits.run_if(
     ///         not(in_state(PlayerState::Alive).and_then(in_state(EnemyState::Alive))),
     ///     ),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// ```
     fn nand_then<M, C: SystemCondition<M, In>>(
@@ -380,26 +368,23 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     NotFertilized,
     /// }
     ///
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # fn slow_plant_growth() {}
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // The slow_plant_growth system will only execute if both the `in_state(WeatherState::Sunny)`
     ///     // run condition and `in_state(SoilState::Fertilized)` run condition evaluate to `false`.
     ///     slow_plant_growth.run_if(
     ///         in_state(WeatherState::Sunny).nor_else(in_state(SoilState::Fertilized)),
     ///     ),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// ```
     ///
     /// Equivalent logic can be achieved by using `not` in concert with `or`:
     ///
     /// ```compile_fail
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     slow_plant_growth.run_if(
     ///         not(in_state(WeatherState::Sunny).or_else(in_state(SoilState::Fertilized))),
     ///     ),
@@ -464,17 +449,15 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #[derive(Resource, PartialEq)]
     /// struct B(u32);
     ///
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # #[derive(Resource)] struct C(bool);
     /// # fn my_system(mut c: ResMut<C>) { c.0 = true; }
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // Only run the system if either `A` or else `B` exist.
     ///     my_system.run_if(resource_exists::<A>.or_else(resource_exists::<B>)),
     /// );
     /// #
-    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # world.insert_resource(C(false));
     /// # schedule.run(&mut world);
     /// # assert!(!world.resource::<C>().0);
@@ -538,11 +521,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # fn take_drink_orders() {}
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // The take_drink_orders system will only execute if the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition and `in_state(TeaKettleState::Inactive)` run conditions both evaluate to `false`,
     ///     // or both evaluate to `true`.
@@ -550,15 +532,13 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xnor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// ```
     ///
     /// Equivalent logic can be achieved by using `not` in concert with `xor`:
     ///
     /// ```compile_fail
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     take_drink_orders.run_if(
     ///         not(in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive)))
     ///     ),
@@ -596,11 +576,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # fn prepare_beverage() {}
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // The prepare_beverage system will only execute if either the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition or `in_state(TeaKettleState::Inactive)` run condition evaluates to `true`,
     ///     // but not both.
@@ -608,7 +587,6 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
-    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// ```
     fn xor<M, C: SystemCondition<M, In>>(self, other: C) -> Xor<Self::System, C::System> {
@@ -647,11 +625,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // `run_once` will only return true the first time it's evaluated
     ///     my_system.run_if(run_once),
     /// );
@@ -659,8 +636,6 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // This is the first time the condition will be evaluated so `my_system` will run
     /// schedule.run(&mut world);
@@ -691,10 +666,9 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // `resource_exists` will only return true if the given resource exists in the world
     ///     my_system.run_if(resource_exists::<Counter>),
     /// );
@@ -702,8 +676,6 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been added so `my_system` won't run
     /// schedule.run(&mut world);
@@ -733,11 +705,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // `resource_equals` will only return true if the given resource equals the given value
     ///     my_system.run_if(resource_equals(Counter(0))),
     /// );
@@ -745,8 +716,6 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` is `0` so `my_system` can run
     /// schedule.run(&mut world);
@@ -774,10 +743,9 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // `resource_exists_and_equals` will only return true
     ///     // if the given resource exists and equals the given value
     ///     my_system.run_if(resource_exists_and_equals(Counter(0))),
@@ -786,8 +754,6 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been added so `my_system` can't run
     /// schedule.run(&mut world);
@@ -824,10 +790,9 @@ pub mod common_conditions {
     /// # struct Counter(i16);
     /// # #[derive(Resource)]
     /// # struct ShouldRun(String);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // `resource_exists_and` will only return true
     ///     // if the given resource exists and satisfies the given condition
     ///     increment.run_if(resource_exists_and(|should_run: &ShouldRun| should_run.0.is_ascii())),
@@ -838,8 +803,6 @@ pub mod common_conditions {
     /// }
     ///
     /// world.insert_resource(Counter(0));
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `ShouldRun` hasn't been added, so `increment` can't run
     /// schedule.run(&mut world);
@@ -877,10 +840,9 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // `resource_added` will only return true if the
     ///     // given resource was just added
     ///     my_system.run_if(resource_added::<Counter>),
@@ -891,8 +853,6 @@ pub mod common_conditions {
     /// }
     ///
     /// world.init_resource::<Counter>();
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` was just added so `my_system` will run
     /// schedule.run(&mut world);
@@ -929,11 +889,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // `resource_changed` will only return true if the
     ///     // given resource was just changed (or added)
     ///     my_system.run_if(
@@ -948,8 +907,6 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
     /// schedule.run(&mut world);
@@ -983,10 +940,9 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // `resource_exists_and_changed` will only return true if the
     ///     // given resource exists and was just changed (or added)
     ///     my_system.run_if(
@@ -1001,8 +957,6 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` doesn't exist so `my_system` won't run
     /// schedule.run(&mut world);
@@ -1043,11 +997,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // `resource_changed_or_removed` will only return true if the
     ///     // given resource was just changed or removed (or added)
     ///     my_system.run_if(
@@ -1070,8 +1023,6 @@ pub mod common_conditions {
     ///         commands.init_resource::<MyResource>();
     ///     }
     /// }
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
     /// schedule.run(&mut world);
@@ -1113,11 +1064,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // `resource_removed` will only return true if the
     ///     // given resource was just removed
     ///     my_system.run_if(resource_removed::<MyResource>),
@@ -1131,8 +1081,6 @@ pub mod common_conditions {
     /// }
     ///
     /// world.init_resource::<MyResource>();
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `MyResource` hasn't just been removed so `my_system` won't run
     /// schedule.run(&mut world);
@@ -1170,14 +1118,13 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// # world.init_resource::<Messages<MyMessage>>();
-    /// # schedules.add_systems(Update, bevy_ecs::message::message_update_system.before(my_system));
+    /// # schedule.add_systems(bevy_ecs::message::message_update_system.before(my_system));
     ///
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     my_system.run_if(on_message::<MyMessage>),
     /// );
     ///
@@ -1187,8 +1134,6 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // No new `MyMessage` messages have been pushed so `my_system` won't run
     /// schedule.run(&mut world);
@@ -1223,11 +1168,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     my_system.run_if(any_with_component::<MyComponent>),
     /// );
     ///
@@ -1237,8 +1181,6 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // No entities exist yet with a `MyComponent` component so `my_system` won't run
     /// schedule.run(&mut world);
@@ -1285,18 +1227,15 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     // `not` will inverse any condition you pass in.
     ///     // Since the condition we choose always returns true
     ///     // this system will never run
     ///     my_system.run_if(not(always)),
     /// );
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
@@ -1329,11 +1268,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     my_system.run_if(condition_changed(resource_exists::<MyResource>)),
     /// );
     ///
@@ -1343,8 +1281,6 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);
@@ -1383,11 +1319,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedules = Schedules::default();
+    /// # let mut schedule = Schedule::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedules.add_systems(
-    ///     Update,
+    /// schedule.add_systems(
     ///     my_system.run_if(condition_changed_to(true, resource_exists::<MyResource>)),
     /// );
     ///
@@ -1397,8 +1332,6 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
-    ///
-    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -105,7 +105,7 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// # Examples
     ///
     /// ```should_panic
-    /// use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::prelude::*;
     /// # use bevy_ecs::schedule::ScheduleLabel;
     /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
     /// # struct Update;
@@ -401,11 +401,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     NotFertilized,
     /// }
     ///
-    /// # let mut app = Schedules::default();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # fn slow_plant_growth() {}
     /// app.add_systems(
-    ///     Update,
     ///     // The slow_plant_growth system will only execute if both the `in_state(WeatherState::Sunny)`
     ///     // run condition and `in_state(SoilState::Fertilized)` run condition evaluate to `false`.
     ///     slow_plant_growth.run_if(
@@ -419,7 +418,6 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```compile_fail
     /// app.add_systems(
-    ///     Update,
     ///     slow_plant_growth.run_if(
     ///         not(in_state(WeatherState::Sunny).or_else(in_state(SoilState::Fertilized))),
     ///     ),
@@ -476,7 +474,7 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// # Examples
     ///
     /// ```
-    /// use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::prelude::*;
     /// # use bevy_ecs::schedule::ScheduleLabel;
     /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
     /// # struct Update;
@@ -561,11 +559,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut app = Schedules::default();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # fn take_drink_orders() {}
     /// app.add_systems(
-    ///     Update,
     ///     // The take_drink_orders system will only execute if the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition and `in_state(TeaKettleState::Inactive)` run conditions both evaluate to `false`,
     ///     // or both evaluate to `true`.
@@ -573,7 +570,6 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xnor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
-    /// # let app = app.get_mut(Update).unwrap();
     /// # app.run(&mut world);
     /// ```
     ///
@@ -581,7 +577,6 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```compile_fail
     /// app.add_systems(
-    ///     Update,
     ///     take_drink_orders.run_if(
     ///         not(in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive)))
     ///     ),
@@ -619,11 +614,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut app = Schedules::default();
+    /// # let mut app = Schedule::default();
     /// # let mut world = World::new();
     /// # fn prepare_beverage() {}
     /// app.add_systems(
-    ///     Update,
     ///     // The prepare_beverage system will only execute if either the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition or `in_state(TeaKettleState::Inactive)` run condition evaluates to `true`,
     ///     // but not both.
@@ -631,7 +625,6 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
-    /// # let app = app.get_mut(Update).unwrap();
     /// # app.run(&mut world);
     /// ```
     fn xor<M, C: SystemCondition<M, In>>(self, other: C) -> Xor<Self::System, C::System> {
@@ -686,8 +679,7 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // This is the first time the condition will be evaluated so `my_system` will run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
@@ -732,8 +724,7 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // `Counter` hasn't been added so `my_system` won't run
     /// app.run(&mut world);
     /// world.init_resource::<Counter>();
@@ -778,8 +769,7 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // `Counter` is `0` so `my_system` can run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
@@ -822,8 +812,7 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // `Counter` hasn't been added so `my_system` can't run
     /// app.run(&mut world);
     /// world.init_resource::<Counter>();
@@ -877,8 +866,7 @@ pub mod common_conditions {
     ///
     /// world.insert_resource(Counter(0));
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // `ShouldRun` hasn't been added, so `increment` can't run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
@@ -933,8 +921,7 @@ pub mod common_conditions {
     ///
     /// world.init_resource::<Counter>();
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // `Counter` was just added so `my_system` will run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
@@ -993,8 +980,7 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // `Counter` hasn't been changed so `my_system` won't run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
@@ -1049,8 +1035,7 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // `Counter` doesn't exist so `my_system` won't run
     /// app.run(&mut world);
     /// world.init_resource::<Counter>();
@@ -1121,8 +1106,7 @@ pub mod common_conditions {
     ///     }
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // `Counter` hasn't been changed so `my_system` won't run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
@@ -1185,8 +1169,7 @@ pub mod common_conditions {
     ///
     /// world.init_resource::<MyResource>();
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // `MyResource` hasn't just been removed so `my_system` won't run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
@@ -1244,8 +1227,7 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // No new `MyMessage` messages have been pushed so `my_system` won't run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
@@ -1297,8 +1279,7 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // No entities exist yet with a `MyComponent` component so `my_system` won't run
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
@@ -1358,8 +1339,7 @@ pub mod common_conditions {
     ///     my_system.run_if(not(always)),
     /// );
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
@@ -1409,8 +1389,7 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);
     /// app.run(&mut world);
@@ -1466,8 +1445,7 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
-    ///
+    /// # let app = app.get_mut(Update).unwrap();
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);
     /// app.run(&mut world);

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -35,9 +35,6 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 /// A condition that returns true every other time it's called.
 /// ```
 /// # use bevy_ecs::prelude::*;
-/// # use bevy_ecs::schedule::ScheduleLabel;
-/// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-/// # struct Update;
 /// fn every_other_time() -> impl SystemCondition<()> {
 ///     IntoSystem::into_system(|mut flag: Local<bool>| {
 ///         *flag = !*flag;
@@ -47,15 +44,15 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 ///
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
-/// # let mut app = Schedules::default();
-/// app.add_systems(Update, my_system.run_if(every_other_time()));
+/// # let mut schedules = Schedules::default();
+/// schedules.add_systems(Update, my_system.run_if(every_other_time()));
 /// # let mut world = World::new();
-/// # let app = app.get_mut(Update).unwrap();
+/// # let schedule = schedules.get_mut(Update).unwrap();
 /// # world.insert_resource(DidRun(false));
-/// # app.run(&mut world);
+/// # schedule.run(&mut world);
 /// # assert!(world.resource::<DidRun>().0);
 /// # world.insert_resource(DidRun(false));
-/// # app.run(&mut world);
+/// # schedule.run(&mut world);
 /// # assert!(!world.resource::<DidRun>().0);
 /// ```
 ///
@@ -63,22 +60,19 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
-/// # use bevy_ecs::schedule::ScheduleLabel;
-/// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-/// # struct Update;
 /// fn identity() -> impl SystemCondition<(), In<bool>> {
 ///     IntoSystem::into_system(|In(x): In<bool>| x)
 /// }
 ///
 /// # fn always_true() -> bool { true }
-/// # let mut app = Schedules::default();
+/// # let mut schedules = Schedules::default();
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
-/// app.add_systems(Update, my_system.run_if(always_true.pipe(identity())));
+/// schedules.add_systems(Update, my_system.run_if(always_true.pipe(identity())));
 /// # let mut world = World::new();
 /// # world.insert_resource(DidRun(false));
-/// # let app = app.get_mut(Update).unwrap();
-/// # app.run(&mut world);
+/// # let schedule = schedules.get_mut(Update).unwrap();
+/// # schedule.run(&mut world);
 /// # assert!(world.resource::<DidRun>().0);
 pub trait SystemCondition<Marker, In: SystemInput = ()>:
     IntoSystem<In, bool, Marker, System: ReadOnlySystem>
@@ -106,45 +100,39 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```should_panic
     /// use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     ///
     /// #[derive(Resource, PartialEq)]
     /// struct R(u32);
     ///
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # fn my_system() {}
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // The `resource_equals` run condition will panic since we don't initialize `R`,
     ///     // just like if we used `Res<R>` in a system.
     ///     my_system.run_if(resource_equals(R(0))),
     /// );
-    /// # let app = app.get_mut(Update).unwrap();
-    /// # app.run(&mut world);
+    /// # let schedule = schedules.get_mut(Update).unwrap();
+    /// # schedule.run(&mut world);
     /// ```
     ///
     /// Use `.and_then()` to avoid checking the condition.
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, PartialEq)]
     /// # struct R(u32);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # fn my_system() { unreachable!() }
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // `resource_equals` will only get run if the resource `R` exists.
     ///     my_system.run_if(resource_exists::<R>.and_then(resource_equals(R(0)))),
     /// );
-    /// # let app = app.get_mut(Update).unwrap();
-    /// # app.run(&mut world);
+    /// # let schedule = schedules.get_mut(Update).unwrap();
+    /// # schedule.run(&mut world);
     /// ```
     ///
     /// Note that in this specific case, it's better to just use the run condition [`resource_exists_and_equals`].
@@ -181,14 +169,11 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
     /// # use std::sync::atomic::AtomicBool;
     /// # use std::sync::atomic::Ordering;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, PartialEq)]
     /// # struct R(u32);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # fn my_system() { unreachable!() }
     /// # static CONDITION_A_RAN: AtomicBool = AtomicBool::new(false);
@@ -201,13 +186,13 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #   CONDITION_B_RAN.store(true, Ordering::Relaxed);
     /// #   true
     /// # }
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // both conditions will execute, even though the first one returned false
     ///     my_system.run_if(returns_false.and_eager(returns_true)),
     /// );
-    /// # let app = app.get_mut(Update).unwrap();
-    /// # app.run(&mut world);
+    /// # let schedule = schedules.get_mut(Update).unwrap();
+    /// # schedule.run(&mut world);
     /// # assert!(CONDITION_A_RAN.load(Ordering::Relaxed));
     /// # assert!(CONDITION_B_RAN.load(Ordering::Relaxed));
     /// ```
@@ -244,9 +229,6 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// #
     /// # #[derive(Resource, Debug, Clone, PartialEq, Eq, Hash)]
     /// # pub enum PlayerState {
@@ -272,10 +254,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// # #[derive(Resource)]
     /// # struct RanGameOver(bool);
     /// # fn game_over_credits(mut commands: Commands) { commands.insert_resource(RanGameOver(true)); }
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.insert_resource(PlayerState::Dead);
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // The game_over_credits system will only execute if either the `in_state(PlayerState::Alive)`
     ///     // run condition or `in_state(EnemyState::Alive)` run condition evaluates to `false`.
@@ -283,21 +265,21 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(PlayerState::Alive).nand_then(in_state(EnemyState::Alive)),
     ///     ),
     /// );
-    /// # let app = app.get_mut(Update).unwrap();
-    /// # app.run(&mut world);
+    /// # let schedule = schedules.get_mut(Update).unwrap();
+    /// # schedule.run(&mut world);
     /// # assert_eq!(IN_STATE_RUN_COUNT.load(Ordering::Relaxed), 1);
     /// # assert!(world.resource::<RanGameOver>().0);
     /// # IN_STATE_RUN_COUNT.store(0, Ordering::Relaxed);
     /// # world.insert_resource(RanGameOver(false));
     /// # world.insert_resource(PlayerState::Alive);
     /// # world.insert_resource(EnemyState::Dead);
-    /// # app.run(&mut world);
+    /// # schedule.run(&mut world);
     /// # assert_eq!(IN_STATE_RUN_COUNT.load(Ordering::Relaxed), 2);
     /// # assert!(world.resource::<RanGameOver>().0);
     /// # IN_STATE_RUN_COUNT.store(0, Ordering::Relaxed);
     /// # world.insert_resource(RanGameOver(false));
     /// # world.insert_resource(EnemyState::Alive);
-    /// # app.run(&mut world);
+    /// # schedule.run(&mut world);
     /// # assert_eq!(IN_STATE_RUN_COUNT.load(Ordering::Relaxed), 2);
     /// # assert!(!world.resource::<RanGameOver>().0);
     /// ```
@@ -306,9 +288,6 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Debug, Clone, PartialEq, Eq, Hash)]
     /// # pub enum PlayerState {
     /// #     Alive,
@@ -323,18 +302,18 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #   move |current_state| state == *current_state
     /// # }
     /// # fn game_over_credits() { unreachable!() }
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.insert_resource(PlayerState::Alive);
     /// # world.insert_resource(EnemyState::Alive);
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     game_over_credits.run_if(
     ///         not(in_state(PlayerState::Alive).and_then(in_state(EnemyState::Alive))),
     ///     ),
     /// );
-    /// # let app = app.get_mut(Update).unwrap();
-    /// # app.run(&mut world);
+    /// # let schedule = schedules.get_mut(Update).unwrap();
+    /// # schedule.run(&mut world);
     /// ```
     fn nand_then<M, C: SystemCondition<M, In>>(
         self,
@@ -401,10 +380,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     NotFertilized,
     /// }
     ///
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # fn slow_plant_growth() {}
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // The slow_plant_growth system will only execute if both the `in_state(WeatherState::Sunny)`
     ///     // run condition and `in_state(SoilState::Fertilized)` run condition evaluate to `false`.
@@ -412,13 +391,14 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(WeatherState::Sunny).nor_else(in_state(SoilState::Fertilized)),
     ///     ),
     /// );
-    /// # app.run(&mut world);
+    /// # let schedule = schedules.get_mut(Update).unwrap();
+    /// # schedule.run(&mut world);
     /// ```
     ///
     /// Equivalent logic can be achieved by using `not` in concert with `or`:
     ///
     /// ```compile_fail
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     slow_plant_growth.run_if(
     ///         not(in_state(WeatherState::Sunny).or_else(in_state(SoilState::Fertilized))),
@@ -477,9 +457,6 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///
     /// ```
     /// use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     ///
     /// #[derive(Resource, PartialEq)]
     /// struct A(u32);
@@ -487,29 +464,29 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #[derive(Resource, PartialEq)]
     /// struct B(u32);
     ///
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # #[derive(Resource)] struct C(bool);
     /// # fn my_system(mut c: ResMut<C>) { c.0 = true; }
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // Only run the system if either `A` or else `B` exist.
     ///     my_system.run_if(resource_exists::<A>.or_else(resource_exists::<B>)),
     /// );
     /// #
-    /// # let app = app.get_mut(Update).unwrap();
+    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # world.insert_resource(C(false));
-    /// # app.run(&mut world);
+    /// # schedule.run(&mut world);
     /// # assert!(!world.resource::<C>().0);
     /// #
     /// # world.insert_resource(A(0));
-    /// # app.run(&mut world);
+    /// # schedule.run(&mut world);
     /// # assert!(world.resource::<C>().0);
     /// #
     /// # world.remove_resource::<A>();
     /// # world.insert_resource(B(0));
     /// # world.insert_resource(C(false));
-    /// # app.run(&mut world);
+    /// # schedule.run(&mut world);
     /// # assert!(world.resource::<C>().0);
     /// ```
     fn or_else<M, C: SystemCondition<M, In>>(self, else_run: C) -> OrElse<Self::System, C::System> {
@@ -561,10 +538,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # fn take_drink_orders() {}
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // The take_drink_orders system will only execute if the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition and `in_state(TeaKettleState::Inactive)` run conditions both evaluate to `false`,
@@ -573,14 +550,14 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xnor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
-    /// # let app = app.get_mut(Update).unwrap();
-    /// # app.run(&mut world);
+    /// # let schedule = schedules.get_mut(Update).unwrap();
+    /// # schedule.run(&mut world);
     /// ```
     ///
     /// Equivalent logic can be achieved by using `not` in concert with `xor`:
     ///
     /// ```compile_fail
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     take_drink_orders.run_if(
     ///         not(in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive)))
@@ -619,10 +596,10 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # fn prepare_beverage() {}
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // The prepare_beverage system will only execute if either the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition or `in_state(TeaKettleState::Inactive)` run condition evaluates to `true`,
@@ -631,8 +608,8 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
-    /// # let app = app.get_mut(Update).unwrap();
-    /// # app.run(&mut world);
+    /// # let schedule = schedules.get_mut(Update).unwrap();
+    /// # schedule.run(&mut world);
     /// ```
     fn xor<M, C: SystemCondition<M, In>>(self, other: C) -> Xor<Self::System, C::System> {
         let a = IntoSystem::into_system(self);
@@ -668,15 +645,12 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // `run_once` will only return true the first time it's evaluated
     ///     my_system.run_if(run_once),
@@ -686,14 +660,14 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // This is the first time the condition will be evaluated so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // This is the seconds time the condition will be evaluated so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn run_once(mut has_run: Local<bool>) -> bool {
@@ -715,14 +689,11 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // `resource_exists` will only return true if the given resource exists in the world
     ///     my_system.run_if(resource_exists::<Counter>),
@@ -732,14 +703,14 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been added so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// world.init_resource::<Counter>();
     ///
     /// // `Counter` has now been added so `my_system` can run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_exists<T>(res: Option<Res<T>>) -> bool
@@ -760,15 +731,12 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // `resource_equals` will only return true if the given resource equals the given value
     ///     my_system.run_if(resource_equals(Counter(0))),
@@ -778,14 +746,14 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` is `0` so `my_system` can run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // `Counter` is no longer `0` so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_equals<T>(value: T) -> impl FnMut(Res<T>) -> bool
@@ -804,14 +772,11 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // `resource_exists_and_equals` will only return true
     ///     // if the given resource exists and equals the given value
@@ -822,18 +787,18 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been added so `my_system` can't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// world.init_resource::<Counter>();
     ///
     /// // `Counter` is `0` so `my_system` can run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // `Counter` is no longer `0` so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_exists_and_equals<T>(value: T) -> impl FnMut(Option<Res<T>>) -> bool
@@ -855,16 +820,13 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, PartialEq)]
     /// # struct Counter(i16);
     /// # #[derive(Resource)]
     /// # struct ShouldRun(String);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // `resource_exists_and` will only return true
     ///     // if the given resource exists and satisfies the given condition
@@ -877,21 +839,21 @@ pub mod common_conditions {
     ///
     /// world.insert_resource(Counter(0));
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `ShouldRun` hasn't been added, so `increment` can't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     /// world.insert_resource(ShouldRun(String::from("bevy")));
     ///
     /// // `ShouldRun` exists and satisfies the run conditions, so `increment` can run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// world.get_resource_mut::<ShouldRun>().unwrap().0 = String::from("bevy ❤");
     ///
     /// // `ShouldRun` exists but has non-ASCII characters and thus
     /// // does not satisfy the run conditions, so `increment` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_exists_and<T>(
@@ -913,14 +875,11 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // `resource_added` will only return true if the
     ///     // given resource was just added
@@ -933,14 +892,14 @@ pub mod common_conditions {
     ///
     /// world.init_resource::<Counter>();
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` was just added so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // `Counter` was not just added so `my_system` will not run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_added<T>(res: Option<Res<T>>) -> bool
@@ -968,15 +927,12 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // `resource_changed` will only return true if the
     ///     // given resource was just changed (or added)
@@ -993,16 +949,16 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.resource_mut::<Counter>().0 = 50;
     ///
     /// // `Counter` was just changed so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 51);
     /// ```
     pub fn resource_changed<T>(res: Res<T>) -> bool
@@ -1025,14 +981,11 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // `resource_exists_and_changed` will only return true if the
     ///     // given resource exists and was just changed (or added)
@@ -1049,20 +1002,20 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` doesn't exist so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// world.init_resource::<Counter>();
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.resource_mut::<Counter>().0 = 50;
     ///
     /// // `Counter` was just changed so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 51);
     /// ```
     pub fn resource_exists_and_changed<T>(res: Option<Res<T>>) -> bool
@@ -1088,15 +1041,12 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // `resource_changed_or_removed` will only return true if the
     ///     // given resource was just changed or removed (or added)
@@ -1121,22 +1071,22 @@ pub mod common_conditions {
     ///     }
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.resource_mut::<Counter>().0 = 50;
     ///
     /// // `Counter` was just changed so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 51);
     ///
     /// world.remove_resource::<Counter>();
     ///
     /// // `Counter` was just removed so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.contains_resource::<MyResource>(), true);
     /// ```
     pub fn resource_changed_or_removed<T>(res: Option<Res<T>>, mut existed: Local<bool>) -> bool
@@ -1161,15 +1111,12 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // `resource_removed` will only return true if the
     ///     // given resource was just removed
@@ -1185,16 +1132,16 @@ pub mod common_conditions {
     ///
     /// world.init_resource::<MyResource>();
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `MyResource` hasn't just been removed so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.remove_resource::<MyResource>();
     ///
     /// // `MyResource` was just removed so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn resource_removed<T>(res: Option<Res<T>>, mut existed: Local<bool>) -> bool
@@ -1221,18 +1168,15 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// # world.init_resource::<Messages<MyMessage>>();
-    /// # app.add_systems(Update, bevy_ecs::message::message_update_system.before(my_system));
+    /// # schedules.add_systems(Update, bevy_ecs::message::message_update_system.before(my_system));
     ///
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     my_system.run_if(on_message::<MyMessage>),
     /// );
@@ -1244,16 +1188,16 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // No new `MyMessage` messages have been pushed so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.resource_mut::<Messages<MyMessage>>().write(MyMessage);
     ///
     /// // A `MyMessage` message has been pushed so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn on_message<M: Message>(mut reader: MessageReader<M>) -> bool {
@@ -1277,15 +1221,12 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     my_system.run_if(any_with_component::<MyComponent>),
     /// );
@@ -1297,16 +1238,16 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // No entities exist yet with a `MyComponent` component so `my_system` won't run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     ///
     /// world.spawn(MyComponent);
     ///
     /// // An entities with `MyComponent` now exists so `my_system` will run
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     /// ```
     pub fn any_with_component<T: Component>(query: Query<(), With<T>>) -> bool {
@@ -1342,15 +1283,12 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     // `not` will inverse any condition you pass in.
     ///     // Since the condition we choose always returns true
@@ -1358,7 +1296,7 @@ pub mod common_conditions {
     ///     my_system.run_if(not(always)),
     /// );
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
@@ -1368,7 +1306,7 @@ pub mod common_conditions {
     ///     true
     /// }
     ///
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     /// ```
     pub fn not<Marker, TOut, T>(condition: T) -> NotSystem<T::System>
@@ -1389,15 +1327,12 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     my_system.run_if(condition_changed(resource_exists::<MyResource>)),
     /// );
@@ -1409,20 +1344,20 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // We remove `MyResource`, the inner condition is now false, the system runs one more time.
     /// world.remove_resource::<MyResource>();
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
     /// ```
     pub fn condition_changed<Marker, CIn, C>(condition: C) -> impl SystemCondition<(), CIn>
@@ -1446,15 +1381,12 @@ pub mod common_conditions {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # use bevy_ecs::schedule::ScheduleLabel;
-    /// # #[derive(Debug, Clone, Hash, PartialEq, Eq, ScheduleLabel)]
-    /// # struct Update;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedules::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// app.add_systems(
+    /// schedules.add_systems(
     ///     Update,
     ///     my_system.run_if(condition_changed_to(true, resource_exists::<MyResource>)),
     /// );
@@ -1466,25 +1398,25 @@ pub mod common_conditions {
     ///     counter.0 += 1;
     /// }
     ///
-    /// let app = app.get_mut(Update).unwrap();
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // We remove `MyResource`, the inner condition is now false, the system doesn't run.
     /// world.remove_resource::<MyResource>();
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 1);
     ///
     /// // We reinsert `MyResource` again, so the system will run one more time
     /// world.insert_resource(MyResource);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
-    /// app.run(&mut world);
+    /// schedule.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 2);
     /// ```
     pub fn condition_changed_to<Marker, CIn, C>(

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -44,9 +44,10 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 ///
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
-/// # let mut schedule = Schedule::default();
-/// schedule.add_systems(my_system.run_if(every_other_time()));
+/// # let mut schedules = Schedules::default();
+/// schedules.add_systems(Update, my_system.run_if(every_other_time()));
 /// # let mut world = World::new();
+/// # let schedule = schedules.get_mut(Update).unwrap();
 /// # world.insert_resource(DidRun(false));
 /// # schedule.run(&mut world);
 /// # assert!(world.resource::<DidRun>().0);
@@ -64,12 +65,13 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 /// }
 ///
 /// # fn always_true() -> bool { true }
-/// # let mut schedule = Schedule::default();
+/// # let mut schedules = Schedules::default();
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
-/// schedule.add_systems(my_system.run_if(always_true.pipe(identity())));
+/// schedules.add_systems(Update, my_system.run_if(always_true.pipe(identity())));
 /// # let mut world = World::new();
 /// # world.insert_resource(DidRun(false));
+/// # let schedule = schedules.get_mut(Update).unwrap();
 /// # schedule.run(&mut world);
 /// # assert!(world.resource::<DidRun>().0);
 pub trait SystemCondition<Marker, In: SystemInput = ()>:
@@ -102,14 +104,16 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #[derive(Resource, PartialEq)]
     /// struct R(u32);
     ///
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # fn my_system() {}
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // The `resource_equals` run condition will panic since we don't initialize `R`,
     ///     // just like if we used `Res<R>` in a system.
     ///     my_system.run_if(resource_equals(R(0))),
     /// );
+    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// ```
     ///
@@ -119,13 +123,15 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, PartialEq)]
     /// # struct R(u32);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # fn my_system() { unreachable!() }
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // `resource_equals` will only get run if the resource `R` exists.
     ///     my_system.run_if(resource_exists::<R>.and_then(resource_equals(R(0)))),
     /// );
+    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// ```
     ///
@@ -167,7 +173,7 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// # use std::sync::atomic::Ordering;
     /// # #[derive(Resource, PartialEq)]
     /// # struct R(u32);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # fn my_system() { unreachable!() }
     /// # static CONDITION_A_RAN: AtomicBool = AtomicBool::new(false);
@@ -180,10 +186,12 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #   CONDITION_B_RAN.store(true, Ordering::Relaxed);
     /// #   true
     /// # }
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // both conditions will execute, even though the first one returned false
     ///     my_system.run_if(returns_false.and_eager(returns_true)),
     /// );
+    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// # assert!(CONDITION_A_RAN.load(Ordering::Relaxed));
     /// # assert!(CONDITION_B_RAN.load(Ordering::Relaxed));
@@ -246,16 +254,18 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// # #[derive(Resource)]
     /// # struct RanGameOver(bool);
     /// # fn game_over_credits(mut commands: Commands) { commands.insert_resource(RanGameOver(true)); }
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.insert_resource(PlayerState::Dead);
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // The game_over_credits system will only execute if either the `in_state(PlayerState::Alive)`
     ///     // run condition or `in_state(EnemyState::Alive)` run condition evaluates to `false`.
     ///     game_over_credits.run_if(
     ///         in_state(PlayerState::Alive).nand_then(in_state(EnemyState::Alive)),
     ///     ),
     /// );
+    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// # assert_eq!(IN_STATE_RUN_COUNT.load(Ordering::Relaxed), 1);
     /// # assert!(world.resource::<RanGameOver>().0);
@@ -292,15 +302,17 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #   move |current_state| state == *current_state
     /// # }
     /// # fn game_over_credits() { unreachable!() }
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.insert_resource(PlayerState::Alive);
     /// # world.insert_resource(EnemyState::Alive);
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     game_over_credits.run_if(
     ///         not(in_state(PlayerState::Alive).and_then(in_state(EnemyState::Alive))),
     ///     ),
     /// );
+    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// ```
     fn nand_then<M, C: SystemCondition<M, In>>(
@@ -368,23 +380,26 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     NotFertilized,
     /// }
     ///
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # fn slow_plant_growth() {}
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // The slow_plant_growth system will only execute if both the `in_state(WeatherState::Sunny)`
     ///     // run condition and `in_state(SoilState::Fertilized)` run condition evaluate to `false`.
     ///     slow_plant_growth.run_if(
     ///         in_state(WeatherState::Sunny).nor_else(in_state(SoilState::Fertilized)),
     ///     ),
     /// );
+    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// ```
     ///
     /// Equivalent logic can be achieved by using `not` in concert with `or`:
     ///
     /// ```compile_fail
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     slow_plant_growth.run_if(
     ///         not(in_state(WeatherState::Sunny).or_else(in_state(SoilState::Fertilized))),
     ///     ),
@@ -449,15 +464,17 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     /// #[derive(Resource, PartialEq)]
     /// struct B(u32);
     ///
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # #[derive(Resource)] struct C(bool);
     /// # fn my_system(mut c: ResMut<C>) { c.0 = true; }
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // Only run the system if either `A` or else `B` exist.
     ///     my_system.run_if(resource_exists::<A>.or_else(resource_exists::<B>)),
     /// );
     /// #
+    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # world.insert_resource(C(false));
     /// # schedule.run(&mut world);
     /// # assert!(!world.resource::<C>().0);
@@ -521,10 +538,11 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # fn take_drink_orders() {}
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // The take_drink_orders system will only execute if the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition and `in_state(TeaKettleState::Inactive)` run conditions both evaluate to `false`,
     ///     // or both evaluate to `true`.
@@ -532,13 +550,15 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xnor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
+    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// ```
     ///
     /// Equivalent logic can be achieved by using `not` in concert with `xor`:
     ///
     /// ```compile_fail
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     take_drink_orders.run_if(
     ///         not(in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive)))
     ///     ),
@@ -576,10 +596,11 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///     Inactive,
     /// }
     ///
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # fn prepare_beverage() {}
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // The prepare_beverage system will only execute if either the `in_state(CoffeeMachineState::Inactive)`
     ///     // run condition or `in_state(TeaKettleState::Inactive)` run condition evaluates to `true`,
     ///     // but not both.
@@ -587,6 +608,7 @@ pub trait SystemCondition<Marker, In: SystemInput = ()>:
     ///         in_state(CoffeeMachineState::Inactive).xor(in_state(TeaKettleState::Inactive))
     ///     ),
     /// );
+    /// # let schedule = schedules.get_mut(Update).unwrap();
     /// # schedule.run(&mut world);
     /// ```
     fn xor<M, C: SystemCondition<M, In>>(self, other: C) -> Xor<Self::System, C::System> {
@@ -625,10 +647,11 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // `run_once` will only return true the first time it's evaluated
     ///     my_system.run_if(run_once),
     /// );
@@ -636,6 +659,8 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // This is the first time the condition will be evaluated so `my_system` will run
     /// schedule.run(&mut world);
@@ -666,9 +691,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // `resource_exists` will only return true if the given resource exists in the world
     ///     my_system.run_if(resource_exists::<Counter>),
     /// );
@@ -676,6 +702,8 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been added so `my_system` won't run
     /// schedule.run(&mut world);
@@ -705,10 +733,11 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // `resource_equals` will only return true if the given resource equals the given value
     ///     my_system.run_if(resource_equals(Counter(0))),
     /// );
@@ -716,6 +745,8 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` is `0` so `my_system` can run
     /// schedule.run(&mut world);
@@ -743,9 +774,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // `resource_exists_and_equals` will only return true
     ///     // if the given resource exists and equals the given value
     ///     my_system.run_if(resource_exists_and_equals(Counter(0))),
@@ -754,6 +786,8 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been added so `my_system` can't run
     /// schedule.run(&mut world);
@@ -790,9 +824,10 @@ pub mod common_conditions {
     /// # struct Counter(i16);
     /// # #[derive(Resource)]
     /// # struct ShouldRun(String);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // `resource_exists_and` will only return true
     ///     // if the given resource exists and satisfies the given condition
     ///     increment.run_if(resource_exists_and(|should_run: &ShouldRun| should_run.0.is_ascii())),
@@ -803,6 +838,8 @@ pub mod common_conditions {
     /// }
     ///
     /// world.insert_resource(Counter(0));
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `ShouldRun` hasn't been added, so `increment` can't run
     /// schedule.run(&mut world);
@@ -840,9 +877,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // `resource_added` will only return true if the
     ///     // given resource was just added
     ///     my_system.run_if(resource_added::<Counter>),
@@ -853,6 +891,8 @@ pub mod common_conditions {
     /// }
     ///
     /// world.init_resource::<Counter>();
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` was just added so `my_system` will run
     /// schedule.run(&mut world);
@@ -889,10 +929,11 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // `resource_changed` will only return true if the
     ///     // given resource was just changed (or added)
     ///     my_system.run_if(
@@ -907,6 +948,8 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
     /// schedule.run(&mut world);
@@ -940,9 +983,10 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // `resource_exists_and_changed` will only return true if the
     ///     // given resource exists and was just changed (or added)
     ///     my_system.run_if(
@@ -957,6 +1001,8 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` doesn't exist so `my_system` won't run
     /// schedule.run(&mut world);
@@ -997,10 +1043,11 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // `resource_changed_or_removed` will only return true if the
     ///     // given resource was just changed or removed (or added)
     ///     my_system.run_if(
@@ -1023,6 +1070,8 @@ pub mod common_conditions {
     ///         commands.init_resource::<MyResource>();
     ///     }
     /// }
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `Counter` hasn't been changed so `my_system` won't run
     /// schedule.run(&mut world);
@@ -1064,10 +1113,11 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // `resource_removed` will only return true if the
     ///     // given resource was just removed
     ///     my_system.run_if(resource_removed::<MyResource>),
@@ -1081,6 +1131,8 @@ pub mod common_conditions {
     /// }
     ///
     /// world.init_resource::<MyResource>();
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `MyResource` hasn't just been removed so `my_system` won't run
     /// schedule.run(&mut world);
@@ -1118,13 +1170,14 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// # world.init_resource::<Messages<MyMessage>>();
-    /// # schedule.add_systems(bevy_ecs::message::message_update_system.before(my_system));
+    /// # schedules.add_systems(Update, bevy_ecs::message::message_update_system.before(my_system));
     ///
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     my_system.run_if(on_message::<MyMessage>),
     /// );
     ///
@@ -1134,6 +1187,8 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // No new `MyMessage` messages have been pushed so `my_system` won't run
     /// schedule.run(&mut world);
@@ -1168,10 +1223,11 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     my_system.run_if(any_with_component::<MyComponent>),
     /// );
     ///
@@ -1181,6 +1237,8 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // No entities exist yet with a `MyComponent` component so `my_system` won't run
     /// schedule.run(&mut world);
@@ -1227,15 +1285,18 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     // `not` will inverse any condition you pass in.
     ///     // Since the condition we choose always returns true
     ///     // this system will never run
     ///     my_system.run_if(not(always)),
     /// );
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
@@ -1268,10 +1329,11 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     my_system.run_if(condition_changed(resource_exists::<MyResource>)),
     /// );
     ///
@@ -1281,6 +1343,8 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);
@@ -1319,10 +1383,11 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedules = Schedules::default();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
-    /// schedule.add_systems(
+    /// schedules.add_systems(
+    ///     Update,
     ///     my_system.run_if(condition_changed_to(true, resource_exists::<MyResource>)),
     /// );
     ///
@@ -1332,6 +1397,8 @@ pub mod common_conditions {
     /// fn my_system(mut counter: ResMut<Counter>) {
     ///     counter.0 += 1;
     /// }
+    ///
+    /// let schedule = schedules.get_mut(Update).unwrap();
     ///
     /// // `MyResource` is initially there, the inner condition is true, the system runs once
     /// world.insert_resource(MyResource);


### PR DESCRIPTION
# Objective

A variable named `app` calling `add_system` is potentially confusing since the variable is actually of type `Schedule`, and thus doesn't specify a schedule in the call.

Fixes #11814
Alternative to #11815

## Solution

Rename app to schedule to match the actual type being used.

## Alternatives

- Introduce a mock `ScheduleLabel` for each non `compile_fail` doc example, and mock `app.add_systems` with it.
- Do nothing. It's not all that confusing and I think only people looking closely at it will be confused by the lack of a schedule parameter.