### PR TITLE
Don't cull rotated UI text glyphs

### DIFF
--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -1915,9 +1915,12 @@ pub fn prepare_uinodes(
                                 .transform
                                 .transform_vector2(rect_size)
                                 .abs();
-                            if positions_diff[0].x - positions_diff[1].x >= transformed_rect_size.x
-                                || positions_diff[1].y - positions_diff[2].y
-                                    >= transformed_rect_size.y
+                            // Don't try to cull glyphs that have a rotation.
+                            if extracted_uinode.transform.x_axis[1] == 0.0
+                                && (positions_diff[0].x - positions_diff[1].x
+                                    >= transformed_rect_size.x
+                                    || positions_diff[1].y - positions_diff[2].y
+                                        >= transformed_rect_size.y)
                             {
                                 continue;
                             }


### PR DESCRIPTION
# Objective

Fixes #24953. UI text glyphs could disappear at specific rotation angles due to incorrect clipping culling.

## Solution

The bug was incorrect CPU-side glyph culling.

We calculated a rotated glyph’s size like this:

```rust
transform.transform_vector2(rect_size).abs()
```

At exactly 45° or 135°, the rotated width/height components can cancel out and become zero or extremely small. Bevy then mistakenly concluded that some glyphs were completely outside the clipping rectangle and skipped them with `continue`.

The fix disables this unreliable culling optimization for rotated glyphs. The glyphs are still rendered and clipped normally; they’re simply no longer discarded prematurely. Other rotated UI elements already use the same safeguard.

