### PR TITLE
Add App::setup_non_send, deprecate insert_non_send

### DIFF
--- a/_release-content/migration-guides/setup_non_send.md
+++ b/_release-content/migration-guides/setup_non_send.md
@@ -1,0 +1,25 @@
+---
+title: "`App::insert_non_send` is deprecated in favor of `App::setup_non_send`"
+pull_requests: [25067]
+---
+
+`App::insert_non_send` (and the older `App::insert_non_send_resource` alias) construct their
+value immediately, at the call site, before the app's runner (e.g. `WinitPlugin`) has chosen
+which thread `!Send` data should actually live on. This tightly couples "where you write
+app-building code" to "which thread `!Send` data gets built on."
+
+`App::setup_non_send` replaces this: it takes a `Send` closure that is stored and only run once
+`App::run` starts, on the thread that calls it, which is where `!Send` data typically needs to
+live. `App::insert_non_send` is deprecated in favor of it.
+
+```rust
+// 0.19
+app.insert_non_send(MyNonSendResource::new());
+
+// 0.20
+app.setup_non_send(|world| {
+    world.insert_non_send(MyNonSendResource::new());
+});
+```
+
+`App::init_non_send` is unaffected and does not need to change.

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -92,6 +92,9 @@ pub struct App {
     /// [`ScheduleRunnerPlugin`]: https://docs.rs/bevy/latest/bevy/app/struct.ScheduleRunnerPlugin.html
     pub(crate) runner: RunnerFn,
     fallback_error_handler: Option<ErrorHandler>,
+    /// Closures queued by [`setup_non_send`](App::setup_non_send), run once at the start of
+    /// [`App::run`] on the thread that calls it.
+    non_send_setups: Vec<Box<dyn FnOnce(&mut World) + Send>>,
 }
 
 impl Debug for App {
@@ -150,6 +153,7 @@ impl App {
             },
             runner: Box::new(run_once),
             fallback_error_handler: None,
+            non_send_setups: Vec::new(),
         }
     }
 
