### PR TITLE
Migrate `transparency_ui` example to use `bevy::ui_widgets::Button` (Phase 1 Item 1)

### DIFF
--- a/examples/ui/styling/transparency_ui.rs
+++ b/examples/ui/styling/transparency_ui.rs
@@ -2,6 +2,7 @@
 //! Shows two colored buttons with transparent text.
 
 use bevy::prelude::*;
+use bevy::ui_widgets::Button;
 
 fn main() {
     App::new()
@@ -46,12 +47,18 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             ..default()
                         },
                         // Alpha channel of the color controls transparency.
+                        // An alpha value of 0.2 means that the color is mostly transparent,
+                        // but a little bit of the RGB color is still visible.
+                        // (The color is white in this case since RGB values are all 1.0)
+
+                        // An alpha value of 1.0 means that the color is not transparent at all.
+                        // An alpha value of 0.0 means the color is completely transparent.
                         TextColor(Color::srgba(1.0, 1.0, 1.0, 0.2)),
                     ));
                 });
 
-            // Button with a different color,
-            // to demonstrate the text looks different due to its transparency.
+            // Button with a different background color,
+            // to demonstrate that the same color text looks different due to its transparency.
             parent
                 .spawn((
                     Button,


### PR DESCRIPTION
# Objective

- Part of #24112 , the very first item in Phase 1, just to demonstrate how simple that phase is.

## Solution

- Instead of the `Button` component using bevy::ui::Button via the prelude, explicitly import the `bevy::ui_widgets::Button` so that it is used instead. This example doesn’t use anything related to Interaction or clicking, so there are no changes there.
- Added some clarifying comments while I’m here since this is a very basic introductory example.

## Testing

- Ran the example and it looks good. What a simple one!

<img width="1273" height="745" alt="Screenshot 2026-07-15 at 2 39 02 PM" src="https://github.com/user-attachments/assets/9e584675-609b-4257-8e3c-ec0cdd6d6c8c" />
