### PR TITLE
Make `TextLayoutInfo::scale_factor` default to one

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -470,7 +470,7 @@ pub fn resolve_font_source<'a>(
 ///
 /// Contains scaled glyphs and their size. Generated via [`TextPipeline::update_text_layout_info`] when an entity has
 /// [`TextLayout`] and [`ComputedTextBlock`] components.
-#[derive(Component, Clone, Default, Debug, Reflect)]
+#[derive(Component, Clone, Debug, Reflect)]
 #[reflect(Component, Default, Debug, Clone)]
 pub struct TextLayoutInfo {
     /// The target scale factor for this text layout
@@ -504,6 +504,20 @@ impl TextLayoutInfo {
         self.cursor = None;
         self.selection_rects.clear();
         self.preedit_underline_rects.clear();
+    }
+}
+
+impl Default for TextLayoutInfo {
+    fn default() -> Self {
+        Self {
+            scale_factor: 1.,
+            glyphs: Default::default(),
+            run_geometry: Default::default(),
+            size: Vec2::ZERO,
+            cursor: None,
+            selection_rects: Default::default(),
+            preedit_underline_rects: Default::default(),
+        }
     }
 }
 


### PR DESCRIPTION
## Objective

Fix potential issue where a zero scale leads to NaNs.

## Background

`TextLayoutInfo::scale_factor` defaults to zero. If it's left at zero then `calculate_bounds_text2d` will do `scale_factor.recip()` and end up setting a NaN `Aabb`.

In practice this is difficult to trigger - normally `update_text2d_layout` calls `TextLayoutInfo::clear`, which sets `scale_factor` to one. But it's technically possible to sidestep that, which I managed to do while fiddling about with some unit tests.

## Solution

Default `TextLayoutInfo::scale_factor` to 1.

## Testing

```sh
cargo test -p bevy_sprite --all-features
cargo run --example text2d
```

I accidentally triggered the bug by commenting out the `visible_entities.push(Entity::PLACEHOLDER, TypeId::of::<Sprite>());` line in `bevy_sprite::tests::setup_with_scale_factor`.

## Alternatives

Arguably `calculate_bounds_text2d` should either clamp the scale to a reasonable range or error out. But setting the default is a reasonable precaution either way.