### PR TITLE
Use rustup to configure targets and components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build & run tests
@@ -81,10 +79,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
+      - run: |
+          rustup override set stable
+          rustup component add rustfmt clippy
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
         with:
@@ -117,10 +114,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
-          components: miri
+      - run: |
+          rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
+          rustup component add miri
       - name: CI job
         # To run the tests one item at a time for troubleshooting, use
         # cargo --quiet test --lib -- --list | sed 's/: test$//' | MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation" xargs -n1 cargo miri test -p bevy_ecs --lib -- --exact
@@ -154,9 +150,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -185,10 +179,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
-          targets: x86_64-unknown-none
+      - run: |
+          rustup override set stable
+          rustup target add x86_64-unknown-none
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -221,10 +214,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
-          targets: thumbv6m-none-eabi
+      - run: |
+          rustup override set stable
+          rustup target add thumbv6m-none-eabi
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -252,10 +244,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
-          targets: x86_64-unknown-none
+      - run: |
+          rustup override set stable
+          rustup target add x86_64-unknown-none
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -283,10 +274,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
+      - run: |
+          rustup override set stable
+          rustup target add wasm32-unknown-unknown
       - name: Check wasm
         env:
           RUSTFLAGS: --cfg getrandom_backend="wasm_js"
@@ -314,11 +304,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
-          targets: wasm32-unknown-unknown
-          components: rust-src
+      - run: |
+          rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
+          rustup target add wasm32-unknown-unknown
+          rustup component add rust-src
       - name: Check wasm
         run: cargo check --target wasm32-unknown-unknown -Z build-std=std,panic_abort
         env:
@@ -404,9 +393,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
         with:
@@ -434,9 +421,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: check for missing metadata
         id: missing-metadata
         run: cargo run -p build-templated-pages -- check-missing examples
@@ -473,9 +458,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: check for missing features
         id: missing-features
         run: cargo run -p build-templated-pages -- check-missing features
@@ -512,17 +495,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: get MSRV
         id: msrv
         run: |
           msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
           echo "msrv=$msrv" >> $GITHUB_OUTPUT
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: ${{ steps.msrv.outputs.msrv }}
+      - run: rustup override set ${{ steps.msrv.outputs.msrv }}
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # key won't match, will rely on restore-keys
@@ -584,9 +563,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: Check Release Content
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,9 @@ jobs:
         run: |
           msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
           echo "msrv=$msrv" >> $GITHUB_OUTPUT
-      - run: rustup override set ${{ steps.msrv.outputs.msrv }}
+      - run: rustup override set ${MSRV}
+        env:
+          MSRV: ${{ steps.msrv.outputs.msrv }}
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # key won't match, will rely on restore-keys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,8 +545,8 @@ jobs:
           echo "msrv=$msrv" >> $GITHUB_OUTPUT
       - name: Install toolchain
         run: |
