### PR TITLE
Add color wheel widgets to bevy_feathers

### DIFF
--- a/crates/bevy_feathers/src/assets/shaders/color_triangle.wgsl
+++ b/crates/bevy_feathers/src/assets/shaders/color_triangle.wgsl
@@ -1,0 +1,94 @@
+// This shader draws a hue ring and an inner whiteness/blackness triangle.
+#import bevy_ui::ui_vertex_output::UiVertexOutput
+#import bevy_render::color_operations::{
+    hwb_to_linear_rgb,
+}
+#import bevy_render::maths::PI_2
+
+/// Constants must be the same as in color_triangle.rs
+const RING_WIDTH: f32 = 12.0;
+const SPACING: f32 = 4.0;
+const MIN_HEIGHT: f32 = 100.0;
+const PADDING: f32 = 4.0;
+const MIN_DIAMETER: f32 = MIN_HEIGHT - 2.0 * PADDING;
+
+struct ColorPlaneUniform {
+  // Hue in degrees, in the range [0, 360).
+  hue : f32,
+#ifdef SIXTEEN_BYTE_ALIGNMENT
+  _webgl2_padding_12b : vec3<f32>,
+#endif
+}
+
+@group(1) @binding(0) var<uniform> uniform_data : ColorPlaneUniform;
+
+// 2d cross product
+fn cross_2d(a: vec2<f32>, b: vec2<f32>) -> f32 {
+    return a.x * b.y - a.y * b.x;
+}
+
+// Line distance for triangle SDF, positive on left
+fn line_distance(p: vec2<f32>, a: vec2<f32>, b: vec2<f32>) -> f32 {
+    return cross_2d(b - a, p - a) / distance(a, b);
+}
+
+@fragment
+fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
+    let min_side = max(min(in.size.x, in.size.y), MIN_DIAMETER);
+    let diameters = min_side / in.size;
+    // UV space is from -0.5 to 0.5
+    let centered = (in.uv - vec2(0.5)) / diameters;
+    let radial = length(centered);
+    let aa = fwidth(radial);
+
+    let inner_radius = 0.5 - RING_WIDTH / min_side;
+    let ring_hue = fract(atan2(centered.y, centered.x) / PI_2);
+    let ring_alpha = smoothstep(inner_radius - aa, inner_radius, radial)
+        - smoothstep(0.5 - aa, 0.5, radial);
+
+    let triangle_radius = 0.5 - (RING_WIDTH + 2.0 * SPACING) / min_side;
+    let triangle_hue = fract(uniform_data.hue / 360.0);
+    let hue_angle = radians(uniform_data.hue);
+    let white_angle = hue_angle + PI_2 / 3.0;
+    let black_angle = hue_angle - PI_2 / 3.0;
+    let hue_point = vec2(cos(hue_angle), sin(hue_angle)) * triangle_radius;
+    let white_point = vec2(cos(white_angle), sin(white_angle)) * triangle_radius;
+    let black_point = vec2(cos(black_angle), sin(black_angle)) * triangle_radius;
+
+    // Calculate WB values
+    let area = cross_2d(white_point - hue_point, black_point - hue_point);
+    var whiteness = cross_2d(centered - hue_point, black_point - hue_point) / area;
+    var blackness = cross_2d(white_point - hue_point, centered - hue_point) / area;
+
+    // Clamp pixels outside triangle, for antialiasing
+    whiteness = clamp(whiteness, 0.0, 1.0);
+    blackness = clamp(blackness, 0.0, 1.0);
+    let wb = whiteness + blackness;
+    if wb > 1.0 {
+        whiteness /= wb;
+        blackness /= wb;
+    }
+
+    // Triangle SDF, winding counterclockwise, positive inside
+    let triangle_sd = min(
+        line_distance(centered, hue_point, white_point),
+        min(
+            line_distance(centered, white_point, black_point),
+            line_distance(centered, black_point, hue_point),
+        ),
+    );
+    let triangle_aa = fwidth(triangle_sd);
+    let triangle_alpha = smoothstep(-triangle_aa, 0.0, triangle_sd);
+
+    let alpha = min(ring_alpha + triangle_alpha, 1.0);
+
+#ifdef TRIANGLE_HWB
+    let ring_color = hwb_to_linear_rgb(vec3(ring_hue, 0.0, 0.0));
+    let triangle_color = hwb_to_linear_rgb(vec3(triangle_hue, whiteness, blackness));
+    let color = (ring_color * ring_alpha + triangle_color * triangle_alpha) / max(alpha, 0.001);
+    return vec4(color, alpha);
+#else
+    // Error color
+    return vec4(1.0, 0.0, 1.0, alpha);
+#endif
+}

--- a/crates/bevy_feathers/src/assets/shaders/color_triangle.wgsl
+++ b/crates/bevy_feathers/src/assets/shaders/color_triangle.wgsl
@@ -5,7 +5,7 @@
 }
 #import bevy_render::maths::PI_2
 
-/// Constants must be the same as in color_triangle.rs
+/// Constants must be the same as in `color_triangle.rs`
 const RING_WIDTH: f32 = 12.0;
 const SPACING: f32 = 4.0;
 const MIN_HEIGHT: f32 = 100.0;

--- a/crates/bevy_feathers/src/assets/shaders/color_wheel.wgsl
+++ b/crates/bevy_feathers/src/assets/shaders/color_wheel.wgsl
@@ -1,0 +1,41 @@
+// This shader draws the color wheel in various color spaces.
+#import bevy_ui::ui_vertex_output::UiVertexOutput
+#import bevy_render::color_operations::{
+    hsv_to_linear_rgb,
+    hsl_to_linear_rgb,
+}
+#import bevy_render::maths::PI_2
+
+struct ColorPlaneUniform {
+  fixed_channel : f32,
+#ifdef SIXTEEN_BYTE_ALIGNMENT
+  _webgl2_padding_12b : vec3<f32>,
+#endif
+}
+
+@group(1) @binding(0) var<uniform> uniform_data : ColorPlaneUniform;
+
+@fragment
+fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
+    let min_side = min(in.size.x, in.size.y);
+    let diameters = min_side / in.size;
+    // UV space is from -0.5 to 0.5
+    let centered = (in.uv - vec2(0.5)) / diameters;
+    let radial = length(centered);
+
+    let hue = fract(atan2(centered.y, centered.x) / PI_2);
+    let saturation = radial * 2.0;
+    let hsx = vec3(hue, saturation, uniform_data.fixed_channel);
+
+    let aa = fwidth(radial);
+    let alpha = 1.0 - smoothstep(0.5 - aa, 0.5, radial);
+
+#ifdef WHEEL_HSL
+    return vec4(hsl_to_linear_rgb(hsx), alpha);
+#else ifdef WHEEL_HSV
+    return vec4(hsv_to_linear_rgb(hsx), alpha);
+#else
+    // Error color
+    return vec4(1.0, 0.0, 1.0, alpha);
+#endif
+}

