### PR TITLE
Chore: Remove duplicate PointerFocusPlugin registrations from examples to prevent panics

### DIFF
--- a/examples/ui/text/ime_support.rs
+++ b/examples/ui/text/ime_support.rs
@@ -18,7 +18,7 @@ use bevy::text::{EditableText, TextCursorStyle};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins((TabNavigationPlugin))
+        .add_plugins(TabNavigationPlugin)
         .add_systems(Startup, setup)
         .add_systems(Update, text_submission)
         .run();

--- a/examples/ui/text/ime_support.rs
+++ b/examples/ui/text/ime_support.rs
@@ -9,7 +9,6 @@
 use bevy::color::palettes::css::DARK_GREY;
 use bevy::color::palettes::tailwind::SLATE_300;
 use bevy::input_focus::{
-    pointer_focus::PointerFocusPlugin,
     tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
     InputFocus,
 };
@@ -19,7 +18,7 @@ use bevy::text::{EditableText, TextCursorStyle};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins((TabNavigationPlugin, PointerFocusPlugin))
+        .add_plugins((TabNavigationPlugin))
         .add_systems(Startup, setup)
         .add_systems(Update, text_submission)
         .run();

--- a/examples/ui/text/multiline_text_input.rs
+++ b/examples/ui/text/multiline_text_input.rs
@@ -3,7 +3,6 @@
 use bevy::color::palettes::css::DARK_SLATE_GRAY;
 use bevy::color::palettes::tailwind::SLATE_300;
 use bevy::input::keyboard::{Key, KeyboardInput};
-use bevy::input_focus::pointer_focus::PointerFocusPlugin;
 use bevy::input_focus::tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin};
 use bevy::input_focus::{AutoFocus, FocusCause, FocusedInput, InputFocus};
 use bevy::prelude::*;
@@ -16,7 +15,7 @@ use bevy::ui_widgets::{
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, TabNavigationPlugin, PointerFocusPlugin))
+        .add_plugins((DefaultPlugins, TabNavigationPlugin))
         .add_systems(Startup, setup)
         .run();
 }

--- a/examples/ui/text/multiple_text_inputs.rs
+++ b/examples/ui/text/multiple_text_inputs.rs
@@ -8,19 +8,18 @@
 use bevy::color::palettes::tailwind::SLATE_300;
 use bevy::input::keyboard::Key;
 use bevy::input_focus::tab_navigation::NavAction;
+use bevy::input_focus::{tab_navigation::TabNavigation, AutoFocus, FocusCause};
 use bevy::input_focus::{
-    pointer_focus::PointerFocusPlugin,
-    tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
+    tab_navigation::{TabGroup, TabIndex},
     InputFocus,
 };
