### PR TITLE
Solari: Reduce transform gpu binding by 16 bytes per transform 

### DIFF
--- a/crates/bevy_solari/src/scene/binder.rs
+++ b/crates/bevy_solari/src/scene/binder.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     resource::Resource,
     system::{Query, Res, ResMut},
 };
-use bevy_math::{ops::cos, Mat4, Vec3};
+use bevy_math::{ops::cos, Affine3, Affine3Ext, Mat4, Vec3, Vec4};
 use bevy_pbr::{
     DfgLut, ExtractedDirectionalLight, MeshMaterial3d, PreviousGlobalTransform, StandardMaterial,
 };
@@ -81,8 +81,8 @@ pub fn prepare_raytracing_scene_bindings(
             update_mode: AccelerationStructureUpdateMode::Build,
             max_instances: instances_query.iter().len() as u32,
         });
-    let mut transforms = StorageBufferList::<Mat4>::default();
-    let mut previous_frame_transforms = StorageBufferList::<Mat4>::default();
+    let mut transforms = StorageBufferList::<[Vec4; 3]>::default();
+    let mut previous_frame_transforms = StorageBufferList::<[Vec4; 3]>::default();
     let mut geometry_ids = StorageBufferList::<GpuInstanceGeometryIds>::default();
     let mut material_ids = StorageBufferList::<u32>::default();
     let mut light_sources = StorageBufferList::<GpuLightSource>::default();
@@ -169,18 +169,18 @@ pub fn prepare_raytracing_scene_bindings(
             continue;
         };
 
-        let transform = transform.to_matrix();
         *tlas.get_mut_single(instance_id).unwrap() = Some(TlasInstance::new(
             blas,
-            tlas_transform(&transform),
+            tlas_transform(&transform.to_matrix()),
             Default::default(),
             0xFF,
         ));
 
+        let transform = Affine3::from(transform.affine()).to_transpose();
         transforms.get_mut().push(transform);
         previous_frame_transforms.get_mut().push(
             previous_frame_transform
-                .map(|t| Mat4::from(t.0))
+                .map(|t| Affine3::from(t.0).to_transpose())
                 .unwrap_or(transform),
         );
 

--- a/crates/bevy_solari/src/scene/raytracing_scene_bindings.wgsl
+++ b/crates/bevy_solari/src/scene/raytracing_scene_bindings.wgsl
@@ -4,6 +4,7 @@ enable wgpu_binding_array;
 #define_import_path bevy_solari::scene_bindings
 
 #import bevy_pbr::pbr_functions::calculate_tbn_mikktspace
+#import bevy_render::maths::affine3_to_square
 
 struct InstanceGeometryIds {
     vertex_buffer_id: u32,
@@ -80,8 +81,8 @@ const LIGHT_NOT_PRESENT_THIS_FRAME = 0xFFFFFFFFu;
 @group(0) @binding(3) var samplers: binding_array<sampler>;
 @group(0) @binding(4) var<storage> materials: array<Material>;
 @group(0) @binding(5) var tlas: acceleration_structure;
-@group(0) @binding(6) var<storage> transforms: array<mat4x4<f32>>; // TODO: Use mat3x4<f32>?
-@group(0) @binding(7) var<storage> previous_frame_transforms: array<mat4x4<f32>>; // TODO: Use mat3x4<f32>?
+@group(0) @binding(6) var<storage> transforms: array<mat3x4<f32>>;
+@group(0) @binding(7) var<storage> previous_frame_transforms: array<mat3x4<f32>>;
 @group(0) @binding(8) var<storage> geometry_ids: array<InstanceGeometryIds>;
 @group(0) @binding(9) var<storage> material_ids: array<u32>; // TODO: Store material_id in instance_custom_index instead?
 @group(0) @binding(10) var<storage> light_sources: array<LightSource>;
@@ -187,8 +188,8 @@ fn resolve_triangle_data_full(instance_id: u32, triangle_id: u32, barycentrics: 
     let material_id = material_ids[instance_id];
     let material = materials[material_id];
 
-    let transform = transforms[instance_id];
-    let previous_frame_transform = previous_frame_transforms[instance_id];
+    let transform = affine3_to_square(transforms[instance_id]);
+    let previous_frame_transform = affine3_to_square(previous_frame_transforms[instance_id]);
 
     let instance_geometry_ids = geometry_ids[instance_id];
     let vertices = load_vertices(instance_geometry_ids, triangle_id);


### PR DESCRIPTION
Save some memory and bandwidth by using a smaller transform type.