### PR TITLE
Add automatic input focus cause

### DIFF
--- a/_release-content/migration-guides/focus_cause_auto.md
+++ b/_release-content/migration-guides/focus_cause_auto.md
@@ -1,0 +1,6 @@
+---
+title: FocusCause has a new Auto variant
+pull_requests: [25059]
+---
+
+`FocusCause` has a new `Auto` variant, which is emitted when an `AutoFocus` component causes an entity to gain focus. Exhaustive matches on `FocusCause` must handle the new variant.

--- a/crates/bevy_input_focus/src/autofocus.rs
+++ b/crates/bevy_input_focus/src/autofocus.rs
@@ -25,6 +25,6 @@ pub struct AutoFocus;
 
 fn on_auto_focus_added(mut world: DeferredWorld, HookContext { entity, .. }: HookContext) {
     if let Some(mut input_focus) = world.get_resource_mut::<InputFocus>() {
-        input_focus.set(entity, FocusCause::Navigated);
+        input_focus.set(entity, FocusCause::Auto);
     }
 }

--- a/crates/bevy_input_focus/src/gained_and_lost.rs
+++ b/crates/bevy_input_focus/src/gained_and_lost.rs
@@ -21,6 +21,9 @@ pub enum FocusCause {
     ///
     /// This is only sent for primary mouse presses. Focus gained from other mouse buttons or gestures will be `Navigated`.
     Pressed,
+
+    /// Focus was assigned automatically when an [`AutoFocus`](crate::AutoFocus) component was added.
+    Auto,
 }
 
 /// An [`EntityEvent`] that is sent when an entity gains [`InputFocus`].

--- a/crates/bevy_ui_widgets/src/text_input.rs
+++ b/crates/bevy_ui_widgets/src/text_input.rs
@@ -560,7 +560,7 @@ fn on_focus_select_all(
                     queued_select_all.0 = Some(target);
                 }
             }
-            FocusCause::Navigated => {
+            FocusCause::Auto | FocusCause::Navigated => {
                 if select_all_on_focus {
                     editable_text.queue_edit(TextEdit::SelectAll);
                 }


### PR DESCRIPTION
# Objective

Fixes #24958.

`AutoFocus` currently reports focus changes as `FocusCause::Navigated`, making automatic focus indistinguishable from keyboard or gamepad navigation.

## Solution

- Added `FocusCause::Auto`.
- Emit `FocusCause::Auto` when an `AutoFocus` component assigns focus.
- Preserve the existing text-input select-all behavior for automatic focus.