### PR TITLE
add W axis to `bevy_feathers` builtin colors/tokens

### DIFF
--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -283,6 +283,7 @@ pub fn create_dark_theme() -> ThemeProps {
             (tokens::TEXT_INPUT_X_AXIS, palette::X_AXIS),
             (tokens::TEXT_INPUT_Y_AXIS, palette::Y_AXIS),
             (tokens::TEXT_INPUT_Z_AXIS, palette::Z_AXIS),
+            (tokens::TEXT_INPUT_W_AXIS, palette::W_AXIS),
             // Pane
             (tokens::PANE_HEADER_BG, palette::GRAY_0),
             (tokens::PANE_HEADER_BORDER, palette::WARM_GRAY_1),

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -53,6 +53,7 @@ pub fn create_dark_theme() -> ThemeProps {
             (semantic::AXIS_X, palette::X_AXIS),
             (semantic::AXIS_Y, palette::Y_AXIS),
             (semantic::AXIS_Z, palette::Z_AXIS),
+            (semantic::AXIS_W, palette::W_AXIS),
             (semantic::FOCUS_RING, palette::ACCENT.with_alpha(0.5)),
         ]),
         semantic_overrides: HashMap::from([
@@ -310,6 +311,7 @@ pub fn create_dark_theme() -> ThemeProps {
             (tokens::TEXT_INPUT_X_AXIS, semantic::AXIS_X),
             (tokens::TEXT_INPUT_Y_AXIS, semantic::AXIS_Y),
             (tokens::TEXT_INPUT_Z_AXIS, semantic::AXIS_Z),
+            (tokens::TEXT_INPUT_W_AXIS, semantic::AXIS_W),
             // Pane
             (tokens::PANE_HEADER_BG, semantic::SURFACE_PANE_HEADER),
             (tokens::PANE_HEADER_BORDER, semantic::SURFACE_PANE_BODY),

--- a/crates/bevy_feathers/src/palette.rs
+++ b/crates/bevy_feathers/src/palette.rs
@@ -31,3 +31,5 @@ pub const X_AXIS: Color = Color::oklcha(0.5232, 0.1404, 13.84, 1.0);
 pub const Y_AXIS: Color = Color::oklcha(0.5866, 0.1543, 129.84, 1.0);
 /// <div style="background-color: #2160A3; width: 10px; padding: 10px; border: 1px solid;"></div> - for Z-axis inputs and drag handles
 pub const Z_AXIS: Color = Color::oklcha(0.4847, 0.1249, 253.08, 1.0);
+/// <div style="background-color: #e0ded7; width: 10px; padding: 10px; border: 1px solid;"></div> - for W-axis inputs and drag handles
+pub const W_AXIS: Color = Color::oklcha(0.9, 0.01, 95.0, 1.0);

--- a/crates/bevy_feathers/src/palette.rs
+++ b/crates/bevy_feathers/src/palette.rs
@@ -31,3 +31,5 @@ pub const X_AXIS: Color = Color::oklcha(0.5232, 0.1404, 13.84, 1.0);
 pub const Y_AXIS: Color = Color::oklcha(0.5866, 0.1543, 129.84, 1.0);
 /// <div style="background-color: #2160A3; width: 10px; padding: 10px; border: 1px solid;"></div> - for Z-axis inputs and drag handles
 pub const Z_AXIS: Color = Color::oklcha(0.4847, 0.1249, 253.08, 1.0);
+/// <div style="background-color: #e0ded7; width: 10px; padding: 10px; border: 1px solid;"></div> - for Alpha color channel and W-axis inputs and drag handles
+pub const W_AXIS: Color = Color::oklcha(0.9, 0.01, 95.0, 1.0);

--- a/crates/bevy_feathers/src/tokens.rs
+++ b/crates/bevy_feathers/src/tokens.rs
@@ -349,6 +349,8 @@ pub const TEXT_INPUT_X_AXIS: ThemeToken = ThemeToken::new_static("feathers.texti
 pub const TEXT_INPUT_Y_AXIS: ThemeToken = ThemeToken::new_static("feathers.textinput.axis.y");
 /// Sigil color for Z
 pub const TEXT_INPUT_Z_AXIS: ThemeToken = ThemeToken::new_static("feathers.textinput.axis.z");
+/// Sigil color for W
+pub const TEXT_INPUT_W_AXIS: ThemeToken = ThemeToken::new_static("feathers.textinput.axis.w");
 
 // Pane
 

--- a/crates/bevy_feathers/src/tokens.rs
+++ b/crates/bevy_feathers/src/tokens.rs
@@ -351,6 +351,8 @@ pub const TEXT_INPUT_X_AXIS: ThemeToken = ThemeToken::new_static("feathers.texti
 pub const TEXT_INPUT_Y_AXIS: ThemeToken = ThemeToken::new_static("feathers.textinput.axis.y");
 /// Sigil color for Z
 pub const TEXT_INPUT_Z_AXIS: ThemeToken = ThemeToken::new_static("feathers.textinput.axis.z");
+/// Sigil color for W
+pub const TEXT_INPUT_W_AXIS: ThemeToken = ThemeToken::new_static("feathers.textinput.axis.w");
 
 // Pane
 
@@ -508,6 +510,8 @@ pub mod semantic {
     pub const AXIS_Y: SemanticToken = SemanticToken::new_static("axis.y");
     /// Z-Axis
     pub const AXIS_Z: SemanticToken = SemanticToken::new_static("axis.z");
+    /// Z-Axis
+    pub const AXIS_W: SemanticToken = SemanticToken::new_static("axis.w");
     /// Focus ring
     pub const FOCUS_RING: SemanticToken = SemanticToken::new_static("focus.ring");
 }

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -36,7 +36,7 @@ struct DemoWidgetStates {
     rgb_color: Srgba,
     hsl_color: Hsla,
     scalar_prop: f32,
-    vec3_prop: Vec3,
+    vec4_prop: Vec4,
 }
 
 #[derive(Component, Clone, Copy, PartialEq, FromTemplate)]
@@ -59,11 +59,12 @@ struct DemoDialogToggle;
 struct DemoScalarField;
 
 #[derive(Component, Clone, Copy, Default, VariantDefaults)]
-enum DemoVec3Field {
+enum DemoVec4Field {
     #[default]
     X,
     Y,
     Z,
+    W,
 }
 
 fn main() {
@@ -74,7 +75,7 @@ fn main() {
             rgb_color: palettes::tailwind::EMERALD_800.with_alpha(0.7),
             hsl_color: palettes::tailwind::AMBER_800.into(),
             scalar_prop: 7.0,
-            vec3_prop: Vec3::new(10.1, 7.124, 100.0),
+            vec4_prop: Vec4::new(10.1, 7.124, 100.0, 10.0),
         })
         .add_systems(Startup, scene.spawn())
         .add_systems(Update, update_colors)
@@ -838,7 +839,7 @@ fn demo_column_2() -> impl Scene {
                                                     states.scalar_prop = value_change.value;
                                                 })
                                             ),
-                                            label_small("Vec3 property"),
+                                            label_small("Vec4 property"),
                                             Node {
                                                 display: Display::Flex,
                                                 flex_direction: FlexDirection::Row,
@@ -853,7 +854,7 @@ fn demo_column_2() -> impl Scene {
                                                         @label_text: "X",
                                                     }
                                                     NumberInputPrecision(2)
-                                                    DemoVec3Field::X
+                                                    DemoVec4Field::X
                                                     Node {
                                                         flex_grow: 1.0,
                                                     }
@@ -861,7 +862,7 @@ fn demo_column_2() -> impl Scene {
                                                     on(
                                                         |value_change: On<ValueChange<f32>>,
                                                         mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec3_prop.x = value_change.value;
+                                                        states.vec4_prop.x = value_change.value;
                                                     })
                                                 ),
                                                 (
@@ -870,14 +871,14 @@ fn demo_column_2() -> impl Scene {
                                                         @label_text: "Y",
                                                     }
                                                     NumberInputPrecision(2)
-                                                    DemoVec3Field::Y
+                                                    DemoVec4Field::Y
                                                     Node {
                                                         flex_grow: 1.0,
                                                     }
                                                     on(
                                                         |value_change: On<ValueChange<f32>>,
                                                         mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec3_prop.y = value_change.value;
+                                                        states.vec4_prop.y = value_change.value;
                                                     })
                                                 ),
                                                 (
@@ -886,14 +887,30 @@ fn demo_column_2() -> impl Scene {
                                                         @label_text: "Z",
                                                     }
                                                     NumberInputPrecision(2)
-                                                    DemoVec3Field::Z
+                                                    DemoVec4Field::Z
                                                     Node {
                                                         flex_grow: 1.0,
                                                     }
                                                     on(
                                                         |value_change: On<ValueChange<f32>>,
                                                         mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec3_prop.z = value_change.value;
+                                                        states.vec4_prop.z = value_change.value;
+                                                    })
+                                                ),
+                                                (
+                                                    @FeathersNumberInput {
+                                                        @sigil_color: tokens::TEXT_INPUT_W_AXIS,
+                                                        @label_text: "W",
+                                                    }
+                                                    NumberInputPrecision(2)
+                                                    DemoVec4Field::W
+                                                    Node {
+                                                        flex_grow: 1.0,
+                                                    }
+                                                    on(
+                                                        |value_change: On<ValueChange<f32>>,
+                                                        mut states: ResMut<DemoWidgetStates>| {
+                                                        states.vec4_prop.w = value_change.value;
                                                     })
                                                 ),
                                             ],
@@ -943,7 +960,7 @@ fn update_colors(
     mut color_planes: Query<&mut ColorPlaneValue, With<FeathersColorPlane>>,
     q_text_input: Single<(Entity, &mut EditableText), With<HexColorInput>>,
     q_scalar_input: Query<Entity, With<DemoScalarField>>,
-    q_vec3_input: Query<(Entity, &DemoVec3Field)>,
+    q_vec3_input: Query<(Entity, &DemoVec4Field)>,
     mut commands: Commands,
     focus: Res<InputFocus>,
 ) {
@@ -1024,9 +1041,10 @@ fn update_colors(
 
         for (vec3_input_ent, axis) in q_vec3_input.iter() {
             let new_value = match axis {
-                DemoVec3Field::X => states.vec3_prop.x,
-                DemoVec3Field::Y => states.vec3_prop.y,
-                DemoVec3Field::Z => states.vec3_prop.z,
+                DemoVec4Field::X => states.vec4_prop.x,
+                DemoVec4Field::Y => states.vec4_prop.y,
+                DemoVec4Field::Z => states.vec4_prop.z,
+                DemoVec4Field::W => states.vec4_prop.w,
             };
 
             commands

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -36,7 +36,7 @@ struct DemoWidgetStates {
     rgb_color: Srgba,
     hsl_color: Hsla,
     scalar_prop: f32,
-    vec3_prop: Vec3,
+    vec4_prop: Vec4,
 }
 
 #[derive(Component, Clone, Copy, PartialEq, FromTemplate)]
@@ -59,11 +59,12 @@ struct DemoDialogToggle;
 struct DemoScalarField;
 
 #[derive(Component, Clone, Copy, Default, VariantDefaults)]
-enum DemoVec3Field {
+enum DemoVec4Field {
     #[default]
     X,
     Y,
     Z,
+    W,
 }
 
 fn main() {
@@ -74,7 +75,7 @@ fn main() {
             rgb_color: palettes::tailwind::EMERALD_800.with_alpha(0.7),
             hsl_color: palettes::tailwind::AMBER_800.into(),
             scalar_prop: 7.0,
-            vec3_prop: Vec3::new(10.1, 7.124, 100.0),
+            vec4_prop: Vec4::new(10.1, 7.124, 100.0, 10.0),
         })
         .add_systems(Startup, scene.spawn())
         .add_systems(Update, update_colors)
@@ -739,7 +740,7 @@ fn demo_column_2() -> impl Scene {
                                                     states.scalar_prop = value_change.value;
                                                 })
                                             ),
-                                            label_small("Vec3 property"),
+                                            label_small("Vec4 property"),
                                             Node {
                                                 display: Display::Flex,
                                                 flex_direction: FlexDirection::Row,
@@ -754,7 +755,7 @@ fn demo_column_2() -> impl Scene {
                                                         @label_text: "X",
                                                     }
                                                     NumberInputPrecision(2)
-                                                    DemoVec3Field::X
+                                                    DemoVec4Field::X
                                                     Node {
                                                         flex_grow: 1.0,
                                                     }
@@ -762,7 +763,7 @@ fn demo_column_2() -> impl Scene {
                                                     on(
                                                         |value_change: On<ValueChange<f32>>,
                                                         mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec3_prop.x = value_change.value;
+                                                        states.vec4_prop.x = value_change.value;
                                                     })
                                                 ),
                                                 (
@@ -771,14 +772,14 @@ fn demo_column_2() -> impl Scene {
                                                         @label_text: "Y",
                                                     }
                                                     NumberInputPrecision(2)
-                                                    DemoVec3Field::Y
+                                                    DemoVec4Field::Y
                                                     Node {
                                                         flex_grow: 1.0,
                                                     }
                                                     on(
                                                         |value_change: On<ValueChange<f32>>,
                                                         mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec3_prop.y = value_change.value;
+                                                        states.vec4_prop.y = value_change.value;
                                                     })
                                                 ),
                                                 (
@@ -787,14 +788,30 @@ fn demo_column_2() -> impl Scene {
                                                         @label_text: "Z",
                                                     }
                                                     NumberInputPrecision(2)
-                                                    DemoVec3Field::Z
+                                                    DemoVec4Field::Z
                                                     Node {
                                                         flex_grow: 1.0,
                                                     }
                                                     on(
                                                         |value_change: On<ValueChange<f32>>,
                                                         mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec3_prop.z = value_change.value;
+                                                        states.vec4_prop.z = value_change.value;
+                                                    })
+                                                ),
+                                                (
+                                                    @FeathersNumberInput {
+                                                        @sigil_color: tokens::TEXT_INPUT_W_AXIS,
+                                                        @label_text: "W",
+                                                    }
+                                                    NumberInputPrecision(2)
+                                                    DemoVec4Field::W
+                                                    Node {
+                                                        flex_grow: 1.0,
+                                                    }
+                                                    on(
+                                                        |value_change: On<ValueChange<f32>>,
+                                                        mut states: ResMut<DemoWidgetStates>| {
+                                                        states.vec4_prop.w = value_change.value;
                                                     })
                                                 ),
                                             ],
