### PR TITLE
Resolve memory leaks in tests reported by miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,7 @@ jobs:
           RUSTFLAGS: -Zrandomize-layout
           # https://github.com/rust-lang/miri#miri--z-flags-and-environment-variables
           # -Zmiri-disable-isolation is needed because our executor uses `fastrand` which accesses system time.
-          # -Zmiri-ignore-leaks is necessary because a bunch of tests don't join all threads before finishing.
-          MIRIFLAGS: -Zmiri-ignore-leaks -Zmiri-disable-isolation
+          MIRIFLAGS: -Zmiri-disable-isolation
 
   check-compiles:
     runs-on: ubuntu-latest

--- a/crates/bevy_ecs/src/intern.rs
+++ b/crates/bevy_ecs/src/intern.rs
@@ -28,6 +28,7 @@ use bevy_reflect::Reflect;
 // NOTE: This type must NEVER implement Borrow since it does not obey that trait's invariants.
 /// ```
 /// # use bevy_ecs::intern::*;
+/// # use std::sync::Mutex;
 /// #[derive(PartialEq, Eq, Hash, Debug)]
 /// struct Value(i32);
 /// impl Internable for Value {
@@ -41,6 +42,12 @@ use bevy_reflect::Reflect;
 /// // Even though both values are identical, their interned forms do not
 /// // compare equal as they use different interner instances.
 /// assert_ne!(interner_1.intern(&Value(42)), interner_2.intern(&Value(42)));
