### PR TITLE
Scrollbars autohide, select fix for reselecting current item closing popup

### DIFF
--- a/crates/bevy_feathers/src/controls/listview.rs
+++ b/crates/bevy_feathers/src/controls/listview.rs
@@ -25,7 +25,7 @@ use bevy_ui_widgets::{ActiveDescendant, ControlOrientation, ListBox, ListItem, S
 
 use crate::{
     constants::{fonts, size},
-    controls::FeathersScrollbar,
+    controls::{FeathersScrollbar, ScrollbarGutter},
     cursor::EntityCursor,
     font_styles::InheritableFont,
     theme::{InheritableThemeTextColor, ThemeBackgroundColor, ThemeBorderColor},
@@ -66,9 +66,10 @@ impl FeathersListView {
                 align_items: AlignItems::Stretch,
                 justify_content: JustifyContent::Start,
                 padding: UiRect {
-                    right: px(10) // Room for scrollbar
-                }
+                    right: px(14) // Room for scrollbar
+                },
             }
+            ScrollbarGutter(px(14))
             ListBox
             AccessibilityNode(accesskit::Node::new(Role::ListBox))
             TabIndex(0)
@@ -95,7 +96,7 @@ impl FeathersListView {
                 }
                 Node {
                     position_type: PositionType::Absolute,
-                    right: px(0),
+                    right: px(4),
                     top: px(0),
                     bottom: px(0),
                     width: px(6),

--- a/crates/bevy_feathers/src/controls/scrollbar.rs
+++ b/crates/bevy_feathers/src/controls/scrollbar.rs
@@ -1,18 +1,20 @@
-use bevy_app::{Plugin, PreUpdate};
+use bevy_app::{Plugin, PostUpdate, PreUpdate};
+use bevy_camera::visibility::Visibility;
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    hierarchy::Children,
+    hierarchy::{ChildOf, Children},
     query::{Changed, Or, With},
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     system::{Commands, Query},
     template::EntityTemplate,
 };
+use bevy_math::Vec2;
 use bevy_picking::{hover::Hovered, PickingSystems};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::prelude::*;
-use bevy_ui::{px, BorderRadius, Node};
+use bevy_ui::{px, BorderRadius, ComputedNode, Node, UiSystems, Val};
 use bevy_ui_widgets::{ControlOrientation, Scrollbar, ScrollbarDragState, ScrollbarThumb};
 
 use crate::{cursor::EntityCursor, theme::ThemeBackgroundColor, tokens};
@@ -22,25 +24,48 @@ use crate::{cursor::EntityCursor, theme::ThemeBackgroundColor, tokens};
 #[derive(SceneComponent, Default, Clone, Reflect)]
 #[scene(FeathersScrollbarProps)]
 #[reflect(Component, Clone, Default)]
-pub struct FeathersScrollbar;
+pub struct FeathersScrollbar {
+    auto_hide: bool,
+}
 
 /// Props used to construct a [`FeathersScrollbar`] scene.
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct FeathersScrollbarProps {
     /// The entity whose scroll position will be synchronized with this scrollbar.
     pub target: EntityTemplate,
     /// Whether this is a vertical or horizontal scrollbar.
     pub orientation: ControlOrientation,
+    /// Auto hide if content fits
+    pub auto_hide: bool,
+}
+
+impl Default for FeathersScrollbarProps {
+    fn default() -> Self {
+        Self {
+            target: EntityTemplate::default(),
+            orientation: ControlOrientation::default(),
+            auto_hide: true,
+        }
+    }
 }
 
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone, Default)]
 struct FeathersScrollbarThumb;
 
