### PR TITLE
Fix Ctrl+A/C/X/V shortcuts in EditableText on non-Latin keyboard layouts

### DIFF
--- a/crates/bevy_ui_widgets/src/text_input.rs
+++ b/crates/bevy_ui_widgets/src/text_input.rs
@@ -9,7 +9,7 @@
 use bevy_a11y::AccessibilitySystems;
 use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
 use bevy_ecs::prelude::*;
-use bevy_input::keyboard::{Key, KeyboardInput};
+use bevy_input::keyboard::{Key, KeyCode, KeyboardInput};
 use bevy_input::{ButtonInput, InputSystems};
 use bevy_input_focus::{
     FocusCause, FocusGained, FocusLost, FocusedInput, InputFocus, InputFocusSystems,
@@ -56,6 +56,31 @@ const AUTOSCROLL_MAX_SPEED: f32 = 2.0;
 /// Distance from the input to the point along an axis where `AUTOSCROLL_MAX_SPEED` is reached.
 /// Proportional to the input size.
 const AUTOSCROLL_RAMP_DISTANCE: f32 = 0.5;
+
+/// Returns `true` if the given keyboard input matches an editing-shortcut
+/// character (like the `C` in `Ctrl+C`).
+///
+/// Shortcut matching uses a hybrid strategy, mirroring the behavior of native
+/// text fields and browsers:
+///
+/// - The layout-aware [`logical_key`](KeyboardInput::logical_key) is checked
+///   first, so Latin non-QWERTY layouts (AZERTY, Dvorak, ...) keep their
+///   conventional shortcut positions.
+/// - If the logical key is not an ASCII character (non-Latin layouts such as
+///   Cyrillic, Greek, Arabic or Hebrew), the physical
+///   [`key_code`](KeyboardInput::key_code) is used as a layout-independent
+///   fallback.
+///
+/// Matching purely on `logical_key` breaks these shortcuts on non-Latin
+/// layouts, while matching purely on `key_code` breaks Latin non-QWERTY
+/// conventions. See <https://github.com/bevyengine/bevy/issues/24997>.
+fn matches_edit_shortcut(input: &KeyboardInput, character: &str, key_code: KeyCode) -> bool {
+    match &input.logical_key {
+        Key::Character(c) if c.is_ascii() => c.eq_ignore_ascii_case(character),
+        Key::Character(_) => input.key_code == key_code,
+        _ => false,
+    }
+}
 
 /// System that processes keyboard input events into text edit actions for focused [`EditableText`] widgets.
 ///
@@ -106,14 +131,24 @@ fn on_focused_keyboard_input(
         (NONE, Key::Copy) => queue_edit(TextEdit::Copy),
         (NONE, Key::Cut) => queue_edit(TextEdit::Cut),
         (NONE, Key::Paste) => queue_edit(TextEdit::Paste),
-        (COMMAND, Key::Character(c)) if c.eq_ignore_ascii_case("a") => {
+        (COMMAND, Key::Character(_))
+            if matches_edit_shortcut(&keyboard_input.input, "a", KeyCode::KeyA) =>
+        {
             queue_edit(TextEdit::SelectAll);
         }
-        (COMMAND, Key::Character(c)) if c.eq_ignore_ascii_case("c") => {
+        (COMMAND, Key::Character(_))
+            if matches_edit_shortcut(&keyboard_input.input, "c", KeyCode::KeyC) =>
+        {
             queue_edit(TextEdit::Copy);
         }
-        (COMMAND, Key::Character(c)) if c.eq_ignore_ascii_case("x") => queue_edit(TextEdit::Cut),
-        (COMMAND, Key::Character(c)) if c.eq_ignore_ascii_case("v") => {
+        (COMMAND, Key::Character(_))
+            if matches_edit_shortcut(&keyboard_input.input, "x", KeyCode::KeyX) =>
+        {
+            queue_edit(TextEdit::Cut);
+        }
+        (COMMAND, Key::Character(_))
+            if matches_edit_shortcut(&keyboard_input.input, "v", KeyCode::KeyV) =>
+        {
             queue_edit(TextEdit::Paste);
         }
         #[cfg(not(target_os = "macos"))]
@@ -674,6 +709,7 @@ impl Plugin for EditableTextInputPlugin {
 mod tests {
     use super::*;
     use bevy_app::Update;
+    use bevy_input::ButtonState;
     use bevy_math::Rect;
     use bevy_picking::{events::DragEntry, pointer::PointerId};
     use core::time::Duration;
@@ -885,5 +921,44 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    fn shortcut_keyboard_input(logical_key: Key, key_code: KeyCode) -> KeyboardInput {
+        KeyboardInput {
+            key_code,
+            logical_key,
+            state: ButtonState::Pressed,
+            text: None,
+            repeat: false,
+            window: Entity::PLACEHOLDER,
+        }
+    }
+
+    #[test]
+    fn logical_key_wins_on_latin_layouts() {
+        // US QWERTY: logical "c" on the physical `KeyC`.
+        let event = shortcut_keyboard_input(Key::Character("c".into()), KeyCode::KeyC);
+        assert!(matches_edit_shortcut(&event, "c", KeyCode::KeyC));
+
+        // AZERTY: logical "a" lives on the physical `KeyQ`.
+        // The layout convention must win over the physical location.
+        let event = shortcut_keyboard_input(Key::Character("a".into()), KeyCode::KeyQ);
+        assert!(matches_edit_shortcut(&event, "a", KeyCode::KeyA));
+        assert!(!matches_edit_shortcut(&event, "q", KeyCode::KeyQ));
+    }
+
+    #[test]
+    fn physical_fallback_on_non_latin_layouts() {
+        // Cyrillic layout: the key at the `KeyC` position produces Cyrillic "с".
+        let event = shortcut_keyboard_input(Key::Character("с".into()), KeyCode::KeyC);
+        assert!(matches_edit_shortcut(&event, "c", KeyCode::KeyC));
+        // ...but it must not match a different physical key.
+        assert!(!matches_edit_shortcut(&event, "a", KeyCode::KeyA));
+    }
+
+    #[test]
+    fn named_keys_never_match() {
+        let event = shortcut_keyboard_input(Key::Enter, KeyCode::Enter);
+        assert!(!matches_edit_shortcut(&event, "c", KeyCode::KeyC));
     }
 }


### PR DESCRIPTION
# Objective

Fixes #24997.

Select All / Copy / Cut / Paste shortcuts in `EditableText`
(`bevy_ui_widgets`) don't work while a non-Latin keyboard layout (Cyrillic,
Greek, Hebrew, Arabic, ...) is active: the shortcuts were matched only
against the layout-dependent `logical_key`, so with e.g. a Russian layout
`Ctrl+C` arrives as `Key::Character("с")` and never matches `"c"`.

# Solution

Use the hybrid matching strategy approved in the issue (the convention used
by most toolkits and browsers):

- match the layout-aware `logical_key` first, keeping AZERTY/QWERTZ/Dvorak
  shortcut conventions intact;
- fall back to the physical `key_code` (`KeyCode::KeyA/KeyC/KeyX/KeyV`) when
  the logical key is not an ASCII character.

The check is extracted into a `matches_edit_shortcut` helper with unit tests.
Behavior for `Named` keys (arrows, Home/End, Backspace, ...) is unchanged,
and unmatched combinations still propagate.

Longer term, exposing winit's `key_without_modifiers` in `bevy_input` would
allow a more principled solution: #25055.

# Testing

- `cargo run --example text_input` on Windows 10 and Linux: with a
  Russian/Ukrainian layout active, Ctrl+A/C/X/V now work; on US QWERTY the
  behavior is unchanged; named-key shortcuts and plain text input are
  unaffected.
- New unit tests for the helper: `cargo test -p bevy_ui_widgets`.
- `cargo run -p ci -- lints` passes.