### PR TITLE
bug fix: example - compute_mesh - fix type mismatch

### DIFF
--- a/examples/shader_advanced/compute_mesh.rs
+++ b/examples/shader_advanced/compute_mesh.rs
@@ -225,7 +225,7 @@ fn init_compute_pipeline(
                 // offsets
                 uniform_buffer::<DataRanges>(false),
                 // vertices
-                storage_buffer::<Vec<u32>>(false),
+                storage_buffer::<Vec<f32>>(false),
                 // indices
                 storage_buffer::<Vec<u32>>(false),
             ),


### PR DESCRIPTION
in the [compute_mesh example](https://github.com/bevyengine/bevy/blob/0ecdfaa0b6909b581bbb51759adf5999ea663b7a/examples/shader_advanced/compute_mesh.rs#L228) a storage buffer is defined with data type `u32` while the mirrored type in the [shader definition](https://github.com/bevyengine/bevy/blob/0ecdfaa0b6909b581bbb51759adf5999ea663b7a/assets/shaders/compute_mesh.wgsl#L15) is `f32`.
since both types are 4 bytes long, the example still works with the mismatch but it is potentially confusing, especially for beginners which are more likely to examine this example code, if these types don't match.

# Objective

fix type mismatch between example and shader code.

## Solution

replaced storage buffer type with shader definition type.

## Testing

ran example locally - no changes observed.
