### PR TITLE
Scene transition refactor for the testbed examples

### DIFF
--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -50,7 +50,7 @@ fn main() {
     app.run();
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, States, Default)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, States, Default)]
 enum Scene {
     #[default]
     Shapes,
@@ -61,6 +61,19 @@ enum Scene {
     Gizmos,
     TextureAtlasBuilder,
     ColorConsistency,
+}
+
+impl Scene {
+    const ALL_ORDERED: &'static [Scene] = &[
+        Scene::Shapes,
+        Scene::Bloom,
+        Scene::Text,
+        Scene::Sprite,
+        Scene::SpriteSlicing,
+        Scene::Gizmos,
+        Scene::TextureAtlasBuilder,
+        Scene::ColorConsistency,
+    ];
 }
 
 impl std::str::FromStr for Scene {
@@ -80,16 +93,11 @@ impl std::str::FromStr for Scene {
 
 impl Next for Scene {
     fn next(&self) -> Self {
-        match self {
-            Scene::Shapes => Scene::Bloom,
-            Scene::Bloom => Scene::Text,
-            Scene::Text => Scene::Sprite,
-            Scene::Sprite => Scene::SpriteSlicing,
-            Scene::SpriteSlicing => Scene::Gizmos,
-            Scene::Gizmos => Scene::TextureAtlasBuilder,
-            Scene::TextureAtlasBuilder => Scene::ColorConsistency,
-            Scene::ColorConsistency => Scene::Shapes,
-        }
+        let index = Scene::ALL_ORDERED
+            .iter()
+            .position(|scene| scene == self)
+            .unwrap();
+        Scene::ALL_ORDERED[(index + 1) % Scene::ALL_ORDERED.len()]
     }
 }
 

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -93,11 +93,12 @@ impl std::str::FromStr for Scene {
 
 impl Next for Scene {
     fn next(&self) -> Self {
-        let index = Scene::ALL_ORDERED
+        Scene::ALL_ORDERED[(Scene::ALL_ORDERED
             .iter()
             .position(|scene| scene == self)
-            .unwrap();
-        Scene::ALL_ORDERED[(index + 1) % Scene::ALL_ORDERED.len()]
+            .unwrap()
+            + 1)
+            % Scene::ALL_ORDERED.len()]
     }
 }
 

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -105,8 +105,12 @@ impl std::str::FromStr for Scene {
 
 impl Next for Scene {
     fn next(&self) -> Self {
-        let index = Scene::ALL_ORDERED.iter().position(|scene| scene == self).unwrap();
-        Scene::ALL_ORDERED[(index + 1) % Scene::ALL_ORDERED.len()]
+        Scene::ALL_ORDERED[(Scene::ALL_ORDERED
+            .iter()
+            .position(|scene| scene == self)
+            .unwrap()
+            + 1)
+            % Scene::ALL_ORDERED.len()]
     }
 }
 

--- a/examples/testbed/3d.rs
+++ b/examples/testbed/3d.rs
@@ -60,7 +60,7 @@ fn main() {
     app.run();
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, States, Default)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, States, Default)]
 enum Scene {
     #[default]
     Light,
@@ -72,6 +72,20 @@ enum Scene {
     WhiteFurnaceSolidColorLight,
     WhiteFurnaceEnvironmentMapLight,
     RenderLayers,
+}
+
+impl Scene {
+    const ALL_ORDERED: &'static [Scene] = &[
+        Scene::Light,
+        Scene::Bloom,
+        Scene::Gltf,
+        Scene::Animation,
+        Scene::Gizmos,
+        Scene::GltfCoordinateConversion,
+        Scene::WhiteFurnaceSolidColorLight,
+        Scene::WhiteFurnaceEnvironmentMapLight,
+        Scene::RenderLayers,
+    ];
 }
 
 impl std::str::FromStr for Scene {
@@ -91,17 +105,8 @@ impl std::str::FromStr for Scene {
 
 impl Next for Scene {
     fn next(&self) -> Self {
-        match self {
-            Scene::Light => Scene::Bloom,
-            Scene::Bloom => Scene::Gltf,
-            Scene::Gltf => Scene::Animation,
-            Scene::Animation => Scene::Gizmos,
-            Scene::Gizmos => Scene::GltfCoordinateConversion,
-            Scene::GltfCoordinateConversion => Scene::WhiteFurnaceSolidColorLight,
-            Scene::WhiteFurnaceSolidColorLight => Scene::WhiteFurnaceEnvironmentMapLight,
-            Scene::WhiteFurnaceEnvironmentMapLight => Scene::RenderLayers,
-            Scene::RenderLayers => Scene::Light,
-        }
+        let index = Scene::ALL_ORDERED.iter().position(|scene| scene == self).unwrap();
+        Scene::ALL_ORDERED[(index + 1) % Scene::ALL_ORDERED.len()]
     }
 }
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -144,11 +144,12 @@ impl std::str::FromStr for Scene {
 
 impl Next for Scene {
     fn next(&self) -> Self {
-        let index = Scene::ALL_ORDERED
+        Scene::ALL_ORDERED[(Scene::ALL_ORDERED
             .iter()
             .position(|scene| scene == self)
-            .unwrap();
-        Scene::ALL_ORDERED[(index + 1) % Scene::ALL_ORDERED.len()]
+            .unwrap()
+            + 1)
+            % Scene::ALL_ORDERED.len()]
     }
 }
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -74,7 +74,7 @@ fn main() {
     app.run();
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, States, Default)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, States, Default)]
 #[states(scoped_entities)]
 enum Scene {
     #[default]
@@ -101,6 +101,32 @@ enum Scene {
     EditableText,
 }
 
+impl Scene {
+    const ALL_ORDERED: &'static [Scene] = &[
+        Scene::Image,
+        Scene::ImageMeasure,
+        Scene::Text,
+        Scene::TextMeasurement,
+        Scene::Grid,
+        Scene::Borders,
+        Scene::EllipticalBorderRadius,
+        Scene::BoxShadow,
+        Scene::TextWrap,
+        Scene::Overflow,
+        Scene::Slice,
+        Scene::LayoutRounding,
+        Scene::LinearGradient,
+        Scene::RadialGradient,
+        #[cfg(feature = "bevy_ui_debug")]
+        Scene::DebugOutlines,
+        Scene::Transformations,
+        Scene::ViewportCoords,
+        Scene::OuterColor,
+        Scene::BoxedContent,
+        Scene::EditableText,
+    ];
+}
+
 impl std::str::FromStr for Scene {
     type Err = String;
 
@@ -118,32 +144,11 @@ impl std::str::FromStr for Scene {
 
 impl Next for Scene {
     fn next(&self) -> Self {
-        match self {
-            Scene::Image => Scene::ImageMeasure,
-            Scene::ImageMeasure => Scene::Text,
-            Scene::Text => Scene::TextMeasurement,
-            Scene::TextMeasurement => Scene::Grid,
-            Scene::Grid => Scene::Borders,
-            Scene::Borders => Scene::EllipticalBorderRadius,
-            Scene::EllipticalBorderRadius => Scene::BoxShadow,
-            Scene::BoxShadow => Scene::TextWrap,
-            Scene::TextWrap => Scene::Overflow,
-            Scene::Overflow => Scene::Slice,
-            Scene::Slice => Scene::LayoutRounding,
-            Scene::LayoutRounding => Scene::LinearGradient,
-            Scene::LinearGradient => Scene::RadialGradient,
-            #[cfg(feature = "bevy_ui_debug")]
-            Scene::RadialGradient => Scene::DebugOutlines,
-            #[cfg(feature = "bevy_ui_debug")]
-            Scene::DebugOutlines => Scene::Transformations,
-            #[cfg(not(feature = "bevy_ui_debug"))]
-            Scene::RadialGradient => Scene::Transformations,
-            Scene::Transformations => Scene::ViewportCoords,
-            Scene::ViewportCoords => Scene::OuterColor,
-            Scene::OuterColor => Scene::BoxedContent,
-            Scene::BoxedContent => Scene::EditableText,
-            Scene::EditableText => Scene::Image,
-        }
+        let index = Scene::ALL_ORDERED
+            .iter()
+            .position(|scene| scene == self)
+            .unwrap();
+        Scene::ALL_ORDERED[(index + 1) % Scene::ALL_ORDERED.len()]
     }
 }
 


### PR DESCRIPTION
# Objective

Each of the testbeds use an explicit transition map in the `next` method on `Scene`. This makes it a little more awkward and error prone to add new scenes, especially where there are feature gates.

## Solution

Store the scenes in order in a static array. Select the next scene by incrementing an index modulo the number of scenes.

## Testing

If there are problems, the testbed screenshot CI should fail.