### PR TITLE
Don't panic on despawn of render-synced entities without a render world

### DIFF
--- a/crates/bevy_render/src/sync_component.rs
+++ b/crates/bevy_render/src/sync_component.rs
@@ -5,6 +5,7 @@ use bevy_ecs::{
     bundle::{Bundle, NoBundleEffect},
     component::Component,
 };
+use bevy_log::warn_once;
 
 use crate::{
     sync_world::{EntityRecord, PendingSyncEntity, SyncToRenderWorld},
@@ -57,7 +58,14 @@ impl<C: SyncComponent<RenderApp, F>, F: Send + Sync + 'static> Plugin
         app.world_mut()
             .register_component_hooks::<C>()
             .on_remove(|mut world, context| {
-                let mut pending = world.resource_mut::<PendingSyncEntity>();
+                let Some(mut pending) = world.get_resource_mut::<PendingSyncEntity>() else {
+                    warn_once!(
+                        "Removed a render-synced component, but the render world does not exist \
+                        (e.g. the app is running headless with `WgpuSettings {{ backends: None }}`), \
+                        so there is nothing to sync. Skipping render world cleanup."
+                    );
+                    return;
+                };
                 pending.push(EntityRecord::ComponentRemoved(
                     context.entity,
                     |mut entity| {
@@ -65,5 +73,34 @@ impl<C: SyncComponent<RenderApp, F>, F: Send + Sync + 'static> Plugin
                     },
                 ));
             });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy_app::App;
+    use bevy_ecs::component::Component;
+
+    use super::{SyncComponent, SyncComponentPlugin};
+    use crate::RenderApp;
+
+    #[derive(Component)]
+    struct SyncedComponent;
+
+    impl SyncComponent<RenderApp> for SyncedComponent {
+        type Target = Self;
+    }
+
+    // Regression test for https://github.com/bevyengine/bevy/issues/24927:
+    // without a render world (e.g. headless with no rendering backend),
+    // `PendingSyncEntity` does not exist and removing a synced component must
+    // not panic.
+    #[test]
+    fn remove_synced_component_without_render_world() {
+        let mut app = App::new();
+        app.add_plugins(SyncComponentPlugin::<SyncedComponent>::default());
+
+        let entity = app.world_mut().spawn(SyncedComponent).id();
+        app.world_mut().despawn(entity);
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #24927
- Headless apps (`WgpuSettings { backends: None }`) panic on the first despawn of any render-synced entity (`Camera3d`, `Mesh3d`, lights, ...) with `Requested resource bevy_render::sync_world::PendingSyncEntity does not exist`.
- `SyncComponentPlugin::<C>` registers its `on_remove` hook unconditionally, but `PendingSyncEntity` is only inserted by `SyncWorldPlugin`, which is only added when a rendering backend is available. With `backends: None` the hook fires on despawn and reads a resource that never exists.

## Solution

- Make the hook degrade gracefully: use `get_resource_mut` and early-return when `PendingSyncEntity` is absent — there is no render world, so there is nothing to sync.
- Emit a `warn_once!` in that path, as requested by @alice-i-cecile in the issue.

## Testing

- Added a regression test in `sync_component.rs`: registering `SyncComponentPlugin` in an `App` without a render world, then despawning an entity with the synced component. Panics before this change, passes after (`cargo test -p bevy_render --lib sync_component`).
- Verified the same patch against 0.19 via `[patch.crates-io]` with the minimal headless repro from #24927 (spawn `Camera3d`, despawn a few frames later, `ScheduleRunnerPlugin` + `backends: None`): the despawn completes cleanly and the app keeps running.
- Apps with a render world are unaffected: the resource exists, so the hook behaves exactly as before.

---
