### PR TITLE
Fix crash when adding ContactShadows to a camera at runtime

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1,4 +1,4 @@
-use crate::contact_shadows::ViewContactShadowsUniformOffset;
+use crate::contact_shadows::ContactShadows;
 use crate::{resources::prepare_atmosphere_buffers, skin::skin_uniforms_from_world};
 use alloc::sync::Arc;
 use bevy_asset::uuid::Uuid;
@@ -385,7 +385,7 @@ pub fn check_views_need_specialization(
             Has<OrderIndependentTransparencySettings>,
             Has<ExtractedAtmosphere>,
             Has<ScreenSpaceReflectionsUniform>,
-            Has<ViewContactShadowsUniformOffset>,
+            Has<ContactShadows>,
         ),
     )>,
 ) {


### PR DESCRIPTION
# Objective

Fixes #24951

## Solution

Key the view's `CONTACT_SHADOWS` bit off the extracted `ContactShadows` component instead of `ViewContactShadowsUniformOffset`, which is only inserted in `PrepareResources`, after `check_views_need_specialization` has already run. Same pattern as the other view key bits (`DistanceFog`, OIT, atmosphere).

## Testing

Ran the repro from #24951: crashes on main, runs clean with this change. Also removed and re-inserted `ContactShadows` on a live camera, no validation errors either way.
