### PR TITLE
change to pbr_pcss_example

### DIFF
--- a/examples/3d/pcss.rs
+++ b/examples/3d/pcss.rs
@@ -184,27 +184,35 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
 }
 
 /// Spawns the initial light.
+/// Spawns the light of the correct type based on app_status.
 fn spawn_light(commands: &mut Commands, app_status: &AppStatus) {
-    // Because this light can become a directional light, point light, or spot
-    // light depending on the settings, we add the union of the components
-    // necessary for this light to behave as all three of those.
-    commands
-        .spawn((
-            create_directional_light(app_status),
-            Transform::from_rotation(Quat::from_array([
-                0.6539259,
-                -0.34646285,
-                0.36505926,
-                -0.5648683,
-            ]))
+    let mut entity = commands.spawn((
+        Transform::from_rotation(Quat::from_array([
+            0.6539259,
+            -0.34646285,
+            0.36505926,
+            -0.5648683,
+        ]))
             .with_translation(vec3(57.693, 34.334, -6.422)),
-        ))
         // These two are needed for point lights.
-        .insert(CubemapVisibleEntities::default())
-        .insert(CubemapFrusta::default())
+        CubemapVisibleEntities::default(),
+        CubemapFrusta::default(),
         // These two are needed for spot lights.
-        .insert(VisibleMeshEntities::default())
-        .insert(Frustum::default());
+        VisibleMeshEntities::default(),
+        Frustum::default(),
+    ));
+
+    match app_status.light_type {
+        LightType::Directional => {
+            entity.insert(create_directional_light(app_status));
+        }
+        LightType::Point => {
+            entity.insert(create_point_light(app_status));
+        }
+        LightType::Spot => {
+            entity.insert(create_spot_light(app_status));
+        }
+    }
 }
 
 /// Loads and spawns the glTF palm tree scene.

--- a/examples/3d/pcss.rs
+++ b/examples/3d/pcss.rs
@@ -297,7 +297,6 @@ fn handle_light_type_change(
             commands.entity(old_light).despawn();
         }
 
-        //println!("Light type changed to {:?}", app_status.light_type);
         // Spawn a fresh light entity with the new type
         spawn_light(&mut commands, &app_status);
     }

--- a/examples/3d/pcss.rs
+++ b/examples/3d/pcss.rs
@@ -186,14 +186,27 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
 /// Spawns the initial light.
 /// Spawns the light of the correct type based on app_status.
 fn spawn_light(commands: &mut Commands, app_status: &AppStatus) {
-    let mut entity = commands.spawn((
+    spawn_light_with_transform(
+        commands,
+        app_status,
         Transform::from_rotation(Quat::from_array([
             0.6539259,
             -0.34646285,
             0.36505926,
             -0.5648683,
         ]))
-            .with_translation(vec3(57.693, 34.334, -6.422)),
+        .with_translation(vec3(57.693, 34.334, -6.422)),
+    );
+}
+
+fn spawn_light_with_transform(
+    commands: &mut Commands,
+    app_status: &AppStatus,
+    transform: Transform,
+) {
+
+    let mut light = commands.spawn((
+        transform,
         // These two are needed for point lights.
         CubemapVisibleEntities::default(),
         CubemapFrusta::default(),
@@ -204,13 +217,13 @@ fn spawn_light(commands: &mut Commands, app_status: &AppStatus) {
 
     match app_status.light_type {
         LightType::Directional => {
-            entity.insert(create_directional_light(app_status));
+            light.insert(create_directional_light(app_status));
         }
         LightType::Point => {
-            entity.insert(create_point_light(app_status));
+            light.insert(create_point_light(app_status));
         }
         LightType::Spot => {
-            entity.insert(create_spot_light(app_status));
+            light.insert(create_spot_light(app_status));
         }
     }
 }
@@ -287,10 +300,13 @@ fn update_radio_buttons(
     }
 }
 
-/// Handles requests from the user to change the type of light.
+/// Handles requests from the user to change the type of light. Handles multiple lights.
 fn handle_light_type_change(
     mut commands: Commands,
-    mut lights: Query<Entity, Or<(With<DirectionalLight>, With<PointLight>, With<SpotLight>)>>,
+    mut lights: Query<
+        (Entity, &Transform),
+        Or<(With<DirectionalLight>, With<PointLight>, With<SpotLight>)>,
+    >,
     mut events: MessageReader<WidgetClickEvent<AppSetting>>,
     mut app_status: ResMut<AppStatus>,
 ) {
@@ -300,13 +316,17 @@ fn handle_light_type_change(
         };
         app_status.light_type = light_type;
 
-        for old_light in lights.iter_mut() {
-            // Despawn the old light entirely
+        // Despawn each old light, then recreate the same number of lights with
+        // the new type and the old transforms.
+        let mut old_light_transforms = Vec::new();
+        for (old_light, transform) in lights.iter_mut() {
+            old_light_transforms.push(*transform);
             commands.entity(old_light).despawn();
         }
 
-        // Spawn a fresh light entity with the new type
-        spawn_light(&mut commands, &app_status);
+        for transform in old_light_transforms {
+            spawn_light_with_transform(&mut commands, &app_status, transform);
+        }
     }
 }
 

--- a/examples/3d/pcss.rs
+++ b/examples/3d/pcss.rs
@@ -292,24 +292,14 @@ fn handle_light_type_change(
         };
         app_status.light_type = light_type;
 
-        for light in lights.iter_mut() {
-            let mut light_commands = commands.entity(light);
-            light_commands
-                .remove::<DirectionalLight>()
-                .remove::<PointLight>()
-                .remove::<SpotLight>();
-            match light_type {
-                LightType::Point => {
-                    light_commands.insert(create_point_light(&app_status));
-                }
-                LightType::Spot => {
-                    light_commands.insert(create_spot_light(&app_status));
-                }
-                LightType::Directional => {
-                    light_commands.insert(create_directional_light(&app_status));
-                }
-            }
+        for old_light in lights.iter_mut() {
+            // Despawn the old light entirely
+            commands.entity(old_light).despawn();
         }
+
+        //println!("Light type changed to {:?}", app_status.light_type);
+        // Spawn a fresh light entity with the new type
+        spawn_light(&mut commands, &app_status);
     }
 }
 


### PR DESCRIPTION
# Objective

- Issue with changing light source in the pbr example
- Fixes #24973 

## Solution

- with `experimental_pbr_pcss` enabled, it's reading the `instance_count=2` when you change the components connected to light entity. instead now despawning the old light and spawning in a new one with the correct light type.

## Testing

- Did you test these changes? printing out the LightType enum before spawning in entity to ensure its the right type.
- Are there any parts that need more testing? It prints out the correct light type but I don't see a visual difference between them. I don't know if there was an actual difference in this example before but the shadows look identical.
- How can other people (reviewers) test your changes? Is there anything specific they need to know? run `cargo run --example pcss --features="experimental_pbr_pcss"`
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? N/A

---