### PR TITLE
Make Ctrl+C plugin instant for reactive apps

### DIFF
--- a/crates/bevy_app/src/terminal_ctrl_c_handler.rs
+++ b/crates/bevy_app/src/terminal_ctrl_c_handler.rs
@@ -1,5 +1,8 @@
 use core::sync::atomic::{AtomicU8, Ordering};
 
+use alloc::{boxed::Box, vec::Vec};
+use std::sync::Mutex;
+
 use bevy_ecs::message::MessageWriter;
 
 use crate::{App, AppExit, Plugin, Update};
@@ -8,6 +11,9 @@ pub use ctrlc;
 
 /// Indicates that all [`App`]'s should exit.
 static SHOULD_EXIT: AtomicU8 = AtomicU8::new(0);
+
+/// Handlers run when the app is asked to exit via `Ctrl+C`.
+static ON_EXIT_HANDLERS: Mutex<Vec<Box<dyn Fn() + Send>>> = Mutex::new(Vec::new());
 
 /// Gracefully handles `Ctrl+C` by emitting a [`AppExit`] event. This plugin is part of the `DefaultPlugins`.
 ///
@@ -51,6 +57,21 @@ impl TerminalCtrlCHandlerPlugin {
             log::error!("Received more than one ctrl+c. Skipping graceful shutdown.");
             std::process::exit(Self::EXIT_CODE.into());
         };
+
+        if let Ok(handlers) = ON_EXIT_HANDLERS.lock() {
+            for handler in handlers.iter() {
+                handler();
+            }
+        }
+    }
+
+    /// Registers a `handler` that is invoked when `Ctrl+C` is received.
+    ///
+    /// This can be used to e.g. waking a sleeping event loop so it can observe the [`AppExit`].
+    pub fn register_exit_handler(handler: impl Fn() + Send + 'static) {
+        if let Ok(mut handlers) = ON_EXIT_HANDLERS.lock() {
+            handlers.push(Box::new(handler));
+        }
     }
 
     /// Sends a [`AppExit`] event when the user presses `Ctrl+C` on the terminal.

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -136,10 +136,22 @@ impl Plugin for WinitPlugin {
             .build()
             .expect("Failed to build event loop");
 
+        let event_loop_proxy = event_loop.create_proxy();
+
+        // Wake up the event loop when `Ctrl+C` is received so that the app can
+        // exit even while idle in a reactive update mode
+        #[cfg(any(all(unix, not(target_os = "horizon")), windows))]
+        {
+            let event_loop_proxy = event_loop_proxy.clone();
+            bevy_app::TerminalCtrlCHandlerPlugin::register_exit_handler(move || {
+                let _ = event_loop_proxy.send_event(WinitUserEvent::WakeUp);
+            });
+        }
+
         app.init_resource::<WinitMonitors>()
             .init_resource::<WinitSettings>()
             .insert_resource(DisplayHandleWrapper(event_loop.owned_display_handle()))
-            .insert_resource(EventLoopProxyWrapper(event_loop.create_proxy()))
+            .insert_resource(EventLoopProxyWrapper(event_loop_proxy))
             .add_message::<RawWinitWindowEvent>()
             .set_runner(|app| winit_runner(app, event_loop))
             .add_systems(


### PR DESCRIPTION
# Objective

The Ctrl+C plugin works by sending an `AppExit` message, but when using a reactive `UpdateMode` this message is ignored until some unrelated OS event is triggered or the reactive timeout is hit. This is a mild annoyance when developing, but one that I hit many times per day.

## Solution

Add the possibility to add on exit handlers to `TerminalCtrlCHandlerPlugin`, and register one that causes a wakeup from the winit plugin.

## Testing

Tested using `cargo run --example low_power`, switching to reactive and doing Ctrl+C in the terminal.