### PR TITLE
Migrate `app_under_test` and `integration_test` to use a `FeathersButton` (Phase 2 Item 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4975,7 +4975,7 @@ wasm = false
 name = "app_under_test"
 path = "examples/remote/app_under_test.rs"
 doc-scrape-examples = true
-required-features = ["bevy_remote"]
+required-features = ["bevy_remote", "bevy_feathers"]
 
 [package.metadata.example.app_under_test]
 name = "App Under Test"
@@ -4987,7 +4987,7 @@ wasm = false
 name = "integration_test"
 path = "examples/remote/integration_test.rs"
 doc-scrape-examples = true
-required-features = ["bevy_remote"]
+required-features = ["bevy_remote", "bevy_feathers"]
 
 [package.metadata.example.integration_test]
 name = "Integration Test"

--- a/examples/remote/app_under_test.rs
+++ b/examples/remote/app_under_test.rs
@@ -12,6 +12,7 @@
 use bevy::{
     prelude::*,
     remote::{http::RemoteHttpPlugin, RemotePlugin},
+    text::FontSourceTemplate,
     time::common_conditions::on_timer,
     ui::UiGlobalTransform,
 };
@@ -68,46 +69,38 @@ fn move_button(mut rng: ResMut<SeededRng>, mut button_query: Query<&mut Node, Wi
     }
 }
 
