### PR TITLE
Add entity label resolution infrastructure for entity inspectors

### DIFF
--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -52,7 +52,7 @@ bevy_ui_render = { path = "../bevy_ui_render", version = "0.20.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.20.0-dev", optional = true }
 bevy_window = { path = "../bevy_window", version = "0.20.0-dev" }
 bevy_state = { path = "../bevy_state", version = "0.20.0-dev" }
-bevy_platform = { path = "../bevy_platform", version = "0.20.0-dev", optional = true }
+bevy_platform = { path = "../bevy_platform", version = "0.20.0-dev" }
 bevy_mesh = { path = "../bevy_mesh", version = "0.20.0-dev" }
 bevy_world_serialization = { path = "../bevy_world_serialization", version = "0.20.0-dev" }
 

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -24,7 +24,9 @@ serialize = ["dep:serde"]
 
 [dependencies]
 # bevy
+bevy_animation = { path = "../bevy_animation", version = "0.20.0-dev" }
 bevy_app = { path = "../bevy_app", version = "0.20.0-dev" }
+bevy_audio = { path = "../bevy_audio", version = "0.20.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.20.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.20.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.20.0-dev" }
@@ -33,6 +35,7 @@ bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.20.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.20.0-dev" }
 bevy_image = { path = "../bevy_image", version = "0.20.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.20.0-dev" }
+bevy_light = { path = "../bevy_light", version = "0.20.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.20.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.20.0-dev" }
 bevy_pbr = { path = "../bevy_pbr", version = "0.20.0-dev" }
@@ -43,6 +46,7 @@ bevy_time = { path = "../bevy_time", version = "0.20.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.20.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.20.0-dev" }
 bevy_shader = { path = "../bevy_shader", version = "0.20.0-dev" }
+bevy_sprite = { path = "../bevy_sprite", version = "0.20.0-dev" }
 bevy_ui = { path = "../bevy_ui", version = "0.20.0-dev" }
 bevy_ui_render = { path = "../bevy_ui_render", version = "0.20.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.20.0-dev", optional = true }

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -20,6 +20,7 @@ schedule_data = [
   "dep:bevy_utils",
   "dep:thiserror",
 ]
