### PR TITLE
Implements `merge_scene` variant function.

### DIFF
--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -900,8 +900,8 @@
 pub mod prelude {
     pub use crate::{
         bsn, bsn_list, on, template_value, CommandsSceneExt, EntityCommandsSceneExt,
-        EntityWorldMutSceneExt, PatchFromTemplate, PatchTemplate, RelationshipBehavior, Scene, SceneComponent, SceneList,
-        ScenePatchInstance, SpawnListSystem, SpawnSystem, WorldSceneExt,
+        EntityWorldMutSceneExt, PatchFromTemplate, PatchTemplate, RelationshipBehavior, Scene,
+        SceneComponent, SceneList, ScenePatchInstance, SpawnListSystem, SpawnSystem, WorldSceneExt,
     };
 }
 

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -900,7 +900,7 @@
 pub mod prelude {
     pub use crate::{
         bsn, bsn_list, on, template_value, CommandsSceneExt, EntityCommandsSceneExt,
-        EntityWorldMutSceneExt, PatchFromTemplate, PatchTemplate, Scene, SceneComponent, SceneList,
+        EntityWorldMutSceneExt, PatchFromTemplate, PatchTemplate, RelationshipBehavior, Scene, SceneComponent, SceneList,
         ScenePatchInstance, SpawnListSystem, SpawnSystem, WorldSceneExt,
     };
 }

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -15,12 +15,7 @@ use core::any::{Any, TypeId};
 use thiserror::Error;
 
 /// Controls how scene application handles existing [`RelationshipTarget`] components on the entity.
-///
-/// Insert this component on an entity before calling [`EntityWorldMutSceneExt::apply_scene`] to
-/// retain and extend existing related entities instead of replacing them.
-///
-/// [`EntityWorldMutSceneExt::apply_scene`]: crate::EntityWorldMutSceneExt::apply_scene
-#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum RelationshipBehavior {
     /// Replaces existing [`RelationshipTarget`] components with new collections for the scene's related entities.
     #[default]
