### PR TITLE
fix(menu): move focus acquisition to PostUpdate after VisibilityPropagate

### DIFF
--- a/crates/bevy_ui_widgets/src/menu.rs
+++ b/crates/bevy_ui_widgets/src/menu.rs
@@ -49,14 +49,14 @@ use bevy_input::{
 };
 use bevy_input_focus::{
     tab_navigation::{NavAction, TabGroup, TabNavigation},
-    FocusCause, FocusedInput, InputFocus,
+    FocusCause, FocusedInput, InputFocus, InputFocusSystems,
 };
 use bevy_log::warn;
 use bevy_picking::events::{Cancel, Click, DragEnd, Pointer, Press, Release};
 use bevy_reflect::Reflect;
-use bevy_ui::{widget::Button, InteractionDisabled, Pressed};
+use bevy_ui::{widget::Button, InteractionDisabled, Pressed, UiSystems};
 
-use crate::{Activate, ActivateOnPress};
+use crate::{text_input::text_input_autoscroll_system, Activate, ActivateOnPress};
 
 /// Action type for [`MenuEvent`].
 #[derive(Clone, Copy, Debug, Reflect)]
@@ -476,7 +476,10 @@ impl Plugin for MenuPlugin {
             PostUpdate,
             (menu_acquire_focus, menu_on_lose_focus)
                 .chain()
-                .after(VisibilitySystems::VisibilityPropagate),
+                .after(VisibilitySystems::VisibilityPropagate)
+                .before(InputFocusSystems::FocusChangeEvents)
+                .before(text_input_autoscroll_system)
+                .before(UiSystems::PostLayout),
         )
         .add_observer(menu_on_key_event)
         .add_observer(menu_item_on_pointer_down)

--- a/crates/bevy_ui_widgets/src/menu.rs
+++ b/crates/bevy_ui_widgets/src/menu.rs
@@ -30,7 +30,8 @@
 
 use accesskit::Role;
 use bevy_a11y::AccessibilityNode;
-use bevy_app::{App, Plugin, Update};
+use bevy_app::{App, Plugin, PostUpdate};
+use bevy_camera::visibility::VisibilitySystems;
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -471,7 +472,12 @@ pub struct MenuPlugin;
 
 impl Plugin for MenuPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, (menu_acquire_focus, menu_on_lose_focus).chain())
+        app.add_systems(
+            PostUpdate,
+            (menu_acquire_focus, menu_on_lose_focus)
+                .chain()
+                .after(VisibilitySystems::VisibilityPropagate),
+            )
             .add_observer(menu_on_key_event)
             .add_observer(menu_item_on_pointer_down)
             .add_observer(menu_item_on_pointer_up)

--- a/crates/bevy_ui_widgets/src/menu.rs
+++ b/crates/bevy_ui_widgets/src/menu.rs
@@ -477,15 +477,15 @@ impl Plugin for MenuPlugin {
             (menu_acquire_focus, menu_on_lose_focus)
                 .chain()
                 .after(VisibilitySystems::VisibilityPropagate),
-            )
-            .add_observer(menu_on_key_event)
-            .add_observer(menu_item_on_pointer_down)
-            .add_observer(menu_item_on_pointer_up)
-            .add_observer(menu_item_on_pointer_click)
-            .add_observer(menu_item_on_pointer_drag_end)
-            .add_observer(menu_item_on_pointer_cancel)
-            .add_observer(menubutton_on_key_event)
-            .add_observer(menubutton_on_activate);
+        )
+        .add_observer(menu_on_key_event)
+        .add_observer(menu_item_on_pointer_down)
+        .add_observer(menu_item_on_pointer_up)
+        .add_observer(menu_item_on_pointer_click)
+        .add_observer(menu_item_on_pointer_drag_end)
+        .add_observer(menu_item_on_pointer_cancel)
+        .add_observer(menubutton_on_key_event)
+        .add_observer(menubutton_on_activate);
     }
 }
 

--- a/crates/bevy_ui_widgets/src/text_input.rs
+++ b/crates/bevy_ui_widgets/src/text_input.rs
@@ -278,7 +278,7 @@ fn on_pointer_drag(
     ));
 }
 
-fn text_input_autoscroll_system(
+pub(crate) fn text_input_autoscroll_system(
     time: Res<Time<Real>>,
     pointer_state: Res<PointerState>,
     input_focus: Res<InputFocus>,


### PR DESCRIPTION
## Summary

Fixes the timing issue also present and causing #24935.

Related to #24769 and #24968

`menu_acquire_focus` and `menu_on_lose_focus` were running in `Update`, before `VisibilitySystems::VisibilityPropagate` had updated `InheritedVisibility` on the newly-visible popup's children. When `menu_acquire_focus` called `tab_navigation.initialize()`, `gather_focusable` found no focusable entities in the still-hidden subtree and returned `NoFocusableEntities`. `menu_on_lose_focus` then ran immediately after, saw no focus within the menu, and closed it.

## Solution

Move `menu_acquire_focus` and `menu_on_lose_focus` to `PostUpdate`, scheduled after `VisibilitySystems::VisibilityPropagate`, so that `InheritedVisibility` is accurate by the time focus acquisition runs.

## Testing

- Verified that menus in the `feathers_gallery` example open correctly and can be navigated.
- Existing menu tests continue to pass.