### PR TITLE
Remove bevy_camera dependency from bevy_world_serialization

### DIFF
--- a/_release-content/migration-guides/world_root_visibility.md
+++ b/_release-content/migration-guides/world_root_visibility.md
@@ -1,0 +1,17 @@
+---
+title: World root components no longer require Visibility
+pull_requests: [24963]
+---
+
+`WorldAssetRoot` and `DynamicWorldRoot` no longer automatically insert
+`Visibility`. This removes the `bevy_world_serialization` dependency on
+`bevy_camera`.
+
+Users relying on this behavior should add `Visibility` explicitly:
+
+```rust
+commands.spawn((
+    WorldAssetRoot(handle),
+    Visibility::default(),
+));
+```

--- a/_release-content/migration-guides/world_root_visibility.md
+++ b/_release-content/migration-guides/world_root_visibility.md
@@ -15,3 +15,14 @@ commands.spawn((
     Visibility::default(),
 ));
 ```
+
+Alternatively, applications can preserve the previous automatic insertion
+behavior by manually registering `Visibility` as a required component:
+
+```rust
+app.register_required_components::<WorldAssetRoot, Visibility>();
+app.register_required_components::<DynamicWorldRoot, Visibility>();
+```
+
+This registration must occur before either root component is first inserted
+into the world.

--- a/crates/bevy_world_serialization/Cargo.toml
+++ b/crates/bevy_world_serialization/Cargo.toml
@@ -27,7 +27,6 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.20.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.20.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.20.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.20.0-dev" }
-bevy_camera = { path = "../bevy_camera", version = "0.20.0-dev" }
 bevy_platform = { path = "../bevy_platform", version = "0.20.0-dev", default-features = false, features = [
   "std",
 ] }

--- a/crates/bevy_world_serialization/src/components.rs
+++ b/crates/bevy_world_serialization/src/components.rs
@@ -5,8 +5,6 @@ use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_transform::components::Transform;
 use derive_more::derive::From;
 
-use bevy_camera::visibility::Visibility;
-
 use crate::{DynamicWorld, WorldAsset};
 
 /// Adding this component will spawn the world as a child of that entity.
@@ -19,7 +17,6 @@ use crate::{DynamicWorld, WorldAsset};
 )]
 #[reflect(Component, Default, Debug, PartialEq, Clone)]
 #[require(Transform)]
-#[require(Visibility)]
 pub struct WorldAssetRoot(pub Handle<WorldAsset>);
 
 impl AsAssetId for WorldAssetRoot {
@@ -37,7 +34,6 @@ impl AsAssetId for WorldAssetRoot {
 )]
 #[reflect(Component, Default, Debug, PartialEq, Clone)]
 #[require(Transform)]
-#[require(Visibility)]
 pub struct DynamicWorldRoot(pub Handle<DynamicWorld>);
 
 impl AsAssetId for DynamicWorldRoot {


### PR DESCRIPTION
## Objective
Fixes #24805. Removes the `bevy_camera` dependency from `bevy_world_serialization`, which had no functional need for it — it was only used for `#[require(Visibility)]` annotations on `WorldAssetRoot` and `DynamicWorldRoot`.

Per https://github.com/bevyengine/bevy/issues/24805#issuecomment-4951981689

## Solution
- Removed `#[require(Visibility)]` from `WorldAssetRoot` and `DynamicWorldRoot`
- Removed `bevy_camera` from `Cargo.toml` dependencies
- Removed the `use bevy_camera::visibility::Visibility` import

## Testing
- `cargo check -p bevy_world_serialization` — zero references to bevy_camera remain
- No other crates depend on `WorldAssetRoot` or `DynamicWorldRoot` auto-inserting `Visibility`

## Migration Guide
Users who relied on `WorldAssetRoot` or `DynamicWorldRoot` auto-inserting `Visibility` should now add `Visibility` explicitly when spawning these components.