+/// # // Store the interners inside a `static` so
+/// # // that miri doesn't report them as a memory leak.
+/// # static LEAKS: Mutex<Vec<Interner<Value>>> = Mutex::new(Vec::new());
+/// # let mut leaks = LEAKS.lock().unwrap();
+/// # leaks.push(interner_1);
+/// # leaks.push(interner_2);
 /// ```
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Clone, PartialEq, Hash))]
@@ -174,9 +181,10 @@ impl<T: ?Sized> Default for Interner<T> {
 
 #[cfg(test)]
 mod tests {
-    use alloc::{boxed::Box, string::ToString};
+    use alloc::{string::ToString, vec::Vec};
     use bevy_platform::hash::FixedHasher;
     use core::hash::{BuildHasher, Hash, Hasher};
+    use std::sync::Mutex;
 
     use crate::intern::{Internable, Interned, Interner};
 
@@ -252,6 +260,11 @@ mod tests {
         let y = interner.intern(b);
         // Same pointers returned by interner
         assert_eq!(x, y);
+
+        // Store the interned values inside a `static` so
+        // that miri doesn't report them as a memory leak.
+        static LEAKS: Mutex<Vec<Interned<str>>> = Mutex::new(Vec::new());
+        LEAKS.lock().unwrap().push(x);
     }
 
     #[test]
@@ -269,10 +282,17 @@ mod tests {
 
     #[test]
     fn same_interned_content() {
-        let a = Interned::<str>(Box::leak(Box::new("A".to_string())));
-        let b = Interned::<str>(Box::leak(Box::new("A".to_string())));
+        let a = Interned::<str>("A".to_string().leak());
+        let b = Interned::<str>("A".to_string().leak());
 
         assert_ne!(a, b);
+
+        // Store the interned values inside a `static` so
+        // that miri doesn't report them as a memory leak.
+        static LEAKS: Mutex<Vec<Interned<str>>> = Mutex::new(Vec::new());
+        let mut leaks = LEAKS.lock().unwrap();
+        leaks.push(a);
+        leaks.push(b);
     }
 
     #[test]

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1620,9 +1620,15 @@ mod tests {
 
     #[test]
     fn non_send_drop_from_different_thread() {
+        struct MustNotDrop;
+        impl Drop for MustNotDrop {
+            fn drop(&mut self) {
+                panic!("Must not be dropped");
+            }
+        }
+
         let mut world = World::default();
-        let (dropck, dropped) = DropCk::new_pair();
-        world.insert_non_send(dropck);
+        world.insert_non_send(MustNotDrop);
 
         let thread = std::thread::spawn(move || {
             // Dropping the world in another thread must
@@ -1633,9 +1639,6 @@ mod tests {
         if let Err(err) = thread.join() {
             std::panic::resume_unwind(err);
         }
-
-        // The non-send data was not dropped, since the world was dropped on the wrong thread.
-        assert_eq!(0, dropped.load(Ordering::Relaxed));
     }
 
     #[test]

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1623,14 +1623,20 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn non_send_drop_from_different_thread() {
+        struct MustNotDrop;
+        impl Drop for MustNotDrop {
+            fn drop(&mut self) {
+                panic!("Must not be dropped");
+            }
+        }
+
         let mut world = World::default();
-        world.insert_non_send(NonSendA::default());
+        world.insert_non_send(MustNotDrop);
 
         let thread = std::thread::spawn(move || {
-            // Dropping the non-send resource on a different thread
-            // Should result in a panic
+            // Dropping the world in another thread must
+            // not access the non-send resource to drop it.
             drop(world);
         });
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -173,7 +173,6 @@ mod tests {
     use bevy_tasks::{ComputeTaskPool, TaskPool};
     use core::{
         any::TypeId,
-        marker::PhantomData,
         sync::atomic::{AtomicUsize, Ordering},
     };
     use std::sync::Mutex;
@@ -186,9 +185,6 @@ mod tests {
     struct B(usize);
     #[derive(Component, Debug, PartialEq, Eq, Clone, Copy)]
     struct C;
-
-    #[derive(Default)]
-    struct NonSendA(PhantomData<*mut ()>);
 
     #[derive(Component, Clone, Debug)]
     struct DropCk(Arc<AtomicUsize>);
@@ -1624,15 +1620,9 @@ mod tests {
 
     #[test]
     fn non_send_drop_from_different_thread() {
-        struct MustNotDrop;
-        impl Drop for MustNotDrop {
-            fn drop(&mut self) {
-                panic!("Must not be dropped");
-            }
-        }
-
         let mut world = World::default();
-        world.insert_non_send(MustNotDrop);
+        let (dropck, dropped) = DropCk::new_pair();
+        world.insert_non_send(dropck);
 
         let thread = std::thread::spawn(move || {
             // Dropping the world in another thread must
@@ -1643,13 +1633,27 @@ mod tests {
         if let Err(err) = thread.join() {
             std::panic::resume_unwind(err);
         }
+
+        // The non-send data was not dropped, since the world was dropped on the wrong thread.
+        assert_eq!(0, dropped.load(Ordering::Relaxed));
     }
 
     #[test]
     fn non_send_drop_from_same_thread() {
         let mut world = World::default();
-        world.insert_non_send(NonSendA::default());
+        let (dropck, dropped) = DropCk::new_pair();
+        world.insert_non_send(dropck);
         drop(world);
+        // The non-send data was dropped with the world.
+        assert_eq!(1, dropped.load(Ordering::Relaxed));
+
+        let mut world = World::default();
+        let (dropck, dropped) = DropCk::new_pair();
+        world.insert_non_send(dropck);
+        let _removed = world.remove_non_send::<DropCk>();
+        drop(world);
+        // The non-send data was not dropped, since it was removed from the world.
+        assert_eq!(0, dropped.load(Ordering::Relaxed));
     }
 
     #[test]

--- a/crates/bevy_ecs/src/storage/non_send.rs
+++ b/crates/bevy_ecs/src/storage/non_send.rs
@@ -45,7 +45,7 @@ impl Drop for NonSendData {
             && self.origin_thread_id != Some(std::thread::current().id())
         {
             log::warn!(
-                "Attempted drop non-send data {} from thread {:?} while dropping `World` a thread {:?}.  The data will be forgotten instead.",
+                "Attempted drop non-send data {} from thread {:?} while dropping `World` in thread {:?}.  The data will be forgotten instead.",
                 self.type_name,
                 self.origin_thread_id,
                 std::thread::current().id()

--- a/crates/bevy_ecs/src/storage/non_send.rs
+++ b/crates/bevy_ecs/src/storage/non_send.rs
@@ -33,22 +33,29 @@ pub struct NonSendData {
 
 impl Drop for NonSendData {
     fn drop(&mut self) {
-        // We need to validate that correct thread is dropping the data.
-        // This validation is not needed if there is no data.
-        if self.is_present() {
-            // If this thread is already panicking, panicking again will cause
-            // the entire process to abort. In this case we choose to avoid
-            // dropping or checking this altogether and just leak the column.
-            #[cfg(feature = "std")]
-            if std::thread::panicking() {
-                return;
-            }
-            self.validate_access();
+        // If this is running on the wrong thread to access the data
+        // then it cannot be dropped and must be forgotten,
+        // but the memory can still be deallocated.
+        // TODO: Handle no_std non-send.
+        // Currently, no_std is single-threaded only, so this is safe to ignore.
+        // To support no_std multithreading, an alternative will be required.
+        #[cfg(feature = "std")]
+        if self.is_present()
+            && self.data.get_drop().is_some()
+            && self.origin_thread_id != Some(std::thread::current().id())
+        {
+            log::warn!(
+                "Attempted drop non-send data {} from thread {:?} while dropping `World` a thread {:?}.  The data will be forgotten instead.",
+                self.type_name,
+                self.origin_thread_id,
+                std::thread::current().id()
+            );
+            self.is_present = false;
         }
         // SAFETY: Drop is only called once upon dropping the NonSendData
         // and is inaccessible after this as the parent NonSendData has
-        // been dropped. The validate_access call above will check that the
-        // data is dropped on the thread it was inserted from.
+        // been dropped. The check above will ensure that the
+        // data is only dropped on the thread it was inserted from.
         unsafe {
             self.data.drop(1, self.is_present().into());
         }


### PR DESCRIPTION
# Objective

Make it possible to run miri with memory leak detection enabled.  It is enabled by default, so it reports errors whenever I run it locally.  And running it in CI should help prevent any new leaks from being introduced.  

See #4310 and #4959 for previous attempts to enable this.  Note that miri has added backtraces to leaked allocations since then (https://github.com/rust-lang/rust/pull/109061), so leaks are much easier to diagnose.  

## Solution

The first leak: When trying to drop non-send data on the wrong thread, the allocation for the value was being leaked.  We can't drop the value from the wrong thread, but we could still deallocate its storage.  

Rework the thread check in `NonSendData::drop` so that it still deallocates, setting `present = false` to ensure the value's `drop` is not called.  Change the `panic!` to a `warn!` so that we can have the check work the same way during unwinding.  

The second leak: The tests for `Interned` intentionally leak data!  So we can't exactly "fix" them, but I'd like miri to stop failing on them.  Then I realized that miri does not report leaks for our use of `Interned` for things like `ScheduleLabel`.  That's because those values are stored in a `static`, so are still reachable.

So, add a `static` to each of the tests with intentional leaks and store the leaked values there.  miri will consider those values reachable, and not report any leaks.  