### PR TITLE
Match documented behavior of Winit UpdateMode::Reactive with Duration::MAX

### DIFF
--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -719,7 +719,10 @@ impl WinitAppRunnerState {
                             self.scheduled_tick_start = Some(next);
                         }
                     } else {
+                        // If the checked_add fails, we have no concrete instant to wait til.
+                        // In such a case, set our control flow to wait indefinitely..
                         event_loop.set_control_flow(ControlFlow::Wait);
+                        // .. and set no scheduled re-start instant.
                         self.scheduled_tick_start = None;
                     }
                 }

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -718,6 +718,9 @@ impl WinitAppRunnerState {
                             event_loop.set_control_flow(ControlFlow::WaitUntil(next));
                             self.scheduled_tick_start = Some(next);
                         }
+                    } else {
+                        event_loop.set_control_flow(ControlFlow::Wait);
+                        self.scheduled_tick_start = None;
                     }
                 }
             }


### PR DESCRIPTION
# Objective

This fixes an issue in handling Winit windows with `UpdateMode::Reactive` containing a wait duration of `Duration::MAX`.

According to the docs on `UpdateMode::Reactive.wait`: `This has no upper limit. The App will wait indefinitely if you set this to Duration::MAX.`
In practice, though, configuring the `WinitSettings` resource like the following could cause indefinitely-repeating window redraws after transitioning into the unfocused mode:
```rust
WinitSettings {
    focused_mode: WinitUpdateMode::reactive(Duration::from_secs(1)),
    unfocused_mode: WinitUpdateMode::reactive_low_power(Duration::MAX),
}
```

In the file, this was because the `None` case on the `checked_add` was unhandled, meaning that reaching it with Duration::MAX would cause Winit to always be waiting for a time that had already passed and never properly suspend.

## Solution

Simply handle the `None` case by updating the control flow to `Wait`.
See code comment for more info.

## Testing

In MacOS, I've tested with both the vanilla window/low_power example, alongside a fork modified to use the aforementioned WinitSettings. Between this and brief testing in a personal project, I've found no behavioral regressions.