### PR TITLE
Fix: Manually derive FromTemplate for RenderTarget

### DIFF
--- a/crates/bevy_camera/Cargo.toml
+++ b/crates/bevy_camera/Cargo.toml
@@ -35,6 +35,9 @@ downcast-rs = { version = "2", default-features = false, features = ["std"] }
 derive_more = { version = "2", default-features = false, features = ["from"] }
 smallvec = { version = "1", default-features = false, features = ["const_new"] }
 
+[dev-dependencies]
+bevy_scene = { path = "../bevy_scene" }
+
 [features]
 default = []
 

--- a/crates/bevy_camera/Cargo.toml
+++ b/crates/bevy_camera/Cargo.toml
@@ -36,7 +36,7 @@ derive_more = { version = "2", default-features = false, features = ["from"] }
 smallvec = { version = "1", default-features = false, features = ["const_new"] }
 
 [dev-dependencies]
-bevy_scene = { path = "../bevy_scene" }
+bevy_scene = { path = "../bevy_scene", version = "0.20.0-dev" }
 
 [features]
 default = []

--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -887,10 +887,11 @@ impl Default for CameraOutputMode {
 
 /// The "target" that a [`Camera`] will render to. For example, this could be a `Window`
 /// swapchain or an [`Image`].
-#[derive(Component, Debug, Clone, Reflect, From)]
+#[derive(Component, FromTemplate, Debug, Clone, Reflect, From)]
 #[reflect(Clone, Component)]
 pub enum RenderTarget {
     /// Window to which the camera's view is rendered.
+    #[default]
     Window(WindowRef),
     /// Image to which the camera's view is rendered.
     Image(ImageRenderTarget),
@@ -980,7 +981,7 @@ pub enum NormalizedRenderTarget {
 pub struct ManualTextureViewHandle(pub u32);
 
 /// A render target that renders to an [`Image`].
-#[derive(Debug, Clone, Reflect)]
+#[derive(FromTemplate, Debug, Clone, Reflect)]
 #[reflect(Clone, PartialEq, Hash)]
 pub struct ImageRenderTarget {
     /// The image to render to.

--- a/crates/bevy_camera/src/camera.rs
+++ b/crates/bevy_camera/src/camera.rs
@@ -1067,11 +1067,13 @@ impl CameraMainTextureUsages {
 #[cfg(test)]
 mod test {
     use bevy_math::{Vec2, Vec3};
+    use bevy_scene::bsn;
     use bevy_transform::components::GlobalTransform;
+    use bevy_window::WindowRef;
 
     use crate::{
-        Camera, OrthographicProjection, PerspectiveProjection, Projection, RenderTargetInfo,
-        Viewport,
+        Camera, OrthographicProjection, PerspectiveProjection, Projection, RenderTarget,
+        RenderTargetInfo, Viewport,
     };
 
     fn make_camera(mut projection: Projection, physical_size: Vec2) -> Camera {
@@ -1146,5 +1148,12 @@ mod test {
         let ray = camera.viewport_to_world(&transform, size * 0.5).unwrap();
         assert_eq!(ray.direction, transform.forward());
         assert_eq!(ray.origin, transform.forward() * 0.1);
+    }
+
+    #[test]
+    fn render_target_in_bsn() {
+        let _ = bsn! {
+            RenderTarget::Window(WindowRef::default())
+        };
     }
 }


### PR DESCRIPTION
# Objective

RenderTarget cannot currently be used in the bsn macro.

If I understand it correctly, this is because a variant of RenderTarget contains a type that is Unpin because it contains a Handle, which makes the blanket implementation of FromTemplate for T: Clone + Copy not apply to RenderTarget.

## Solution

Deriving FromTemplate for RenderTarget and ImageRenderTarget should solve this.

Additionally, I don't think this will be necessary once the specialization trick is removed from Handle, but it is needed for now.