--- a/crates/bevy_feathers/src/controls/color_triangle.rs
+++ b/crates/bevy_feathers/src/controls/color_triangle.rs
@@ -1,0 +1,614 @@
+use core::f32::consts::TAU;
+
+use bevy_app::{Plugin, PostUpdate};
+use bevy_asset::{Asset, Assets};
+use bevy_ecs::{
+    change_detection::{DetectChanges, Ref},
+    component::Component,
+    entity::Entity,
+    hierarchy::{ChildOf, Children},
+    observer::On,
+    query::{Has, With},
+    reflect::ReflectComponent,
+    schedule::IntoScheduleConfigs,
+    system::{Commands, Query, Res, ResMut},
+    template::FromTemplate,
+};
+use bevy_math::Vec2;
+use bevy_picking::{
+    events::{Cancel, Drag, DragEnd, DragStart, Pointer, Press},
+    Pickable,
+};
+use bevy_reflect::{prelude::ReflectDefault, Reflect, TypePath};
+use bevy_render::render_resource::AsBindGroup;
+use bevy_scene::prelude::*;
+use bevy_shader::{ShaderDefVal, ShaderRef};
+use bevy_ui::{
+    percent, px, AlignSelf, BorderColor, BorderRadius, ComputedNode, ComputedUiRenderTargetInfo,
+    Display, InteractionDisabled, Node, Outline, PositionType, UiGlobalTransform, UiRect, UiScale,
+    UiSystems, UiTransform, Val2,
+};
+use bevy_ui_render::{prelude::UiMaterial, ui_material::MaterialNode, UiMaterialPlugin};
+use bevy_ui_widgets::ValueChange;
+
+use crate::{cursor::EntityCursor, palette, theme::ThemeBackgroundColor, tokens};
+
+/// Constants must be the same as in color_triangle.wgsl
+const RING_WIDTH: f32 = 12.0;
+const SPACING: f32 = 4.0;
+const MIN_HEIGHT: f32 = 100.0;
+const PADDING: f32 = 4.0;
+const MIN_DIAMETER: f32 = MIN_HEIGHT - 2.0 * PADDING;
+
+/// A "color triangle" widget, which is a 2d picker that allows selecting all three components of
+/// a HWB color space. It consists of a hue ring surrounding a triangle where the corners are max
+/// whiteness, max blackness, and zero whiteness/blackness.
+///
+/// This is spawnable by inheriting it as a "scene component".
+///
+/// The control emits a [`ValueChange<ColorTriangleValue>`] containing the hue, whiteness and
+/// blackness of the selection.
+///
+/// The control does not do any color space conversions internally, except when converting for
+/// display.
+#[derive(
+    SceneComponent, FromTemplate, Debug, Reflect, Copy, PartialEq, Eq, Hash, Default, Clone,
+)]
+#[reflect(Component)]
+#[require(ColorTriangleDragState)]
+pub enum FeathersColorTriangle {
+    /// Use the HWB color space.
+    #[default]
+    Hwb,
+}
+
+/// Component that contains the selected hue on the ring, and the whiteness and blackness
+/// selected within the triangle.
+///
+/// This is also emitted by [`FeathersColorTriangle`] via [`ValueChange`] when the selection
+/// changes.
+#[derive(Component, Debug, Default, Clone, Copy, PartialEq, Reflect)]
+#[reflect(Component, Clone, Default)]
+pub struct ColorTriangleValue {
+    /// Hue in degrees, in the range [0, 360).
+    pub hue: f32,
+    /// Whiteness in the range [0, 1].
+    pub whiteness: f32,
+    /// Blackness in the range [0, 1].
+    pub blackness: f32,
+}
+
+/// Marker identifying the inner element of the color triangle.
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone, Default)]
+struct ColorTriangleInner;
+
+/// Marker identifying the thumb element of the color triangle.
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone, Default)]
+struct ColorTriangleThumb;
+
+/// Marker identifying the thumb element of the ring surrounding the color triangle.
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone, Default)]
+struct ColorTriangleRingThumb;
+
+/// Component used to manage the state of a color triangle during dragging. A drag that
+/// starts in the ring only changes the hue, and a drag that starts in the triangle only
+/// changes whiteness/blackness.
+#[derive(Component, Default, Reflect)]
+#[reflect(Component)]
+struct ColorTriangleDragState {
+    /// The segment the most recent press landed in, or `None`.
+    segment: Option<ColorTriangleSegment>,
+    /// Whether a drag is in progress.
+    dragging: bool,
+}
+
+/// The part of the widget a press or drag interacts with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect)]
+enum ColorTriangleSegment {
+    Ring,
+    Triangle,
+}
+
+#[repr(C)]
+#[derive(Eq, PartialEq, Hash, Copy, Clone)]
+struct ColorTriangleMaterialKey {
+    triangle: FeathersColorTriangle,
+}
+
+#[derive(AsBindGroup, Asset, TypePath, Default, Debug, Clone)]
+#[bind_group_data(ColorTriangleMaterialKey)]
+struct ColorTriangleMaterial {
+    triangle: FeathersColorTriangle,
+
+    #[uniform(0)]
+    hue: f32,
+
+    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+    #[uniform(0)]
+    _webgl2_padding_12b: bevy_math::Vec3,
+}
+
+impl From<&ColorTriangleMaterial> for ColorTriangleMaterialKey {
+    fn from(material: &ColorTriangleMaterial) -> Self {
+        Self {
+            triangle: material.triangle,
+        }
+    }
+}
+
+impl UiMaterial for ColorTriangleMaterial {
+    fn fragment_shader() -> ShaderRef {
+        "embedded://bevy_feathers/assets/shaders/color_triangle.wgsl".into()
+    }
+
+    fn specialize(
+        descriptor: &mut bevy_render::render_resource::RenderPipelineDescriptor,
+        key: bevy_ui_render::prelude::UiMaterialKey<Self>,
+    ) {
+        let triangle_def = match key.bind_group_data.triangle {
+            FeathersColorTriangle::Hwb => "TRIANGLE_HWB",
+        };
+        descriptor.fragment.as_mut().unwrap().shader_defs =
+            vec![ShaderDefVal::Bool(triangle_def.into(), true)];
+    }
+}
+
+impl FeathersColorTriangle {
+    fn scene() -> impl Scene {
+        bsn! {
+            Node {
+                display: Display::Flex,
+                min_height: px(MIN_HEIGHT),
+                aspect_ratio: 1.0f32,
+                flex_grow: 0.,
+                flex_shrink: 1.,
+                align_self: AlignSelf::FlexStart,
+                padding: UiRect::all(px(PADDING)),
+                border_radius: BorderRadius::all(percent(50)),
+            }
+            ColorTriangleValue
+            ThemeBackgroundColor(tokens::COLOR_PLANE_BG)
+            EntityCursor::System(bevy_window::SystemCursorIcon::Crosshair)
+            Children [(
+                Node {
+                    align_self: AlignSelf::Stretch,
+                    flex_grow: 1.0,
+                }
+                ColorTriangleInner
+                Children [
+                    (
+                        Node {
+                            position_type: PositionType::Absolute,
+                            left: percent(0),
+                            top: percent(0),
+                            width: px(10),
+                            height: px(10),
+                            border: px(1),
+                            border_radius: BorderRadius::MAX,
+                        }
+                        ColorTriangleThumb
+                        BorderColor::all(palette::WHITE)
+                        Outline {
+                            width: px(1),
+                            offset: px(0),
+                            color: palette::BLACK
+                        }
+                        Pickable::IGNORE
+                        UiTransform::from_translation(Val2::percent(-50., -50.),)
+                    ),
+                    (
+                        Node {
+                            position_type: PositionType::Absolute,
+                            left: percent(0),
+                            top: percent(0),
+                            width: px(10),
+                            height: px(10),
+                            border: px(1),
+                            border_radius: BorderRadius::MAX,
+                        }
+                        ColorTriangleRingThumb
+                        BorderColor::all(palette::WHITE)
+                        Outline {
+                            width: px(1),
+                            offset: px(0),
+                            color: palette::BLACK
+                        }
+                        Pickable::IGNORE
+                        UiTransform::from_translation(Val2::percent(-50., -50.),)
+                    )
+                ]
+            )]
+        }
+    }
+}
+
+/// Positions of the triangle's corners for a given hue, relative to the center.
+fn triangle_corners(hue_angle: f32, triangle_radius: f32) -> (Vec2, Vec2, Vec2) {
+    (
+        Vec2::from_angle(hue_angle) * triangle_radius,
+        Vec2::from_angle(hue_angle + TAU / 3.0) * triangle_radius,
+        Vec2::from_angle(hue_angle - TAU / 3.0) * triangle_radius,
+    )
+}
+
+fn update_triangle_color(
+    q_color_triangle: Query<(Entity, Ref<FeathersColorTriangle>, Ref<ColorTriangleValue>)>,
+    q_children: Query<&Children>,
+    q_material_node: Query<&MaterialNode<ColorTriangleMaterial>>,
+    q_computed_node: Query<Ref<ComputedNode>>,
+    mut q_node: Query<&mut Node>,
+    mut r_materials: ResMut<Assets<ColorTriangleMaterial>>,
+    mut commands: Commands,
+) {
+    for (triangle_ent, triangle, triangle_value) in q_color_triangle.iter() {
+        // Find the inner entity
+        let Ok(children) = q_children.get(triangle_ent) else {
+            continue;
+        };
+        let Some(inner_ent) = children.first() else {
+            continue;
+        };
+
+        let value_changed = triangle.is_changed() || triangle_value.is_changed();
+
+        if let Ok(material_node) = q_material_node.get(*inner_ent) {
+            // Node component exists, update it
+            if value_changed && let Some(mut material) = r_materials.get_mut(material_node.id()) {
+                // Update properties
+                material.triangle = *triangle;
+                material.hue = triangle_value.hue;
+            }
+        } else {
+            // Insert new node component
+            let material = r_materials.add(ColorTriangleMaterial {
+                triangle: *triangle,
+                hue: triangle_value.hue,
+                #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+                _webgl2_padding_12b: Default::default(),
+            });
+            commands.entity(*inner_ent).insert(MaterialNode(material));
+        }
+
+        // The thumb positions depend on the inner node's layout size, so they also must be
+        // refreshed when the node is resized, not just when the value changes.
+        let Ok(inner_node) = q_computed_node.get(*inner_ent) else {
+            continue;
+        };
+        if !value_changed && !inner_node.is_changed() {
+            continue;
+        }
+
+        // Find the triangle thumb.
+        let Ok(children_inner) = q_children.get(*inner_ent) else {
+            continue;
+        };
+        let Some(thumb_ent) = children_inner.first() else {
+            continue;
+        };
+
+        let Ok(mut thumb_node) = q_node.get_mut(*thumb_ent) else {
+            continue;
+        };
+
+        // Ensure square aspect ratio.
+        let min_side = inner_node.size().min_element();
+        if min_side <= 0.0 {
+            continue;
+        }
+        let min_side = min_side.max(MIN_DIAMETER);
+        let scale = inner_node.inverse_scale_factor();
+        let center = inner_node.size() * scale * 0.5;
+
+        // Position the triangle thumb relative to the corners.
+        let hue_angle = triangle_value.hue.to_radians();
+        let triangle_radius = min_side * 0.5 - (RING_WIDTH + 2.0 * SPACING);
+        let (hue_point, white_point, black_point) = triangle_corners(hue_angle, triangle_radius);
+        let offset = (hue_point
+            + (white_point - hue_point) * triangle_value.whiteness
+            + (black_point - hue_point) * triangle_value.blackness)
+            * scale;
+        let left = px(center.x + offset.x);
+        let top = px(center.y + offset.y);
+        if thumb_node.left != left || thumb_node.top != top {
+            thumb_node.left = left;
+            thumb_node.top = top;
+        }
+
+        // Find the ring thumb.
+        let Some(ring_thumb_ent) = children_inner.get(1) else {
+            continue;
+        };
+
+        let Ok(mut ring_thumb_node) = q_node.get_mut(*ring_thumb_ent) else {
+            continue;
+        };
+
+        // Position ring thumb centered in the ring width and at the hue value.
+        let ring_offset = Vec2::from_angle(triangle_value.hue.to_radians())
+            * (min_side - RING_WIDTH)
+            * 0.5
+            * scale;
+        let ring_left = px(center.x + ring_offset.x);
+        let ring_top = px(center.y + ring_offset.y);
+        if ring_thumb_node.left != ring_left || ring_thumb_node.top != ring_top {
+            ring_thumb_node.left = ring_left;
+            ring_thumb_node.top = ring_top;
+        }
+    }
+}
+
+/// Determine which segment of the widget a pointer position hits, and the value the widget
+/// would take at that position.
+///
+/// When `drag_segment` is `Some`, the value is computed for that segment regardless of where
+/// the pointer is.
+fn get_segment_value(
+    current: &ColorTriangleValue,
+    node: &ComputedNode,
+    node_target: &ComputedUiRenderTargetInfo,
+    transform: &UiGlobalTransform,
+    pointer_position: Vec2,
+    ui_scale: f32,
+    drag_segment: Option<ColorTriangleSegment>,
+) -> Option<(ColorTriangleSegment, ColorTriangleValue)> {
+    let inverse_transform = transform.try_inverse()?;
+    let local = inverse_transform
+        .transform_point2(pointer_position * node_target.scale_factor() / ui_scale);
+    let min_side = node.size().min_element();
+    if min_side <= 0.0 {
+        return None;
+    }
+    let min_side = min_side.max(MIN_DIAMETER);
+    let pos = local / min_side;
+    let radial = pos.length();
+
+    let triangle_radius = 0.5 - (RING_WIDTH + 2.0 * SPACING) / min_side;
+
+    // Select segment based on distance from center, with SPACING pixels of wiggle room.
+    let spacing = SPACING / min_side;
+    let segment = if let Some(segment) = drag_segment {
+        segment
+    } else if radial <= triangle_radius + spacing {
+        ColorTriangleSegment::Triangle
+    } else if radial <= 0.5 + spacing {
+        ColorTriangleSegment::Ring
+    } else {
+        return None;
+    };
+
+    let value = match segment {
+        ColorTriangleSegment::Ring => {
+            // Keep the current hue when radial is 0.
+            if radial > 0.0 {
+                ColorTriangleValue {
+                    hue: pos.to_angle().rem_euclid(TAU).to_degrees(),
+                    ..*current
+                }
+            } else {
+                *current
+            }
+        }
+        ColorTriangleSegment::Triangle => {
+            let hue_angle = current.hue.to_radians();
+            let (hue_point, white_point, black_point) =
+                triangle_corners(hue_angle, triangle_radius);
+
+            let area = (white_point - hue_point).perp_dot(black_point - hue_point);
+            let mut whiteness = (pos - hue_point).perp_dot(black_point - hue_point) / area;
+            let mut blackness = (white_point - hue_point).perp_dot(pos - hue_point) / area;
+
+            // Clamp positions outside the triangle
+            whiteness = whiteness.clamp(0.0, 1.0);
+            blackness = blackness.clamp(0.0, 1.0);
+            let wb = whiteness + blackness;
+            if wb > 1.0 {
+                whiteness /= wb;
+                blackness /= wb;
+            }
+            ColorTriangleValue {
+                hue: current.hue,
+                whiteness,
+                blackness,
+            }
+        }
+    };
+
+    Some((segment, value))
+}
+
+fn emit_color_triangle_value_change(
+    commands: &mut Commands,
+    source: Entity,
+    value: ColorTriangleValue,
+    is_final: bool,
+) {
+    commands.trigger(ValueChange {
+        source,
+        value,
+        is_final,
+    });
+}
+
+fn on_pointer_press(
+    mut press: On<Pointer<Press>>,
+    mut q_color_triangles: Query<
+        (
+            &ColorTriangleValue,
+            &mut ColorTriangleDragState,
+            Has<InteractionDisabled>,
+        ),
+        With<FeathersColorTriangle>,
+    >,
+    q_color_triangle_inner: Query<
+        (
+            &ComputedNode,
+            &ComputedUiRenderTargetInfo,
+            &UiGlobalTransform,
+            &ChildOf,
+        ),
+        With<ColorTriangleInner>,
+    >,
+    ui_scale: Res<UiScale>,
+    mut commands: Commands,
+) {
+    if let Ok((node, node_target, transform, parent)) = q_color_triangle_inner.get(press.entity)
+        && let Ok((value, mut state, disabled)) = q_color_triangles.get_mut(parent.0)
+    {
+        press.propagate(false);
+        if !disabled {
+            let segment_value = get_segment_value(
+                value,
+                node,
+                node_target,
+                transform,
+                press.pointer_location.position,
+                ui_scale.0,
+                None,
+            );
+            state.segment = segment_value.map(|(segment, _)| segment);
+            if let Some((_, new_value)) = segment_value {
+                emit_color_triangle_value_change(&mut commands, parent.0, new_value, false);
+            }
+        }
+    }
+}
+
+fn on_drag_start(
+    mut drag_start: On<Pointer<DragStart>>,
+    mut q_color_triangles: Query<
+        (&mut ColorTriangleDragState, Has<InteractionDisabled>),
+        With<FeathersColorTriangle>,
+    >,
+    q_color_triangle_inner: Query<&ChildOf, With<ColorTriangleInner>>,
+) {
+    if let Ok(parent) = q_color_triangle_inner.get(drag_start.entity)
+        && let Ok((mut state, disabled)) = q_color_triangles.get_mut(parent.0)
+    {
+        drag_start.propagate(false);
+        if !disabled {
+            state.dragging = true;
+        }
+    }
+}
+
+fn on_drag(
+    mut drag: On<Pointer<Drag>>,
+    q_color_triangles: Query<
+        (
+            &ColorTriangleValue,
+            &ColorTriangleDragState,
+            Has<InteractionDisabled>,
+        ),
+        With<FeathersColorTriangle>,
+    >,
+    q_color_triangle_inner: Query<
+        (
+            &ComputedNode,
+            &ComputedUiRenderTargetInfo,
+            &UiGlobalTransform,
+            &ChildOf,
+        ),
+        With<ColorTriangleInner>,
+    >,
+    ui_scale: Res<UiScale>,
+    mut commands: Commands,
+) {
+    if let Ok((node, node_target, transform, parent)) = q_color_triangle_inner.get(drag.entity)
+        && let Ok((value, state, disabled)) = q_color_triangles.get(parent.0)
+    {
+        drag.propagate(false);
+        if state.dragging
+            && state.segment.is_some()
+            && !disabled
+            && let Some((_, new_value)) = get_segment_value(
+                value,
+                node,
+                node_target,
+                transform,
+                drag.pointer_location.position,
+                ui_scale.0,
+                state.segment,
+            )
+        {
+            emit_color_triangle_value_change(&mut commands, parent.0, new_value, false);
+        }
+    }
+}
+
+fn on_drag_end(
+    mut drag_end: On<Pointer<DragEnd>>,
+    mut q_color_triangles: Query<
+        (
+            &ColorTriangleValue,
+            &mut ColorTriangleDragState,
+            Has<InteractionDisabled>,
+        ),
+        With<FeathersColorTriangle>,
+    >,
+    q_color_triangle_inner: Query<
+        (
+            &ComputedNode,
+            &ComputedUiRenderTargetInfo,
+            &UiGlobalTransform,
+            &ChildOf,
+        ),
+        With<ColorTriangleInner>,
+    >,
+    ui_scale: Res<UiScale>,
+    mut commands: Commands,
+) {
+    if let Ok((node, node_target, transform, parent)) = q_color_triangle_inner.get(drag_end.entity)
+        && let Ok((value, mut state, disabled)) = q_color_triangles.get_mut(parent.0)
+    {
+        drag_end.propagate(false);
+        if state.dragging
+            && state.segment.is_some()
+            && !disabled
+            && let Some((_, new_value)) = get_segment_value(
+                value,
+                node,
+                node_target,
+                transform,
+                drag_end.pointer_location.position,
+                ui_scale.0,
+                state.segment,
+            )
+        {
+            emit_color_triangle_value_change(&mut commands, parent.0, new_value, true);
+        }
+        state.segment = None;
+        state.dragging = false;
+    }
+}
+
+fn on_drag_cancel(
+    drag_cancel: On<Pointer<Cancel>>,
+    mut q_color_triangles: Query<&mut ColorTriangleDragState, With<FeathersColorTriangle>>,
+    q_color_triangle_inner: Query<&ChildOf, With<ColorTriangleInner>>,
+) {
+    if let Ok(parent) = q_color_triangle_inner.get(drag_cancel.entity)
+        && let Ok(mut state) = q_color_triangles.get_mut(parent.0)
+    {
+        state.segment = None;
+        state.dragging = false;
+    }
+}
+
+/// Plugin which registers the observers for updating the triangle color.
+pub struct ColorTrianglePlugin;
+
+impl Plugin for ColorTrianglePlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        app.add_plugins(UiMaterialPlugin::<ColorTriangleMaterial>::default());
+        // Ensure thumbs stay inside ring/triangle on next frame when layout changes
+        app.add_systems(PostUpdate, update_triangle_color.before(UiSystems::Layout));
+        app.add_observer(on_pointer_press)
+            .add_observer(on_drag_start)
+            .add_observer(on_drag)
+            .add_observer(on_drag_end)
+            .add_observer(on_drag_cancel);
+    }
+}

