### PR TITLE
ecs: improve diagnostic note for Rust 2024 impl Trait lifetime capture

### DIFF
--- a/crates/bevy_ecs/compile_fail/tests/ui/rust2024_captured_lifetimes.rs
+++ b/crates/bevy_ecs/compile_fail/tests/ui/rust2024_captured_lifetimes.rs
@@ -1,0 +1,18 @@
+//@edition: 2024
+use bevy_ecs::prelude::*;
+
+trait Scene {}
+
+#[derive(Resource)]
+struct MyScene;
+impl Scene for MyScene {}
+
+fn make_scene(_res: Res<MyScene>) -> impl Scene {
+    MyScene
+}
+
+fn main() {
+    let mut schedule = Schedule::default();
+    schedule.add_systems(make_scene);
+    //~^ E0277
+}

--- a/crates/bevy_ecs/compile_fail/tests/ui/rust2024_captured_lifetimes.stderr
+++ b/crates/bevy_ecs/compile_fail/tests/ui/rust2024_captured_lifetimes.stderr
@@ -1,0 +1,33 @@
+error[E0277]: `for<'a> fn(bevy_ecs::change_detection::Res<'a, MyScene>) -> impl Scene {make_scene}` does not describe a valid system configuration
+  --> tests/ui/rust2024_captured_lifetimes.rs:16:26
+   |
+16 |     schedule.add_systems(make_scene);
+   |              ----------- ^^^^^^^^^^ invalid system configuration
+   |              |
+   |              required by a bound introduced by this call
+   |
+   = help: the trait `IntoSystem<(), (), _>` is not implemented for fn item `for<'a> fn(bevy_ecs::change_detection::Res<'a, MyScene>) -> impl Scene {make_scene}`
+   = note: If `for<'a> fn(bevy_ecs::change_detection::Res<'a, MyScene>) -> impl Scene {make_scene}` is a function and returns `impl Trait`, it may capture lifetimes from its parameters.
+           In Rust 2024, returning `impl Trait` from a function implicitly captures all lifetimes in scope. You can opt out of this by adding `+ use<>` to the return type: `impl Trait + use<>`
+help: the following other types implement trait `IntoSystem<In, Out, Marker>`
+  --> crates/bevy_ecs/src/system/builder.rs:284:0
+  ::: crates/bevy_ecs/src/system/builder.rs:291:69
+   |
+   = note: `IntoBuilderSystem<Marker, In, Out, Func, Builder>` implements `IntoSystem<In, Out, (bevy_ecs::system::IsBuilderSystem, Marker)>`
+  --> crates/bevy_ecs/src/system/adapter_system.rs:84:0
+  ::: crates/bevy_ecs/src/system/adapter_system.rs:89:27
+   |
+   = note: `IntoAdapterSystem<Func, S>` implements `IntoSystem<<Func as Adapt<...>>::In, ..., ...>`
+  --> crates/bevy_ecs/src/system/combinator.rs:303:0
+  ::: crates/bevy_ecs/src/system/combinator.rs:309:44
+   |
+   = note: `IntoPipeSystem<A, B>` implements `IntoSystem<IA, OB, (bevy_ecs::system::IsPipeSystemMarker, OA, IB, MA, MB)>`
+   = note: required for `for<'a> fn(bevy_ecs::change_detection::Res<'a, MyScene>) -> impl Scene {make_scene}` to implement `IntoScheduleConfigs<Box<(dyn bevy_ecs::system::System<In = (), Out = ()> + 'static)>, _>`
+note: required by a bound in `bevy_ecs::schedule::Schedule::add_systems`
+  --> crates/bevy_ecs/src/schedule/schedule.rs:430:4
+   = note: the full name for the type has been written to '$BEVY_ROOT/bevy_ecs/compile_fail/target/ui/0/tests/ui/rust2024_captured_lifetimes.long-type-13086334430028765271.txt'
+   = note: consider using `--verbose` to print the full type name to the console
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -309,7 +309,8 @@ impl<T: Schedulable<Metadata = GraphInfo, GroupMetadata = Chain>> ScheduleConfig
 /// ```
 #[diagnostic::on_unimplemented(
     message = "`{Self}` does not describe a valid system configuration",
