### PR TITLE
fix: document post_process_write ordering, fix HDR example

### DIFF
--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -957,8 +957,8 @@ impl ViewTarget {
     ///
     /// Multiple systems that call `post_process_write()` on the same view must be
     /// **explicitly ordered** relative to each other (e.g. with
-    /// [`.before(tonemapping)`] or [`.after(tonemapping)`]). If multiple unordered
-    /// systems call this method in the same [`Core3dSystems::PostProcess`] set, the
+    /// `.before(tonemapping)` or `.after(tonemapping)`). If multiple unordered
+    /// systems call this method in the same `Core3dSystems::PostProcess` set, the
     /// internal texture swap (atomic `fetch_xor`) races and produces silent
     /// corruption — typically a flat gray frame in HDR mode.
     ///
@@ -966,8 +966,6 @@ impl ViewTarget {
     /// `fxaa` and `smaa` run `.after(tonemapping)`. Custom post-process effects
     /// must follow the same pattern. See the `custom_post_processing` example.
     ///
-    /// [`.before(tonemapping)`]: bevy_core_pipeline::tonemapping::tonemapping
-    /// [`.after(tonemapping)`]: bevy_core_pipeline::tonemapping::tonemapping
     pub fn post_process_write(&self) -> PostProcessWrite<'_> {
         let old_is_a_main_texture = self.main_texture.fetch_xor(1, Ordering::SeqCst);
         // if the old main texture is a, then the post processing must write from a to b

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -952,6 +952,22 @@ impl ViewTarget {
     /// [`ViewTarget`]'s main texture to the `destination` texture, so the caller
     /// _must_ ensure `source` is copied to `destination`, with or without modifications.
     /// Failing to do so will cause the current main texture information to be lost.
+    ///
+    /// # Ordering requirement
+    ///
+    /// Multiple systems that call `post_process_write()` on the same view must be
+    /// **explicitly ordered** relative to each other (e.g. with
+    /// [`.before(tonemapping)`] or [`.after(tonemapping)`]). If multiple unordered
+    /// systems call this method in the same [`Core3dSystems::PostProcess`] set, the
+    /// internal texture swap (atomic `fetch_xor`) races and produces silent
+    /// corruption — typically a flat gray frame in HDR mode.
+    ///
+    /// Built-in systems are already ordered: `bloom` runs `.before(tonemapping)`,
+    /// `fxaa` and `smaa` run `.after(tonemapping)`. Custom post-process effects
+    /// must follow the same pattern. See the `custom_post_processing` example.
+    ///
+    /// [`.before(tonemapping)`]: bevy_core_pipeline::tonemapping::tonemapping
+    /// [`.after(tonemapping)`]: bevy_core_pipeline::tonemapping::tonemapping
     pub fn post_process_write(&self) -> PostProcessWrite<'_> {
         let old_is_a_main_texture = self.main_texture.fetch_xor(1, Ordering::SeqCst);
         // if the old main texture is a, then the post processing must write from a to b

--- a/examples/shader_advanced/custom_post_processing.rs
+++ b/examples/shader_advanced/custom_post_processing.rs
@@ -7,9 +7,7 @@
 //! This is a fairly low level example and assumes some familiarity with rendering concepts and wgpu.
 
 use bevy::{
-    core_pipeline::{
-        schedule::Core3d, tonemapping::tonemapping, Core3dSystems, FullscreenShader,
-    },
+    core_pipeline::{schedule::Core3d, tonemapping::tonemapping, Core3dSystems, FullscreenShader},
     prelude::*,
     render::{
         extract_component::{

--- a/examples/shader_advanced/custom_post_processing.rs
+++ b/examples/shader_advanced/custom_post_processing.rs
@@ -7,7 +7,9 @@
 //! This is a fairly low level example and assumes some familiarity with rendering concepts and wgpu.
 
 use bevy::{
-    core_pipeline::{schedule::Core3d, Core3dSystems, FullscreenShader},
+    core_pipeline::{
+        schedule::Core3d, tonemapping::tonemapping, Core3dSystems, FullscreenShader,
+    },
     prelude::*,
     render::{
         extract_component::{
@@ -62,7 +64,15 @@ impl Plugin for PostProcessPlugin {
         render_app.add_systems(RenderStartup, init_post_process_pipeline);
         render_app.add_systems(
             Core3d,
-            post_process_system.in_set(Core3dSystems::PostProcess),
+            // Custom post-process effects that call `post_process_write()` MUST be
+            // ordered relative to tonemapping. Without this, the atomic texture swap
+            // in `post_process_write()` races, producing silent corruption (a flat gray
+            // frame) when HDR is enabled (e.g. with Bloom or the `Hdr` camera component).
+            // Place your effect `.after(tonemapping)` unless it needs the pre-tonemapped
+            // HDR data (like bloom, which runs `.before(tonemapping)`).
+            post_process_system
+                .after(tonemapping)
+                .in_set(Core3dSystems::PostProcess),
         );
     }
 }


### PR DESCRIPTION
Fixes #24839. Adds ordering requirement docs to post_process_write() and .after(tonemapping) to the custom_post_processing example.