+serialize = ["dep:serde"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -13,13 +13,7 @@ bevy_ci_testing = ["dep:serde", "dep:ron"]
 screenrecording = ["dep:x264"]
 webgl = ["bevy_render/webgl"]
 webgpu = ["bevy_render/webgpu"]
-schedule_data = [
-  "dep:serde",
-  "dep:ron",
-  "dep:bevy_platform",
-  "dep:bevy_utils",
-  "dep:thiserror",
-]
+schedule_data = ["dep:serde", "dep:ron", "dep:bevy_utils", "dep:thiserror"]
 serialize = ["dep:serde"]
 
 [dependencies]

--- a/crates/bevy_dev_tools/src/inspection/label_resolution.rs
+++ b/crates/bevy_dev_tools/src/inspection/label_resolution.rs
@@ -1,17 +1,34 @@
 //! Rules and strategies for determining the inspection-displayed label of an entity.
 
-use bevy::core_pipeline::Skybox;
-use bevy::ecs::component::ComponentId;
-use bevy::ecs::system::SystemIdMarker;
-use bevy::light::{Atmosphere, FogVolume, IrradianceVolume, SunDisk};
-use bevy::pbr::wireframe::Wireframe;
-use bevy::pbr::Lightmap;
-use bevy::picking::pointer::PointerId;
-use bevy::platform::collections::HashMap;
-use bevy::prelude::*;
-use bevy::window::Monitor;
-use bevy_ecs::name::Name;
-use core::any::TypeId;
+use bevy_animation::AnimationPlayer;
+use bevy_app::{App, Plugin};
+use bevy_audio::{AudioPlayer, AudioSink};
+use bevy_camera::{Camera, Camera2d};
+use bevy_core_pipeline::Skybox;
+use bevy_ecs::{
+    component::ComponentId, entity::Entity, name::Name, observer::Observer, resource::Resource,
+    system::SystemIdMarker, world::World,
+};
+use bevy_input::gamepad::Gamepad;
+use bevy_light::{
+    AmbientLight, Atmosphere, DirectionalLight, FogVolume, IrradianceVolume, LightProbe,
+    PointLight, SpotLight, SunDisk,
+};
+use bevy_mesh::{Mesh2d, Mesh3d};
+use bevy_pbr::{wireframe::Wireframe, DistanceFog, Lightmap};
+use bevy_picking::pointer::PointerId;
+use bevy_platform::collections::HashMap;
+use bevy_sprite::{Sprite, Text2d};
+use bevy_text::TextSpan;
+use bevy_ui::{
+    widget::{Button, ImageNode, Text, ViewportNode},
+    Node,
+};
+use bevy_window::{Monitor, Window};
+use core::{
+    any::TypeId,
+    ops::{Deref, DerefMut},
+};
 
 /// The priority level for label-defining components.
 ///
@@ -27,10 +44,7 @@ use core::any::TypeId;
 /// Leaving space between these priority levels allows for future expansion
 /// and customization in tricky edge cases.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(
-    feature = "serialize",
-    derive(serialize::Serialize, serialize::Deserialize)
-)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct LabelDefinitionPriority(pub i8);
 
 impl LabelDefinitionPriority {
@@ -66,20 +80,30 @@ pub struct ComponentLabelData<'a> {
 /// when determining the entity's label.
 ///
 /// This data is produced by [`resolve_label`].
-#[derive(Clone, Debug, PartialEq, Eq, Deref, DerefMut)]
-#[cfg_attr(
-    feature = "serialize",
-    derive(serialize::Serialize, serialize::Deserialize)
-)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct EntityLabel {
     /// The resolved label to display for the entity.
     ///
     /// Stored as a [`Name`] to take advantage of the optimizations and conveniences of that type,
     /// even though not all labels are [`Name`]-derived.
-    #[deref]
     pub label: Name,
     /// How the label was determined, which can be used to inform display decisions.
     pub origin: LabelOrigin,
+}
+
+impl Deref for EntityLabel {
+    type Target = Name;
+
+    fn deref(&self) -> &Self::Target {
+        &self.label
+    }
+}
+
+impl DerefMut for EntityLabel {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.label
+    }
 }
 
 impl EntityLabel {
@@ -116,10 +140,7 @@ impl EntityLabel {
 
 /// Identifies how the inspected entity's label was determined.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serialize",
-    derive(serialize::Serialize, serialize::Deserialize)
-)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub enum LabelOrigin {
     /// The entity label comes from the [`Name`] component.
     Custom,
@@ -287,7 +308,7 @@ impl Plugin for LabelResolutionPlugin {
         label_resolution_registry
             .register_label_defining_type::<Camera2d>(LabelDefinitionPriority::LIBRARY);
         label_resolution_registry
-            .register_label_defining_type::<Camera3d>(LabelDefinitionPriority::LIBRARY);
+            .register_label_defining_type::<Camera2d>(LabelDefinitionPriority::LIBRARY);
 
         // Lights
         label_resolution_registry

--- a/crates/bevy_dev_tools/src/inspection/label_resolution.rs
+++ b/crates/bevy_dev_tools/src/inspection/label_resolution.rs
@@ -214,12 +214,12 @@ pub fn resolve_label(
 ///
 /// # Priority Conventions
 ///
-/// See the associated constants on [`NameDefinitionPriority`] for recommended priority levels.
+/// See the associated constants on [`LabelDefinitionPriority`] for recommended priority levels.
 ///
 /// # Usage
 ///
 /// Components that should be "label-defining" should be registered in this registry
-/// using [`NameResolutionRegistry::register_label_defining_type`],
+/// using [`LabelResolutionRegistry::register_label_defining_type`],
 /// typically in the plugin that defines the component.
 #[derive(Debug, Resource, Default)]
 pub struct LabelResolutionRegistry {

--- a/crates/bevy_dev_tools/src/inspection/label_resolution.rs
+++ b/crates/bevy_dev_tools/src/inspection/label_resolution.rs
@@ -27,7 +27,10 @@ use core::any::TypeId;
 /// Leaving space between these priority levels allows for future expansion
 /// and customization in tricky edge cases.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serialize::Serialize, serialize::Deserialize)
+)]
 pub struct LabelDefinitionPriority(pub i8);
 
 impl LabelDefinitionPriority {
@@ -64,7 +67,10 @@ pub struct ComponentLabelData<'a> {
 ///
 /// This data is produced by [`resolve_label`].
 #[derive(Clone, Debug, PartialEq, Eq, Deref, DerefMut)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serialize::Serialize, serialize::Deserialize)
+)]
 pub struct EntityLabel {
     /// The resolved label to display for the entity.
     ///
@@ -110,7 +116,10 @@ impl EntityLabel {
 
 /// Identifies how the inspected entity's label was determined.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serialize::Serialize, serialize::Deserialize)
+)]
 pub enum LabelOrigin {
     /// The entity label comes from the [`Name`] component.
     Custom,

--- a/crates/bevy_dev_tools/src/inspection/label_resolution.rs
+++ b/crates/bevy_dev_tools/src/inspection/label_resolution.rs
@@ -223,7 +223,7 @@ pub fn resolve_label(
 /// typically in the plugin that defines the component.
 #[derive(Debug, Resource, Default)]
 pub struct LabelResolutionRegistry {
-    /// A mapping of label-defining component TypeIds to their priority levels.
+    /// A mapping of label-defining component [`TypeId`]s to their priority levels.
     label_defining_types: HashMap<TypeId, LabelDefinitionPriority>,
 }
 

--- a/crates/bevy_dev_tools/src/inspection/label_resolution.rs
+++ b/crates/bevy_dev_tools/src/inspection/label_resolution.rs
@@ -1,0 +1,339 @@
+//! Rules and strategies for determining the inspection-displayed label of an entity.
+
+use bevy::core_pipeline::Skybox;
+use bevy::ecs::component::ComponentId;
+use bevy::ecs::system::SystemIdMarker;
+use bevy::light::{Atmosphere, FogVolume, IrradianceVolume, SunDisk};
+use bevy::pbr::wireframe::Wireframe;
+use bevy::pbr::Lightmap;
+use bevy::picking::pointer::PointerId;
+use bevy::platform::collections::HashMap;
+use bevy::prelude::*;
+use bevy::window::Monitor;
+use bevy_ecs::name::Name;
+use core::any::TypeId;
+
+/// The priority level for label-defining components.
+///
+/// Higher values indicate higher priority when determining an entity's label.
+///
+/// # Priority Conventions
+///
+/// - User-defined label-defining components should use [`USER`](Self::USER) priority (`0`).
+/// - Library-defined components (in Bevy, or in third-party Bevy crates)
+///   that are label-defining should use [`LIBRARY`](Self::LIBRARY) priority (`-10`).
+/// - Fallback components (e.g. [`Camera`]) should use [`FALLBACK`](Self::FALLBACK) priority (`-20`).
+///
+/// Leaving space between these priority levels allows for future expansion
+/// and customization in tricky edge cases.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct LabelDefinitionPriority(pub i8);
+
+impl LabelDefinitionPriority {
+    /// The recommended priority for user-defined label-defining components.
+    pub const USER: Self = Self(0);
+
+    /// The recommended priority for library-defined label-defining components
+    /// (e.g. Bevy built-ins or third-party crate types).
+    pub const LIBRARY: Self = Self(-10);
+
+    /// The recommended priority for fallback label-defining components
+    /// that should only be used when no better label is available
+    /// (e.g. [`Camera`], [`Node`]).
+    pub const FALLBACK: Self = Self(-20);
+}
+
+/// Summary of a component on an entity, used for label resolution in [`resolve_label`].
+#[derive(Clone, Copy, Debug)]
+pub struct ComponentLabelData<'a> {
+    /// The [`ComponentId`] of the component.
+    pub component_id: ComponentId,
+    /// The short (i.e. unqualified) name of the component type.
+    pub short_name: &'a str,
+    /// The label-defining priority, if this component is registered as label-defining.
+    pub label_definition_priority: Option<LabelDefinitionPriority>,
+}
+
+/// The label of an inspected entity, used for inspection.
+///
+/// This is distinct from the entity's [`Name`],
+/// which is an explicitly set component that is used in priority
+/// over any [label defining](LabelDefinitionPriority) components
+/// when determining the entity's label.
+///
+/// This data is produced by [`resolve_label`].
+#[derive(Clone, Debug, PartialEq, Eq, Deref, DerefMut)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct EntityLabel {
+    /// The resolved label to display for the entity.
+    ///
+    /// Stored as a [`Name`] to take advantage of the optimizations and conveniences of that type,
+    /// even though not all labels are [`Name`]-derived.
+    #[deref]
+    pub label: Name,
+    /// How the label was determined, which can be used to inform display decisions.
+    pub origin: LabelOrigin,
+}
+
+impl EntityLabel {
+    /// Constructs a [`Custom`] entity label.
+    ///
+    /// [`Custom`]: LabelOrigin::Custom
+    pub fn custom(label: &str) -> Self {
+        Self {
+            label: Name::new(label.to_owned()),
+            origin: LabelOrigin::Custom,
+        }
+    }
+
+    /// Constructs a [`Resolved`] entity label.
+    ///
+    /// [`Resolved`]: LabelOrigin::Resolved
+    pub fn resolved(label: &str) -> Self {
+        Self {
+            label: Name::new(label.to_owned()),
+            origin: LabelOrigin::Resolved,
+        }
+    }
+
+    /// Constructs a [`Fallback`] entity label.
+    ///
+    /// [`Fallback`]: LabelOrigin::Fallback
+    pub fn fallback(label: &str) -> Self {
+        Self {
+            label: Name::new(label.to_owned()),
+            origin: LabelOrigin::Fallback,
+        }
+    }
+}
+
+/// Identifies how the inspected entity's label was determined.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum LabelOrigin {
+    /// The entity label comes from the [`Name`] component.
+    Custom,
+    /// The label was resolved from label-defining components via [`resolve_label`].
+    Resolved,
+    /// No [`Name`] component or label-defining component was found;
+    /// the caller provided a fallback label.
+    Fallback,
+}
+
+/// Determines the label to display for the given `entity`.
+///
+/// If the [`Name`] component is present, its value will be used as the label.
+///
+/// If any component marked as "label-defining" is present
+/// (i.e., has a [`LabelDefinitionPriority`]), its label will be used.
+/// If multiple label-defining components with the same highest priority are present,
+/// they will be joined in alphabetical order,
+/// separated by a "|" character.
+///
+/// Otherwise, [`None`] is returned.
+/// The caller can then fall back to a default label such as "Entity".
+///
+/// # Arguments
+///
+/// * `world` - The world to query for the entity's [`Name`] component.
+/// * `entity` - The entity to resolve the label for.
+/// * `components` - A slice of [`ComponentLabelData`] describing each component on the entity.
+///   Callers should assemble these from whatever component data they have.
+pub fn resolve_label(
+    world: &World,
+    entity: Entity,
+    components: &[ComponentLabelData],
+) -> Option<EntityLabel> {
+    if let Some(custom_label) = world.get::<Name>(entity).cloned() {
+        return Some(EntityLabel::custom(custom_label.as_str()));
+    }
+
+    let mut label_resolution_priorities: Vec<(&str, LabelDefinitionPriority)> = components
+        .iter()
+        .filter_map(|c| c.label_definition_priority.map(|p| (c.short_name, p)))
+        .collect();
+
+    if label_resolution_priorities.is_empty() {
+        return None;
+    }
+
+    // Sort by priority (higher priority first), then alphabetically
+    label_resolution_priorities.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+
+    // Only include labels with the highest priority
+    // PERF: we could do this more efficiently by combining the sort and filter steps
+    let highest_priority = label_resolution_priorities[0].1;
+    label_resolution_priorities.retain(|&(_, priority)| priority == highest_priority);
+
+    let resolved_label = label_resolution_priorities
+        .into_iter()
+        .map(|(label, _)| label)
+        .collect::<Vec<&str>>()
+        .join(" | ");
+
+    Some(EntityLabel::resolved(&resolved_label))
+}
+
+/// Stores the registered label-defining component types and their priorities.
+///
+/// When determining an entity's label via [`resolve_label`], components with higher priority values
+/// will take precedence over those with lower priority values.
+///
+/// Entities with an explicit [`Name`] component will always take precedence over label-defining components.
+///
+/// # Priority Conventions
+///
+/// See the associated constants on [`NameDefinitionPriority`] for recommended priority levels.
+///
+/// # Usage
+///
+/// Components that should be "label-defining" should be registered in this registry
+/// using [`NameResolutionRegistry::register_label_defining_type`],
+/// typically in the plugin that defines the component.
+#[derive(Debug, Resource, Default)]
+pub struct LabelResolutionRegistry {
+    /// A mapping of label-defining component TypeIds to their priority levels.
+    label_defining_types: HashMap<TypeId, LabelDefinitionPriority>,
+}
+
+impl LabelResolutionRegistry {
+    /// Creates a new, empty [`LabelResolutionRegistry`].
+    pub const fn new() -> Self {
+        Self {
+            label_defining_types: HashMap::new(),
+        }
+    }
+
+    /// Registers a label-defining component type with the given priority.
+    ///
+    /// Higher priority components will take precedence when determining an entity's label.
+    pub fn register_label_defining_type<T: 'static>(&mut self, priority: LabelDefinitionPriority) {
+        let type_id = TypeId::of::<T>();
+        self.label_defining_types.insert(type_id, priority);
+    }
+
+    /// Gets the priority of a label-defining component type, if registered.
+    pub fn get_priority<T: 'static>(&self) -> Option<LabelDefinitionPriority> {
+        let type_id = TypeId::of::<T>();
+        self.get_priority_by_type_id(type_id)
+    }
+
+    /// Gets the priority of a label-defining component type by its [`TypeId`], if registered.
+    pub fn get_priority_by_type_id(&self, type_id: TypeId) -> Option<LabelDefinitionPriority> {
+        self.label_defining_types.get(&type_id).copied()
+    }
+
+    /// Removes a label-defining component type from the registry.
+    pub fn unregister_label_defining_type<T: 'static>(&mut self) {
+        let type_id = TypeId::of::<T>();
+        self.unregister_label_defining_type_by_type_id(type_id);
+    }
+
+    /// Removes a label-defining component type from the registry by its [`TypeId`].
+    pub fn unregister_label_defining_type_by_type_id(&mut self, type_id: TypeId) {
+        self.label_defining_types.remove(&type_id);
+    }
+}
+
+/// A plugin which registers label-defining components for Bevy's first-party types
+/// in the [`LabelResolutionRegistry`] resource.
+///
+/// When upstreamed, this plugin should not be necessary,
+/// as each label-defining component can register itself in its own plugin.
+pub struct LabelResolutionPlugin;
+impl Plugin for LabelResolutionPlugin {
+    fn build(&self, app: &mut App) {
+        let mut label_resolution_registry = LabelResolutionRegistry::new();
+
+        // Windowing and input
+        label_resolution_registry
+            .register_label_defining_type::<Window>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<Monitor>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<Gamepad>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<PointerId>(LabelDefinitionPriority::LIBRARY);
+
+        // UI
+        label_resolution_registry
+            .register_label_defining_type::<Node>(LabelDefinitionPriority::FALLBACK);
+        label_resolution_registry
+            .register_label_defining_type::<Button>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<Text>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<TextSpan>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<Text2d>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<ImageNode>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<ViewportNode>(LabelDefinitionPriority::LIBRARY);
+
+        // Cameras
+        label_resolution_registry
+            .register_label_defining_type::<Camera>(LabelDefinitionPriority::FALLBACK);
+        label_resolution_registry
+            .register_label_defining_type::<Camera2d>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<Camera3d>(LabelDefinitionPriority::LIBRARY);
+
+        // Lights
+        label_resolution_registry
+            .register_label_defining_type::<DirectionalLight>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<PointLight>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<SpotLight>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<AmbientLight>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<LightProbe>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<IrradianceVolume>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<SunDisk>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<Lightmap>(LabelDefinitionPriority::LIBRARY);
+
+        // Core rendering components
+        label_resolution_registry
+            .register_label_defining_type::<Sprite>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<Mesh2d>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<Mesh3d>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<Wireframe>(LabelDefinitionPriority::LIBRARY);
+
+        // Atmospherics
+        label_resolution_registry
+            .register_label_defining_type::<Skybox>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<FogVolume>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<Atmosphere>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<DistanceFog>(LabelDefinitionPriority::LIBRARY);
+
+        // Animation
+        label_resolution_registry
+            .register_label_defining_type::<AnimationPlayer>(LabelDefinitionPriority::LIBRARY);
+
+        // Audio
+        label_resolution_registry
+            .register_label_defining_type::<AudioPlayer>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<AudioSink>(LabelDefinitionPriority::LIBRARY);
+
+        // System-likes
+        label_resolution_registry
+            .register_label_defining_type::<Observer>(LabelDefinitionPriority::LIBRARY);
+        label_resolution_registry
+            .register_label_defining_type::<SystemIdMarker>(LabelDefinitionPriority::LIBRARY);
+
+        app.insert_resource(label_resolution_registry);
+    }
+}