@@ -844,7 +861,7 @@ fn update_colors(
     mut color_planes: Query<&mut ColorPlaneValue, With<FeathersColorPlane>>,
     q_text_input: Single<(Entity, &mut EditableText), With<HexColorInput>>,
     q_scalar_input: Query<Entity, With<DemoScalarField>>,
-    q_vec3_input: Query<(Entity, &DemoVec3Field)>,
+    q_vec3_input: Query<(Entity, &DemoVec4Field)>,
     mut commands: Commands,
     focus: Res<InputFocus>,
 ) {
@@ -925,9 +942,10 @@ fn update_colors(
 
         for (vec3_input_ent, axis) in q_vec3_input.iter() {
             let new_value = match axis {
-                DemoVec3Field::X => states.vec3_prop.x,
-                DemoVec3Field::Y => states.vec3_prop.y,
-                DemoVec3Field::Z => states.vec3_prop.z,
+                DemoVec4Field::X => states.vec4_prop.x,
+                DemoVec4Field::Y => states.vec4_prop.y,
+                DemoVec4Field::Z => states.vec4_prop.z,
+                DemoVec4Field::W => states.vec4_prop.w,
             };
 
             commands

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -36,7 +36,7 @@ struct DemoWidgetStates {
     rgb_color: Srgba,
     hsl_color: Hsla,
     scalar_prop: f32,
-    vec4_prop: Vec4,
+    vec3_prop: Vec3,
 }
 
 #[derive(Component, Clone, Copy, PartialEq, FromTemplate)]
@@ -59,12 +59,11 @@ struct DemoDialogToggle;
 struct DemoScalarField;
 
 #[derive(Component, Clone, Copy, Default, VariantDefaults)]
-enum DemoVec4Field {
+enum DemoVec3Field {
     #[default]
     X,
     Y,
     Z,
-    W,
 }
 
 fn main() {
@@ -75,7 +74,7 @@ fn main() {
             rgb_color: palettes::tailwind::EMERALD_800.with_alpha(0.7),
             hsl_color: palettes::tailwind::AMBER_800.into(),
             scalar_prop: 7.0,
-            vec4_prop: Vec4::new(10.1, 7.124, 100.0, 10.0),
+            vec3_prop: Vec3::new(10.1, 7.124, 100.0),
         })
         .add_systems(Startup, scene.spawn())
         .add_systems(Update, update_colors)
@@ -839,7 +838,7 @@ fn demo_column_2() -> impl Scene {
                                                     states.scalar_prop = value_change.value;
                                                 })
                                             ),
-                                            label_small("Vec4 property"),
+                                            label_small("Vec3 property"),
                                             Node {
                                                 display: Display::Flex,
                                                 flex_direction: FlexDirection::Row,
@@ -854,7 +853,7 @@ fn demo_column_2() -> impl Scene {
                                                         @label_text: "X",
                                                     }
                                                     NumberInputPrecision(2)
-                                                    DemoVec4Field::X
+                                                    DemoVec3Field::X
                                                     Node {
                                                         flex_grow: 1.0,
                                                     }
@@ -862,7 +861,7 @@ fn demo_column_2() -> impl Scene {
                                                     on(
                                                         |value_change: On<ValueChange<f32>>,
                                                         mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec4_prop.x = value_change.value;
+                                                        states.vec3_prop.x = value_change.value;
                                                     })
                                                 ),
                                                 (
@@ -871,14 +870,14 @@ fn demo_column_2() -> impl Scene {
                                                         @label_text: "Y",
                                                     }
                                                     NumberInputPrecision(2)
-                                                    DemoVec4Field::Y
+                                                    DemoVec3Field::Y
                                                     Node {
                                                         flex_grow: 1.0,
                                                     }
                                                     on(
                                                         |value_change: On<ValueChange<f32>>,
                                                         mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec4_prop.y = value_change.value;
+                                                        states.vec3_prop.y = value_change.value;
                                                     })
                                                 ),
                                                 (
@@ -887,31 +886,74 @@ fn demo_column_2() -> impl Scene {
                                                         @label_text: "Z",
                                                     }
                                                     NumberInputPrecision(2)
-                                                    DemoVec4Field::Z
+                                                    DemoVec3Field::Z
                                                     Node {
                                                         flex_grow: 1.0,
                                                     }
                                                     on(
                                                         |value_change: On<ValueChange<f32>>,
                                                         mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec4_prop.z = value_change.value;
+                                                        states.vec3_prop.z = value_change.value;
                                                     })
+                                                ),
+                                            ],
+                                            label_small("Color property"),
+                                            Node {
+                                                display: Display::Flex,
+                                                flex_direction: FlexDirection::Row,
+                                                column_gap: px(6),
+                                                align_items: AlignItems::Center,
+                                                justify_content: JustifyContent::SpaceBetween,
+                                            }
+                                            Children [
+                                                (
+                                                    @FeathersNumberInput {
+                                                        @sigil_color: tokens::TEXT_INPUT_X_AXIS,
+                                                        @label_text: "R",
+                                                    }
+                                                    InteractionDisabled
+                                                    NumberInputPrecision(2)
+                                                    template_value(HardLimit(NumberInputRange::F32(0.0..=1.0)))
+                                                    Node {
+                                                        flex_grow: 1.0,
+                                                    }
+                                                    BorderColor::all(palette::X_AXIS)
+                                                ),
+                                                (
+                                                    @FeathersNumberInput {
+                                                        @sigil_color: tokens::TEXT_INPUT_Y_AXIS,
+                                                        @label_text: "G",
+                                                    }
+                                                    InteractionDisabled
+                                                    NumberInputPrecision(2)
+                                                    template_value(HardLimit(NumberInputRange::F32(0.0..=1.0)))
+                                                    Node {
+                                                        flex_grow: 1.0,
+                                                    }
+                                                ),
+                                                (
+                                                    @FeathersNumberInput {
+                                                        @sigil_color: tokens::TEXT_INPUT_Z_AXIS,
+                                                        @label_text: "B",
+                                                    }
+                                                    InteractionDisabled
+                                                    NumberInputPrecision(2)
+                                                    template_value(HardLimit(NumberInputRange::F32(0.0..=1.0)))
+                                                    Node {
+                                                        flex_grow: 1.0,
+                                                    }
                                                 ),
                                                 (
                                                     @FeathersNumberInput {
                                                         @sigil_color: tokens::TEXT_INPUT_W_AXIS,
-                                                        @label_text: "W",
+                                                        @label_text: "A",
                                                     }
+                                                    InteractionDisabled
                                                     NumberInputPrecision(2)
-                                                    DemoVec4Field::W
+                                                    template_value(HardLimit(NumberInputRange::F32(0.0..=1.0)))
                                                     Node {
                                                         flex_grow: 1.0,
                                                     }
-                                                    on(
-                                                        |value_change: On<ValueChange<f32>>,
-                                                        mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec4_prop.w = value_change.value;
-                                                    })
                                                 ),
                                             ],
                                         ],