-          rustup toolchain install ${MSRV} --no-self-update --profile=minimal
-          rustup override set ${MSRV}
+          rustup toolchain install "$MSRV" --no-self-update --profile=minimal
+          rustup override set "$MSRV"
           cargo -V
         env:
           MSRV: ${{ steps.msrv.outputs.msrv }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build & run tests
@@ -79,9 +83,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - run: |
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal --component clippy,rustfmt
           rustup override set stable
-          rustup component add rustfmt clippy
+          cargo -V
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
         with:
@@ -114,9 +120,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - run: |
+      - name: Install toolchain
+        run: |
+          rustup toolchain install ${{ env.NIGHTLY_TOOLCHAIN }} --no-self-update --profile=minimal --component miri
           rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
-          rustup component add miri
+          cargo -V
       - name: CI job
         # To run the tests one item at a time for troubleshooting, use
         # cargo --quiet test --lib -- --list | sed 's/: test$//' | MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation" xargs -n1 cargo miri test -p bevy_ecs --lib -- --exact
@@ -150,7 +158,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -179,9 +191,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - run: |
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup target add x86_64-unknown-none --toolchain stable
           rustup override set stable
-          rustup target add x86_64-unknown-none
+          cargo -V
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -214,9 +229,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - run: |
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup target add thumbv6m-none-eabi --toolchain stable
           rustup override set stable
-          rustup target add thumbv6m-none-eabi
+          cargo -V
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -244,9 +262,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - run: |
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup target add x86_64-unknown-none --toolchain stable
           rustup override set stable
-          rustup target add x86_64-unknown-none
+          cargo -V
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -274,9 +295,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - run: |
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup target add wasm32-unknown-unknown --toolchain stable
           rustup override set stable
-          rustup target add wasm32-unknown-unknown
+          cargo -V
       - name: Check wasm
         env:
           RUSTFLAGS: --cfg getrandom_backend="wasm_js"
@@ -304,10 +328,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - run: |
+      - name: Install toolchain
+        run: |
+          rustup toolchain install ${{ env.NIGHTLY_TOOLCHAIN }} --no-self-update --profile=minimal --component rust-src
+          rustup target add wasm32-unknown-unknown --toolchain ${{ env.NIGHTLY_TOOLCHAIN }}
           rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
-          rustup target add wasm32-unknown-unknown
-          rustup component add rust-src
+          cargo -V
       - name: Check wasm
         run: cargo check --target wasm32-unknown-unknown -Z build-std=std,panic_abort
         env:
@@ -393,7 +419,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
         with:
@@ -421,7 +451,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: check for missing metadata
         id: missing-metadata
         run: cargo run -p build-templated-pages -- check-missing examples
@@ -458,7 +492,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: check for missing features
         id: missing-features
         run: cargo run -p build-templated-pages -- check-missing features
@@ -495,13 +533,21 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: get MSRV
         id: msrv
         run: |
           msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
           echo "msrv=$msrv" >> $GITHUB_OUTPUT
-      - run: rustup override set ${MSRV}
+      - name: Install toolchain
+        run: |
+          rustup toolchain install ${MSRV} --no-self-update --profile=minimal
+          rustup override set ${MSRV}
+          cargo -V
         env:
           MSRV: ${{ steps.msrv.outputs.msrv }}
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -565,7 +611,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: Check Release Content
         shell: bash
         run: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -29,9 +29,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for security advisories and unmaintained crates
@@ -43,9 +41,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for banned and duplicated dependencies
@@ -57,9 +53,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for unauthorized licenses
@@ -71,9 +65,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Checked for unauthorized crate sources

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -29,7 +29,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for security advisories and unmaintained crates
@@ -41,7 +45,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for banned and duplicated dependencies
@@ -53,7 +61,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for unauthorized licenses
@@ -65,7 +77,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Checked for unauthorized crate sources

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,9 +39,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+      - run: rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
 
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
+      - name: Install toolchain
+        run: |
+          rustup toolchain install ${{ env.NIGHTLY_TOOLCHAIN }} --no-self-update --profile=minimal
+          rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
+          cargo -V
 
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps

--- a/.github/workflows/example-run.yml
+++ b/.github/workflows/example-run.yml
@@ -26,9 +26,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: Disable audio
         # Disable audio through a patch. on github m1 runners, audio timeouts after 15 minutes
         run: git apply --ignore-whitespace tools/example-showcase/disable-audio.patch
@@ -122,9 +120,7 @@ jobs:
             sudo add-apt-repository ppa:kisak/turtle -y
             sudo apt-get install --no-install-recommends libgl1-mesa-dri mesa-vulkan-drivers
           fi
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # key won't match, will rely on restore-keys
@@ -191,9 +187,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # key won't match, will rely on restore-keys

--- a/.github/workflows/example-run.yml
+++ b/.github/workflows/example-run.yml
@@ -26,7 +26,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: Disable audio
         # Disable audio through a patch. on github m1 runners, audio timeouts after 15 minutes
         run: git apply --ignore-whitespace tools/example-showcase/disable-audio.patch
@@ -120,7 +124,11 @@ jobs:
             sudo add-apt-repository ppa:kisak/turtle -y
             sudo apt-get install --no-install-recommends libgl1-mesa-dri mesa-vulkan-drivers
           fi
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # key won't match, will rely on restore-keys
@@ -187,7 +195,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # key won't match, will rely on restore-keys

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -105,8 +105,11 @@ jobs:
       - name: Setup Rust
         id: rust
         run: |
-          rustup override set ${{ matrix.toolchain }}
-          rustup target add ${{ matrix.target }}
+          rustup override set ${RUST_TOOLCHAIN}
+          rustup target add ${RUST_TARGET}
+        env:
+          RUST_TOOLCHAIN: ${{ matrix.toolchain }}
+          RUST_TARGET: ${{ matrix.target }}
 
       # prepare the lockfile - to have a complete image of the dependencies on the current platform
       - name: Create lock file

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -32,9 +32,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: get MSRV
         id: msrv
         run: |
@@ -106,10 +104,9 @@ jobs:
 
       - name: Setup Rust
         id: rust
-        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.target }}
+        run: |
+          rustup override set ${{ matrix.toolchain }}
+          rustup target add ${{ matrix.target }}
 
       # prepare the lockfile - to have a complete image of the dependencies on the current platform
       - name: Create lock file

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -32,7 +32,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: get MSRV
         id: msrv
         run: |
@@ -102,11 +106,13 @@ jobs:
           ref: "main"
           persist-credentials: false
 
-      - name: Setup Rust
+      - name: Install toolchain
         id: rust
         run: |
-          rustup override set ${RUST_TOOLCHAIN}
-          rustup target add ${RUST_TARGET}
+          rustup toolchain install ${{ env.RUST_TOOLCHAIN }} --no-self-update --profile=minimal
+          rustup target add ${{ env.RUST_TARGET }} --toolchain ${{ env.RUST_TOOLCHAIN }}
+          rustup override set ${{ env.RUST_TOOLCHAIN }}
+          cargo -V
         env:
           RUST_TOOLCHAIN: ${{ matrix.toolchain }}
           RUST_TARGET: ${{ matrix.target }}

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -107,10 +107,13 @@ jobs:
           persist-credentials: false
 
       - name: Install toolchain
