### PR TITLE
Remove Default constraint from blanket Template impl

### DIFF
--- a/crates/bevy_ecs/src/template.rs
+++ b/crates/bevy_ecs/src/template.rs
@@ -387,7 +387,7 @@ all_tuples!(template_impl, 0, 12, T);
 
 // This includes `Unpin` to enable specialization for Templates that also implement Default, by using the
 // ["auto trait specialization" trick](https://github.com/coolcatcoder/rust_techniques/issues/1)
-impl<T: Clone + Default + Unpin> Template for T {
+impl<T: Clone + Unpin> Template for T {
     type Output = T;
 
     fn build_template(&self, _context: &mut TemplateContext) -> Result<Self::Output> {

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -421,6 +421,34 @@ impl ResolvedScene {
             .unwrap()
     }
 
+    /// Inserts the given [`Template`]. This will overwrite the existing [`Template`] of that type if it already exists.
+    pub fn insert_template<T: Template<Output: Component> + Send + Sync + 'static>(
+        &mut self,
+        template: T,
+    ) {
+        self.insert_erased_template(TypeId::of::<T>(), Box::new(template));
+    }
+
+    /// Inserts the given [`Template`] with the given `type_id`. This will overwrite the existing [`Template`] of that type if it already exists.
+    pub fn insert_erased_template(
+        &mut self,
+        type_id: TypeId,
+        template: Box<dyn ErasedComponentTemplate>,
+    ) {
+        match self.template_indices.entry(type_id) {
+            bevy_utils::TypeIdMapEntry::Occupied(occupied_entry) => {
+                let index = *occupied_entry.get();
+                // SAFETY: just looked up a valid index
+                let stored_template = unsafe { self.component_templates.get_unchecked_mut(index) };
+                *stored_template = template;
+            }
+            bevy_utils::TypeIdMapEntry::Vacant(vacant_entry) => {
+                vacant_entry.insert(self.component_templates.len());
+                self.component_templates.push(template);
+            }
+        }
+    }
+
     /// This will get the [`ErasedComponentTemplate`] for the given [`TypeId`], if it already exists in this [`ResolvedScene`]. If it doesn't exist,
     /// it will use the `default` function to create a new [`ErasedComponentTemplate`]. _For correctness, the [`TypeId`] of the [`Template`] returned
     /// by `default` should match the passed in `type_id`_.

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -288,7 +288,10 @@ pub struct TemplatePatch<F: FnOnce(&mut T, &mut ResolveContext), T>(pub F, pub P
 pub fn template_value<T: Template<Output: Component> + Send + Sync + 'static>(
     value: T,
 ) -> InsertTemplate {
-    InsertTemplate(TypeId::of::<T>(), Box::new(value))
+    InsertTemplate {
+        type_id: TypeId::of::<T>(),
+        template: Box::new(value),
+    }
 }
 
 /// A helper function that returns a [`TemplatePatch`] [`Scene`] for something that implements [`FromTemplate`].
@@ -344,14 +347,19 @@ impl<
 }
 
 /// A [`Scene`] that replaces the given template with the given value
-pub struct InsertTemplate(pub TypeId, pub Box<dyn ErasedComponentTemplate>);
+pub struct InsertTemplate {
+    /// The type id of the [`Template`] in `template`.
+    pub type_id: TypeId,
+    /// The template to insert.
+    pub template: Box<dyn ErasedComponentTemplate>,
+}
 impl Scene for InsertTemplate {
     fn resolve(
         self,
         _context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
-        scene.insert_erased_template(self.0, self.1);
+        scene.insert_erased_template(self.type_id, self.template);
         Ok(())
     }
 }

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,4 +1,4 @@
-use crate::{CachedSceneError, ResolvedScene, SceneList, ScenePatch};
+use crate::{CachedSceneError, ErasedComponentTemplate, ResolvedScene, SceneList, ScenePatch};
 use bevy_asset::{Asset, AssetPath, AssetServer, Assets};
 use bevy_ecs::{
     bundle::Bundle,
@@ -285,15 +285,10 @@ pub struct TemplatePatch<F: FnOnce(&mut T, &mut ResolveContext), T>(pub F, pub P
 
 /// Returns a [`Scene`] that completely overwrites the current value of a [`Template`] `T` with the given `value`.
 /// The `value` is cloned each time the [`Template`] is built.
-pub fn template_value<T: Template>(
+pub fn template_value<T: Template<Output: Component> + Send + Sync + 'static>(
     value: T,
-) -> TemplatePatch<impl FnOnce(&mut T, &mut ResolveContext), T> {
-    TemplatePatch(
-        move |input: &mut T, _context: &mut ResolveContext| {
-            *input = value;
-        },
-        PhantomData,
-    )
+) -> InsertTemplate {
+    InsertTemplate(TypeId::of::<T>(), Box::new(value))
 }
 
 /// A helper function that returns a [`TemplatePatch`] [`Scene`] for something that implements [`FromTemplate`].
@@ -344,6 +339,19 @@ impl<
     ) -> Result<(), ResolveSceneError> {
         let template = scene.get_or_insert_template::<T>(context);
         (self.0)(template, context);
+        Ok(())
+    }
+}
+
+/// A [`Scene`] that replaces the given template with the given value
+pub struct InsertTemplate(pub TypeId, pub Box<dyn ErasedComponentTemplate>);
+impl Scene for InsertTemplate {
+    fn resolve(
+        self,
+        _context: &mut ResolveContext,
+        scene: &mut ResolvedScene,
+    ) -> Result<(), ResolveSceneError> {
+        scene.insert_erased_template(self.0, self.1);
         Ok(())
     }
 }


### PR DESCRIPTION
# Objective

It turns out that `Template` is currently overly constrained. We really only need the blanket `FromTemplate` impl to constrain to `Default`, as _that_ is the `Default` analog. `Template` itself only relies on `Clone` for its functionality.

This does require reframing `template_value` to not be a "patch", as "patching" relies on being able to initialize a default template.

This enables the following:

```rust
#[derive(Component, Clone)
struct X;

bsn! {
  template_value(X)
}
```

This opens the doors to using Components without `FromTemplate` _or_ `Default` in BSN.

## Solution

- Remove the `Default` constraint from the blanket `Template` impl
- Add `ResolvedScene::insert_template` and an erased variant
- Add `InsertTemplate` scene impl, and switch `template_value` to use that.

## Testing

- `template_value` is already used extensively, and everything still works
- I also temporarily removed the `Unpin` specialization hack to ensure that this doesn't rely on it / have weird interactions with it (as we ideally can remove that eventually ... ex: once `Handle::default` is removed).
