### PR TITLE
Add memory size helpers to bevy_utils

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -135,6 +135,7 @@ serialize = [
   "bevy_time/serialize",
   "bevy_transform/serialize",
   "bevy_ui?/serialize",
+  "bevy_utils?/serialize",
   "bevy_window?/serialize",
   "bevy_winit?/serialize",
   "bevy_platform/serialize",

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -135,7 +135,7 @@ serialize = [
   "bevy_time/serialize",
   "bevy_transform/serialize",
   "bevy_ui?/serialize",
-  "bevy_utils?/serialize",
+  "bevy_utils/serialize",
   "bevy_window?/serialize",
   "bevy_winit?/serialize",
   "bevy_platform/serialize",

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -20,7 +20,7 @@ std = ["disqualified/alloc"]
 
 debug = ["bevy_platform/alloc"]
 
-serialize = ["dep::serde"]
+serialize = ["dep:serde"]
 
 [dependencies]
 bevy_platform = { path = "../bevy_platform", version = "0.20.0-dev", default-features = false }

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -20,6 +20,8 @@ std = ["disqualified/alloc"]
 
 debug = ["bevy_platform/alloc"]
 
+serialize = ["dep::serde"]
+
 [dependencies]
 bevy_platform = { path = "../bevy_platform", version = "0.20.0-dev", default-features = false }
 

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -27,6 +27,7 @@ disqualified = { version = "1.0", default-features = false }
 thread_local = { version = "1.0", optional = true }
 async-channel = { version = "2.3.0", optional = true }
 indexmap = { version = "2", default-features = false }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 static_assertions = "1.1.0"

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -62,6 +62,7 @@ mod bloom_filter;
 pub use bloom_filter::*;
 mod debug_info;
 mod default;
+pub mod memory_size;
 mod once;
 
 #[doc(hidden)]

--- a/crates/bevy_utils/src/memory_size.rs
+++ b/crates/bevy_utils/src/memory_size.rs
@@ -1,0 +1,115 @@
+//! Types for representing the size of objects in memory.
+
+use core::fmt::Display;
+
+/// The size of an object in memory, in bytes.
+///
+/// The helper methods on this type use powers of 2 for conversions between units,
+/// consistent with the standards for memory reporting.
+///
+/// While it would technically be more correct to use e.g.
+/// "kibibytes" instead of "kilobytes", "mebibytes" instead of "megabytes", etc.,
+/// the more common terms are used here for familiarity and discoverability.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MemorySize(pub u64);
+
+impl MemorySize {
+    /// Creates a new [`MemorySize`] from the given number of bytes.
+    ///
+    /// This method is provided for convenience,
+    /// as many other APIs in Rust use `usize` for sizes and counts.
+    /// To initialize this type with a `u64`, just call `MemorySize(bytes)` directly.
+    pub fn new(bytes: usize) -> Self {
+        MemorySize(bytes as u64)
+    }
+
+    /// Returns the size in bytes, as a `usize`.
+    ///
+    /// This method is provided for convenience,
+    /// as many other APIs in Rust use `usize` for sizes and counts.
+    /// To access the value as a `u64`, just use the `.0` field directly.
+    ///
+    /// 1 byte = 8 bits.
+    pub fn as_bytes(&self) -> usize {
+        self.0 as usize
+    }
+
+    /// Returns the size in kilobytes.
+    ///
+    /// 1 kilobyte = 1024 bytes.
+    pub fn as_kilobytes(&self) -> f64 {
+        self.0 as f64 / 1024.0
+    }
+
+    /// Returns the size in megabytes.
+    ///
+    /// 1 megabyte = 1024 kilobytes.
+    pub fn as_megabytes(&self) -> f64 {
+        self.0 as f64 / (1024.0 * 1024.0)
+    }
+
+    /// Returns the size in gigabytes.
+    ///
+    /// 1 gigabyte = 1024 megabytes.
+    pub fn as_gigabytes(&self) -> f64 {
+        self.0 as f64 / (1024.0 * 1024.0 * 1024.0)
+    }
+
+    /// Returns the size in terabytes.
+    ///
+    /// 1 terabyte = 1024 gigabytes.
+    pub fn as_terabytes(&self) -> f64 {
+        self.0 as f64 / (1024.0 * 1024.0 * 1024.0 * 1024.0)
+    }
+
+    /// Determine the appropriate unit for displaying the memory size.
+    ///
+    /// Units are chosen such that the value is at least 1 in that unit.
+    ///
+    /// This is used for formatting the memory size in a human-readable way,
+    /// such as in the [`Display`] implementation for this type.
+    pub fn appropriate_unit(&self) -> MemoryUnit {
+        if self.0 >= 1024 * 1024 * 1024 * 1024 {
+            MemoryUnit::Terabytes
+        } else if self.0 >= 1024 * 1024 * 1024 {
+            MemoryUnit::Gigabytes
+        } else if self.0 >= 1024 * 1024 {
+            MemoryUnit::Megabytes
+        } else if self.0 >= 1024 {
+            MemoryUnit::Kilobytes
+        } else {
+            MemoryUnit::Bytes
+        }
+    }
+}
+
+impl Display for MemorySize {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let unit = self.appropriate_unit();
+        match unit {
+            MemoryUnit::Bytes => write!(f, "{} B", self.as_bytes()),
+            MemoryUnit::Kilobytes => write!(f, "{:.2} KiB", self.as_kilobytes()),
+            MemoryUnit::Megabytes => write!(f, "{:.2} MiB", self.as_megabytes()),
+            MemoryUnit::Gigabytes => write!(f, "{:.2} GiB", self.as_gigabytes()),
+            MemoryUnit::Terabytes => write!(f, "{:.2} TiB", self.as_terabytes()),
+        }
+    }
+}
+
+/// Common units for representing memory size.
+///
+/// Used for determining the most appropriate unit to display a [`MemorySize`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MemoryUnit {
+    /// 8 bits
+    Bytes,
+    /// 1 kilobyte = 1024 bytes
+    Kilobytes,
+    /// 1 megabyte = 1024 kilobytes
+    Megabytes,
+    /// 1 gigabyte = 1024 megabytes
+    Gigabytes,
+    /// 1 terabyte = 1024 gigabytes
+    Terabytes,
+}

--- a/crates/bevy_utils/src/memory_size.rs
+++ b/crates/bevy_utils/src/memory_size.rs
@@ -11,7 +11,7 @@ use core::fmt::Display;
 /// "kibibytes" instead of "kilobytes", "mebibytes" instead of "megabytes", etc.,
 /// the more common terms are used here for familiarity and discoverability.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct MemorySize(pub u64);
 
 impl MemorySize {


### PR DESCRIPTION
# Objective

As part of #23013, we want to be able to report memory usage of various game objects.

## Solution

Write a tiny helper module, sticking it in `bevy_utils` because it is not actually coupled to inspector functionality at all.

As the docs state, this uses powers of 2 but the more casual powers of 10 names. Reviewers, if you think it's important to be pedantically correct here, I'll change it over, but I think on the balance conforming to user expectations with a note for the pedants is the right call.

I also considered putting this in `bevy_diagnostic`, where it is thematically a better fit. I stuck it here though as it doesn't rely on any of the `bevy_diagnostics` infrastructure. No strong feelings though; it's just helper types.

This is so small that it is not worth adding a dependency for.

Oh and added an optional `serde` dependencies to `bevy_utils` so we can conditionally derive `Serialize`/`Deserialize`, plumbing that up through `bevy_internal` through to `bevy` as is tradition.

## Testing

Tested in `feathers_inspector`. IDK man it's very simple code.
