### PR TITLE
Fix `filtered_backtrace_test` for Rust 1.97

### DIFF
--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -704,15 +704,17 @@ mod tests {
         }
 
         let expected_lines = alloc::vec![
+            "<bevy_ecs::error::bevy_error::BevyError as core::convert::From<core::num::error::ParseIntError>>::from",
+            "<core::result::Result<(), bevy_ecs::error::bevy_error::BevyError> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible, core::num::error::ParseIntError>>>::from_residual",
             "bevy_ecs::error::bevy_error::tests::filtered_backtrace_test::i_fail",
             "bevy_ecs::error::bevy_error::tests::filtered_backtrace_test",
-            "bevy_ecs::error::bevy_error::tests::filtered_backtrace_test::{{closure}}",
-            "core::ops::function::FnOnce::call_once",
+            "bevy_ecs::error::bevy_error::tests::filtered_backtrace_test::{closure#0}",
+            "<bevy_ecs::error::bevy_error::tests::filtered_backtrace_test::{closure#0} as core::ops::function::FnOnce<()>>::call_once",
+            "<fn() -> core::result::Result<(), alloc::string::String> as core::ops::function::FnOnce<()>>::call_once",
         ];
 
         for expected in expected_lines {
-            let line = lines.next().unwrap();
-            assert_eq!(&line[6..], expected);
+            // On mac, it can sometimes start with an "at" line
             let mut skip = false;
             if let Some(line) = lines.peek()
                 && line.starts_with("             at")
@@ -723,6 +725,20 @@ mod tests {
             if skip {
                 lines.next().unwrap();
             }
+
+            let line = lines.next().unwrap();
+            assert_eq!(&line[6..], expected);
+        }
+        // To handle any potential "at" line after the expected lines
+        let mut skip = false;
+        if let Some(line) = lines.peek()
+            && line.starts_with("             at")
+        {
+            skip = true;
+        }
+
+        if skip {
+            lines.next().unwrap();
         }
 
         // on linux there is a second call_once

--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -710,7 +710,6 @@ mod tests {
             "bevy_ecs::error::bevy_error::tests::filtered_backtrace_test",
             "bevy_ecs::error::bevy_error::tests::filtered_backtrace_test::{closure#0}",
             "<bevy_ecs::error::bevy_error::tests::filtered_backtrace_test::{closure#0} as core::ops::function::FnOnce<()>>::call_once",
-            "<fn() -> core::result::Result<(), alloc::string::String> as core::ops::function::FnOnce<()>>::call_once",
         ];
 
         for expected in expected_lines {
@@ -744,7 +743,7 @@ mod tests {
         // on linux there is a second call_once
         let mut skip = false;
         if let Some(line) = lines.peek()
-            && &line[6..] == "core::ops::function::FnOnce::call_once"
+            && &line[6..] == "<fn() -> core::result::Result<(), alloc::string::String> as core::ops::function::FnOnce<()>>::call_once"
         {
             skip = true;
         }


### PR DESCRIPTION
# Objective

- Fixes #24871 
- Fix the flaky `filtered_backtrace_test` that’s been causing CI failures (e.g. https://github.com/bevyengine/bevy/actions/runs/29093719993/job/86365018081)

## Solution

- After updating my rust version via `rustup update`, I just ran it locally and updated the test accordingly. Note that I’m testing on a Mac.

## Testing

- Ran `RUST_BACKTRACE=1 cargo test` in the bevy_ecs crate and the test passes
- Hopefully ci is happy too