@@ -960,7 +1002,7 @@ fn update_colors(
     mut color_planes: Query<&mut ColorPlaneValue, With<FeathersColorPlane>>,
     q_text_input: Single<(Entity, &mut EditableText), With<HexColorInput>>,
     q_scalar_input: Query<Entity, With<DemoScalarField>>,
-    q_vec3_input: Query<(Entity, &DemoVec4Field)>,
+    q_vec3_input: Query<(Entity, &DemoVec3Field)>,
     mut commands: Commands,
     focus: Res<InputFocus>,
 ) {
@@ -1041,10 +1083,9 @@ fn update_colors(
 
         for (vec3_input_ent, axis) in q_vec3_input.iter() {
             let new_value = match axis {
-                DemoVec4Field::X => states.vec4_prop.x,
-                DemoVec4Field::Y => states.vec4_prop.y,
-                DemoVec4Field::Z => states.vec4_prop.z,
-                DemoVec4Field::W => states.vec4_prop.w,
+                DemoVec3Field::X => states.vec3_prop.x,
+                DemoVec3Field::Y => states.vec3_prop.y,
+                DemoVec3Field::Z => states.vec3_prop.z,
             };
 
             commands


### PR DESCRIPTION

# Objective

- Bevy natively supports vectors up to 4 dimensions. Currently bevy feathers natively only supports the X,Y,Z axes. This commit adds a color and a token for the W axis.

## Solution

- The commit uses a dim yellow color which was picked to fit nicely into the existing colors

## Testing

- The bevy feathers gallery was adjusted to use a vec4 for showroom purposes

---

## Showcase

<img width="354" height="85" alt="screenshot-20260709-211104" src="https://github.com/user-attachments/assets/1c4eb579-93a3-430f-bb45-63c806dbddb0" />
