### PR TITLE
Improved documentation for headless and feathers widgets.

### DIFF
--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -43,6 +43,9 @@ use crate::{
 /// * [`bevy_ui_widgets::ValueChange<bool>`] with the new value when the checkbox changes state.
 ///
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
+///
+/// A more complete explanation of how to control this widget can be found in the documentation
+/// for [`Checkbox`] and [`bevy_ui_widgets`].
 #[derive(SceneComponent, FromTemplate)]
 #[scene(FeathersCheckboxProps)]
 #[derive(Reflect)]

--- a/crates/bevy_feathers/src/controls/color_plane.rs
+++ b/crates/bevy_feathers/src/controls/color_plane.rs
@@ -43,6 +43,9 @@ use crate::{cursor::EntityCursor, palette, theme::ThemeBackgroundColor, tokens};
 /// The control does not do any color space conversions internally, other than the shader code
 /// for displaying gradients. Avoiding excess conversions helps avoid gimble-lock problems when
 /// implementing a color picker for cylindrical color spaces such as HSL.
+///
+/// **Note:** For information on how widget state is managed
+/// and how to respond to state changes, see the [`bevy_ui_widgets` documentation](bevy_ui_widgets).
 #[derive(
     SceneComponent, FromTemplate, Debug, Reflect, Copy, PartialEq, Eq, Hash, Default, Clone,
 )]

