### PR TITLE
Remove expensive queue submit from sparse buffer vec

### DIFF
--- a/crates/bevy_render/src/render_resource/sparse_buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/sparse_buffer_vec.rs
@@ -31,12 +31,12 @@ use weak_table::WeakKeyHashMap;
 use wgpu::{BufferDescriptor, BufferUsages, ComputePassDescriptor, ShaderStages};
 
 use crate::{
-    diagnostic::{DiagnosticsRecorder, RecordDiagnostics as _},
+    diagnostic::RecordDiagnostics as _,
     render_resource::{
         AtomicPod, BindGroup, BindGroupEntries, Buffer, PipelineCache, RawBufferVec,
         SpecializedComputePipeline, SpecializedComputePipelines, UniformBuffer,
     },
-    renderer::{RenderDevice, RenderGraph, RenderGraphSystems, RenderQueue},
+    renderer::{RenderContext, RenderDevice, RenderGraph, RenderGraphSystems, RenderQueue},
     ExtractSchedule, RenderApp,
 };
 
@@ -153,8 +153,6 @@ pub struct SparseBufferUpdateJob {
     updated_element_count: u32,
     /// The size of each element in 32-bit words.
     element_word_size: u32,
-    /// A debugging label for the buffer.
-    label: Arc<str>,
 }
 
 impl SparseBufferUpdateJob {
@@ -189,33 +187,30 @@ fn update_sparse_buffers(
     sparse_buffer_update_jobs: Res<SparseBufferUpdateJobs>,
     sparse_buffer_update_bind_groups: Res<SparseBufferUpdateBindGroups>,
     pipeline_cache: Res<PipelineCache>,
-    mut diagnostics: Option<ResMut<DiagnosticsRecorder>>,
-    render_device: Res<RenderDevice>,
-    render_queue: Res<RenderQueue>,
+    mut render_context: RenderContext,
 ) {
     // Bail if we have nothing to do.
     if sparse_buffer_update_jobs.is_empty() {
         return;
     }
 
-    // We need to create a command encoder since this pass isn't associated with
-    // a view.
-    let mut command_encoder =
-        render_device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("sparse buffer update"),
-        });
-
-    let time_span = diagnostics
-        .as_mut()
-        .map(|diagnostics| diagnostics.time_span(&mut command_encoder, "sparse buffer update"));
-
-    command_encoder.push_debug_group("sparse buffer update");
-
     let Some(compute_pipeline) =
         pipeline_cache.get_compute_pipeline(sparse_buffer_update_bind_groups.pipeline_id)
     else {
         return;
     };
+
+    let diagnostics = render_context.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+    let command_encoder = render_context.command_encoder();
+
+    let mut sparse_buffer_update_pass =
+        command_encoder.begin_compute_pass(&ComputePassDescriptor {
+            label: Some("sparse buffer updates"),
+            timestamp_writes: None,
+        });
+    sparse_buffer_update_pass.set_pipeline(compute_pipeline);
+    let time_span = diagnostics.time_span(&mut sparse_buffer_update_pass, "sparse buffer updates");
 
     // Process each sparse buffer update job.
     for sparse_buffer_update_job in sparse_buffer_update_jobs.iter() {
@@ -226,15 +221,6 @@ fn update_sparse_buffers(
             continue;
         };
 
-        let mut sparse_buffer_update_pass =
-            command_encoder.begin_compute_pass(&ComputePassDescriptor {
-                label: Some(&*format!(
-                    "sparse buffer update ({})",
-                    sparse_buffer_update_job.label
-                )),
-                timestamp_writes: None,
-            });
-        sparse_buffer_update_pass.set_pipeline(compute_pipeline);
         sparse_buffer_update_pass.set_bind_group(
             0,
             &sparse_buffer_update_bind_group.bind_group,
@@ -247,12 +233,7 @@ fn update_sparse_buffers(
         );
     }
 
-    command_encoder.pop_debug_group();
-    if let Some(time_span) = time_span {
-        time_span.end(&mut command_encoder);
-    }
-
-    render_queue.submit([command_encoder.finish()]);
+    time_span.end(&mut sparse_buffer_update_pass);
 }
 
 /// A system that clears out the sparse buffer update jobs in preparation for a
@@ -952,7 +933,6 @@ fn prepare_to_populate_buffers(
         sparse_buffer_handle: sparse_buffer_handle.clone(),
         updated_element_count: staging_buffers.updated_element_count(),
         element_word_size: staging_buffers.element_word_size,
-        label: (*label).clone(),
     });
 
     // Create the bind group.


### PR DESCRIPTION
# Objective

- The queue submit for sparse buffer vec is expensive and not worth it (GPU work  is like 15us, it's not worth uploading early)

## Solution

- Remove the dedicated submit, just add a command encoder like normal
- Also use a single compute pass and pipeline set for all the uploads

## Testing
- Tested on bevy_city with `max_car_density = 0.2`.

Main
<img width="3840" height="2040" alt="image" src="https://github.com/user-attachments/assets/f3b3660d-1a13-4a88-b5d6-b6f3dd011dca" />
This PR
<img width="3840" height="2040" alt="image" src="https://github.com/user-attachments/assets/dc323765-cdab-4e91-b6c9-d2b6e273ed2f" />

