### PR TITLE
Remove `ui::widget::Button` and `Interaction` from `testbed/ui` (Phase 6 Item 5)

### DIFF
--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -1780,6 +1780,7 @@ mod linear_gradient {
     use bevy::ecs::prelude::*;
     use bevy::state::state_scoped::DespawnOnExit;
     use bevy::text::TextFont;
+    use bevy::ui::widget::Text;
     use bevy::ui::AlignItems;
     use bevy::ui::BackgroundGradient;
     use bevy::ui::ColorStop;
@@ -1789,7 +1790,6 @@ mod linear_gradient {
     use bevy::ui::LinearGradient;
     use bevy::ui::Node;
     use bevy::ui::PositionType;
-    use bevy::ui::widget::Text;
     use bevy::utils::default;
 
     pub fn setup(mut commands: Commands) {

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -1623,7 +1623,6 @@ mod overflow {
                                     min_height: px(100),
                                     ..default()
                                 },
-                                Interaction::default(),
                                 Outline {
                                     width: px(2),
                                     offset: px(2),
@@ -1675,7 +1674,6 @@ mod slice {
                         .with_children(|parent| {
                             for [w, h] in [[200.0, 200.0], [300.0, 200.0], [150., 200.0]] {
                                 parent.spawn((
-                                    Button,
                                     ImageNode {
                                         image: image.clone(),
                                         image_mode: NodeImageMode::Sliced(slicer.clone()),
@@ -1791,6 +1789,7 @@ mod linear_gradient {
     use bevy::ui::LinearGradient;
     use bevy::ui::Node;
     use bevy::ui::PositionType;
+    use bevy::ui::widget::Text;
     use bevy::utils::default;
 
     pub fn setup(mut commands: Commands) {
@@ -1888,7 +1887,7 @@ mod linear_gradient {
                                                 ..default()
                                             },
                                             TextFont::from_font_size(10.),
-                                            bevy::ui::widget::Text(format!("{color_space:?}")),
+                                            Text(format!("{color_space:?}")),
                                         ]
                                     )],
                                 ));


### PR DESCRIPTION
# Objective

- Part of #24112

## Solution

- Simple removal of `Button` and `Interaction` from the two places where I see them.
- I did not do any further migration because I think `testbed/ui` should only be focused on ui fundamental building blocks i.e. `Node` level stuff. If we want to test out `ui_widgets`, I think a separate `testbed` should be created, and maybe one that perhaps uses `bevy_remote` to test interactivity.
- Since I’m focused on deprecating `Button` and `Interaction`, I did not migrate anything to bsn!

## Testing

- ci should catch if the testbed renders differently given the removals. I checked manually and there didn’t seem to be a difference.