--- a/crates/bevy_dev_tools/src/inspection/mod.rs
+++ b/crates/bevy_dev_tools/src/inspection/mod.rs
@@ -1,0 +1,5 @@
+//! Entity and world inspection tools for Bevy.
+//!
+//! This module uses a front-end/backend architecture,
+//! dividing its responsibilities between extracting data about the world state,
+//! and presenting that data to the user in a number of convenient, often interactive ways.

--- a/crates/bevy_dev_tools/src/inspection/mod.rs
+++ b/crates/bevy_dev_tools/src/inspection/mod.rs
@@ -3,3 +3,5 @@
 //! This module uses a front-end/backend architecture,
 //! dividing its responsibilities between extracting data about the world state,
 //! and presenting that data to the user in a number of convenient, often interactive ways.
+
+pub mod label_resolution;

--- a/crates/bevy_dev_tools/src/lib.rs
+++ b/crates/bevy_dev_tools/src/lib.rs
@@ -18,6 +18,8 @@ mod easy_screenshot;
 pub mod fps_overlay;
 pub mod frame_time_graph;
 
+pub mod inspection;
+
 pub mod picking_debug;
 
 #[cfg(feature = "schedule_data")]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -127,6 +127,7 @@ shader_format_wesl = ["bevy_shader/shader_format_wesl"]
 serialize = [
   "bevy_a11y?/serialize",
   "bevy_color?/serialize",
+  "bevy_dev_tools?/serialize",
   "bevy_ecs/serialize",
   "bevy_image?/serialize",
   "bevy_input/serialize",


### PR DESCRIPTION
# Objective

As part of #23013, when presenting a list of entities to a user, you want to have some heuristics to be able to quickly communicate what *type* of entity it is to them. Simply displaying `Entity v0214156` is unhelpful, when `Camera2d` is much better!

If a `Name` exists, we *should* display that, but not every entity has a `Name`, nor should we force users to start doing so.

Previously discussed in #3833.

## Solution

Introduce the concept of an `EntityLabel`, a heuristic display-only name that can be used when communicating "what is this thing" in inspectors.

There are a few wrinkles in the design space that have to be considered:

1. This needs to be user extensible: simply hard-coding a list of all Bevy types does not work well for either third-party crates or end user applications. `Player` is very important information to have!
2. We should have sane defaults.
3. Some components are more important than others and should take priority. For example, while `Camera` is a decent label, `Camera2d` is better!

These requirements push us into a prioritized, user-modifiable registry as our core design. I've opted for simple integer priorities with nice constants and space between them. That should be sufficient to define sensible ecosystem conventions without overcomplicating the design.

I've opted to put this (and future inspection code) into `bevy_dev_tools/inspector`. Please, please do not bikeshed that decision here: go to the working group. We can make a final call before releasing 0.20.

This should probably all be more granularly feature-flagged, but that's a pre-existing problem with bevy_dev_tools, and not one that I particularly want to fix *right* here.

## Testing

Tested in `feathers_inspector`: names obtained were pretty solid!

I think I've managed to hit all the core Bevy "object" types, but we can always add more.