--- a/crates/bevy_feathers/src/controls/color_triangle.rs
+++ b/crates/bevy_feathers/src/controls/color_triangle.rs
@@ -33,7 +33,7 @@ use bevy_ui_widgets::ValueChange;
 
 use crate::{cursor::EntityCursor, palette, theme::ThemeBackgroundColor, tokens};
 
-/// Constants must be the same as in color_triangle.wgsl
+/// Constants must be the same as in `color_triangle.wgsl`
 const RING_WIDTH: f32 = 12.0;
 const SPACING: f32 = 4.0;
 const MIN_HEIGHT: f32 = 100.0;
@@ -46,8 +46,8 @@ const MIN_DIAMETER: f32 = MIN_HEIGHT - 2.0 * PADDING;
 ///
 /// This is spawnable by inheriting it as a "scene component".
 ///
-/// The control emits a [`ValueChange<ColorTriangleValue>`] containing the hue, whiteness and
-/// blackness of the selection.
+/// The control emits a [`ValueChange<ColorTriangleValue>`] containing the `hue`, `whiteness` and
+/// `blackness` of the selection.
 ///
 /// The control does not do any color space conversions internally, except when converting for
 /// display.
@@ -62,7 +62,7 @@ pub enum FeathersColorTriangle {
     Hwb,
 }
 