@@ -186,6 +190,10 @@ impl App {
         let _bevy_app_run_span = info_span!("bevy_app").entered();
         if self.is_building_plugins() {
             panic!("App::run() was called while a plugin was building.");
+        }
+
+        for setup in core::mem::take(&mut self.non_send_setups) {
+            setup(self.world_mut());
         }
 
         let runner = core::mem::replace(&mut self.runner, Box::new(run_once));
@@ -488,7 +496,8 @@ impl App {
 
     /// Inserts the [`!Send`](Send) resource into the app, overwriting any existing data
     /// of the same type.
-    #[deprecated(since = "0.19.0", note = "use App::insert_non_send")]
+    #[deprecated(since = "0.19.0", note = "use App::setup_non_send")]
+    #[expect(deprecated, reason = "delegates to another deprecated method")]
     pub fn insert_non_send_resource<R: 'static>(&mut self, resource: R) -> &mut Self {
         self.insert_non_send(resource)
     }
@@ -512,8 +521,40 @@ impl App {
     /// App::new()
     ///     .insert_non_send(MyCounter { counter: 0 });
     /// ```
+    #[deprecated(since = "0.19.0", note = "use App::setup_non_send")]
     pub fn insert_non_send<R: 'static>(&mut self, resource: R) -> &mut Self {
         self.world_mut().insert_non_send(resource);
+        self
+    }
+
+    /// Queues a `Send` closure that inserts [`!Send`](Send) data into the app's [`World`].
+    ///
+    /// Unlike [`insert_non_send`](Self::insert_non_send), `func` is not run immediately.
+    /// It is stored and only run once [`App::run`] starts, on the thread that calls it,
+    /// which is where `!Send` data (e.g. windowing handles) usually needs to live. This
+    /// decouples *where app-building code runs* from *when `!Send` data is actually
+    /// constructed*, which `insert_non_send` conflates.
+    ///
+    /// Queued closures run in the order they were added, before the app's runner starts.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_app::prelude::*;
+    /// # use bevy_ecs::prelude::*;
+    /// #
+    /// struct MyCounter {
+    ///     counter: usize,
+    /// }
+    ///
+    /// App::new()
+    ///     .setup_non_send(|world| world.insert_non_send(MyCounter { counter: 0 }));
+    /// ```
+    pub fn setup_non_send<F>(&mut self, func: F) -> &mut Self
+    where
+        F: FnOnce(&mut World) + Send + 'static,
+    {
+        self.non_send_setups.push(Box::new(func));
         self
     }
 
@@ -1619,6 +1660,7 @@ impl Termination for AppExit {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{sync::Arc, vec, vec::Vec};
     use core::marker::PhantomData;
     use std::sync::Mutex;
 
@@ -2049,6 +2091,48 @@ mod tests {
         App::new()
             .init_non_send::<NonSendTestResource>()
             .init_resource::<TestResource>();
+    }
+
+    #[test]
+    fn setup_non_send_is_deferred_until_run() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        struct NonSendMarker(PhantomData<Mutex<()>>);
+
+        let mut app = App::new();
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran_clone = ran.clone();
+        app.setup_non_send(move |world| {
+            ran_clone.store(true, Ordering::SeqCst);
+            world.insert_non_send(NonSendMarker(PhantomData));
+        });
+
+        // The closure must not run just from being queued.
+        assert!(!ran.load(Ordering::SeqCst));
+
+        app.set_runner(|app| {
+            // By the time the runner is invoked, the closure has already run.
+            assert!(app.world().contains_non_send::<NonSendMarker>());
+            AppExit::Success
+        });
+        app.run();
+
+        assert!(ran.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn setup_non_send_runs_in_order() {
+        let mut app = App::new();
+        let order = Arc::new(Mutex::new(Vec::new()));
+        for i in 0..3 {
+            let order = order.clone();
+            app.setup_non_send(move |_| order.lock().unwrap().push(i));
+        }
+
+        app.set_runner(|_| AppExit::Success);
+        app.run();
+
+        assert_eq!(*order.lock().unwrap(), vec![0, 1, 2]);
     }
 
     #[test]

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -529,11 +529,10 @@ impl App {
 
     /// Queues a `Send` closure that inserts [`!Send`](Send) data into the app's [`World`].
     ///
-    /// Unlike [`insert_non_send`](Self::insert_non_send), `func` is not run immediately.
-    /// It is stored and only run once [`App::run`] starts, on the thread that calls it,
-    /// which is where `!Send` data (e.g. windowing handles) usually needs to live. This
-    /// decouples *where app-building code runs* from *when `!Send` data is actually
-    /// constructed*, which `insert_non_send` conflates.
+    /// The closure is not run immediately: it is stored and only run once [`App::run`]
+    /// starts, on the thread that calls it, which is where `!Send` data (e.g. windowing
+    /// handles) usually needs to live. This decouples *where app-building code runs* from
+    /// *when `!Send` data is actually constructed*.
     ///
     /// Queued closures run in the order they were added, before the app's runner starts.
     ///

--- a/examples/app/log_layers_ecs.rs
+++ b/examples/app/log_layers_ecs.rs
@@ -104,7 +104,7 @@ fn custom_layer(app: &mut App) -> Option<BoxedLayer> {
     let layer = CaptureLayer { sender };
     let resource = CapturedLogMessages(receiver);
 
-    app.insert_non_send(resource);
+    app.setup_non_send(move |world| world.insert_non_send(resource));
     app.add_message::<LogMessage>();
     app.add_systems(Update, transfer_log_messages);
 


### PR DESCRIPTION
# Objective

- `App::insert_non_send` constructs `!Send` values immediately at the app-building call site, which can put them on the wrong thread relative to the runner (e.g. `WinitPlugin`).
- Provide a deferred API so `!Send` data is created on the thread that actually runs the app.

## Solution

- Add `App::setup_non_send`, which queues a `Send` closure and runs it once at the start of `App::run` on the calling thread.
- Deprecate `App::insert_non_send` (and update the `insert_non_send_resource` note) in favor of `setup_non_send`.
- Migrate `examples/app/log_layers_ecs.rs` and add a migration guide.
- `App::init_non_send` is unchanged.

## Testing

- Added unit tests covering deferred execution and FIFO ordering of queued setups.
- Reviewers can run:
  - `cargo test -p bevy_app setup_non_send`
  - `cargo run --example log_layers_ecs`