### PR TITLE
Fix parallel render graph

### DIFF
--- a/crates/bevy_core_pipeline/src/schedule.rs
+++ b/crates/bevy_core_pipeline/src/schedule.rs
@@ -233,7 +233,7 @@ pub(crate) fn submit_pending_command_buffers(
     let (mut pending, queue) = state.get_mut(world).unwrap();
     #[cfg(feature = "trace")]
     let buffer_count = pending.len();
-    let mut buffers = pending.take().peekable();
+    let mut buffers = pending.finish().peekable();
 
     if buffers.peek().is_some() {
         #[cfg(feature = "trace")]

--- a/crates/bevy_render/src/diagnostic/mod.rs
+++ b/crates/bevy_render/src/diagnostic/mod.rs
@@ -114,7 +114,7 @@ pub fn resolve_encoder(
     let mut encoder =
         render_device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
     recorder.resolve(&mut encoder);
-    pending_buffers.push_encoder(encoder);
+    pending_buffers.push_encoder(encoder, "resolve_diagnostics");
 }
 
 /// Ends the current frame for the diagnostics recorder and syncs it with the main world.

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -15,13 +15,22 @@ use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_ecs::world::DeferredWorld;
 #[cfg(feature = "trace")]
 use bevy_log::info_span;
+use bevy_tasks::ComputeTaskPool;
 use core::marker::PhantomData;
 use wgpu::CommandBuffer;
 
 #[derive(Default)]
 struct PendingCommandBuffersInner {
-    buffers: Vec<CommandBuffer>,
-    encoders: Vec<CommandEncoder>,
+    commands: Vec<PendingCommandBuffer>,
+}
+
+enum PendingCommandBuffer {
+    Buffer(CommandBuffer),
+    Encoder {
+        encoder: CommandEncoder,
+        #[cfg(feature = "trace")]
+        name: Option<String>,
+    },
 }
 
 /// A resource that holds command buffers and encoders that are pending submission to the render queue.
@@ -36,53 +45,96 @@ impl Default for PendingCommandBuffers {
 
 impl PendingCommandBuffers {
     pub fn push(&mut self, buffers: impl IntoIterator<Item = CommandBuffer>) {
-        self.0.buffers.extend(buffers);
+        self.0
+            .commands
+            .extend(buffers.into_iter().map(PendingCommandBuffer::Buffer));
     }
 
-    pub fn append(&mut self, buffers: &mut Vec<CommandBuffer>) {
-        self.0.buffers.append(buffers);
+    fn append(&mut self, commands: &mut Vec<PendingCommandBuffer>) {
+        self.0.commands.append(commands);
     }
 
-    pub fn push_encoder(&mut self, encoder: CommandEncoder) {
-        self.0.encoders.push(encoder);
+    pub fn push_encoder(&mut self, encoder: CommandEncoder, name: &'static str) {
+        #[cfg(not(feature = "trace"))]
+        let _ = name;
+
+        self.0.commands.push(PendingCommandBuffer::Encoder {
+            encoder,
+            #[cfg(feature = "trace")]
+            name: Some(name.into()),
+        });
     }
 
-    pub fn take(&mut self) -> impl Iterator<Item = CommandBuffer> {
-        let inner = &mut *self.0;
-        inner
-            .buffers
-            .drain(..)
-            .chain(inner.encoders.drain(..).map(CommandEncoder::finish))
+    pub fn finish(&mut self) -> impl Iterator<Item = CommandBuffer> {
+        #[cfg(feature = "trace")]
+        let _finish_command_buffers_span = info_span!("finish_command_buffers").entered();
+
+        let commands = core::mem::take(&mut self.0.commands);
+        let mut command_buffers = Vec::with_capacity(commands.len());
+        let mut finished_encoders = ComputeTaskPool::get().scope(|scope| {
+            for (index, command) in commands.into_iter().enumerate() {
+                match command {
+                    PendingCommandBuffer::Buffer(command_buffer) => {
+                        command_buffers.push((index, command_buffer));
+                    }
+                    PendingCommandBuffer::Encoder {
+                        encoder,
+                        #[cfg(feature = "trace")]
+                        name,
+                    } => {
+                        scope.spawn(async move {
+                            #[cfg(feature = "trace")]
+                            let _span = info_span!(
+                                "finish_command_buffer",
+                                system = name.as_deref().unwrap_or("unknown")
+                            )
+                            .entered();
+                            (index, encoder.finish())
+                        });
+                    }
+                }
+            }
+        });
+
+        command_buffers.append(&mut finished_encoders);
+        command_buffers.sort_unstable_by_key(|(index, _)| *index);
+        command_buffers
+            .into_iter()
+            .map(|(_, command_buffer)| command_buffer)
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.buffers.is_empty() && self.0.encoders.is_empty()
+        self.0.commands.is_empty()
     }
 
     pub fn len(&self) -> usize {
-        self.0.buffers.len() + self.0.encoders.len()
+        self.0.commands.len()
     }
 }
 
 #[derive(Default)]
 struct RenderContextStateInner {
     command_encoder: Option<CommandEncoder>,
-    command_buffers: Vec<CommandBuffer>,
+    commands: Vec<PendingCommandBuffer>,
     render_device: Option<RenderDevice>,
 }
 
 impl RenderContextStateInner {
     fn flush_encoder(&mut self) {
         if let Some(encoder) = self.command_encoder.take() {
-            self.command_buffers.push(encoder.finish());
+            self.commands.push(PendingCommandBuffer::Encoder {
+                encoder,
+                #[cfg(feature = "trace")]
+                name: None,
+            });
         }
     }
 }
 
 /// A resource that holds the current render context state, including command encoder and command buffers.
 /// This is used internally by the [`RenderContext`] system parameter. Implements [`SystemBuffer`] to
-/// append command buffers, which have already been finished by their producing systems, in topological
-/// system order.
+/// append command buffers and unfinished encoders in topological system order. Pending encoders are
+/// finished in parallel immediately before submission.
 pub struct RenderContextState(WgpuWrapper<RenderContextStateInner>);
 
 impl Default for RenderContextState {
@@ -110,7 +162,11 @@ impl RenderContextState {
 
     pub fn finish(&mut self) -> impl Iterator<Item = CommandBuffer> {
         self.flush_encoder();
-        self.0.command_buffers.drain(..)
+        let commands = core::mem::take(&mut self.0.commands);
+        commands.into_iter().map(|command| match command {
+            PendingCommandBuffer::Buffer(command_buffer) => command_buffer,
+            PendingCommandBuffer::Encoder { encoder, .. } => encoder.finish(),
+        })
     }
 }
 
@@ -122,14 +178,18 @@ impl SystemBuffer for RenderContextState {
 
         let inner = &mut *self.0;
 
-        debug_assert!(
-            inner.command_encoder.is_none(),
-            "RenderContext must finish its command encoder before deferred buffers are applied"
-        );
+        inner.flush_encoder();
 
-        if !inner.command_buffers.is_empty() {
+        #[cfg(feature = "trace")]
+        for command in &mut inner.commands {
+            if let PendingCommandBuffer::Encoder { name, .. } = command {
+                *name = Some(_system_meta.name().to_string());
+            }
+        }
+
+        if !inner.commands.is_empty() {
             let mut pending = world.resource_mut::<PendingCommandBuffers>();
-            pending.append(&mut inner.command_buffers);
+            pending.append(&mut inner.commands);
         }
 
         inner.render_device = None;
@@ -147,12 +207,6 @@ pub struct RenderContext<'w, 's> {
 }
 
 impl<'w, 's> RenderContext<'w, 's> {
-    fn flush_encoder(&mut self) {
-        if self.state.0.command_encoder.is_some() {
-            self.state.flush_encoder();
-        }
-    }
-
     fn ensure_device(&mut self) {
         if self.state.0.render_device.is_none() {
             self.state.0.render_device = Some(self.render_device.clone());
@@ -193,15 +247,11 @@ impl<'w, 's> RenderContext<'w, 's> {
 
     /// Adds a finished command buffer to be submitted later.
     pub fn add_command_buffer(&mut self, command_buffer: CommandBuffer) {
-        self.flush_encoder();
-        self.state.0.command_buffers.push(command_buffer);
-    }
-}
-
-impl Drop for RenderContext<'_, '_> {
-    fn drop(&mut self) {
-        // Finish the encoder on the thread that ran this system for parallelism
-        self.flush_encoder();
+        self.state.flush_encoder();
+        self.state
+            .0
+            .commands
+            .push(PendingCommandBuffer::Buffer(command_buffer));
     }
 }
 
@@ -217,7 +267,7 @@ pub struct FlushCommands<'w> {
 impl<'w> FlushCommands<'w> {
     /// Flushes all pending command buffers to the render queue.
     pub fn flush(&mut self) {
-        let mut buffers = self.pending.take().peekable();
+        let mut buffers = self.pending.finish().peekable();
         if buffers.peek().is_some() {
             self.queue.submit(buffers);
         }

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -15,6 +15,7 @@ use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_ecs::world::DeferredWorld;
 #[cfg(feature = "trace")]
 use bevy_log::info_span;
+#[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::ComputeTaskPool;
 use core::marker::PhantomData;
 use wgpu::CommandBuffer;
@@ -70,37 +71,16 @@ impl PendingCommandBuffers {
         let _finish_command_buffers_span = info_span!("finish_command_buffers").entered();
 
         let commands = core::mem::take(&mut self.0.commands);
-        let mut command_buffers = Vec::with_capacity(commands.len());
-        let mut finished_encoders = ComputeTaskPool::get().scope(|scope| {
-            for (index, command) in commands.into_iter().enumerate() {
-                match command {
-                    PendingCommandBuffer::Buffer(command_buffer) => {
-                        command_buffers.push((index, command_buffer));
-                    }
-                    PendingCommandBuffer::Encoder {
-                        encoder,
-                        #[cfg(feature = "trace")]
-                        name,
-                    } => {
-                        scope.spawn(async move {
-                            #[cfg(feature = "trace")]
-                            let _span = info_span!(
-                                "finish_command_buffer",
-                                system = name.as_deref().unwrap_or("unknown")
-                            )
-                            .entered();
-                            (index, encoder.finish())
-                        });
-                    }
-                }
-            }
-        });
 
-        command_buffers.append(&mut finished_encoders);
-        command_buffers.sort_unstable_by_key(|(index, _)| *index);
-        command_buffers
-            .into_iter()
-            .map(|(_, command_buffer)| command_buffer)
+        #[cfg(target_arch = "wasm32")]
+        {
+            finish_sequential(commands)
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            finish_parallel(commands)
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -110,6 +90,55 @@ impl PendingCommandBuffers {
     pub fn len(&self) -> usize {
         self.0.commands.len()
     }
+}
+
+/// Finishes pending command buffers sequentially, preserving their order.
+///
+/// Used on wasm, where wgpu command encoders and buffers are `!Send` and so
+/// cannot be finished across task pool threads.
+#[cfg(target_arch = "wasm32")]
+fn finish_sequential(commands: Vec<PendingCommandBuffer>) -> impl Iterator<Item = CommandBuffer> {
+    commands.into_iter().map(|command| match command {
+        PendingCommandBuffer::Buffer(command_buffer) => command_buffer,
+        PendingCommandBuffer::Encoder { encoder, .. } => encoder.finish(),
+    })
+}
+
+/// Finishes pending command encoders in parallel on the [`ComputeTaskPool`],
+/// then reassembles the command buffers in their original order.
+#[cfg(not(target_arch = "wasm32"))]
+fn finish_parallel(commands: Vec<PendingCommandBuffer>) -> impl Iterator<Item = CommandBuffer> {
+    let mut command_buffers = Vec::with_capacity(commands.len());
+    let mut finished_encoders = ComputeTaskPool::get().scope(|scope| {
+        for (index, command) in commands.into_iter().enumerate() {
+            match command {
+                PendingCommandBuffer::Buffer(command_buffer) => {
+                    command_buffers.push((index, command_buffer));
+                }
+                PendingCommandBuffer::Encoder {
+                    encoder,
+                    #[cfg(feature = "trace")]
+                    name,
+                } => {
+                    scope.spawn(async move {
+                        #[cfg(feature = "trace")]
+                        let _span = info_span!(
+                            "finish_command_buffer",
+                            system = name.as_deref().unwrap_or("unknown")
+                        )
+                        .entered();
+                        (index, encoder.finish())
+                    });
+                }
+            }
+        }
+    });
+
+    command_buffers.append(&mut finished_encoders);
+    command_buffers.sort_unstable_by_key(|(index, _)| *index);
+    command_buffers
+        .into_iter()
+        .map(|(_, command_buffer)| command_buffer)
 }
 
 #[derive(Default)]

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -80,8 +80,9 @@ impl RenderContextStateInner {
 }
 
 /// A resource that holds the current render context state, including command encoder and command buffers.
-/// This is used internally by the [`RenderContext`] system parameter. Implements [`SystemBuffer`] to flush
-/// command buffers at the end of each render system in topological system order.
+/// This is used internally by the [`RenderContext`] system parameter. Implements [`SystemBuffer`] to
+/// append command buffers, which have already been finished by their producing systems, in topological
+/// system order.
 pub struct RenderContextState(WgpuWrapper<RenderContextStateInner>);
 
 impl Default for RenderContextState {
@@ -121,8 +122,10 @@ impl SystemBuffer for RenderContextState {
 
         let inner = &mut *self.0;
 
-        // flush to ensure correct submission order
-        inner.flush_encoder();
+        debug_assert!(
+            inner.command_encoder.is_none(),
+            "RenderContext must finish its command encoder before deferred buffers are applied"
+        );
 
         if !inner.command_buffers.is_empty() {
             let mut pending = world.resource_mut::<PendingCommandBuffers>();
@@ -144,6 +147,12 @@ pub struct RenderContext<'w, 's> {
 }
 
 impl<'w, 's> RenderContext<'w, 's> {
+    fn flush_encoder(&mut self) {
+        if self.state.0.command_encoder.is_some() {
+            self.state.flush_encoder();
+        }
+    }
+
     fn ensure_device(&mut self) {
         if self.state.0.render_device.is_none() {
             self.state.0.render_device = Some(self.render_device.clone());
@@ -184,8 +193,15 @@ impl<'w, 's> RenderContext<'w, 's> {
 
     /// Adds a finished command buffer to be submitted later.
     pub fn add_command_buffer(&mut self, command_buffer: CommandBuffer) {
-        self.state.flush_encoder();
+        self.flush_encoder();
         self.state.0.command_buffers.push(command_buffer);
+    }
+}
+
+impl Drop for RenderContext<'_, '_> {
+    fn drop(&mut self) {
+        // Finish the encoder on the thread that ran this system for parallelism
+        self.flush_encoder();
     }
 }
 


### PR DESCRIPTION
# Objective
- Parallelize expensive `wgpu::CommandEncoder::finish()` calls, since add_command_buffer_generation_task() was removed in the render graph as-systems rewrite.

## Solution

- Render graph systems act like normal systems and run in parallel where possible, unless they have serial constraints
- CommandEncoders produced by each system (via RenderContext) are left open, and appended to a list (respecting system ordering as needed, because the systems run in order)
- Finish all command encoders in parallel and then sort back to match their original order, equivalent to what add_command_buffer_generation_task() used to do

Note that add_command_buffer_generation_task() could parallelize the encoding even for ordered nodes, beyond what we can do now (since encoding is only parallelized for systems that can run in parallel). 

**So we're still a bit worse than what we used to have (but it's way more ergonomic now).**

---

## Showcase

Main
<img width="3840" height="2040" alt="image" src="https://github.com/user-attachments/assets/d6d9a06a-96e6-4e7a-a01d-7c6724f2dbfa" />


This PR
<img width="3840" height="2040" alt="image" src="https://github.com/user-attachments/assets/6f05b907-4a5c-43a3-9873-2c08ae6fca4c" />

Comparison (this trace = PR, external trace = main)
<img width="2102" height="1392" alt="image" src="https://github.com/user-attachments/assets/c31639dc-b2a3-4ca7-bb0d-0199f1e93d5f" />