-/// Component that contains the selected hue on the ring, and the whiteness and blackness
+/// Component that contains the selected `hue` on the ring, and the `whiteness` and `blackness`
 /// selected within the triangle.
 ///
 /// This is also emitted by [`FeathersColorTriangle`] via [`ValueChange`] when the selection

--- a/crates/bevy_feathers/src/controls/color_wheel.rs
+++ b/crates/bevy_feathers/src/controls/color_wheel.rs
@@ -1,0 +1,486 @@
+use core::f32::consts::TAU;
+
+use bevy_app::{Plugin, PostUpdate};
+use bevy_asset::{Asset, Assets};
+use bevy_ecs::{
+    change_detection::{DetectChanges, Ref},
+    component::Component,
+    entity::Entity,
+    hierarchy::{ChildOf, Children},
+    observer::On,
+    query::{Has, With},
+    reflect::ReflectComponent,
+    schedule::IntoScheduleConfigs,
+    system::{Commands, Query, Res, ResMut},
+    template::FromTemplate,
+};
+use bevy_math::Vec2;
+use bevy_picking::{
+    events::{Cancel, Drag, DragEnd, DragStart, Pointer, Press},
+    Pickable,
+};
+use bevy_reflect::{prelude::ReflectDefault, Reflect, TypePath};
+use bevy_render::render_resource::AsBindGroup;
+use bevy_scene::prelude::*;
+use bevy_shader::{ShaderDefVal, ShaderRef};
+use bevy_ui::{
+    percent, px, AlignSelf, BorderColor, BorderRadius, ComputedNode, ComputedUiRenderTargetInfo,
+    Display, InteractionDisabled, Node, Outline, PositionType, UiGlobalTransform, UiRect, UiScale,
+    UiSystems, UiTransform, Val2,
+};
+use bevy_ui_render::{prelude::UiMaterial, ui_material::MaterialNode, UiMaterialPlugin};
+use bevy_ui_widgets::ValueChange;
+
+use crate::{cursor::EntityCursor, palette, theme::ThemeBackgroundColor, tokens};
+
+/// A "color wheel" widget, which is a circular 2d picker that allows selecting two
+/// components of a cylindrical color space.
+///
+/// This is spawnable by inheriting it as a "scene component".
+///
+/// The control emits a [`ValueChange<ColorWheelValue>`] containing the `hue` and `saturation` of
+/// the selected position within the wheel, along with the current fixed channel value. The
+/// control accepts a [`ColorWheelValue`] input value, whose `z` component provides the fixed
+/// constant channel for the background gradient.
+///
+/// The control does not do any color space conversions internally, except when converting to
+/// orthogonal coordinates for display.
+#[derive(
+    SceneComponent, FromTemplate, Debug, Reflect, Copy, PartialEq, Eq, Hash, Default, Clone,
+)]
+#[reflect(Component)]
+#[require(ColorWheelDragState)]
+pub enum FeathersColorWheel {
+    /// Use the HSV color space.
+    #[default]
+    Hsv,
+    /// Use the HSL color space.
+    Hsl,
+}
+
+/// Component that contains the selected position within the wheel in polar form, as well as
+/// the `z` value. The `hue` and `saturation` determine the placement of the thumb element,
+/// while the `z` value controls the background gradient. In the cylindrical color space, `z` is
+/// the position along the cylinder's axis (e.g. lightness or value).
+///
+/// This is also emitted by [`FeathersColorWheel`] via [`ValueChange`] when the selection
+/// changes.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Reflect)]
+#[reflect(Component, Clone, Default)]
+pub struct ColorWheelValue {
+    /// Hue in degrees, in the range [0, 360).
+    pub hue: f32,
+    /// Saturation in the range [0, 1].
+    pub saturation: f32,
+    /// The fixed channel value in the range [0, 1].
+    pub z: f32,
+}
+
+// Sensible default, particularly important for HSL spaces
+impl Default for ColorWheelValue {
+    fn default() -> ColorWheelValue {
+        ColorWheelValue {
+            hue: 0.,
+            saturation: 0.,
+            z: 0.5,
+        }
+    }
+}
+
+/// Marker identifying the inner element of the color wheel.
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone, Default)]
+struct ColorWheelInner;
+
+/// Marker identifying the thumb element of the color wheel.
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone, Default)]
+struct ColorWheelThumb;
+
+/// Component used to manage the state of a color wheel during dragging.
+#[derive(Component, Default, Reflect)]
+#[reflect(Component)]
+struct ColorWheelDragState(bool);
+
+#[repr(C)]
+#[derive(Eq, PartialEq, Hash, Copy, Clone)]
+struct ColorWheelMaterialKey {
+    wheel: FeathersColorWheel,
+}
+
+#[derive(AsBindGroup, Asset, TypePath, Default, Debug, Clone)]
+#[bind_group_data(ColorWheelMaterialKey)]
+struct ColorWheelMaterial {
+    wheel: FeathersColorWheel,
+
+    #[uniform(0)]
+    fixed_channel: f32,
+
+    #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+    #[uniform(0)]
+    _webgl2_padding_12b: bevy_math::Vec3,
+}
+
+impl From<&ColorWheelMaterial> for ColorWheelMaterialKey {
+    fn from(material: &ColorWheelMaterial) -> Self {
+        Self {
+            wheel: material.wheel,
+        }
+    }
+}
+
+impl UiMaterial for ColorWheelMaterial {
+    fn fragment_shader() -> ShaderRef {
+        "embedded://bevy_feathers/assets/shaders/color_wheel.wgsl".into()
+    }
+
+    fn specialize(
+        descriptor: &mut bevy_render::render_resource::RenderPipelineDescriptor,
+        key: bevy_ui_render::prelude::UiMaterialKey<Self>,
+    ) {
+        let wheel_def = match key.bind_group_data.wheel {
+            FeathersColorWheel::Hsv => "WHEEL_HSV",
+            FeathersColorWheel::Hsl => "WHEEL_HSL",
+        };
+        descriptor.fragment.as_mut().unwrap().shader_defs =
+            vec![ShaderDefVal::Bool(wheel_def.into(), true)];
+    }
+}
+
+impl FeathersColorWheel {
+    fn scene() -> impl Scene {
+        bsn! {
+            Node {
+                display: Display::Flex,
+                min_height: px(100.0),
+                aspect_ratio: 1.0f32,
+                flex_grow: 0.,
+                flex_shrink: 1.,
+                align_self: AlignSelf::FlexStart,
+                padding: UiRect::all(px(4)),
+                border_radius: BorderRadius::all(percent(50)),
+            }
+            ColorWheelValue
+            ThemeBackgroundColor(tokens::COLOR_PLANE_BG)
+            EntityCursor::System(bevy_window::SystemCursorIcon::Crosshair)
+            Children [(
+                Node {
+                    align_self: AlignSelf::Stretch,
+                    flex_grow: 1.0,
+                }
+                ColorWheelInner
+                Children [(
+                    Node {
+                        position_type: PositionType::Absolute,
+                        left: percent(0),
+                        top: percent(0),
+                        width: px(10),
+                        height: px(10),
+                        border: px(1),
+                        border_radius: BorderRadius::MAX,
+                    }
+                    ColorWheelThumb
+                    BorderColor::all(palette::WHITE)
+                    Outline {
+                        width: px(1),
+                        offset: px(0),
+                        color: palette::BLACK
+                    }
+                    Pickable::IGNORE
+                    UiTransform::from_translation(Val2::percent(-50., -50.),)
+                )]
+            )]
+        }
+    }
+}
+
+fn update_wheel_color(
+    q_color_wheel: Query<(Entity, Ref<FeathersColorWheel>, Ref<ColorWheelValue>)>,
+    q_children: Query<&Children>,
+    q_material_node: Query<&MaterialNode<ColorWheelMaterial>>,
+    q_computed_node: Query<Ref<ComputedNode>>,
+    mut q_node: Query<&mut Node>,
+    mut r_materials: ResMut<Assets<ColorWheelMaterial>>,
+    mut commands: Commands,
+) {
+    for (wheel_ent, wheel, wheel_value) in q_color_wheel.iter() {
+        // Find the inner entity
+        let Ok(children) = q_children.get(wheel_ent) else {
+            continue;
+        };
+        let Some(inner_ent) = children.first() else {
+            continue;
+        };
+
+        let value_changed = wheel.is_changed() || wheel_value.is_changed();
+
+        if let Ok(material_node) = q_material_node.get(*inner_ent) {
+            // Node component exists, update it
+            if value_changed && let Some(mut material) = r_materials.get_mut(material_node.id()) {
+                // Update properties
+                material.wheel = *wheel;
+                material.fixed_channel = wheel_value.z;
+            }
+        } else {
+            // Insert new node component
+            let material = r_materials.add(ColorWheelMaterial {
+                wheel: *wheel,
+                fixed_channel: wheel_value.z,
+                #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
+                _webgl2_padding_12b: Default::default(),
+            });
+            commands.entity(*inner_ent).insert(MaterialNode(material));
+        }
+
+        // The thumb position depends on the inner node's layout size, so it also must be
+        // refreshed when the node is resized, not just when the value changes.
+        let Ok(inner_node) = q_computed_node.get(*inner_ent) else {
+            continue;
+        };
+        if !value_changed && !inner_node.is_changed() {
+            continue;
+        }
+
+        // Find the thumb.
+        let Ok(children_inner) = q_children.get(*inner_ent) else {
+            continue;
+        };
+        let Some(thumb_ent) = children_inner.first() else {
+            continue;
+        };
+
+        let Ok(mut thumb_node) = q_node.get_mut(*thumb_ent) else {
+            continue;
+        };
+
+        // Ensure thumb is in the wheel even when aspect_ratio fails
+        let size = inner_node.size() * inner_node.inverse_scale_factor();
+        let min_side = size.min_element();
+        let offset = Vec2::from_angle(wheel_value.hue.to_radians())
+            * (wheel_value.saturation.clamp(0.0, 1.0) * 0.5 * min_side);
+        let left = px(size.x * 0.5 + offset.x);
+        let top = px(size.y * 0.5 + offset.y);
+        if thumb_node.left != left || thumb_node.top != top {
+            thumb_node.left = left;
+            thumb_node.top = top;
+        }
+    }
+}
+
+fn emit_color_wheel_value_change(
+    commands: &mut Commands,
+    source: Entity,
+    current: &ColorWheelValue,
+    node: &ComputedNode,
+    node_target: &ComputedUiRenderTargetInfo,
+    transform: &UiGlobalTransform,
+    pointer_position: Vec2,
+    ui_scale: f32,
+    is_final: bool,
+    dragging: bool,
+) {
+    // Ensure press is in the wheel even when aspect_ratio fails
+    let Some(inverse_transform) = transform.try_inverse() else {
+        return;
+    };
+    let local = inverse_transform
+        .transform_point2(pointer_position * node_target.scale_factor() / ui_scale);
+    let min_side = node.size().min_element();
+    if min_side <= 0.0 {
+        return;
+    }
+    let pos = local / min_side;
+    let radial = pos.length();
+
+    // Ignore presses outside wheel
+    if radial > 0.5 && !dragging {
+        return;
+    }
+    let saturation = (radial * 2.0).clamp(0.0, 1.0);
+
+    // Keep the current hue when radial is 0
+    let hue = if radial > 0.0 {
+        pos.to_angle().rem_euclid(TAU).to_degrees()
+    } else {
+        current.hue
+    };
+
+    commands.trigger(ValueChange {
+        source,
+        value: ColorWheelValue {
+            hue,
+            saturation,
+            z: current.z,
+        },
+        is_final,
+    });
+}
+
+fn on_pointer_press(
+    mut press: On<Pointer<Press>>,
+    q_color_wheels: Query<(&ColorWheelValue, Has<InteractionDisabled>), With<FeathersColorWheel>>,
+    q_color_wheel_inner: Query<
+        (
+            &ComputedNode,
+            &ComputedUiRenderTargetInfo,
+            &UiGlobalTransform,
+            &ChildOf,
+        ),
+        With<ColorWheelInner>,
+    >,
+    ui_scale: Res<UiScale>,
+    mut commands: Commands,
+) {
+    if let Ok((node, node_target, transform, parent)) = q_color_wheel_inner.get(press.entity)
+        && let Ok((value, disabled)) = q_color_wheels.get(parent.0)
+    {
+        press.propagate(false);
+        if !disabled {
+            emit_color_wheel_value_change(
+                &mut commands,
+                parent.0,
+                value,
+                node,
+                node_target,
+                transform,
+                press.pointer_location.position,
+                ui_scale.0,
+                false,
+                false,
+            );
+        }
+    }
+}
+
+fn on_drag_start(
+    mut drag_start: On<Pointer<DragStart>>,
+    mut q_color_wheels: Query<
+        (&mut ColorWheelDragState, Has<InteractionDisabled>),
+        With<FeathersColorWheel>,
+    >,
+    q_color_wheel_inner: Query<&ChildOf, With<ColorWheelInner>>,
+) {
+    if let Ok(parent) = q_color_wheel_inner.get(drag_start.entity)
+        && let Ok((mut state, disabled)) = q_color_wheels.get_mut(parent.0)
+    {
+        drag_start.propagate(false);
+        if !disabled {
+            state.0 = true;
+        }
+    }
+}
+
+fn on_drag(
+    mut drag: On<Pointer<Drag>>,
+    q_color_wheels: Query<
+        (
+            &ColorWheelValue,
+            &ColorWheelDragState,
+            Has<InteractionDisabled>,
+        ),
+        With<FeathersColorWheel>,
+    >,
+    q_color_wheel_inner: Query<
+        (
+            &ComputedNode,
+            &ComputedUiRenderTargetInfo,
+            &UiGlobalTransform,
+            &ChildOf,
+        ),
+        With<ColorWheelInner>,
+    >,
+    ui_scale: Res<UiScale>,
+    mut commands: Commands,
+) {
+    if let Ok((node, node_target, transform, parent)) = q_color_wheel_inner.get(drag.entity)
+        && let Ok((value, state, disabled)) = q_color_wheels.get(parent.0)
+    {
+        drag.propagate(false);
+        if state.0 && !disabled {
+            emit_color_wheel_value_change(
+                &mut commands,
+                parent.0,
+                value,
+                node,
+                node_target,
+                transform,
+                drag.pointer_location.position,
+                ui_scale.0,
+                false,
+                true,
+            );
+        }
+    }
+}
+
+fn on_drag_end(
+    mut drag_end: On<Pointer<DragEnd>>,
+    mut q_color_wheels: Query<
+        (
+            &ColorWheelValue,
+            &mut ColorWheelDragState,
+            Has<InteractionDisabled>,
+        ),
+        With<FeathersColorWheel>,
+    >,
+    q_color_wheel_inner: Query<
+        (
+            &ComputedNode,
+            &ComputedUiRenderTargetInfo,
+            &UiGlobalTransform,
+            &ChildOf,
+        ),
+        With<ColorWheelInner>,
+    >,
+    ui_scale: Res<UiScale>,
+    mut commands: Commands,
+) {
+    if let Ok((node, node_target, transform, parent)) = q_color_wheel_inner.get(drag_end.entity)
+        && let Ok((value, mut state, disabled)) = q_color_wheels.get_mut(parent.0)
+    {
+        drag_end.propagate(false);
+        if state.0 && !disabled {
+            emit_color_wheel_value_change(
+                &mut commands,
+                parent.0,
+                value,
+                node,
+                node_target,
+                transform,
+                drag_end.pointer_location.position,
+                ui_scale.0,
+                true,
+                true,
+            );
+        }
+        state.0 = false;
+    }
+}
+
+fn on_drag_cancel(
+    drag_cancel: On<Pointer<Cancel>>,
+    mut q_color_wheels: Query<&mut ColorWheelDragState, With<FeathersColorWheel>>,
+    q_color_wheel_inner: Query<&ChildOf, With<ColorWheelInner>>,
+) {
+    if let Ok(parent) = q_color_wheel_inner.get(drag_cancel.entity)
+        && let Ok(mut state) = q_color_wheels.get_mut(parent.0)
+    {
+        state.0 = false;
+    }
+}
+
+/// Plugin which registers the observers for updating the wheel color.
+pub struct ColorWheelPlugin;
+
+impl Plugin for ColorWheelPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        app.add_plugins(UiMaterialPlugin::<ColorWheelMaterial>::default());
+        // Ensure thumb stays inside wheel on next frame when layout changes
+        app.add_systems(PostUpdate, update_wheel_color.before(UiSystems::Layout));
+        app.add_observer(on_pointer_press)
+            .add_observer(on_drag_start)
+            .add_observer(on_drag)
+            .add_observer(on_drag_end)
+            .add_observer(on_drag_cancel);
+    }
+}