@@ -82,10 +77,26 @@ impl ResolvedSceneRoot {
         entity: &mut EntityWorldMut,
         bundle_scratch: &mut BundleScratch,
     ) -> Result<(), ApplySceneError> {
+        self.patch(
+            entity,
+            bundle_scratch,
+            RelationshipBehavior::Overwrite,
+        )
+    }
+
+    /// Applies this scene to the given [`EntityWorldMut`] using the given [`RelationshipBehavior`].
+    pub fn patch(
+        &self,
+        entity: &mut EntityWorldMut,
+        bundle_scratch: &mut BundleScratch,
+        relationship_behavior: RelationshipBehavior,
+    ) -> Result<(), ApplySceneError> {
         let mut entity_references = SceneEntityReferences::default();
         let mut context = TemplateContext::new(entity, &mut entity_references);
 
-        let result = self.scene.apply(&mut context, bundle_scratch);
+        let result = self
+            .scene
+            .apply(&mut context, bundle_scratch, relationship_behavior);
         if !bundle_scratch.is_empty() {
             // SAFETY: Components comes from the same world as the `context` passed in to self.scene.apply above
             unsafe {
@@ -149,6 +160,7 @@ impl ResolvedSceneListRoot {
             let result = scene.apply(
                 &mut TemplateContext::new(&mut entity, &mut entity_references),
                 &mut bundle_scratch,
+                RelationshipBehavior::Overwrite,
             );
             if let Err(err) = result {
                 // SAFETY: Components comes from the same world as the `context` passed in to self.scene.apply above
@@ -219,8 +231,9 @@ impl ResolvedScene {
         &self,
         context: &mut TemplateContext,
         bundle_scratch: &mut BundleScratch,
+        relationship_behavior: RelationshipBehavior,
     ) -> Result<(), ApplySceneError> {
-        self.apply_with(context, bundle_scratch, |_, _| {})
+        self.apply_with(context, bundle_scratch, |_, _| {}, relationship_behavior)
     }
 
     /// Applies this scene to the given [`TemplateContext`] (which holds an already-spawned [`EntityWorldMut`]).
@@ -239,12 +252,8 @@ impl ResolvedScene {
         context: &mut TemplateContext,
         bundle_scratch: &mut BundleScratch,
         writer_ops: impl FnOnce(&mut TemplateContext, &mut BundleWriter),
+        relationship_behavior: RelationshipBehavior,
     ) -> Result<(), ApplySceneError> {
-        let relationship_behavior = context
-            .entity
-            .get::<RelationshipBehavior>()
-            .copied()
-            .unwrap_or_default();
         let mut bundle_writer = bundle_scratch.writer();
         for entity_reference in self.entity_references.iter().copied() {
             context
@@ -425,6 +434,7 @@ impl ResolvedScene {
                                     );
                                 }
                             },
+                            RelationshipBehavior::Overwrite,
                         )
                         .map_err(|e| ApplySceneError::RelatedSceneError {
                             relationship_type_name: related_resolved_scenes.relationship_name,

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     component::{Component, ComponentsRegistrator},
     entity::Entity,
     error::{BevyError, Result},
-    relationship::{Relationship, RelationshipTarget},
+    relationship::{Relationship, RelationshipSourceCollection, RelationshipTarget},
     template::{SceneEntityReference, SceneEntityReferences, Template, TemplateContext},
     world::{EntityWorldMut, World},
 };
@@ -13,6 +13,21 @@ use bevy_platform::collections::HashSet;
 use bevy_utils::TypeIdMap;
 use core::any::{Any, TypeId};
 use thiserror::Error;
+
+/// Controls how scene application handles existing [`RelationshipTarget`] components on the entity.
+///
+/// Insert this component on an entity before calling [`EntityWorldMutSceneExt::apply_scene`] to
+/// retain and extend existing related entities instead of replacing them.
+///
+/// [`EntityWorldMutSceneExt::apply_scene`]: crate::EntityWorldMutSceneExt::apply_scene
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RelationshipBehavior {
+    /// Replaces existing [`RelationshipTarget`] components with new collections for the scene's related entities.
+    #[default]
+    Overwrite,
+    /// Retains existing [`RelationshipTarget`] components and appends the scene's related entities.
+    Merge,
+}
 
 /// A final "spawnable" root [`ResolvedScene`].
 pub struct ResolvedSceneRoot {
@@ -225,6 +240,11 @@ impl ResolvedScene {
         bundle_scratch: &mut BundleScratch,
         writer_ops: impl FnOnce(&mut TemplateContext, &mut BundleWriter),
     ) -> Result<(), ApplySceneError> {
+        let relationship_behavior = context
+            .entity
+            .get::<RelationshipBehavior>()
+            .copied()
+            .unwrap_or_default();
         let mut bundle_writer = bundle_scratch.writer();
         for entity_reference in self.entity_references.iter().copied() {
             context
@@ -264,18 +284,13 @@ impl ResolvedScene {
                         error: Box::new(e),
                     })?;
                 self.apply_templates_without_bundle_write(context, &mut bundle_writer, ())?;
-                // SAFETY: World is only used for component registration, which does not affect
-                // the entity location
-                let components = &mut context.entity.world_mut().components_registrator();
                 // This inserts empty RelationshipTarget collections to avoid archetype moves when then related entities are spawned
                 // It pre-allocates space in the collection to avoid reallocs as related entities are added.
-                for related in self.related.values() {
-                    (related.insert_relationship_target)(
-                        &mut bundle_writer,
-                        components,
-                        related.scenes.len(),
-                    );
-                }
+                self.insert_relationship_targets(
+                    context.entity,
+                    &mut bundle_writer,
+                    relationship_behavior,
+                );
 
                 (writer_ops)(context, &mut bundle_writer);
 
@@ -290,18 +305,13 @@ impl ResolvedScene {
             // SAFETY: bundle_writer was used with the same World across all cases in this function,
             unsafe {
                 self.apply_templates_without_bundle_write(context, &mut bundle_writer, ())?;
-                // SAFETY: World is only used for component registration, which does not affect
-                // the entity location
-                let components = &mut context.entity.world_mut().components_registrator();
                 // This inserts empty RelationshipTarget collections to avoid archetype moves when then related entities are spawned
                 // It pre-allocates space in the collection to avoid reallocs as related entities are added.
-                for related in self.related.values() {
-                    (related.insert_relationship_target)(
-                        &mut bundle_writer,
-                        components,
-                        related.scenes.len(),
-                    );
-                }
+                self.insert_relationship_targets(
+                    context.entity,
+                    &mut bundle_writer,
+                    relationship_behavior,
+                );
                 (writer_ops)(context, &mut bundle_writer);
                 bundle_writer.write(context.entity);
                 self.apply_related(context, bundle_scratch)?;
@@ -309,6 +319,37 @@ impl ResolvedScene {
         };
 
         Ok(())
+    }
+
+    fn insert_relationship_targets(
+        &self,
+        entity: &mut EntityWorldMut,
+        bundle_writer: &mut BundleWriter,
+        relationship_behavior: RelationshipBehavior,
+    ) {
+        let mut should_insert = Vec::with_capacity(self.related.len());
+        for related in self.related.values() {
+            should_insert.push((related.prepare_relationship_target)(
+                entity,
+                related.scenes.len(),
+                relationship_behavior,
+            ));
+        }
+        // SAFETY: World is only used for component registration, which does not affect
+        // the entity location
+        let components = unsafe { &mut entity.world_mut().components_registrator() };
+        for (related, insert) in self.related.values().zip(should_insert) {
+            if insert {
+                // SAFETY: caller ensures bundler_writer is always used with the same World
+                unsafe {
+                    (related.insert_relationship_target)(
+                        bundle_writer,
+                        components,
+                        related.scenes.len(),
+                    );
+                }
+            }
+        }
     }
 
     /// # Safety
@@ -626,7 +667,13 @@ pub struct RelatedResolvedScenes {
     pub insert_relationship:
         unsafe fn(&mut BundleWriter, &mut ComponentsRegistrator, target: Entity),
     /// The function that will be called to add the relationship target to the spawned scene with the given capacity.
-    pub insert_relationship_target: unsafe fn(&mut BundleWriter, &mut ComponentsRegistrator, usize),
+    pub(crate) insert_relationship_target:
+        unsafe fn(&mut BundleWriter, &mut ComponentsRegistrator, usize),
+    /// Prepares the relationship target on the entity for the given [`RelationshipBehavior`].
+    ///
+    /// Returns `true` if [`RelatedResolvedScenes::insert_relationship_target`] should be called.
+    pub(crate) prepare_relationship_target:
+        fn(&mut EntityWorldMut, usize, RelationshipBehavior) -> bool,
     /// The type name of the relationship. This is used for more helpful error message.
     pub relationship_name: &'static str,
 }
@@ -657,6 +704,19 @@ impl RelatedResolvedScenes {
                 unsafe {
                     bundle_writer.push_component(components_registrator, relationship_target);
                 };
+            },
+            prepare_relationship_target: |entity, capacity, behavior| match behavior {
+                RelationshipBehavior::Overwrite => true,
+                RelationshipBehavior::Merge => {
+                    if let Some(mut existing) =
+                        entity.get_mut::<<R as Relationship>::RelationshipTarget>()
+                    {
+                        existing.collection_mut_risky().reserve(capacity);
+                        false
+                    } else {
+                        true
+                    }
+                }
             },
             relationship_name: core::any::type_name::<R>(),
         }

--- a/crates/bevy_scene/src/scene_patch.rs
+++ b/crates/bevy_scene/src/scene_patch.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ApplySceneError, ResolveSceneError, ResolvedSceneListRoot, ResolvedSceneRoot, Scene,
-    SceneDependencies, SceneList,
+    ApplySceneError, RelationshipBehavior, ResolveSceneError, ResolvedSceneListRoot,
+    ResolvedSceneRoot, Scene, SceneDependencies, SceneList,
 };
 use alloc::sync::Arc;
 use bevy_asset::{Asset, AssetServer, Assets, Handle, LoadFromPath, UntypedHandle};
@@ -79,12 +79,26 @@ impl ScenePatch {
 
     /// Applies the scene to the given `entity`. This should only be called after [`ScenePatch::resolve`]
     pub fn apply<'w>(&self, entity: &'w mut EntityWorldMut) -> Result<(), SpawnSceneError> {
+        self.patch(entity, RelationshipBehavior::Overwrite)
+    }
+
+    /// Applies the scene to the given `entity` using the given [`RelationshipBehavior`].
+    /// This should only be called after [`ScenePatch::resolve`].
+    pub(crate) fn patch<'w>(
+        &self,
+        entity: &'w mut EntityWorldMut,
+        relationship_behavior: RelationshipBehavior,
+    ) -> Result<(), SpawnSceneError> {
         let resolved = self
             .resolved
             .as_deref()
             .ok_or(SpawnSceneError::UnresolvedSceneError)?;
         resolved
-            .apply(entity, &mut BundleScratch::default())
+            .patch(
+                entity,
+                &mut BundleScratch::default(),
+                relationship_behavior,
+            )
             .map_err(SpawnSceneError::ApplySceneError)
     }
 }

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ResolvedSceneRoot, Scene, SceneList, SceneListPatch, ScenePatch, ScenePatchInstance,
-    SpawnSceneError,
+    RelationshipBehavior, ResolvedSceneRoot, Scene, SceneList, SceneListPatch, ScenePatch,
+    ScenePatchInstance, SpawnSceneError,
 };
 use alloc::sync::Arc;
 use bevy_asset::{AssetEvent, AssetServer, Assets, Handle};
@@ -456,8 +456,10 @@ pub trait EntityWorldMutSceneExt {
     ///
     /// When a scene is resolved, it will replace and orphan the current entity's children.
     ///
-    /// To retain and extend existing children instead, insert [`RelationshipBehavior::Merge`] on
-    /// the entity before calling this method.
+    /// To retain and extend existing children instead, include [`RelationshipBehavior::Merge`] in
+    /// the scene, insert it on the entity, or use [`EntityWorldMutSceneExt::merge_scene`].
+    ///
+    /// If both the scene and entity specify a [`RelationshipBehavior`], the scene takes precedence.
     ///
     /// If resolving and spawning is successful, the entity will contain the full contents of the spawned scene.
     ///
@@ -479,6 +481,18 @@ pub trait EntityWorldMutSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     fn queue_apply_scene<S: Scene>(&mut self, scene: S);
+
+    /// Merges the given [`Scene`] into the current entity, retaining and extending existing related entities.
+    ///
+    /// This inserts [`RelationshipBehavior::Merge`] on the parent entity before calling [`EntityWorldMutSceneExt::apply_scene`].
+    ///
+    /// This approach is semantically awkward because the merge behavior sticks on the entity after
+    /// the scene is applied. A later [`EntityWorldMutSceneExt::apply_scene`] on the same entity will
+    /// keep merging unless the component is removed or overwritten. An alternative would be for
+    /// `apply_scene` to always insert [`RelationshipBehavior::Overwrite`] afterward, but that would
+    /// clobber any behavior intentionally left on the entity, which is equally awkward. Specifying
+    /// behavior on the scene itself avoids this stickiness.
+    fn merge_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError>;
 }
 
 impl EntityWorldMutSceneExt for EntityWorldMut<'_> {
@@ -518,6 +532,11 @@ impl EntityWorldMutSceneExt for EntityWorldMut<'_> {
         self.resource_mut::<QueuedScenes>()
             .new_scene_entities
             .push((id, handle));
+    }
+
+    fn merge_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError> {
+        self.insert(RelationshipBehavior::Merge);
+        self.apply_scene(scene)
     }
 }
 
@@ -582,6 +601,11 @@ pub trait EntityCommandsSceneExt {
     ///
     /// See [`Scene`] for the features of the scene system (and how to use it).
     fn queue_apply_scene<S: Scene>(&mut self, scene: S) -> &mut Self;
+
+    /// Merges the given [`Scene`] into the current entity as soon as [`Commands`] are applied.
+    ///
+    /// See [`EntityWorldMutSceneExt::merge_scene`] for details on merge behavior and its caveats.
+    fn merge_scene<S: Scene>(&mut self, scene: S) -> &mut Self;
 }
 
 impl EntityCommandsSceneExt for EntityCommands<'_> {
@@ -602,6 +626,15 @@ impl EntityCommandsSceneExt for EntityCommands<'_> {
 
     fn queue_apply_scene<S: Scene>(&mut self, scene: S) -> &mut Self {
         self.queue(move |mut entity: EntityWorldMut| entity.queue_apply_scene(scene));
+        self
+    }
+
+    fn merge_scene<S: Scene>(&mut self, scene: S) -> &mut Self {
+        self.queue(move |mut entity: EntityWorldMut| {
+            if let Err(err) = entity.merge_scene(scene) {
+                error!("{err}");
+            }
+        });
         self
     }
 }
