### PR TITLE
Ignore quick-xml security advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,13 @@ all-features = true
 [advisories]
 version = 2
 ignore = [
+  # quick-xml advisory is low priority, and will be resolved
+  # whenever the accesskit and winit dependencies
+  # are updated with the fix.
+  # See: https://rustsec.org/advisories/RUSTSEC-2026-0194
+  # https://rustsec.org/advisories/RUSTSEC-2026-0195
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
   # ttf-parser was announced as unmaintained.
   # See: https://rustsec.org/advisories/RUSTSEC-2026-0192
   # Ignoring to unblock ci


### PR DESCRIPTION
# Objective

- Fixes #25011 
- Ignore them because they are adding noise, and will be resolved in due time through our dependencies.

## Solution

- Adds them to the ignore list for the job