### PR TITLE
Fix atmosphere rendering in rotated and Z-up worlds

### DIFF
--- a/crates/bevy_light/src/atmosphere.rs
+++ b/crates/bevy_light/src/atmosphere.rs
@@ -29,6 +29,7 @@ use wgpu_types::TextureFormat;
 ///
 /// The scale on [`GlobalTransform`] rescales the planet in world space. Tune it with the radius offset
 /// when your scene uses other units, like kilometer-sized scenes.
+/// The rotation is ignored because the atmosphere is spherically symmetric.
 #[derive(Clone, Component, FromTemplate)]
 #[require(GlobalTransform)]
 #[component(on_add = set_default_transform)]

--- a/crates/bevy_pbr/src/atmosphere/mod.rs
+++ b/crates/bevy_pbr/src/atmosphere/mod.rs
@@ -55,7 +55,7 @@ use bevy_ecs::{
     system::{Commands, Query},
 };
 use bevy_light::{atmosphere::ScatteringMedium, Atmosphere};
-use bevy_math::{Mat4, UVec2, UVec3, Vec3};
+use bevy_math::{Mat4, Quat, UVec2, UVec3, Vec3};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     extract_component::{ExtractComponentPlugin, UniformComponentPlugin},
@@ -239,13 +239,20 @@ pub fn extract_atmosphere(
             .expect("checked non-empty above");
         let atmo = selected.1;
         let gt = selected.2;
+        // Atmospheres are spherically symmetric, so ignore their orientation.
+        let (scale, _, translation) = gt.to_scale_rotation_translation();
 
         let extracted = ExtractedAtmosphere {
             inner_radius: atmo.inner_radius,
             outer_radius: atmo.outer_radius,
             ground_albedo: atmo.ground_albedo,
             medium: atmo.medium.id(),
-            world_to_atmosphere: gt.to_matrix().inverse(),
+            world_to_atmosphere: Mat4::from_scale_rotation_translation(
+                scale,
+                Quat::IDENTITY,
+                translation,
+            )
+            .inverse(),
         };
         commands.entity(render_entity).insert(extracted);
         commands

--- a/crates/bevy_pbr/src/atmosphere/resources.rs
+++ b/crates/bevy_pbr/src/atmosphere/resources.rs
@@ -567,7 +567,11 @@ pub(super) fn prepare_atmosphere_transforms(
         // World-horizontal reference for back, projected orthogonal to atmo_y.
         let world_ref = Vec3A::NEG_Z;
         let ref_horizontal = world_ref - atmo_y * atmo_y.dot(world_ref);
-        let atmo_z = ref_horizontal.normalize();
+        let atmo_z = ref_horizontal.try_normalize().unwrap_or_else(|| {
+            // `NEG_Z` is degenerate at the poles of a Z-up world.
+            let fallback_ref = Vec3A::NEG_Y;
+            (fallback_ref - atmo_y * atmo_y.dot(fallback_ref)).normalize()
+        });
         let atmo_x = atmo_y.cross(atmo_z).normalize();
 
         let world_from_atmosphere = Mat4::from(Affine3A::from_cols(


### PR DESCRIPTION


# Objective

Fixes #24811.

Rotating an `Atmosphere` entity incorrectly tilted the sky and sun. Z-up worlds could also produce a degenerate atmosphere basis, resulting in a black sky.

## Solution

Ignore atmosphere rotation while preserving translation and scale, since atmospheres are spherically symmetric. Fall back to a non-degenerate reference axis when constructing the sky basis at the poles of a Z-up world.