-use bevy::input_focus::{tab_navigation::TabNavigation, AutoFocus, FocusCause};
 use bevy::prelude::*;
 use bevy::text::{EditableText, TextCursorStyle, TextEditChange};
 
 fn main() {
     App::new()
         // `EditableTextInputPlugin` is part of `DefaultPlugins`
-        .add_plugins((DefaultPlugins, TabNavigationPlugin, PointerFocusPlugin))
+        .add_plugins((DefaultPlugins, TabNavigationPlugin))
         .add_systems(Startup, setup)
         .add_systems(Update, (submit_text, update_row_border_colors))
         .add_observer(synchronize_output_text)

--- a/examples/ui/text/multiple_text_inputs.rs
+++ b/examples/ui/text/multiple_text_inputs.rs
@@ -10,7 +10,7 @@ use bevy::input::keyboard::Key;
 use bevy::input_focus::tab_navigation::NavAction;
 use bevy::input_focus::{tab_navigation::TabNavigation, AutoFocus, FocusCause};
 use bevy::input_focus::{
-    tab_navigation::{TabGroup, TabIndex},
+    tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
     InputFocus,
 };
 use bevy::prelude::*;

--- a/examples/ui/text/text_input.rs
+++ b/examples/ui/text/text_input.rs
@@ -26,7 +26,6 @@ use bevy::color::palettes::css::DARK_GREY;
 use bevy::color::palettes::tailwind::SLATE_300;
 use bevy::input_focus::AutoFocus;
 use bevy::input_focus::{
-    pointer_focus::PointerFocusPlugin,
     tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
     InputFocus,
 };
@@ -36,7 +35,7 @@ use bevy::text::{EditableText, TextCursorStyle};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins((TabNavigationPlugin, PointerFocusPlugin))
+        .add_plugins((TabNavigationPlugin))
         .add_systems(Startup, setup)
         .add_systems(Update, text_submission)
         .run();

--- a/examples/ui/text/text_input.rs
+++ b/examples/ui/text/text_input.rs
@@ -35,7 +35,7 @@ use bevy::text::{EditableText, TextCursorStyle};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins((TabNavigationPlugin))
+        .add_plugins(TabNavigationPlugin)
         .add_systems(Startup, setup)
         .add_systems(Update, text_submission)
         .run();

--- a/examples/ui/widgets/standard_widgets.rs
+++ b/examples/ui/widgets/standard_widgets.rs
@@ -9,7 +9,6 @@
 use bevy::{
     color::palettes::basic::*,
     input_focus::{
-        pointer_focus::PointerFocusPlugin,
         tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
         FocusCause, InputFocus,
     },
@@ -27,7 +26,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, TabNavigationPlugin, PointerFocusPlugin))
+        .add_plugins((DefaultPlugins, TabNavigationPlugin))
         .insert_resource(DemoWidgetStates {
             slider_value: 50.0,
             slider_click: TrackClick::Snap,

--- a/examples/ui/widgets/standard_widgets_observers.rs
+++ b/examples/ui/widgets/standard_widgets_observers.rs
@@ -6,7 +6,6 @@
 
 use bevy::{
     color::palettes::basic::*,
-    input_focus::pointer_focus::PointerFocusPlugin,
     input_focus::tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
     picking::hover::Hovered,
     prelude::*,
@@ -20,7 +19,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, TabNavigationPlugin, PointerFocusPlugin))
+        .add_plugins((DefaultPlugins, TabNavigationPlugin))
         .insert_resource(DemoWidgetStates { slider_value: 50.0 })
         .add_systems(Startup, setup)
         .add_observer(button_on_interaction::<Add, Pressed>)

--- a/examples/ui/widgets/tab_navigation.rs
+++ b/examples/ui/widgets/tab_navigation.rs
@@ -3,7 +3,6 @@
 use bevy::{
     color::palettes::basic::*,
     input_focus::{
-        pointer_focus::PointerFocusPlugin,
         tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
         FocusCause, InputFocus,
     },
@@ -12,7 +11,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, TabNavigationPlugin, PointerFocusPlugin))
+        .add_plugins((DefaultPlugins, TabNavigationPlugin))
         .add_systems(Startup, setup)
         .add_systems(Update, (button_system, focus_system))
         .run();

--- a/examples/ui/widgets/vertical_slider.rs
+++ b/examples/ui/widgets/vertical_slider.rs
@@ -1,7 +1,6 @@
 //! Simple example showing vertical and horizontal slider widgets with snap behavior and value labels
 
 use bevy::{
-    input_focus::pointer_focus::PointerFocusPlugin,
     input_focus::tab_navigation::{TabGroup, TabIndex, TabNavigationPlugin},
     picking::hover::Hovered,
     prelude::*,
@@ -16,7 +15,7 @@ const SLIDER_THUMB: Color = Color::srgb(0.35, 0.75, 0.35);
 
 fn main() {
     App::new()
-        .add_plugins((DefaultPlugins, TabNavigationPlugin, PointerFocusPlugin))
+        .add_plugins((DefaultPlugins, TabNavigationPlugin))
         .add_systems(Startup, setup)
         .add_systems(Update, (update_slider_visuals, update_value_labels))
         .run();


### PR DESCRIPTION
# Objective

- Follow up from #24757 that fixes duplicate `PointerFocusPlugin` registrations since it is now included by default in `UiWidgetsPlugins`

## Solution

- Remove the duplicate `PointerFocusPlugin` registrations

## Testing

- Built the examples before my changes, resulting in panics
- Built the examples after: clean builds.