--- a/crates/bevy_feathers/src/controls/mod.rs
+++ b/crates/bevy_feathers/src/controls/mod.rs
@@ -6,8 +6,8 @@ mod checkbox;
 mod color_plane;
 mod color_slider;
 mod color_swatch;
-mod dialog;
 mod color_wheel;
+mod dialog;
 mod disclosure_toggle;
 mod listview;
 mod menu;
@@ -24,8 +24,8 @@ pub use checkbox::*;
 pub use color_plane::*;
 pub use color_slider::*;
 pub use color_swatch::*;
-pub use dialog::*;
 pub use color_wheel::*;
+pub use dialog::*;
 pub use disclosure_toggle::*;
 pub use listview::*;
 pub use menu::*;
@@ -62,8 +62,6 @@ impl Plugin for ControlsPlugin {
             SliderPlugin,
             TextInputPlugin,
         ));
-        app.add_plugins(
-            ToggleSwitchPlugin,
-        );
+        app.add_plugins(ToggleSwitchPlugin);
     }
 }

--- a/crates/bevy_feathers/src/controls/mod.rs
+++ b/crates/bevy_feathers/src/controls/mod.rs
@@ -7,6 +7,7 @@ mod color_plane;
 mod color_slider;
 mod color_swatch;
 mod dialog;