+/// Padding reserved on a scrollbar's parent while the scrollbar is visible,
+/// reclaimed when the content fits.
+#[derive(Component, Default, Clone, Reflect)]
+#[reflect(Component, Clone, Default)]
+pub struct ScrollbarGutter(pub Val);
+
 impl FeathersScrollbar {
     /// Scene function for scrollbar.
     pub fn scene(props: FeathersScrollbarProps) -> impl Scene {
         bsn! {
+            FeathersScrollbar {
+                auto_hide: {props.auto_hide},
+            }
             Scrollbar {
                 target: {props.target},
                 orientation: {props.orientation},
@@ -88,6 +113,43 @@ fn update_scrollbar_thumb_styles(
     }
 }
 
+fn update_scrollbar_visibility(
+    mut q_scrollbars: Query<(Entity, &FeathersScrollbar, &Scrollbar, &mut Visibility)>,
+    q_scroll_area: Query<&ComputedNode>,
+    q_parents: Query<&ChildOf>,
+    mut q_gutters: Query<(&ScrollbarGutter, &mut Node)>,
+) {
+    for (scrollbar_ent, feathers_scrollbar, scrollbar, mut visibility) in q_scrollbars.iter_mut() {
+        if !feathers_scrollbar.auto_hide {
+            continue;
+        }
+        let Ok(area) = q_scroll_area.get(scrollbar.target) else {
+            continue;
+        };
+        let visible = (area.size() - area.scrollbar_size).max(Vec2::ZERO);
+        let overflows = match scrollbar.orientation {
+            ControlOrientation::Horizontal => area.content_size().x > visible.x,
+            ControlOrientation::Vertical => area.content_size().y > visible.y,
+        };
+        let target = if overflows {
+            Visibility::Inherited
+        } else {
+            Visibility::Hidden
+        };
+        if *visibility != target {
+            *visibility = target;
+        }
+        if let Ok(child_of) = q_parents.get(scrollbar_ent)
+            && let Ok((gutter, mut node)) = q_gutters.get_mut(child_of.parent())
+        {
+            let padding = if overflows { gutter.0 } else { Val::ZERO };
+            if node.padding.right != padding {
+                node.padding.right = padding;
+            }
+        }
+    }
+}
+
 /// Plugin which registers the systems for updating the scrollbar styles.
 pub struct ScrollbarPlugin;
 
@@ -96,6 +158,10 @@ impl Plugin for ScrollbarPlugin {
         app.add_systems(
             PreUpdate,
             update_scrollbar_thumb_styles.in_set(PickingSystems::Last),
+        );
+        app.add_systems(
+            PostUpdate,
+            update_scrollbar_visibility.after(UiSystems::Layout),
         );
     }
 }

--- a/crates/bevy_feathers/src/controls/scrollbar.rs
+++ b/crates/bevy_feathers/src/controls/scrollbar.rs
@@ -53,8 +53,9 @@ impl Default for FeathersScrollbarProps {
 #[reflect(Component, Clone, Default)]
 struct FeathersScrollbarThumb;
 
-/// Padding reserved on a scrollbar's parent while the scrollbar is visible,
-/// reclaimed when the content fits.
+/// Padding at right (vertical) and bottom (horizontal) reserved on a scrollbar's
+/// parent while the scrollbar is visible. reclaimed when the content fits.
+/// Do not use if scrollbars are not embedded in their parents padding on right & bottom
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone, Default)]
 pub struct ScrollbarGutter(pub Val);
@@ -143,8 +144,17 @@ fn update_scrollbar_visibility(
             && let Ok((gutter, mut node)) = q_gutters.get_mut(child_of.parent())
         {
             let padding = if overflows { gutter.0 } else { Val::ZERO };
-            if node.padding.right != padding {
-                node.padding.right = padding;
+            match scrollbar.orientation {
+                ControlOrientation::Vertical => {
+                    if node.padding.right != padding {
+                        node.padding.right = padding;
+                    }
+                }
+                ControlOrientation::Horizontal => {
+                    if node.padding.bottom != padding {
+                        node.padding.bottom = padding;
+                    }
+                }
             }
         }
     }

--- a/crates/bevy_feathers/src/controls/select.rs
+++ b/crates/bevy_feathers/src/controls/select.rs
@@ -10,11 +10,13 @@ use bevy_ecs::{
     reflect::ReflectComponent,
     system::{Commands, Query, ResMut},
 };
-use bevy_input_focus::{FocusCause, InputFocus, InputFocusVisible};
+use bevy_input_focus::{FocusCause, InputFocus};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::prelude::*;
 use bevy_ui::{px, widget::Text, ComputedNode, Node, Selected};
-use bevy_ui_widgets::{listbox_update_selection, ListBox, SetSelected, ValueChange};
+use bevy_ui_widgets::{
+    listbox_update_selection, ListBox, ReselectListRow, SetSelected, ValueChange,
+};
 
 use super::{
     FeathersListRow, FeathersListView, FeathersMenu, FeathersMenuButton, FeathersMenuPopup,
@@ -116,6 +118,7 @@ impl FeathersSelect {
                             }
                             on(listbox_update_selection)
                             on(re_emit_listbox_value)
+                            on(close_popup_on_reselect)
                             Node {
                                 max_height: {max_height},
                             }
@@ -124,6 +127,26 @@ impl FeathersSelect {
                 )
             ]
         }
+    }
+}
+
+// Event is sent on the FeathersListView
+fn close_popup_on_reselect(
+    ev: On<ReselectListRow>,
+    q_popup: Query<(), With<FeathersMenuPopup>>,
+    q_parents: Query<&ChildOf>,
+    mut commands: Commands,
+) {
+    let mut popup_ent = None;
+    for ancestor in q_parents.iter_ancestors(ev.event_target()) {
+        if q_popup.contains(ancestor) {
+            popup_ent = Some(ancestor);
+            break;
+        }
+    }
+
+    if let Some(popup_ent) = popup_ent {
+        commands.entity(popup_ent).insert(Visibility::Hidden);
     }
 }
 
