### PR TITLE
Add `#[serde(default)]` support to `GltfLoaderSettings`

### DIFF
--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -186,6 +186,7 @@ pub struct GltfLoader {
 ///     .load("my.gltf");
 /// ```
 #[derive(Serialize, Deserialize)]
+#[serde(default)]
 pub struct GltfLoaderSettings {
     /// If empty, the gltf mesh nodes will be skipped.
     ///
@@ -2120,7 +2121,7 @@ pub struct MorphTargetNames {
 mod test {
     use std::path::Path;
 
-    use crate::{Gltf, GltfAssetLabel, GltfMaterial, GltfNode, GltfSkin};
+    use crate::{Gltf, GltfAssetLabel, GltfLoaderSettings, GltfMaterial, GltfNode, GltfSkin};
     use bevy_app::{App, TaskPoolPlugin};
     use bevy_asset::{
         io::{
@@ -2772,5 +2773,27 @@ mod test {
             LoadState::Loading => None,
             state => panic!("Unexpected load state: {state:?}"),
         });
+    }
+
+    #[test]
+    fn partial_loader_settings_use_defaults() {
+        let settings: GltfLoaderSettings = serde_json::from_str(
+            r#"
+            {
+                "load_cameras": false
+            }
+            "#
+        ).unwrap();
+
+        let default = GltfLoaderSettings::default();
+        assert_eq!(settings.load_meshes, default.load_meshes);
+        assert_eq!(settings.load_materials, default.load_materials);
+        assert_eq!(settings.load_cameras, false);
+        assert_eq!(settings.load_lights, default.load_lights);
+        assert_eq!(settings.load_animations, default.load_animations);
+        assert_eq!(settings.include_source, default.include_source);
+        assert_eq!(settings.default_sampler, default.default_sampler);
+        assert_eq!(settings.override_sampler, default.override_sampler);
+        assert_eq!(settings.validate, default.validate);
     }
 }

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -2789,7 +2789,7 @@ mod test {
         let default = GltfLoaderSettings::default();
         assert_eq!(settings.load_meshes, default.load_meshes);
         assert_eq!(settings.load_materials, default.load_materials);
-        assert_eq!(settings.load_cameras, false);
+        assert!(!settings.load_cameras);
         assert_eq!(settings.load_lights, default.load_lights);
         assert_eq!(settings.load_animations, default.load_animations);
         assert_eq!(settings.include_source, default.include_source);

--- a/crates/bevy_gltf/src/loader/mod.rs
+++ b/crates/bevy_gltf/src/loader/mod.rs
@@ -2782,8 +2782,9 @@ mod test {
             {
                 "load_cameras": false
             }
-            "#
-        ).unwrap();
+            "#,
+        )
+        .unwrap();
 
         let default = GltfLoaderSettings::default();
         assert_eq!(settings.load_meshes, default.load_meshes);


### PR DESCRIPTION
# Objective

- Fixes #24822

## Solution
- Added the `#[serde(default)]` attribute to the `GltfLoaderSettings` struct. This ensures that when the loader settings are partially deserialized (for example, from a JSON or RON asset configuration), any omitted fields will automatically fall back to their default values instead of causing a deserialization error.

## Testing
- To ensure the issue was properly reproduced, I first added the new unit test `partial_loader_settings_use_defaults` to `crates/bevy_gltf/src/loader/mod.rs` before applying the fix. As expected, `cargo test` failed with the error `missing field 'load_materials'`.
- After confirming the failure, I added the `#[serde(default)]` attribute to the struct. I then ran `cargo test` again and verified that the test now passes successfully.