+        shell: bash
         id: rust
         run: |
           rustup toolchain install ${RUST_TOOLCHAIN} --no-self-update --profile=minimal
-          rustup target add ${RUST_TARGET} --toolchain ${RUST_TOOLCHAIN}
+          if [ -n "$RUST_TARGET" ]; then
+            rustup target add "$RUST_TARGET" --toolchain "$RUST_TOOLCHAIN"
+          fi
           rustup override set ${RUST_TOOLCHAIN}
           cargo -V
         env:

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -109,9 +109,9 @@ jobs:
       - name: Install toolchain
         id: rust
         run: |
-          rustup toolchain install ${{ env.RUST_TOOLCHAIN }} --no-self-update --profile=minimal
-          rustup target add ${{ env.RUST_TARGET }} --toolchain ${{ env.RUST_TOOLCHAIN }}
-          rustup override set ${{ env.RUST_TOOLCHAIN }}
+          rustup toolchain install ${RUST_TOOLCHAIN} --no-self-update --profile=minimal
+          rustup target add ${RUST_TARGET} --toolchain ${RUST_TOOLCHAIN}
+          rustup override set ${RUST_TOOLCHAIN}
           cargo -V
         env:
           RUST_TOOLCHAIN: ${{ matrix.toolchain }}

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -110,11 +110,11 @@ jobs:
         shell: bash
         id: rust
         run: |
-          rustup toolchain install ${RUST_TOOLCHAIN} --no-self-update --profile=minimal
+          rustup toolchain install "$RUST_TOOLCHAIN" --no-self-update --profile=minimal
           if [ -n "$RUST_TARGET" ]; then
             rustup target add "$RUST_TARGET" --toolchain "$RUST_TOOLCHAIN"
           fi
-          rustup override set ${RUST_TOOLCHAIN}
+          rustup override set "$RUST_TOOLCHAIN"
           cargo -V
         env:
           RUST_TOOLCHAIN: ${{ matrix.toolchain }}

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -33,9 +33,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
 
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -67,9 +65,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -113,10 +109,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          target: wasm32-unknown-unknown
-          toolchain: stable
+      - run: |
+          rustup override set stable
+          rustup target wasm32-unknown-unknown
 
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -175,9 +170,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build
@@ -207,9 +200,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+      - run: rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # key won't match, will rely on restore-keys
@@ -239,9 +230,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
-        with:
-          toolchain: stable
+      - run: rustup override set stable
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # key won't match, will rely on restore-keys

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -33,7 +33,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
 
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -65,7 +69,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
 
       - name: Set up JDK 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -109,9 +117,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: |
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup target add wasm32-unknown-unknown --toolchain stable
           rustup override set stable
-          rustup target wasm32-unknown-unknown
+          cargo -V
 
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -170,7 +181,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build
@@ -200,7 +215,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
+      - name: Install toolchain
+        run: |
+          rustup toolchain install ${{ env.NIGHTLY_TOOLCHAIN }} --no-self-update --profile=minimal
+          rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
+          cargo -V
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # key won't match, will rely on restore-keys
@@ -230,7 +249,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - run: rustup override set stable
+      - name: Install toolchain
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup override set stable
+          cargo -V
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # key won't match, will rely on restore-keys

--- a/examples/no_std/library/README.md
+++ b/examples/no_std/library/README.md
@@ -56,9 +56,9 @@ jobs:
           - "thumbv6m-none-eabi"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      - run: |
+          rustup override set stable
+          rustup target add {{ matrix.target }}
       - name: Check Compile
         run: cargo check --no-default-features --features libm,critical-section --target ${{ matrix.target }}
 ```

--- a/examples/no_std/library/README.md
+++ b/examples/no_std/library/README.md
@@ -56,9 +56,16 @@ jobs:
           - "thumbv6m-none-eabi"
     steps:
       - uses: actions/checkout@v4
-      - run: |
+      - name: Install toolchain
+        env:
+          RUST_TARGET: ${{ matrix.target }}
+        run: |
+          rustup toolchain install stable --no-self-update --profile=minimal
+          rustup target add ${{ env.RUST_TARGET }} --toolchain stable
           rustup override set stable
-          rustup target add {{ matrix.target }}
+          cargo -V
       - name: Check Compile
-        run: cargo check --no-default-features --features libm,critical-section --target ${{ matrix.target }}
+        env:
+          RUST_TARGET: ${{ matrix.target }}
+        run: cargo check --no-default-features --features libm,critical-section --target ${{ env.RUST_TARGET }}
 ```


### PR DESCRIPTION
# Objective

- Attempts to fix #23635

## Solution

- Since rustup is already included in ubuntu-latest we could try to use it to configure targets and components.

## Testing

- Will test by running the CI jobs and verifying their results.