+mod color_wheel;
 mod disclosure_toggle;
 mod listview;
 mod menu;
@@ -24,6 +25,7 @@ pub use color_plane::*;
 pub use color_slider::*;
 pub use color_swatch::*;
 pub use dialog::*;
+pub use color_wheel::*;
 pub use disclosure_toggle::*;
 pub use listview::*;
 pub use menu::*;
@@ -50,6 +52,7 @@ impl Plugin for ControlsPlugin {
             ColorPlanePlugin,
             ColorSliderPlugin,
             ColorSwatchPlugin,
+            ColorWheelPlugin,
             DisclosureTogglePlugin,
             ListViewPlugin,
             MenuPlugin,
@@ -58,7 +61,9 @@ impl Plugin for ControlsPlugin {
             ScrollbarPlugin,
             SliderPlugin,
             TextInputPlugin,
-            ToggleSwitchPlugin,
         ));
+        app.add_plugins(
+            ToggleSwitchPlugin,
+        );
     }
 }

--- a/crates/bevy_feathers/src/controls/mod.rs
+++ b/crates/bevy_feathers/src/controls/mod.rs
@@ -6,6 +6,7 @@ mod checkbox;
 mod color_plane;
 mod color_slider;
 mod color_swatch;
+mod color_triangle;
 mod color_wheel;
 mod dialog;
 mod disclosure_toggle;
