### PR TITLE
Increase timeout minutes on `build` CI job to 40

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
# Objective

I would like to be able to merge PRs.
I currently cannot.

Fixes #25001.

## Solution

Make number go up so our build jobs stop timing out stochastically.

We should try to improve compile times and reduce the work we do in CI, but we should not be blocking on that.