-fn setup(mut commands: Commands, assets: Res<AssetServer>, mut rng: ResMut<SeededRng>) {
+fn setup(mut commands: Commands, mut rng: ResMut<SeededRng>) {
     let (left_pct, top_pct) = random_position(&mut rng.0);
-
     commands.spawn(Camera2d);
-    commands
-        .spawn(Node {
+    commands.spawn_scene(bsn! {
+        Node {
             width: percent(100),
             height: percent(100),
-            ..default()
-        })
-        .with_children(|parent| {
-            parent
-                .spawn((
-                    Button,
-                    Node {
-                        width: px(150),
-                        height: px(65),
-                        border: UiRect::all(px(5)),
-                        justify_content: JustifyContent::Center,
-                        align_items: AlignItems::Center,
-                        border_radius: BorderRadius::MAX,
-                        left: percent(left_pct),
-                        top: percent(top_pct),
-                        ..default()
-                    },
-                    BorderColor::all(Color::WHITE),
-                    BackgroundColor(Color::BLACK),
-                ))
-                .observe(on_button_click)
-                .with_children(|parent| {
-                    parent.spawn((
-                        Text::new("Button"),
-                        TextFont {
-                            font: assets.load("fonts/FiraSans-Bold.ttf").into(),
-                            font_size: FontSize::Px(33.0),
-                            ..default()
-                        },
-                        TextColor(Color::srgb(0.9, 0.9, 0.9)),
-                        TextShadow::default(),
-                    ));
-                });
-        });
+        }
+        Children [
+            Button
+            Node {
+                width: px(150),
+                height: px(65),
+                border: UiRect::all(px(5)),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                border_radius: BorderRadius::MAX,
+                left: percent(left_pct),
+                top: percent(top_pct),
+            }
+            BorderColor::all(Color::WHITE)
+            BackgroundColor(Color::BLACK)
+            on(on_button_click)
+            Children [
+                Text::new("Button")
+                TextFont {
+                    font: FontSourceTemplate::Handle("fonts/FiraSans-Bold.ttf"),
+                    font_size: FontSize::Px(33.0),
+                }
+                TextColor(Color::srgb(0.9, 0.9, 0.9))
+                TextShadow::default()
+            ]
+        ]
+    });
 }

--- a/examples/remote/app_under_test.rs
+++ b/examples/remote/app_under_test.rs
@@ -2,17 +2,20 @@
 //! It displays a button that must be clicked. The button is placed at a random position and
 //! moves every 5 seconds.
 //!
-//! Run with the `bevy_remote` feature enabled:
+//! Run with the `bevy_remote` and `bevy_feathers` feature enabled:
 //! ```bash
-//! cargo run --example app_under_test --features="bevy_remote"
+//! cargo run --example app_under_test --features="bevy_remote bevy_feathers"
 //! ```
 //! This example can be paired with the `integration_test` example, which will run an integration
 //! test on this app.
 
 use bevy::{
+    feathers::{
+        controls::FeathersButton, dark_theme::create_dark_theme, display::caption, theme::UiTheme,
+        FeathersPlugins,
+    },
     prelude::*,
     remote::{http::RemoteHttpPlugin, RemotePlugin},
-    text::FontSourceTemplate,
     time::common_conditions::on_timer,
     ui::UiGlobalTransform,
 };
@@ -21,11 +24,12 @@ use rand::{RngExt, SeedableRng};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins((DefaultPlugins, FeathersPlugins))
         // To make the app available for integration testing, we add these
         // remote plugins to expose API’s for a testing framework to call.
         .add_plugins(RemotePlugin::default())
         .add_plugins(RemoteHttpPlugin::default())
+        .insert_resource(UiTheme(create_dark_theme()))
         .insert_resource(SeededRng(ChaCha8Rng::seed_from_u64(19878367467712)))
         .add_systems(Startup, setup)
         .add_systems(
@@ -47,7 +51,7 @@ fn on_button_click(_click: On<Pointer<Click>>, mut exit: MessageWriter<AppExit>)
 }
 
 fn log_button_position(
-    transform: Single<&UiGlobalTransform, (With<Button>, Changed<UiGlobalTransform>)>,
+    transform: Single<&UiGlobalTransform, (With<FeathersButton>, Changed<UiGlobalTransform>)>,
 ) {
     info!(
         "Button at physical ({}, {})",
@@ -61,7 +65,10 @@ fn random_position(rng: &mut ChaCha8Rng) -> (f32, f32) {
     (left_pct, top_pct)
 }
 
-fn move_button(mut rng: ResMut<SeededRng>, mut button_query: Query<&mut Node, With<Button>>) {
+fn move_button(
+    mut rng: ResMut<SeededRng>,
+    mut button_query: Query<&mut Node, With<FeathersButton>>,
+) {
     let (left_pct, top_pct) = random_position(&mut rng.0);
     for mut node in &mut button_query {
         node.left = percent(left_pct);
@@ -78,29 +85,18 @@ fn setup(mut commands: Commands, mut rng: ResMut<SeededRng>) {
             height: percent(100),
         }
         Children [
-            Button
+            @FeathersButton {
+                @caption: bsn! { caption("Button") }
+            }
             Node {
                 width: px(150),
                 height: px(65),
                 border: UiRect::all(px(5)),
-                justify_content: JustifyContent::Center,
-                align_items: AlignItems::Center,
-                border_radius: BorderRadius::MAX,
                 left: percent(left_pct),
                 top: percent(top_pct),
             }
             BorderColor::all(Color::WHITE)
-            BackgroundColor(Color::BLACK)
             on(on_button_click)
-            Children [
-                Text::new("Button")
-                TextFont {
-                    font: FontSourceTemplate::Handle("fonts/FiraSans-Bold.ttf"),
-                    font_size: FontSize::Px(33.0),
-                }
-                TextColor(Color::srgb(0.9, 0.9, 0.9))
-                TextShadow::default()
-            ]
         ]
     });
 }

--- a/examples/remote/integration_test.rs
+++ b/examples/remote/integration_test.rs
@@ -1,9 +1,9 @@
 //! An integration test that connects to a running Bevy app via the BRP,
 //! finds a button's position, and sends a mouse click to press it.
 //!
-//! Run with the `bevy_remote` feature enabled:
+//! Run with the `bevy_remote` and `bevy_feathers` features enabled:
 //! ```bash
-//! cargo run --example integration_test --features="bevy_remote"
+//! cargo run --example integration_test --features="bevy_remote bevy_feathers"
 //! ```
 //! This example assumes that the `app_under_test` example is running on the same machine.
 
@@ -11,6 +11,7 @@ use std::{any::type_name, io::BufRead};
 
 use anyhow::Result as AnyhowResult;
 use bevy::{
+    feathers::controls::FeathersButton,
     platform::collections::HashMap,
     remote::{
         builtin_methods::{
@@ -22,7 +23,7 @@ use bevy::{
         BrpRequest,
     },
     render::view::screenshot::{Screenshot, ScreenshotCaptured},
-    ui::{widget::Button, UiGlobalTransform},
+    ui::UiGlobalTransform,
     window::{Window, WindowEvent},
 };
 
@@ -104,7 +105,7 @@ fn main() -> AnyhowResult<()> {
             },
             strict: false,
             filter: BrpQueryFilter {
-                with: vec![type_name::<Button>().to_string()],
+                with: vec![type_name::<FeathersButton>().to_string()],
                 without: Vec::default(),
             },
         },


### PR DESCRIPTION
# Objective

- Part of #24112
- Give an example of Phase 2 in case other people want to join in on the fun.

## Solution

- `app_under_test`’s button is now a `FeathersButton` with some minimal example-specific styling (specifying a border for the button).
- `integration_test` had to be updated to query for the `FeathersButton` component now, since `ui::widgets::Button` should not be used anymore.

## Testing

- `cargo run --example app_under_test --features="bevy_remote bevy_feathers”` works as I expected, although the button looks different now of course.
- `cargo run --example integration_test --features="bevy_remote bevy_feathers”` in conjunction with app_under_test works as expected.

The screenshot from the `integration_test` is attached:

<img width="2560" height="1440" alt="screenshot" src="https://github.com/user-attachments/assets/9a9b6e52-e236-4746-8564-4e0815fc5285" />