--- a/crates/bevy_feathers/src/controls/color_slider.rs
+++ b/crates/bevy_feathers/src/controls/color_slider.rs
@@ -309,6 +309,9 @@ impl FeathersColorSlider {
 /// * [`bevy_ui_widgets::ValueChange<f32>`] when the slider value is changed.
 ///
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
+///
+/// **Note:** For information on how widget state is managed
+/// and how to respond to state changes, see the [`bevy_ui_widgets` documentation](bevy_ui_widgets).
 #[deprecated(since = "0.19.0", note = "Use the color_slider() BSN function")]
 pub fn color_slider_bundle<B: Bundle>(
     props: FeathersColorSliderProps,

--- a/crates/bevy_feathers/src/controls/disclosure_toggle.rs
+++ b/crates/bevy_feathers/src/controls/disclosure_toggle.rs
@@ -30,6 +30,9 @@ use crate::{
 /// state.
 ///
 /// This is spawnable by inheriting it as a "scene component".
+///
+/// A more complete explanation of how to control this widget can be found in the documentation
+/// for [`Checkbox`] and [`bevy_ui_widgets`].
 #[derive(SceneComponent, Default, Clone, Reflect)]
 #[reflect(Component, Default, Clone)]
 pub struct FeathersDisclosureToggle;

--- a/crates/bevy_feathers/src/controls/listview.rs
+++ b/crates/bevy_feathers/src/controls/listview.rs
@@ -32,7 +32,10 @@ use crate::{
     tokens,
 };
 
-/// A container that displays a scrolling list of items
+/// A container that displays a scrolling list of items.
+///
+/// A more complete explanation of how to control this widget can be found in the documentation
+/// for [`ListBox`] and [`bevy_ui_widgets`].
 #[derive(SceneComponent, Default, Clone, Reflect)]
 #[scene(FeathersListViewProps)]
 #[reflect(Component, Clone, Default)]

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -42,6 +42,9 @@ use crate::{
 /// * [`bevy_ui_widgets::ValueChange<Entity>`] with the selected entity's id when a new radio button is selected.
 ///
 ///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
+///
+/// A more complete explanation of how to control this widget can be found in the documentation
+/// for [`RadioButton`] and [`bevy_ui_widgets`].
 #[derive(SceneComponent, Default, Clone)]
 #[scene(FeathersRadioProps)]
 #[derive(Reflect)]

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -47,7 +47,10 @@ use crate::{
 ///
 /// * [`bevy_ui_widgets::ValueChange<f32>`] when the slider value is changed.
 ///
-///  These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
+/// These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the entity
+///
+/// A more complete explanation of how to control this widget can be found in the documentation
+/// for [`Slider`] and [`bevy_ui_widgets`].
 #[derive(SceneComponent, Default, Clone, Reflect)]
 #[scene(FeathersSliderProps)]
 #[require(Slider)]

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -39,6 +39,9 @@ use crate::{
 /// * [`bevy_ui_widgets::ValueChange<bool>`] with the new value when the toggle switch changes state.
 ///
 /// These events can be disabled by adding an [`bevy_ui::InteractionDisabled`] component to the bundle
+///
+/// A more complete explanation of how to control this widget can be found in the documentation
+/// for [`Checkbox`] and [`bevy_ui_widgets`].
 #[derive(SceneComponent, Default, Clone, Reflect)]
 #[reflect(Component, Clone, Default)]
 pub struct FeathersToggleSwitch;

--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -18,13 +18,6 @@
 //! This is important when writing your custom widgets, and understanding the behavior of existing widgets.
 //!
 //! For more guidance on this, see the documentation for [`EntityEvent`](bevy_ecs::event::EntityEvent).
-//!
-//! ## Warning: Experimental!
-//! All that said, this crate is still experimental and unfinished!
-//! It will change in breaking ways, and there will be both bugs and limitations.
-//!
-//! Please report issues, submit fixes and propose changes.
-//! Thanks for stress-testing; let's build something better together.
 
 extern crate alloc;
 

--- a/crates/bevy_ui_widgets/src/checkbox.rs
+++ b/crates/bevy_ui_widgets/src/checkbox.rs
@@ -31,6 +31,10 @@ use bevy_ecs::entity::Entity;
 /// The [`Checkbox`] component can be used to implement other kinds of toggle widgets. If you
 /// are going to do a toggle switch, you should override the [`AccessibilityNode`] component with
 /// the `Switch` role instead of the `Checkbox` role.
+///
+/// **Note:** For information on how widget state is managed
+/// and how to respond to state changes, see the [crate-level documentation].
+/// [crate-level documentation]: crate
 #[derive(Component, Debug, Default, Clone)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::CheckBox)), Checkable)]
 #[derive(Reflect)]

--- a/crates/bevy_ui_widgets/src/lib.rs
+++ b/crates/bevy_ui_widgets/src/lib.rs
@@ -2,27 +2,48 @@
 //! These widgets have no inherent styling, it's the responsibility of the user to add styling
 //! appropriate for their game or application.
 //!
-//! ## Warning: Experimental
-//!
-//! This crate is currently experimental and under active development.
-//! The API is likely to change substantially: be prepared to migrate your code.
-//!
-//! We are actively seeking feedback on the design and implementation of this crate, so please
-//! file issues or create PRs if you have any comments or suggestions.
-//!
 //! ## State Management
 //!
-//! Most of the widgets use external state management: this means that the widgets do not
-//! automatically update their own internal state, but instead rely on the app to update the widget
-//! state (as well as any other related game state) in response to a change event emitted by the
-//! widget. The primary motivation for this is to avoid two-way data binding in scenarios where the
-//! user interface is showing a live view of dynamic data coming from deeper within the game engine.
+//! The typical way that UI widgets are used in games is that they often display a view of live
+//! data in the engine - they aren't just passive form fields to fill in and then submit.
+//! For example, a "color picker" might have multiple ways to edit an RGB value, including
+//! sliders, a color plane, a color wheel, hex input, or swatches of recent colors. Interacting with
+//! any of these widgets not only updates the RGB model, but also updates all of the other widgets.
+//!
+//! For this reason, almost all of the widgets use **external** state management: this means that
+//! the widgets do not automatically update their own internal state, but instead rely on the app
+//! to update the widget state (as well as any other related game state) in response to a change
+//! event emitted by the widget.
+//!
+//! These widgets emit a [`ValueChange`] event which carries the proposed new state; the app responds
+//! to this event by updating its own internal model, and by updating the widget state. The general
+//! convention is that the widget state is contained in a specific state-bearing component
+//! (like [`SliderValue`]), and the widget detects when this component is inserted or replaced.
+//!
+//! This design pattern draws from the classic "MVC" (Model / View / Controller) style of
+//! widget design, which is also used by React.js for
+//! [controlled](https://medium.com/@rupalsinghal/controlled-vs-uncontrolled-components-in-react-the-complete-guide-you-cant-afford-to-miss-fbf6ea28b0fd)
+//! widgets.
+//!
+//! There are a few exceptions to this rule:
+//! * Buttons and menu items don't have any state, so they emit an [`Activate`] event instead.
+//!   (The hover and pressed states don't count, because they are purely visual / stylistic).
+//! * Text input widgets have a large and expensive state, so they handle their own state updates.
+//! * Scrollbars don't emit events, they modify the scroll position of the target entity
+//!   directly.
+//!
+//! For users who don't want to bother with writing a state update handler, these widgets provide
+//! a "self update" observer function: for example, the [`checkbox_self_update`] observer will
+//! listen for the [`ValueChange`] event and update the checkbox state. This effectively converts
+//! it into an "uncontrolled" widget, in React.js terms.
 //!
 //! ## Best practices for event propagation
 //!
 //! Generally, when a widget handles an event,
-//! propagation of that event to parent entities should be stopped.
-//! This is important when writing your custom widgets, and understanding the behavior of existing widgets.
+//! propagation of that event to parent entities should be stopped. Events which are not of
+//! interest to the widget should be allowed to propagate.
+//! This "consume what you use" principle is important when writing your custom widgets, and
+//! understanding the behavior of existing widgets.
 //!
 //! For more guidance on this, see the documentation for [`EntityEvent`].
 

--- a/crates/bevy_ui_widgets/src/lib.rs
+++ b/crates/bevy_ui_widgets/src/lib.rs
@@ -15,7 +15,7 @@
 //! to update the widget state (as well as any other related game state) in response to a change
 //! event emitted by the widget.
 //!
-//! These widgets emit a [`ValueChange`] event which carries the proposed new state; the app responds
+//! These widgets emit a [`ValueChange`] event which carries the proposed new state; the app should respond
 //! to this event by updating its own internal model, and by updating the widget state. The general
 //! convention is that the widget state is contained in a specific state-bearing component
 //! (like [`SliderValue`]), and the widget detects when this component is inserted or replaced.

--- a/crates/bevy_ui_widgets/src/list.rs
+++ b/crates/bevy_ui_widgets/src/list.rs
@@ -21,6 +21,13 @@ use crate::{ScrollIntoView, ValueChange};
 
 /// Headless widget implementation for a list box. This component contains multiple [`ListItem`]
 /// entities. It implements the tab navigation logic and keyboard shortcuts for list items.
+///
+/// Functionally, this acts much like a radio group, emitting [`ValueChange`] events which contain
+/// the entity id of the selected item.
+///
+/// **Note:** For information on how widget state is managed
+/// and how to respond to state changes, see the [crate-level documentation].
+/// [crate-level documentation]: crate
 #[derive(Component, Debug, Clone, Default)]
 #[require(
     AccessibilityNode(accesskit::Node::new(Role::ListBox)),

--- a/crates/bevy_ui_widgets/src/radio.rs
+++ b/crates/bevy_ui_widgets/src/radio.rs
@@ -35,6 +35,10 @@ use crate::{ActivateOnPress, ValueChange};
 /// associated with a particular constant value, and would be checked whenever that value is equal
 /// to the group's value. This also means that as long as each button's associated value is unique
 /// within the group, it should never be the case that more than one button is selected at a time.
+///
+/// **Note:** For information on how widget state is managed
+/// and how to respond to state changes, see the [crate-level documentation].
+/// [crate-level documentation]: crate
 #[derive(Component, Debug, Clone, Default)]
 #[require(AccessibilityNode(accesskit::Node::new(Role::RadioGroup)))]
 #[derive(Reflect)]

--- a/crates/bevy_ui_widgets/src/slider.rs
+++ b/crates/bevy_ui_widgets/src/slider.rs
@@ -75,6 +75,9 @@ pub enum TrackClick {
 /// optional step size can be specified via [`SliderStep`], and you can control the rounding
 /// during dragging with [`SliderPrecision`].
 ///
+/// The canonical way to update the slider value is to insert a new [`SliderValue`] component,
+/// overwriting the old one. The value can set during initial construction and updated later.
+///
 /// You can also control the slider remotely by triggering a [`SetSliderValue`] event on it. This
 /// can be useful in a console environment for controlling the value gamepad inputs.
 ///
@@ -92,6 +95,10 @@ pub enum TrackClick {
 ///
 /// In cases where overhang is desired for artistic reasons, the thumb may have additional
 /// decorative child elements, absolutely positioned, which don't affect the size measurement.
+///
+/// **Note:** For information on how widget state is managed
+/// and how to respond to state changes, see the [crate-level documentation].
+/// [crate-level documentation]: crate
 #[derive(Component, Debug, Default, Clone)]
 #[require(
     AccessibilityNode(accesskit::Node::new(Role::Slider)),

--- a/crates/bevy_ui_widgets/src/slider.rs
+++ b/crates/bevy_ui_widgets/src/slider.rs
@@ -76,7 +76,7 @@ pub enum TrackClick {
 /// during dragging with [`SliderPrecision`].
 ///
 /// The canonical way to update the slider value is to insert a new [`SliderValue`] component,
-/// overwriting the old one. The value can set during initial construction and updated later.
+/// overwriting the old one. The value can be set during initial construction and updated later.
 ///
 /// You can also control the slider remotely by triggering a [`SetSliderValue`] event on it. This
 /// can be useful in a console environment for controlling the value gamepad inputs.


### PR DESCRIPTION
This PR contains only doc comment changes, no changes to code.

Lately there has been some confusion around state management in feathers and headless widgets. First, the basic concepts were not explained adequately, and second, what explanations there were, were hard to find. This PR attempts to address these concerns.