@@ -24,6 +25,7 @@ pub use checkbox::*;
 pub use color_plane::*;
 pub use color_slider::*;
 pub use color_swatch::*;
+pub use color_triangle::*;
 pub use color_wheel::*;
 pub use dialog::*;
 pub use disclosure_toggle::*;
@@ -53,6 +55,7 @@ impl Plugin for ControlsPlugin {
             ColorSliderPlugin,
             ColorSwatchPlugin,
             ColorWheelPlugin,
+            ColorTrianglePlugin,
             DisclosureTogglePlugin,
             ListViewPlugin,
             MenuPlugin,
@@ -60,8 +63,7 @@ impl Plugin for ControlsPlugin {
             RadioPlugin,
             ScrollbarPlugin,
             SliderPlugin,
-            TextInputPlugin,
         ));
-        app.add_plugins(ToggleSwitchPlugin);
+        app.add_plugins((TextInputPlugin, ToggleSwitchPlugin));
     }
 }

--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -81,6 +81,7 @@ impl Plugin for FeathersCorePlugin {
         // Embedded shader
         embedded_asset!(app, "assets/shaders/alpha_pattern.wgsl");
         embedded_asset!(app, "assets/shaders/color_plane.wgsl");
+        embedded_asset!(app, "assets/shaders/color_wheel.wgsl");
 
         app.add_plugins((
             ControlsPlugin,

--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -81,6 +81,7 @@ impl Plugin for FeathersCorePlugin {
         // Embedded shader
         embedded_asset!(app, "assets/shaders/alpha_pattern.wgsl");
         embedded_asset!(app, "assets/shaders/color_plane.wgsl");
+        embedded_asset!(app, "assets/shaders/color_triangle.wgsl");
         embedded_asset!(app, "assets/shaders/color_wheel.wgsl");
 
         app.add_plugins((

--- a/crates/bevy_render/src/color_operations.wgsl
+++ b/crates/bevy_render/src/color_operations.wgsl
@@ -133,6 +133,26 @@ fn hsv_to_linear_rgb(hsva: vec3<f32>) -> vec3<f32> {
     return srgb_to_linear_rgb(vec3(r + m, g + m, b + m));
 }
 
+fn hwb_to_hsv(hwb: vec3<f32>) -> vec3<f32> {
+    let hue = hwb.x;
+    let whiteness = hwb.y;
+    let blackness = hwb.z;
+
+    let value = 1. - blackness;
+    var saturation: f32;
+    if (value != 0.0) {
+        saturation = 1. - (whiteness / value);
+    } else {
+        saturation = 0.0;
+    }
+    return vec3(hue, saturation, value);
+}
+
+fn hwb_to_linear_rgb(hwb: vec3<f32>) -> vec3<f32> {
+    let hsv = hwb_to_hsv(hwb);
+    return hsv_to_linear_rgb(hsv);
+}
+
 fn oklch_to_linear_rgb(c: vec3<f32>) -> vec3<f32> {
     let hue = c.z * PI_2;
     return oklab_to_linear_rgb(vec3(c.x, c.y * cos(hue), c.y * sin(hue)));

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -527,6 +527,14 @@ fn demo_column_1() -> impl Scene {
                 ]
             ),
             (
+                @FeathersColorWheel::Hsl
+                on(|change: On<ValueChange<ColorWheelValue>>,
+                   mut color: ResMut<DemoWidgetStates>| {
+                    color.hsl_color.hue = change.value.hue;
+                    color.hsl_color.saturation = change.value.saturation;
+                })
+            ),
+            (
                 @FeathersColorSlider {
                     @value: 0.5,
                     @channel: ColorChannel::HslHue
@@ -757,6 +765,7 @@ fn update_colors(
     mut sliders: Query<(Entity, &ColorSlider, &mut SliderBaseColor)>,
     mut swatches: Query<(&mut ColorSwatchValue, &SwatchType), With<FeathersColorSwatch>>,
     mut color_planes: Query<&mut ColorPlaneValue, With<FeathersColorPlane>>,
+    mut color_wheels: Query<&mut ColorWheelValue, With<FeathersColorWheel>>,
     q_text_input: Single<(Entity, &mut EditableText), With<HexColorInput>>,
     q_scalar_input: Query<Entity, With<DemoScalarField>>,
     q_vec3_input: Query<(Entity, &DemoVec3Field)>,
@@ -822,6 +831,12 @@ fn update_colors(
             plane_value.0.x = states.rgb_color.red;
             plane_value.0.y = states.rgb_color.blue;
             plane_value.0.z = states.rgb_color.green;
+        }
+
+        for mut wheel_value in color_wheels.iter_mut() {
+            wheel_value.hue = states.hsl_color.hue;
+            wheel_value.saturation = states.hsl_color.saturation;
+            wheel_value.z = states.hsl_color.lightness;
         }
 
         // Only update the hex input field when it's not focused, otherwise it interferes

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -527,12 +527,42 @@ fn demo_column_1() -> impl Scene {
                 ]
             ),
             (
-                @FeathersColorWheel::Hsl
-                on(|change: On<ValueChange<ColorWheelValue>>,
-                   mut color: ResMut<DemoWidgetStates>| {
-                    color.hsl_color.hue = change.value.hue;
-                    color.hsl_color.saturation = change.value.saturation;
-                })
+                Node {
+                    display: Display::Flex,
+                    align_items: AlignItems::Center,
+                    flex_direction: FlexDirection::Row,
+                    justify_content: JustifyContent::SpaceAround,
+                }
+                Children [
+                    (
+                        Node {
+                            height: px(200),
+                        }
+                        @FeathersColorWheel::Hsl
+                        on(|change: On<ValueChange<ColorWheelValue>>,
+                        mut color: ResMut<DemoWidgetStates>| {
+                            color.hsl_color.hue = change.value.hue;
+                            color.hsl_color.saturation = change.value.saturation;
+                        })
+                    ),
+                    (
+                        Node {
+                            height: px(200),
+                        }
+                        @FeathersColorTriangle::Hwb
+                        on(|change: On<ValueChange<ColorTriangleValue>>,
+                        mut color: ResMut<DemoWidgetStates>| {
+                            let hsl: Hsla = Hwba::hwb(
+                                change.value.hue,
+                                change.value.whiteness,
+                                change.value.blackness,
+                            ).into();
+                            color.hsl_color.hue = hsl.hue;
+                            color.hsl_color.saturation = hsl.saturation;
+                            color.hsl_color.lightness = hsl.lightness;
+                        })
+                    ),
+                ]
             ),
             (
                 @FeathersColorSlider {
@@ -766,6 +796,7 @@ fn update_colors(
     mut swatches: Query<(&mut ColorSwatchValue, &SwatchType), With<FeathersColorSwatch>>,
     mut color_planes: Query<&mut ColorPlaneValue, With<FeathersColorPlane>>,
     mut color_wheels: Query<&mut ColorWheelValue, With<FeathersColorWheel>>,
+    mut color_triangles: Query<&mut ColorTriangleValue, With<FeathersColorTriangle>>,
     q_text_input: Single<(Entity, &mut EditableText), With<HexColorInput>>,
     q_scalar_input: Query<Entity, With<DemoScalarField>>,
     q_vec3_input: Query<(Entity, &DemoVec3Field)>,
@@ -837,6 +868,13 @@ fn update_colors(
             wheel_value.hue = states.hsl_color.hue;
             wheel_value.saturation = states.hsl_color.saturation;
             wheel_value.z = states.hsl_color.lightness;
+        }
+
+        for mut triangle_value in color_triangles.iter_mut() {
+            let hwb: Hwba = states.hsl_color.into();
+            triangle_value.hue = hwb.hue;
+            triangle_value.whiteness = hwb.whiteness;
+            triangle_value.blackness = hwb.blackness;
         }
 
         // Only update the hex input field when it's not focused, otherwise it interferes

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -540,7 +540,7 @@ fn demo_column_1() -> impl Scene {
                         }
                         @FeathersColorWheel::Hsl
                         on(|change: On<ValueChange<ColorWheelValue>>,
-                        mut color: ResMut<DemoWidgetStates>| {
+                            mut color: ResMut<DemoWidgetStates>| {
                             color.hsl_color.hue = change.value.hue;
                             color.hsl_color.saturation = change.value.saturation;
                         })
@@ -551,7 +551,7 @@ fn demo_column_1() -> impl Scene {
                         }
                         @FeathersColorTriangle::Hwb
                         on(|change: On<ValueChange<ColorTriangleValue>>,
-                        mut color: ResMut<DemoWidgetStates>| {
+                            mut color: ResMut<DemoWidgetStates>| {
                             let hsl: Hsla = Hwba::hwb(
                                 change.value.hue,
                                 change.value.whiteness,


### PR DESCRIPTION
# Objective

A color wheel is a widget often preferred when picking colors in cylindrical color spaces. This adds two types of color wheel widget to bevy_feathers.

## Solution

- Added `color_wheel.rs` + `color_triangle.rs` to `bevy_feathers/src/controls` and `color_wheel.wgsl` + `color_triangle.wgsl` to `bevy_feathers/src/assets/shaders`.
- The widgets are closely based on the existing color plane widget.
- The color wheel supports HSL and HSV color spaces. Could also easily be extended to support Okhsl/Okhsv when #24678 merges.
- The triangle widget natively operates in HWB color space, which is easily converted to HSL or HSV. This could also support the [Okhwb](https://bottosson.github.io/posts/colorpicker/#okhwb) color space if added to Bevy, which is easily converted to Okhsv (though not Okhsl, except through OkLCh).

## Testing

- Tested functionality and appearance by modifying the `feathers_gallery` example, see below.

---

## Showcase
BSN for color wheel widget: 
```
@FeathersColorWheel::Hsl
on(|change: On<ValueChange<ColorWheelValue>>,
    mut color: ResMut<DemoWidgetStates>| {
    color.hsl_color.hue = change.value.hue;
    color.hsl_color.saturation = change.value.saturation;
})
```
BSN for color triangle widget: 
```
@FeathersColorTriangle::Hwb
on(|change: On<ValueChange<ColorTriangleValue>>,
    mut color: ResMut<DemoWidgetStates>| {
    let hsl: Hsla = Hwba::hwb(
        change.value.hue,
        change.value.whiteness,
        change.value.blackness,
    ).into();
    color.hsl_color.hue = hsl.hue;
    color.hsl_color.saturation = hsl.saturation;
    color.hsl_color.lightness = hsl.lightness;
})
```
<img width="578" height="323" alt="color_triangle" src="https://github.com/user-attachments/assets/fe6371df-795b-4f8c-8892-d2698f22e1b1" />