@@ -894,6 +927,24 @@ mod tests {
     #[derive(Component)]
     struct PreExistingChild;
 
+    fn assert_merge_extends_children(world: &World, root: Entity, pre_existing: Entity) {
+        let children: Vec<Entity> = world
+            .entity(root)
+            .get::<Children>()
+            .map(|c| c.iter().collect())
+            .unwrap_or_default();
+
+        assert_eq!(children.len(), 2);
+        assert!(children.contains(&pre_existing));
+        assert!(
+            children
+                .iter()
+                .filter(|entity| world.entity(**entity).contains::<SceneChild>())
+                .count()
+                == 1
+        );
+    }
+
     /// Tests that documented behavior of [`EntityWorldMutSceneExt::apply_scene`] is correct.
     #[test]
     fn apply_scene_replaces_and_orphans_children() {
@@ -929,17 +980,28 @@ mod tests {
     }
 
     #[test]
-    fn apply_scene_with_merge_extends_children() {
+    fn merge_scene_function_extends_children() {
         let mut app = test_app();
         let world = app.world_mut();
 
         let pre_existing = world.spawn(PreExistingChild).id();
         let root = world.spawn(Name::new("root")).add_child(pre_existing).id();
 
-        assert_eq!(
-            world.entity(root).get::<Children>().map(Children::len),
-            Some(1)
-        );
+        let scene = bsn! {
+            Children [ #SceneChild SceneChild ]
+        };
+        world.entity_mut(root).merge_scene(scene).unwrap();
+
+        assert_merge_extends_children(world, root, pre_existing);
+    }
+
+    #[test]
+    fn apply_scene_with_merge_insert_extends_children() {
+        let mut app = test_app();
+        let world = app.world_mut();
+
+        let pre_existing = world.spawn(PreExistingChild).id();
+        let root = world.spawn(Name::new("root")).add_child(pre_existing).id();
 
         let scene = bsn! {
             Children [ #SceneChild SceneChild ]
@@ -950,20 +1012,6 @@ mod tests {
             .apply_scene(scene)
             .unwrap();
 
-        let children: Vec<Entity> = world
-            .entity(root)
-            .get::<Children>()
-            .map(|c| c.iter().collect())
-            .unwrap_or_default();
-
-        assert_eq!(children.len(), 2);
-        assert!(children.contains(&pre_existing));
-        assert!(
-            children
-                .iter()
-                .filter(|entity| world.entity(**entity).contains::<SceneChild>())
-                .count()
-                == 1
-        );
+        assert_merge_extends_children(world, root, pre_existing);
     }
 }

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -979,6 +979,7 @@ mod tests {
         assert!(!children.contains(&pre_existing));
     }
 
+    /// Tests that the [`EntityWorldMutSceneExt::merge_scene`] function extends children.
     #[test]
     fn merge_scene_function_extends_children() {
         let mut app = test_app();
@@ -995,6 +996,7 @@ mod tests {
         assert_merge_extends_children(world, root, pre_existing);
     }
 
+    /// Tests that documented behavior of [`EntityWorldMutSceneExt::apply_scene`] is correct when using [`RelationshipBehavior::Merge`].
     #[test]
     fn apply_scene_with_merge_insert_extends_children() {
         let mut app = test_app();

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -451,17 +451,23 @@ pub trait EntityWorldMutSceneExt {
     /// ```
     fn queue_spawn_related_scenes<T: RelationshipTarget>(self, scenes: impl SceneList) -> Self;
 
+    /// Applies the given [`Scene`] to the current entity using the given [`RelationshipBehavior`].
+    ///
+    /// See [`EntityWorldMutSceneExt::apply_scene`] and [`EntityWorldMutSceneExt::merge_scene`].
+    fn patch_scene<S: Scene>(
+        &mut self,
+        scene: S,
+        relationship_behavior: RelationshipBehavior,
+    ) -> Result<(), SpawnSceneError>;
+
     /// Applies the given [`Scene`] to the current entity immediately. This will resolve the Scene (using [`Scene::resolve`]). If that fails (for example, if there are dependencies that have not been
-    /// loaded yet), it will return a [`SpawnSceneError`]. If resolving the [`Scene`] is successful, the scene will be spawned.
+    /// loaded yet), it will return a [`SpawnSceneError`]. If resolving the [`Scene`] is successful, the scene will be applied.
     ///
     /// When a scene is resolved, it will replace and orphan the current entity's children.
     ///
-    /// To retain and extend existing children instead, include [`RelationshipBehavior::Merge`] in
-    /// the scene, insert it on the entity, or use [`EntityWorldMutSceneExt::merge_scene`].
+    /// To retain and extend existing children instead, use [`EntityWorldMutSceneExt::merge_scene`].
     ///
-    /// If both the scene and entity specify a [`RelationshipBehavior`], the scene takes precedence.
-    ///
-    /// If resolving and spawning is successful, the entity will contain the full contents of the spawned scene.
+    /// If resolving and applying is successful, the entity will contain the full contents of the applied scene.
     ///
     /// This will write directly on top of any existing components on the entity. [`Scene`] is generally used as a spawning mechanism, so for most things, prefer using [`World::spawn_scene`].
     ///
@@ -469,7 +475,9 @@ pub trait EntityWorldMutSceneExt {
     ///
     /// If your scene has a dependency that might not be loaded yet (for example, it includes a `.bsn` asset file), consider using [`World::queue_spawn_scene`].
     /// Note that the .bsn file format is not yet released.
-    fn apply_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError>;
+    fn apply_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError> {
+        self.patch_scene(scene, RelationshipBehavior::Overwrite)
+    }
 
     /// Queues the `scene` to be applied. This will evaluate the `scene`'s dependencies (via [`Scene::register_dependencies`]) and queue it to be resolved and spawned
     /// after all of the dependencies have been loaded. If a [`SpawnSceneError`] occurs, it will be logged as an error.
@@ -484,15 +492,10 @@ pub trait EntityWorldMutSceneExt {
 
     /// Merges the given [`Scene`] into the current entity, retaining and extending existing related entities.
     ///
-    /// This inserts [`RelationshipBehavior::Merge`] on the parent entity before calling [`EntityWorldMutSceneExt::apply_scene`].
-    ///
-    /// This approach is semantically awkward because the merge behavior sticks on the entity after
-    /// the scene is applied. A later [`EntityWorldMutSceneExt::apply_scene`] on the same entity will
-    /// keep merging unless the component is removed or overwritten. An alternative would be for
-    /// `apply_scene` to always insert [`RelationshipBehavior::Overwrite`] afterward, but that would
-    /// clobber any behavior intentionally left on the entity, which is equally awkward. Specifying
-    /// behavior on the scene itself avoids this stickiness.
-    fn merge_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError>;
+    /// This is equivalent to [`EntityWorldMutSceneExt::patch_scene`] with [`RelationshipBehavior::Merge`].
+    fn merge_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError> {
+        self.patch_scene(scene, RelationshipBehavior::Merge)
+    }
 }
 
 impl EntityWorldMutSceneExt for EntityWorldMut<'_> {
@@ -517,11 +520,15 @@ impl EntityWorldMutSceneExt for EntityWorldMut<'_> {
         self
     }
 
-    fn apply_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError> {
+    fn patch_scene<S: Scene>(
+        &mut self,
+        scene: S,
+        relationship_behavior: RelationshipBehavior,
+    ) -> Result<(), SpawnSceneError> {
         let assets = self.resource::<AssetServer>();
         let mut patch = ScenePatch::load(assets, scene);
         patch.resolve(assets, self.resource::<Assets<ScenePatch>>())?;
-        patch.apply(self)
+        patch.patch(self, relationship_behavior)
     }
 
     fn queue_apply_scene<S: Scene>(&mut self, scene: S) {
@@ -532,11 +539,6 @@ impl EntityWorldMutSceneExt for EntityWorldMut<'_> {
         self.resource_mut::<QueuedScenes>()
             .new_scene_entities
             .push((id, handle));
-    }
-
-    fn merge_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError> {
-        self.insert(RelationshipBehavior::Merge);
-        self.apply_scene(scene)
     }
 }
 
@@ -604,7 +606,7 @@ pub trait EntityCommandsSceneExt {
 
     /// Merges the given [`Scene`] into the current entity as soon as [`Commands`] are applied.
     ///
-    /// See [`EntityWorldMutSceneExt::merge_scene`] for details on merge behavior and its caveats.
+    /// See [`EntityWorldMutSceneExt::merge_scene`].
     fn merge_scene<S: Scene>(&mut self, scene: S) -> &mut Self;
 }
 
@@ -906,7 +908,7 @@ impl QueuedScenes {
 #[cfg(test)]
 mod tests {
     use super::EntityWorldMutSceneExt;
-    use crate::{self as bevy_scene, bsn, RelationshipBehavior, ScenePlugin};
+    use crate::{self as bevy_scene, bsn, ScenePlugin};
     use bevy_app::{App, TaskPoolPlugin};
     use bevy_asset::AssetPlugin;
     use bevy_ecs::{name::Name, prelude::*, template::FromTemplate};
@@ -992,27 +994,6 @@ mod tests {
             Children [ #SceneChild SceneChild ]
         };
         world.entity_mut(root).merge_scene(scene).unwrap();
-
-        assert_merge_extends_children(world, root, pre_existing);
-    }
-
-    /// Tests that documented behavior of [`EntityWorldMutSceneExt::apply_scene`] is correct when using [`RelationshipBehavior::Merge`].
-    #[test]
-    fn apply_scene_with_merge_insert_extends_children() {
-        let mut app = test_app();
-        let world = app.world_mut();
-
-        let pre_existing = world.spawn(PreExistingChild).id();
-        let root = world.spawn(Name::new("root")).add_child(pre_existing).id();
-
-        let scene = bsn! {
-            Children [ #SceneChild SceneChild ]
-        };
-        world
-            .entity_mut(root)
-            .insert(RelationshipBehavior::Merge)
-            .apply_scene(scene)
-            .unwrap();
 
         assert_merge_extends_children(world, root, pre_existing);
     }

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -456,6 +456,9 @@ pub trait EntityWorldMutSceneExt {
     ///
     /// When a scene is resolved, it will replace and orphan the current entity's children.
     ///
+    /// To retain and extend existing children instead, insert [`RelationshipBehavior::Merge`] on
+    /// the entity before calling this method.
+    ///
     /// If resolving and spawning is successful, the entity will contain the full contents of the spawned scene.
     ///
     /// This will write directly on top of any existing components on the entity. [`Scene`] is generally used as a spawning mechanism, so for most things, prefer using [`World::spawn_scene`].
@@ -870,7 +873,7 @@ impl QueuedScenes {
 #[cfg(test)]
 mod tests {
     use super::EntityWorldMutSceneExt;
-    use crate::{self as bevy_scene, bsn, ScenePlugin};
+    use crate::{self as bevy_scene, bsn, RelationshipBehavior, ScenePlugin};
     use bevy_app::{App, TaskPoolPlugin};
     use bevy_asset::AssetPlugin;
     use bevy_ecs::{name::Name, prelude::*, template::FromTemplate};
@@ -923,5 +926,44 @@ mod tests {
         // Pre-existing child entity still exists, but is no longer listed under root.
         assert!(world.get_entity(pre_existing).is_ok());
         assert!(!children.contains(&pre_existing));
+    }
+
+    #[test]
+    fn apply_scene_with_merge_extends_children() {
+        let mut app = test_app();
+        let world = app.world_mut();
+
+        let pre_existing = world.spawn(PreExistingChild).id();
+        let root = world.spawn(Name::new("root")).add_child(pre_existing).id();
+
+        assert_eq!(
+            world.entity(root).get::<Children>().map(Children::len),
+            Some(1)
+        );
+
+        let scene = bsn! {
+            Children [ #SceneChild SceneChild ]
+        };
+        world
+            .entity_mut(root)
+            .insert(RelationshipBehavior::Merge)
+            .apply_scene(scene)
+            .unwrap();
+
+        let children: Vec<Entity> = world
+            .entity(root)
+            .get::<Children>()
+            .map(|c| c.iter().collect())
+            .unwrap_or_default();
+
+        assert_eq!(children.len(), 2);
+        assert!(children.contains(&pre_existing));
+        assert!(
+            children
+                .iter()
+                .filter(|entity| world.entity(**entity).contains::<SceneChild>())
+                .count()
+                == 1
+        );
     }
 }


### PR DESCRIPTION
# Objective

- Allow the **user to control relationship updates** by giving the option to merge children (extend relationships generally).
    - As referenced in #24909, the current behavior of `apply_scene` is to replace and orphan children. 
    - **Compare with** stacked PR https://github.com/ramate-io/bevy/pull/2 for further control of relationship behavior. 

## Solution

Critically:

```rust
    fn patch_scene<S: Scene>(
        &mut self,
        scene: S,
        relationship_behavior: RelationshipBehavior,
    ) -> Result<(), SpawnSceneError>;

    fn apply_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError> {
        self.patch_scene(scene, RelationshipBehavior::Overwrite)
    }

    fn merge_scene<S: Scene>(&mut self, scene: S) -> Result<(), SpawnSceneError> {
        self.patch_scene(scene, RelationshipBehavior::Merge)
    }
```

- I used default implementations on the trait to extend marker behavior to a variant function `merge_scene`. 

## Testing

- See unit tests at the bottom of `spawn.rs`.

## Draft Notes

As we start to consider this feature, I would like to note there are, in fact, several potentially configurable behaviors:

1. Do we want to overwrite or extend the relationships? (This is the `RelationshipBehavior` provided here.)
2. If we are overwriting relationships, do we want to orphan exiting relationships or despawn them?  (`RelationshipGc`)
   - Do we want to despawn certain types of relationships? Entities matching certain bundles?
   - At what point does controlling this sort of thing become better as some kind of bespoke system?
3. Is the `RelationshipBehavior` used material? (`MaterializeRelationshipBehavior`)
4. If `RelationshipBehaviors` are material, does the pre-existing `RelationshipBehavior` or the behavior entering with the scene take precedence? 