### PR TITLE
Limited contextual theming

### DIFF
--- a/crates/bevy_feathers/src/containers/group.rs
+++ b/crates/bevy_feathers/src/containers/group.rs
@@ -6,7 +6,7 @@ use crate::{
     constants::{fonts, size},
     font_styles::InheritableFont,
     rounded_corners::RoundedCorners,
-    theme::{InheritableThemeTextColor, ThemeBackgroundColor, ThemeBorderColor},
+    theme::{InheritableThemeTextColor, SurfaceTier, ThemeBackgroundColor, ThemeBorderColor},
     tokens,
 };
 
@@ -42,6 +42,7 @@ pub fn group_header() -> impl Scene {
         ThemeBackgroundColor(tokens::GROUP_HEADER_BG)
         ThemeBorderColor(tokens::GROUP_HEADER_BORDER)
         InheritableThemeTextColor(tokens::GROUP_HEADER_TEXT)
+        SurfaceTier::Level2
         InheritableFont {
             font: fonts::REGULAR,
             font_size: size::MEDIUM_FONT,

--- a/crates/bevy_feathers/src/containers/pane.rs
+++ b/crates/bevy_feathers/src/containers/pane.rs
@@ -9,7 +9,7 @@ use crate::{
     constants::{fonts, size},
     font_styles::InheritableFont,
     rounded_corners::RoundedCorners,
-    theme::{InheritableThemeTextColor, ThemeBackgroundColor, ThemeBorderColor},
+    theme::{InheritableThemeTextColor, SurfaceTier, ThemeBackgroundColor, ThemeBorderColor},
     tokens,
 };
 
@@ -45,6 +45,7 @@ pub fn pane_header() -> impl Scene {
         ThemeBackgroundColor(tokens::PANE_HEADER_BG)
         ThemeBorderColor(tokens::PANE_HEADER_BORDER)
         InheritableThemeTextColor(tokens::PANE_HEADER_TEXT)
+        SurfaceTier::Level1
         InheritableFont {
             font: fonts::REGULAR,
             font_size: size::MEDIUM_FONT,

--- a/crates/bevy_feathers/src/containers/subpane.rs
+++ b/crates/bevy_feathers/src/containers/subpane.rs
@@ -6,7 +6,7 @@ use crate::{
     constants::{fonts, size},
     font_styles::InheritableFont,
     rounded_corners::RoundedCorners,
-    theme::{InheritableThemeTextColor, ThemeBackgroundColor, ThemeBorderColor},
+    theme::{InheritableThemeTextColor, SurfaceTier, ThemeBackgroundColor, ThemeBorderColor},
     tokens,
 };
 
@@ -42,6 +42,7 @@ pub fn subpane_header() -> impl Scene {
         ThemeBackgroundColor(tokens::SUBPANE_HEADER_BG)
         ThemeBorderColor(tokens::SUBPANE_HEADER_BORDER)
         InheritableThemeTextColor(tokens::SUBPANE_HEADER_TEXT)
+        SurfaceTier::Level1
         InheritableFont {
             font: fonts::REGULAR,
             font_size: size::MEDIUM_FONT,

--- a/crates/bevy_feathers/src/controls/dialog.rs
+++ b/crates/bevy_feathers/src/controls/dialog.rs
@@ -19,7 +19,9 @@ use crate::{
     controls::{ButtonVariant, FeathersToolButton},
     display::icon,
     font_styles::InheritableFont,
-    theme::{InheritableThemeTextColor, ThemeBackgroundColor, ThemeBorderColor, ThemedText},
+    theme::{
+        InheritableThemeTextColor, SurfaceTier, ThemeBackgroundColor, ThemeBorderColor, ThemedText,
+    },
     tokens,
 };
 
@@ -146,6 +148,7 @@ impl FeathersFloatingDialog {
             ThemeBackgroundColor(tokens::DIALOG_BG)
             ThemeBorderColor(tokens::DIALOG_BORDER)
             InheritableThemeTextColor(tokens::DIALOG_TEXT)
+            SurfaceTier::Float
             BoxShadow::new(
                 Srgba::BLACK.with_alpha(0.9).into(),
                 px(0),

--- a/crates/bevy_feathers/src/controls/menu.rs
+++ b/crates/bevy_feathers/src/controls/menu.rs
@@ -35,7 +35,7 @@ use crate::{
     display::icon,
     font_styles::InheritableFont,
     rounded_corners::RoundedCorners,
-    theme::{InheritableThemeTextColor, ThemeBackgroundColor, ThemeBorderColor},
+    theme::{InheritableThemeTextColor, SurfaceTier, ThemeBackgroundColor, ThemeBorderColor},
     tokens,
 };
 use bevy_input_focus::{
@@ -357,6 +357,7 @@ impl FeathersMenuPopup {
             FeathersMenuPopup
             MenuPopup
             Visibility::Hidden
+            SurfaceTier::Float
             ThemeBackgroundColor(tokens::MENU_BG)
             ThemeBorderColor(tokens::MENU_BORDER)
             BoxShadow::new(

--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -51,7 +51,10 @@ use crate::{
     controls::{FeathersTextInput, FeathersTextInputContainer},
     cursor::EntityCursor,
     rounded_corners::RoundedCorners,
-    theme::{ThemeBackgroundColor, ThemeBorderColor, ThemeTextColor, ThemeToken, UiTheme},
+    theme::{
+        ThemeBackgroundColor, ThemeBorderColor, ThemeContextualBackgroundColor, ThemeTextColor,
+        ThemeToken, UiTheme,
+    },
     tokens,
 };
 
@@ -1086,17 +1089,42 @@ fn set_slidebar_styles(
         tokens::SLIDER_BAR
     });
 
-    let bg_color = theme.color(&if focused {
-        tokens::TEXT_INPUT_BG
+    let bg_color = if focused {
+        ThemeContextualBackgroundColor {
+            default: tokens::TEXT_INPUT_BG,
+            level1: tokens::TEXT_INPUT_BG_L1,
+            level2: tokens::TEXT_INPUT_BG_L2,
+            float: tokens::TEXT_INPUT_BG_FLOAT,
+        }
     } else if disabled {
-        tokens::SLIDER_BG_DISABLED
+        ThemeContextualBackgroundColor {
+            default: tokens::SLIDER_BG_DISABLED,
+            level1: tokens::SLIDER_BG_DISABLED,
+            level2: tokens::SLIDER_BG_DISABLED,
+            float: tokens::SLIDER_BG_DISABLED,
+        }
     } else if pressed {
-        tokens::SLIDER_BG_PRESSED
+        ThemeContextualBackgroundColor {
+            default: tokens::SLIDER_BG_PRESSED,
+            level1: tokens::SLIDER_BG_PRESSED,
+            level2: tokens::SLIDER_BG_PRESSED,
+            float: tokens::SLIDER_BG_PRESSED,
+        }
     } else if hovered {
-        tokens::SLIDER_BG_HOVER
+        ThemeContextualBackgroundColor {
+            default: tokens::SLIDER_BG_HOVER,
+            level1: tokens::SLIDER_BG_HOVER,
+            level2: tokens::SLIDER_BG_HOVER,
+            float: tokens::SLIDER_BG_HOVER,
+        }
     } else {
-        tokens::SLIDER_BG
-    });
+        ThemeContextualBackgroundColor {
+            default: tokens::SLIDER_BG,
+            level1: tokens::SLIDER_BG,
+            level2: tokens::SLIDER_BG,
+            float: tokens::SLIDER_BG,
+        }
+    };
 
     let font_color_token = match disabled {
         true => tokens::TEXT_INPUT_TEXT_DISABLED,
@@ -1111,15 +1139,14 @@ fn set_slidebar_styles(
     if let [Gradient::Linear(linear_gradient)] = &mut gradient.0[..] {
         linear_gradient.stops[0].color = bar_color;
         linear_gradient.stops[1].color = bar_color;
-        linear_gradient.stops[2].color = bg_color;
-        linear_gradient.stops[3].color = bg_color;
     }
 
-    // Change cursor shape and text color
+    // Change cursor shape and fill color
     commands
         .entity(slidebar_id)
         .insert(EntityCursor::System(cursor_shape))
-        .insert(ThemeTextColor(font_color_token));
+        .insert(ThemeTextColor(font_color_token))
+        .insert(bg_color);
 }
 
 fn emit_drag_value_change(

--- a/crates/bevy_feathers/src/controls/text_input.rs
+++ b/crates/bevy_feathers/src/controls/text_input.rs
@@ -27,7 +27,7 @@ use crate::{
     cursor::EntityCursor,
     focus::FocusWithinIndicator,
     font_styles::InheritableFont,
-    theme::{InheritableThemeTextColor, ThemeBackgroundColor, ThemedText, UiTheme},
+    theme::{InheritableThemeTextColor, ThemeContextualBackgroundColor, ThemedText, UiTheme},
     tokens,
 };
 
@@ -57,7 +57,12 @@ impl FeathersTextInputContainer {
             }
             FeathersTextInputContainer
             FocusWithinIndicator
-            ThemeBackgroundColor(tokens::TEXT_INPUT_BG)
+            ThemeContextualBackgroundColor {
+                default: tokens::TEXT_INPUT_BG,
+                level1: tokens::TEXT_INPUT_BG_L1,
+                level2: tokens::TEXT_INPUT_BG_L2,
+                float: tokens::TEXT_INPUT_BG_FLOAT,
+            }
             InheritableThemeTextColor(tokens::TEXT_INPUT_TEXT)
             InheritableFont {
                 font: fonts::REGULAR,

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -264,10 +264,10 @@ pub fn create_dark_theme() -> ThemeProps {
                 palette::WHITE.with_alpha(0.5),
             ),
             // Text Input
-            (
-                tokens::TEXT_INPUT_BG,
-                palette::LIGHT_GRAY_MIX.with_alpha(0.028),
-            ),
+            (tokens::TEXT_INPUT_BG, palette::GRAY_2),
+            (tokens::TEXT_INPUT_BG_L1, palette::GRAY_3),
+            (tokens::TEXT_INPUT_BG_L2, palette::GRAY_3.lighter(0.1)),
+            (tokens::TEXT_INPUT_BG_FLOAT, palette::GRAY_3),
             (
                 tokens::TEXT_INPUT_LABEL_BG,
                 palette::LIGHT_GRAY_MIX.with_alpha(0.09),

--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -99,10 +99,12 @@ impl Plugin for FeathersCorePlugin {
             PostUpdate,
             (
                 theme::update_theme,
+                theme::update_contextual_theme,
                 display::update_themed_icons.after(PropagateSet::<TextColor>::default()),
             ),
         )
         .add_observer(theme::on_changed_background)
+        .add_observer(theme::on_changed_contextual_background)
         .add_observer(theme::on_changed_border)
         .add_observer(theme::on_changed_font_color)
         .add_observer(theme::on_changed_text_color)

--- a/crates/bevy_feathers/src/theme.rs
+++ b/crates/bevy_feathers/src/theme.rs
@@ -4,12 +4,15 @@ use bevy_color::{palettes, Color};
 use bevy_ecs::{
     change_detection::DetectChanges,
     component::Component,
+    entity::Entity,
+    hierarchy::ChildOf,
     lifecycle::Insert,
     observer::On,
     query::Changed,
     reflect::{ReflectComponent, ReflectResource},
     resource::Resource,
     system::{Commands, Query, Res},
+    VariantDefaults,
 };
 use bevy_log::warn_once;
 use bevy_platform::collections::HashMap;
@@ -150,6 +153,32 @@ pub(crate) fn update_theme(
     }
 }
 
+pub(crate) fn update_contextual_theme(
+    mut q_contextual_background: Query<
+        (
+            Entity,
+            &mut BackgroundColor,
+            &ThemeContextualBackgroundColor,
+        ),
+        Changed<ThemeContextualBackgroundColor>,
+    >,
+    q_tier: Query<&SurfaceTier>,
+    q_parent: Query<&ChildOf>,
+    theme: Res<UiTheme>,
+) {
+    if theme.is_changed() {
+        // Update all contextual background colors
+        for (ent, mut bg, theme_bg) in q_contextual_background.iter_mut() {
+            let tier = q_parent
+                .iter_ancestors(ent)
+                .find_map(|e| q_tier.get(e).ok())
+                .cloned()
+                .unwrap_or_default();
+            bg.0 = theme.color(theme_bg.token_for(&tier));
+        }
+    }
+}
+
 pub(crate) fn on_changed_background(
     insert: On<Insert, ThemeBackgroundColor>,
     mut q_background: Query<
@@ -161,6 +190,27 @@ pub(crate) fn on_changed_background(
     // Update background colors where the design token has changed.
     if let Ok((mut bg, theme_bg)) = q_background.get_mut(insert.entity) {
         bg.0 = theme.color(&theme_bg.0);
+    }
+}
+
+pub(crate) fn on_changed_contextual_background(
+    insert: On<Insert, ThemeContextualBackgroundColor>,
+    q_tier: Query<&SurfaceTier>,
+    q_parent: Query<&ChildOf>,
+    mut q_contextual_background: Query<
+        (&mut BackgroundColor, &ThemeContextualBackgroundColor),
+        Changed<ThemeContextualBackgroundColor>,
+    >,
+    theme: Res<UiTheme>,
+) {
+    // Update background colors where the design token has changed.
+    if let Ok((mut bg, theme_bg)) = q_contextual_background.get_mut(insert.entity) {
+        let tier = q_parent
+            .iter_ancestors(insert.entity)
+            .find_map(|e| q_tier.get(e).ok())
+            .cloned()
+            .unwrap_or_default();
+        bg.0 = theme.color(theme_bg.token_for(&tier));
     }
 }
 
@@ -199,5 +249,57 @@ pub(crate) fn on_changed_font_color(
         commands
             .entity(insert.entity)
             .insert(Propagate(TextColor(color)));
+    }
+}
+
+/// A component which allows widgets to change their style based on context. This allows a
+/// slider or text input to have a different background color depending on the background color
+/// of the container that is has been placed within.
+///
+/// Usage: place this component on the container widget (panel, popup, etc.) to influence the
+/// color variations of the child widgets of that container. This affects all widgets which
+/// are descendants of the container.
+#[derive(Component, Clone, PartialEq, Debug, Default, VariantDefaults)]
+pub enum SurfaceTier {
+    /// The default (level 0) background
+    #[default]
+    Default,
+    /// A container with one level of nesting (such as a panel). In dark themes, these
+    /// backgrounds are slightly lighter.
+    Level1,
+    /// A container which has two levels of nesting.
+    Level2,
+    /// A popup or dialog box container which floats above the backdrop.
+    Float,
+}
+
+/// Component which causes the background color of an entity to be set based on a theme color.
+/// This version chooses a different color based on the [`SurfaceTier`] component of the parent
+/// widget.
+#[derive(Component, Clone, Default)]
+#[require(BackgroundColor)]
+#[component(immutable)]
+#[derive(Reflect)]
+#[reflect(Component, Clone)]
+pub struct ThemeContextualBackgroundColor {
+    /// Color token used when the surface tier is [`SurfaceTier::Default`].
+    pub default: ThemeToken,
+    /// Color token used when the surface tier is [`SurfaceTier::Level1`].
+    pub level1: ThemeToken,
+    /// Color token used when the surface tier is [`SurfaceTier::Level2`].
+    pub level2: ThemeToken,
+    /// Color token used when the surface tier is [`SurfaceTier::Float`].
+    pub float: ThemeToken,
+}
+
+impl ThemeContextualBackgroundColor {
+    /// Returns the [`ThemeToken`] corresponding to the given [`SurfaceTier`].
+    pub fn token_for(&self, tier: &SurfaceTier) -> &ThemeToken {
+        match tier {
+            SurfaceTier::Default => &self.default,
+            SurfaceTier::Level1 => &self.level1,
+            SurfaceTier::Level2 => &self.level2,
+            SurfaceTier::Float => &self.float,
+        }
     }
 }

--- a/crates/bevy_feathers/src/tokens.rs
+++ b/crates/bevy_feathers/src/tokens.rs
@@ -329,6 +329,12 @@ pub const MENUITEM_TEXT_DISABLED: ThemeToken =
 
 /// Background for text input
 pub const TEXT_INPUT_BG: ThemeToken = ThemeToken::new_static("feathers.textinput.bg");
+/// Background for text input for level 1 context
+pub const TEXT_INPUT_BG_L1: ThemeToken = ThemeToken::new_static("feathers.textinput.bg.l1");
+/// Background for text input for level 1 context
+pub const TEXT_INPUT_BG_L2: ThemeToken = ThemeToken::new_static("feathers.textinput.bg.l2");
+/// Background for text input for level 1 context
+pub const TEXT_INPUT_BG_FLOAT: ThemeToken = ThemeToken::new_static("feathers.textinput.bg.float");
 /// Text color for text input
 pub const TEXT_INPUT_TEXT: ThemeToken = ThemeToken::new_static("feathers.textinput.text");
 /// Text color for text input (disabled)

--- a/examples/ui/widgets/feathers_number_input.rs
+++ b/examples/ui/widgets/feathers_number_input.rs
@@ -2,10 +2,11 @@
 
 use bevy::{
     feathers::{
+        containers::{group, group_body, group_header, subpane, subpane_body, subpane_header},
         controls::*,
         dark_theme::create_dark_theme,
         display::label,
-        theme::{ThemeBackgroundColor, UiTheme},
+        theme::{ThemeBackgroundColor, ThemedText, UiTheme},
         tokens, FeathersPlugins,
     },
     input_focus::tab_navigation::TabGroup,
@@ -84,6 +85,32 @@ fn demo_root() -> impl Scene {
                 InteractionDisabled
                 template_value(SoftLimit(NumberInputRange::F32(0.0..10.0)))
             )),
+
+            (
+                subpane()
+                Children [
+                    subpane_header() Children [
+                        (Text("Subpane") ThemedText),
+                    ],
+                    subpane_body()
+                    Children [
+                        demo_field_f32("subpane child", 1.0, bsn!()),
+                    ]
+                ]
+            ),
+
+            (
+                group()
+                Children [
+                    group_header() Children [
+                        (Text("Group") ThemedText),
+                    ],
+                    group_body()
+                    Children [
+                        demo_field_f32("group child", 1.0, bsn!()),
+                    ]
+                ]
+            )
         ]
     }
 }


### PR DESCRIPTION
This introduces a new capability to feathers themes: limited contextual theming. The `ThemeContextualBackgroundColor` allows multiple color tokens to be specified; one of these tokens will be used to determine the background color depending on what kind of container the widget is in. Container types are identified by a `SurfaceTier` component.

This allows widgets to have different coloring in different contexts. The system is intentionally limited to a fixed set of choices and is not intended to be a general mechanism such as CSS variables.

This PR doesn't attempt to define all the tokens for different contexts or assign them; that will be left to subsequent work (since other people are currently working on tweaking the color assignments).