### PR TITLE
Apply suggested fix for `try_update` from nightly 1.99+ compiler.

### DIFF
--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -33,7 +33,7 @@ impl WorldId {
     pub fn new() -> Option<Self> {
         MAX_WORLD_ID
             // We use `Relaxed` here since this atomic only needs to be consistent with itself
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
                 val.checked_add(1)
             })
             .map(WorldId)

--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -31,13 +31,29 @@ impl WorldId {
     /// Please note that the [`WorldId`]s created from this method are unique across
     /// time - if a given [`WorldId`] is [`Drop`]ped its value still cannot be reused
     pub fn new() -> Option<Self> {
-        MAX_WORLD_ID
-            // We use `Relaxed` here since this atomic only needs to be consistent with itself
-            .try_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
-                val.checked_add(1)
-            })
-            .map(WorldId)
-            .ok()
+        // NOTE: this is not really a std vs. no_std change.
+        // The split is done to silence a warning and also satisfy builds for an older no_std target on CI.
+        // Once you see the deprecation warning for no_std, collapse the function into this first branch.
+        #[cfg(feature = "std")]
+        {
+            MAX_WORLD_ID
+                // We use `Relaxed` here since this atomic only needs to be consistent with itself
+                .try_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
+                    val.checked_add(1)
+                })
+                .map(WorldId)
+                .ok()
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            MAX_WORLD_ID
+                // We use `Relaxed` here since this atomic only needs to be consistent with itself
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
+                    val.checked_add(1)
+                })
+                .map(WorldId)
+                .ok()
+        }
     }
 }
 


### PR DESCRIPTION
I've been seeing this for a week, so I guess I'm the only one this is annoying :)

# Objective

Fix this warning from recent 1.99 nightly:
```
warning: use of deprecated method `core::sync::atomic::Atomic::<usize>::fetch_update`: renamed to `try_update` for consistency
  --> crates/bevy_ecs/src/world/identifier.rs:36:14
```

## Solution

Apply fix.

[Atomic*::try_update](https://doc.rust-lang.org/stable/std/sync/atomic/type.AtomicUsize.html#method.try_update) is available since 1.95, so this shouldn't break anyone, given we require nightly.

## Testing

- CI