-    label = "invalid system configuration"
+    label = "invalid system configuration",
+    note = "If `{Self}` is a function and returns `impl Trait`, it may capture lifetimes from its parameters.\nIn Rust 2024, returning `impl Trait` from a function implicitly captures all lifetimes in scope. You can opt out of this by adding `+ use<>` to the return type: `impl Trait + use<>`"
 )]
 pub trait IntoScheduleConfigs<T: Schedulable<Metadata = GraphInfo, GroupMetadata = Chain>, Marker>:
     Sized

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -202,7 +202,8 @@ where
 /// sometimes called higher order systems.
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not an exclusive system",
-    label = "invalid system"
+    label = "invalid system",
+    note = "If `{Self}` is a function and returns `impl Trait`, it may capture lifetimes from its parameters.\nIn Rust 2024, returning `impl Trait` from a function implicitly captures all lifetimes in scope. You can opt out of this by adding `+ use<>` to the return type: `impl Trait + use<>`"
 )]
 pub trait ExclusiveSystemParamFunction<Marker>: Send + Sync + 'static {
     /// The input type to this system. See [`System::In`].

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -848,7 +848,8 @@ where
 /// [`ParamSet`]: crate::system::ParamSet
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not a valid system",
-    label = "invalid system"
+    label = "invalid system",
+    note = "If `{Self}` is a function and returns `impl Trait`, it may capture lifetimes from its parameters.\nIn Rust 2024, returning `impl Trait` from a function implicitly captures all lifetimes in scope. You can opt out of this by adding `+ use<>` to the return type: `impl Trait + use<>`"
 )]
 pub trait SystemParamFunction<Marker>: Send + Sync + 'static {
     /// The input type of this system. See [`System::In`].

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -180,7 +180,8 @@ use crate::world::{FromWorld, World};
 // even though none can currently
 #[diagnostic::on_unimplemented(
     message = "`{Self}` is not a valid system with input `{In}` and output `{Out}`",
-    label = "invalid system"
+    label = "invalid system",
+    note = "If `{Self}` is a function and returns `impl Trait`, it may capture lifetimes from its parameters.\nIn Rust 2024, returning `impl Trait` from a function implicitly captures all lifetimes in scope. You can opt out of this by adding `+ use<>` to the return type: `impl Trait + use<>`"
 )]
 pub trait IntoSystem<In: SystemInput, Out, Marker>: Sized {
     /// The type of [`System`] that this instance converts into.

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -44,7 +44,11 @@ bitflags! {
 /// Systems are executed in parallel, in opportunistic order; data access is managed automatically.
 /// It's possible to specify explicit execution order between specific systems,
 /// see [`IntoScheduleConfigs`](crate::schedule::IntoScheduleConfigs).
-#[diagnostic::on_unimplemented(message = "`{Self}` is not a system", label = "invalid system")]
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a system",
+    label = "invalid system",
+    note = "If `{Self}` is a function and returns `impl Trait`, it may capture lifetimes from its parameters.\nIn Rust 2024, returning `impl Trait` from a function implicitly captures all lifetimes in scope. You can opt out of this by adding `+ use<>` to the return type: `impl Trait + use<>`"
+)]
 pub trait System: Send + Sync + 'static {
     /// The system's input.
     type In: SystemInput;


### PR DESCRIPTION
This PR adds a helpful note to the `#[diagnostic::on_unimplemented]` attribute for traits related to systems (`IntoSystem`, `SystemParamFunction`, `ExclusiveSystemParamFunction`, `IntoScheduleConfigs`, `System`). The note informs the user that returning `impl Trait` in Rust 2024 implicitly captures lifetimes from the parameters and suggests adding `+ use<>` (or similar) to opt out.