### PR TITLE
Escape releases focus from text input

### DIFF
--- a/crates/bevy_ui_widgets/src/text_input.rs
+++ b/crates/bevy_ui_widgets/src/text_input.rs
@@ -91,6 +91,7 @@ fn matches_edit_shortcut(input: &KeyboardInput, character: &str, key_code: KeyCo
 /// and then applied later by the [`apply_text_edits`](`bevy_text::apply_text_edits`) system.
 fn on_focused_keyboard_input(
     mut keyboard_input: On<FocusedInput<KeyboardInput>>,
+    mut input_focus: ResMut<InputFocus>,
     mut query: Query<&mut EditableText, Without<InteractionDisabled>>,
     keys: Res<ButtonInput<Key>>,
 ) {
@@ -183,7 +184,10 @@ fn on_focused_keyboard_input(
         (NONE | SHIFT, Key::End) => queue_edit(TextEdit::LineEnd(shift_pressed)),
         (NONE, Key::Backspace) => queue_edit(TextEdit::Backspace),
         (NONE, Key::Delete) => queue_edit(TextEdit::Delete),
-        (NONE, Key::Escape) => queue_edit(TextEdit::CollapseSelection),
+        (NONE, Key::Escape) => {
+            queue_edit(TextEdit::CollapseSelection);
+            input_focus.clear();
+        }
         (NONE | SHIFT, Key::Character(_)) | (NONE, Key::Space) => {
             if let Some(text) = &keyboard_input.input.text
                 && !text.is_empty()


### PR DESCRIPTION
# Objective

Escape in a text input currently only collapses the selection, and the
event is consumed:

```rust
(NONE, Key::Escape) => queue_edit(TextEdit::CollapseSelection),
```

Two problems with that as the whole behavior:

1. **It can be invisible.** When a selection spans the field (e.g. after
   `SelectAllOnFocus`), collapse-to-caret is barely perceptible, so the
   universal "get me out of this field" key appears to do nothing.
2. **It traps focus.** Because the event is consumed, Escape can neither
   blur the field nor propagate to app-level handlers (close dialog,
   cancel, window-level shortcuts). There is no keyboard path out of a
   text input.

# Solution

Escape now collapses the selection **and** clears `InputFocus`. The field
owns its focus lifecycle: the first Escape exits the field, and the next
one reaches whatever the app dispatches to when nothing is focused. This
matches platform text inputs and the web.

- Deselect-without-blur remains available via the arrow keys, which
  already collapse a selection.
- IME is unaffected: Escape during active composition is consumed by the
  IME layer before the widget sees it, so this only changes the
  plain-Escape case.

# Testing

`cargo run --example text_input`

- Tab or click into a field, press Escape → field blurs (focus ring
  gone), caret stops rendering.
- With a full selection (`SelectAllOnFocus` field), one Escape collapses
  and blurs together.
- Escape pressed again with nothing focused propagates normally (visible
  with a `FocusedInput` observer on the window).