### PR TITLE
fix(tab_navigation): skip hidden subtrees during focusable gathering

### DIFF
--- a/crates/bevy_input_focus/src/tab_navigation.rs
+++ b/crates/bevy_input_focus/src/tab_navigation.rs
@@ -336,19 +336,20 @@ impl TabNavigation<'_, '_> {
         if let Ok((entity, tabindex, children, inherited_visibility)) =
             self.tabindex_query.get(parent)
         {
-            // Skip entities that are not visible in the hierarchy. An entity without an
+            // Skip hidden entities and their entire subtree. An entity without an
             // `InheritedVisibility` component (e.g. a non-UI entity) is treated as visible.
-            if inherited_visibility.is_none_or(|v| v.get())
-                && let Some(tabindex) = tabindex
-                && tabindex.0 >= 0
-            {
-                out.push((entity, *tabindex, tab_group_idx));
-            }
-            if let Some(children) = children {
-                for child in children.iter() {
-                    // Don't traverse into tab groups, as they are handled separately.
-                    if self.tabgroup_query.get(*child).is_err() {
-                        self.gather_focusable(out, *child, tab_group_idx);
+            if inherited_visibility.is_none_or(|v| v.get()) {
+                if let Some(tabindex) = tabindex
+                    && tabindex.0 >= 0
+                {
+                    out.push((entity, *tabindex, tab_group_idx));
+                }
+                if let Some(children) = children {
+                    for child in children.iter() {
+                        // Don't traverse into tab groups, as they are handled separately.
+                        if self.tabgroup_query.get(*child).is_err() {
+                            self.gather_focusable(out, *child, tab_group_idx);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Fixes #24935. Fixes a regression introduced in #24769 where menus would auto-close immediately on open.

`gather_focusable` was skipping hidden entities from the focusable list but still traversing their children. In the `feathers_gallery` example, `FeathersMenuPopup` is always present in the hierarchy and shown/hidden via `Visibility`. When a menu was opened, the popup's children had not yet had their `InheritedVisibility` propagated, so they were visited, found unfocusable, and focus fell outside the menu — which the menu interpreted as a close signal.

## Solution

Move the children traversal inside the `InheritedVisibility` check in `gather_focusable`, so that a hidden entity stops traversal of its entire subtree. This matches the expected behaviour: if a container is hidden, none of its descendants should be reachable via tab navigation.

## Testing

- Verified the `feathers_gallery` example no longer auto-closes menus on open.
- Existing tab navigation tests continue to pass.