### PR TITLE
Handle zero-duration clips in `ActiveAnimation::update`

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -569,23 +569,20 @@ impl ActiveAnimation {
         }
 
         self.elapsed += delta;
-        if clip_duration > 0.0 {
-            self.seek_time += delta * self.speed;
-        }
+        self.seek_time += delta * self.speed;
 
         let over_time = self.speed > 0.0 && self.seek_time >= clip_duration;
         let under_time = self.speed < 0.0 && self.seek_time < 0.0;
 
-        if over_time || under_time || clip_duration == 0.0 {
+        if over_time || under_time {
             self.just_completed = true;
             self.completions += 1;
-
-            if self.is_finished() {
-                return;
-            }
         }
         if clip_duration == 0.0 {
             self.seek_time = 0.0;
+            return;
+        }
+        if self.is_finished() {
             return;
         }
         if self.seek_time >= clip_duration {

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -569,18 +569,24 @@ impl ActiveAnimation {
         }
 
         self.elapsed += delta;
-        self.seek_time += delta * self.speed;
+        if clip_duration > 0.0 {
+            self.seek_time += delta * self.speed;
+        }
 
         let over_time = self.speed > 0.0 && self.seek_time >= clip_duration;
         let under_time = self.speed < 0.0 && self.seek_time < 0.0;
 
-        if over_time || under_time {
+        if over_time || under_time || clip_duration == 0.0 {
             self.just_completed = true;
             self.completions += 1;
 
             if self.is_finished() {
                 return;
             }
+        }
+        if clip_duration == 0.0 {
+            self.seek_time = 0.0;
+            return;
         }
         if self.seek_time >= clip_duration {
             self.seek_time %= clip_duration;
@@ -1707,6 +1713,84 @@ mod tests {
         active_animation.last_seek_time = Some(clip.duration);
         active_animation.update(clip.duration, clip.duration); // 0.3 : 0.0
         assert_triggered_events_with(&active_animation, &clip, [0.3, 0.2]);
+    }
+
+    mod active_animation_duration_zero {
+        use super::*;
+
+        #[test]
+        fn test_events_triggers() {
+            let mut active_animation = ActiveAnimation::default();
+            let mut clip = AnimationClip::default();
+            clip.add_event(0.0, A);
+            assert_eq!(0.0, clip.duration);
+
+            assert_triggered_events_with(&active_animation, &clip, []);
+            active_animation.update(0.1, clip.duration);
+            assert_triggered_events_with(&active_animation, &clip, [0.0]);
+            active_animation.update(0.1, clip.duration);
+            assert_triggered_events_with(&active_animation, &clip, []);
+            assert_eq!(0.0, active_animation.seek_time);
+
+            active_animation = ActiveAnimation {
+                speed: -1.0,
+                ..Default::default()
+            };
+            assert_triggered_events_with(&active_animation, &clip, []);
+            active_animation.update(0.1, clip.duration);
+            assert_triggered_events_with(&active_animation, &clip, [0.0]);
+            active_animation.update(0.1, clip.duration);
+            assert_triggered_events_with(&active_animation, &clip, []);
+            assert_eq!(0.0, active_animation.seek_time);
+        }
+
+        #[test]
+        fn test_events_triggers_looping() {
+            let mut active_animation = ActiveAnimation {
+                repeat: RepeatAnimation::Forever,
+                ..Default::default()
+            };
+            let mut clip = AnimationClip::default();
+            clip.add_event(0.0, A);
+            assert_eq!(0.0, clip.duration);
+
+            assert_triggered_events_with(&active_animation, &clip, []);
+            active_animation.update(0.1, clip.duration);
+            assert_triggered_events_with(&active_animation, &clip, [0.0]);
+            active_animation.update(0.1, clip.duration);
+            assert_triggered_events_with(&active_animation, &clip, [0.0]);
+            assert_eq!(0.0, active_animation.seek_time);
+
+            active_animation = ActiveAnimation {
+                repeat: RepeatAnimation::Forever,
+                speed: -1.0,
+                ..Default::default()
+            };
+            assert_triggered_events_with(&active_animation, &clip, []);
+            active_animation.update(0.1, clip.duration);
+            assert_triggered_events_with(&active_animation, &clip, [0.0]);
+            active_animation.update(0.1, clip.duration);
+            assert_triggered_events_with(&active_animation, &clip, [0.0]);
+            assert_eq!(0.0, active_animation.seek_time);
+        }
+
+        #[test]
+        fn test_events_triggers_looping_after_seek_to() {
+            let mut active_animation = ActiveAnimation {
+                repeat: RepeatAnimation::Forever,
+                ..Default::default()
+            };
+            let mut clip = AnimationClip::default();
+            clip.add_event(0.0, A);
+
+            active_animation.seek_to(11.0); // 0.0 : 11.0
+            assert_triggered_events_with(&active_animation, &clip, [0.0]);
+            active_animation.update(0.1, clip.duration); // 11.0 : 0.0
+            assert_triggered_events_with(&active_animation, &clip, []);
+            active_animation.update(0.1, clip.duration); // 0.0 : 0.0
+            assert_triggered_events_with(&active_animation, &clip, [0.0]);
+            assert_eq!(0.0, active_animation.seek_time);
+        }
     }
 
     #[test]


### PR DESCRIPTION
# Objective

When an animation has a clip duration of zero (for example, a character that is stunned, immobilized, or aiming a rifle), `ActiveAnimation::update` executes `self.seek_time %= clip_duration`. Because `clip_duration` is zero, this sets `seek_time` to `NaN`, causing the subsequent time checks to fail.

As a result, repeating zero-duration animations never repeat after their first completion, and the documented range of `[0, clip_duration]` for `seek_time` is violated.

## Solution

This PR updates `ActiveAnimation::update` to handle a `clip_duration` of zero explicitly. Repeating zero-duration clips now complete every frame without entering an invalid state.

## Testing

Added tests covering the behavior of `ActiveAnimation` with zero-duration clips. They can be run with:

```sh
cargo test -p bevy_animation
```
