### PR TITLE
Parallelize mark_3d_meshes_as_changed_if_their_assets_changed

### DIFF
--- a/crates/bevy_mesh/src/components.rs
+++ b/crates/bevy_mesh/src/components.rs
@@ -143,11 +143,11 @@ pub fn mark_3d_meshes_as_changed_if_their_assets_changed(
         return;
     }
 
-    for mut mesh_3d in &mut meshes_3d {
+    meshes_3d.par_iter_mut().for_each(|mut mesh_3d| {
         if changed_meshes.contains(&mesh_3d.0.id()) {
             mesh_3d.set_changed();
         }
-    }
+    });
 }
 
 /// A component that stores an arbitrary index used to identify the mesh instance when rendering.


### PR DESCRIPTION
# Objective

I have a preview mesh that can change each frame when building in my game, which makes mark_3d_meshes_as_changed_if_their_assets_changed fire each frame.

In my testing it always ran alone with nothing on other threads. So I assume this is safe to parallelize, even though the total time spent on all threads are longer together, but netting a better frame time. 

## Solution

`par_iter_mut()`

## Testing

I ran it on my project and compared Tracy profiles. 

I did not find any examples or benchmarks that test this. 

<details>
  <summary>Tracy images</summary>
Frame before:
<img width="1681" height="1293" alt="image" src="https://github.com/user-attachments/assets/7206895c-c1ed-4384-a915-207644efa0b4" />

Frame after:
<img width="1427" height="1270" alt="image" src="https://github.com/user-attachments/assets/9279e642-c895-45de-bb7a-813494cdc198" />


After = This trace, Before = External trace.
mark_3d_meshes_as_changed_if_their_assets_changed:
<img width="1321" height="748" alt="image" src="https://github.com/user-attachments/assets/3eec3aac-cafb-4936-88dc-88f944ce172d" />
Total frametime: 
<img width="1288" height="735" alt="image" src="https://github.com/user-attachments/assets/c1fda365-4f91-4c25-88bd-0fb68cf8b2e3" />



</details>

## Showcase
N/A