@@ -218,12 +241,10 @@ fn sync_caption(
 fn focus_select_popup(
     q_popups: Query<(Entity, &Visibility), (With<FeathersMenuPopup>, Changed<Visibility>)>,
     q_select: Query<(), With<FeathersSelect>>,
-    q_listbox: Query<(), With<ListBox>>,
     q_button: Query<(), With<FeathersMenuButton>>,
     q_parents: Query<&ChildOf>,
     q_children: Query<&Children>,
     mut focus: ResMut<InputFocus>,
-    mut focus_visible: ResMut<InputFocusVisible>,
 ) {
     for (popup, visibility) in q_popups.iter() {
         let mut select_ent = None;
@@ -237,15 +258,7 @@ fn focus_select_popup(
             continue;
         };
 
-        if *visibility == Visibility::Visible {
-            for descendant in q_children.iter_descendants(popup) {
-                if q_listbox.contains(descendant) {
-                    focus.set(descendant, FocusCause::Navigated);
-                    focus_visible.0 = true;
-                    break;
-                }
-            }
-        } else {
+        if *visibility != Visibility::Visible {
             let focus_in_select = focus.get().is_some_and(|focused| {
                 focused == select_ent || q_parents.iter_ancestors(focused).any(|a| a == select_ent)
             });

--- a/crates/bevy_ui_widgets/src/list.rs
+++ b/crates/bevy_ui_widgets/src/list.rs
@@ -59,6 +59,20 @@ pub struct ListItem;
 #[component(immutable)]
 pub struct ActiveDescendant(pub Option<Entity>);
 
+/// Notification sent by a [`ListBox`] when the user commits the already-selected item, either by
+/// clicking it or by pressing Space/Enter while it is the active row. No [`ValueChange`] is
+/// emitted in this case, since the selection did not change. Used in for example a popup
+/// select control to close the popup when reselecting
+#[derive(Copy, Clone, Debug, PartialEq, EntityEvent, Reflect)]
+#[reflect(Event)]
+pub struct ReselectListRow {
+    /// The listbox that produced this event.
+    #[event_target]
+    pub source: Entity,
+    /// The row that was reselected
+    pub row: Entity,
+}
+
 fn listbox_on_key_input(
     mut ev: On<FocusedInput<KeyboardInput>>,
     q_listbox: Query<&ActiveDescendant, With<ListBox>>,
@@ -146,12 +160,19 @@ fn listbox_on_key_input(
                     // Toggle selected state of active row
                     if prev_active < list_items.len() {
                         let (active_id, selected, disabled) = list_items[prev_active];
-                        if !selected && !disabled {
-                            commands.trigger(ValueChange::<Entity> {
-                                source: listbox,
-                                value: active_id,
-                                is_final: true,
-                            });
+                        if !disabled {
+                            if !selected {
+                                commands.trigger(ValueChange::<Entity> {
+                                    source: listbox,
+                                    value: active_id,
+                                    is_final: true,
+                                });
+                            } else {
+                                commands.trigger(ReselectListRow {
+                                    source: listbox,
+                                    row: active_id,
+                                });
+                            }
                         }
                     }
                     return;
@@ -245,7 +266,11 @@ fn listbox_on_row_click(
             .map(|(id, _)| *id);
 
         if current_row == Some(row_id) {
-            // If they clicked the currently checked list row, do nothing
+            // If click the currently checked list row, send a reselect but no value change
+            commands.trigger(ReselectListRow {
+                source: ev.entity,
+                row: row_id,
+            });
             return;
         }
 
@@ -330,14 +355,21 @@ fn listbox_on_set_selected(
     let Ok((selected, disabled)) = q_listitems.get(ev.row) else {
         return;
     };
-    if disabled || selected {
+    if disabled {
         return;
     }
-    commands.trigger(ValueChange::<Entity> {
-        source: ev.entity,
-        value: ev.row,
-        is_final: true,
-    });
+    if !selected {
+        commands.trigger(ValueChange::<Entity> {
+            source: ev.entity,
+            value: ev.row,
+            is_final: true,
+        });
+    } else {
+        commands.trigger(ReselectListRow {
+            source: ev.entity,
+            row: ev.row,
+        });
+    }
 }
 
 /// Plugin that adds the observers for the [`ListBox`] widget.

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -330,20 +330,10 @@ fn demo_column_1() -> impl Scene {
             (
                 @FeathersSelect {
                     @options: {list_rows_from_strings([
-                        "January",
-                        "February",
-                        "March",
-                        "April",
-                        "May",
-                        "June",
-                        "July",
-                        "August",
-                        "September",
-                        "October",
-                        "November",
-                        "December",
-                    ], Some(2))},
-                    @max_visible: 6,
+                        "One",
+                        "Two",
+                        "Three",
+                    ], Some(0))},
                 }
                 Node {
                     flex_grow: 1.0,


### PR DESCRIPTION

# Objective / Solution

- Select control didn't close when reselecting the current item (mouse or keyboard), because that doesn't send an event from underlying widget (list). Added a new event ReselectListRow to bevy_ui_widget and send that, picked it up in select to close the select.
- Scrollbar was hugging the right side of the popup too much so added some padding on it.
- Scrollbar was visible whether content fitted or not. Added an auto_hide (default to true).

## Solution

`cargo run --example feathers_gallery --features bevy_feathers`

---

## Showcase

Select where all items fit:

<img width="283" height="94" alt="image" src="https://github.com/user-attachments/assets/c37d827b-adc5-43f5-be32-d2420d65b668" />

Select where they don't:

<img width="281" height="161" alt="image" src="https://github.com/user-attachments/assets/3b7a09e6-8755-46c1-88c7-5d51766000de" />
