### PR TITLE
Update macro_doc_test to match doc example

### DIFF
--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -2659,18 +2659,20 @@ mod tests {
                     @some_prop: 3,       // props, look like fields prefixed with @ but end up passed to the components scene as arguments
                     normal_field: 5      // while normal fields are the actual fields of the component
                 },
-                Node {
-                    width: some_var      // you can directly use variables without {}
-                }
-                ComponentB({some_var + 3.})  // values can be expressions, when wrapped in {}
-                @Container {
-                    @items: {
-                        bsn_list![                // sometimes you may need to nest macro calls
-                            #item1 SomeComponent, // note: the name #item1 here is in its own scope
-                            some_scene() #item2
-                        ]
+                (
+                    Node {
+                        width: some_var      // you can directly use variables without {}
                     }
-                }
+                    ComponentB({some_var + 3.})  // values can be expressions, when wrapped in {}
+                    @Container {
+                        @items: {
+                            bsn_list![                // sometimes you may need to nest macro calls
+                                #item1 SomeComponent, // note: the name #item1 here is in its own scope
+                                some_scene() #item2
+                            ]
+                        }
+                    }
+                )
             ]
         };
         // just checking it spawns correctly


### PR DESCRIPTION
# Objective

@laundmo mentioned in #24912 that [the corresponding copy of the macro doc example in the macro_doc_test wasn't updated](https://github.com/bevyengine/bevy/pull/24912#issuecomment-4964144794).

## Solution

Applies the same change as #24912 to the test as well.