### PR TITLE
Migrate `dynamic_mip_generation` to use `FeathersRadio` and `FeathersButton` (Phase 4 Item 6)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5598,6 +5598,7 @@ wasm = true
 name = "dynamic_mip_generation"
 path = "examples/2d/dynamic_mip_generation.rs"
 doc-scrape-examples = true
+required-features = ["bevy_feathers"]
 
 [package.metadata.example.dynamic_mip_generation]
 name = "Dynamic Mipmap Generation"

--- a/examples/2d/dynamic_mip_generation.rs
+++ b/examples/2d/dynamic_mip_generation.rs
@@ -21,6 +21,10 @@ use bevy::{
         },
         schedule::Core2d,
     },
+    feathers::{
+        controls::FeathersButton, dark_theme::create_dark_theme, display::caption, theme::UiTheme,
+        FeathersPlugins,
+    },
     prelude::*,
     reflect::TypePath,
     render::{
@@ -35,18 +39,16 @@ use bevy::{
     shader::ShaderRef,
     sprite::Text2dShadow,
     sprite_render::{AlphaMode2d, Material2d, Material2dPlugin},
+    ui_widgets::{radio_self_update, Activate, ValueChange},
     window::{PrimaryWindow, WindowResized},
 };
 use chacha20::ChaCha8Rng;
 use rand::{RngExt, SeedableRng};
 
-use crate::widgets::{
-    RadioButton, RadioButtonText, WidgetClickEvent, WidgetClickSender, BUTTON_BORDER,
-    BUTTON_BORDER_COLOR, BUTTON_BORDER_RADIUS_SIZE, BUTTON_PADDING,
-};
+use crate::radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptionValue};
 
-#[path = "../helpers/widgets.rs"]
-mod widgets;
+#[path = "../helpers/radio.rs"]
+mod radio;
 
 /// The time in seconds that it takes the animation of the image shrinking and
 /// growing to play.
@@ -93,19 +95,24 @@ impl Default for AppStatus {
     }
 }
 
-/// Identifies one of the settings that can be changed by the user.
-#[derive(Clone)]
-enum AppSetting {
-    /// Regenerates the top mipmap level.
-    ///
-    /// This is more of an *operation* than a *setting* per se, but it was
-    /// convenient to use the `AppSetting` infrastructure for the "Regenerate
-    /// Top Mip Level" button.
-    RegenerateTopMipLevel,
+/// Whether mipmap levels will be generated.
+///
+/// Turning off the generation of mipmap levels, and then regenerating the
+/// image, will cause all mipmap levels other than the first to be blank. This
+/// will in turn cause the image to fade out as it shrinks, as the GPU switches
+/// to rendering mipmap levels that don't have associated images.
+#[derive(Component, Clone, Copy, Default, PartialEq)]
+enum EnableMipGeneration {
+    /// Mipmap levels are generated for the image.
+    #[default]
+    On,
+    /// Mipmap levels aren't generated for the image.
+    Off,
+}
 
-    /// Whether mipmaps should be generated.
-    EnableMipGeneration(EnableMipGeneration),
-
+/// The setting that updates the width or height of the image.
+#[derive(Component, Clone, Copy, PartialEq)]
+enum ImageSizeSetting {
     /// The width of the image.
     ImageWidth(ImageSize),
 
@@ -113,19 +120,10 @@ enum AppSetting {
     ImageHeight(ImageSize),
 }
 
-/// Whether mipmap levels will be generated.
-///
-/// Turning off the generation of mipmap levels, and then regenerating the
-/// image, will cause all mipmap levels other than the first to be blank. This
-/// will in turn cause the image to fade out as it shrinks, as the GPU switches
-/// to rendering mipmap levels that don't have associated images.
-#[derive(Clone, Copy, Default, PartialEq)]
-enum EnableMipGeneration {
-    /// Mipmap levels are generated for the image.
-    #[default]
-    On,
-    /// Mipmap levels aren't generated for the image.
-    Off,
+impl Default for ImageSizeSetting {
+    fn default() -> Self {
+        Self::ImageWidth(default())
+    }
 }
 
 /// Possible lengths for an image side from which the user can choose.
@@ -199,6 +197,10 @@ const MIP_GENERATION_PHASE_ID: MipGenerationPhaseId = MipGenerationPhaseId(0);
 #[derive(Component)]
 struct ImageView;
 
+/// A marker component for the Regenerate Top Mip Level button.
+#[derive(Clone, Copy, Component, Default)]
+struct RegenerateTopMipLevelButton;
+
 /// A message that's sent whenever the image and the corresponding views need to
 /// be regenerated.
 #[derive(Clone, Copy, Debug, Message)]
@@ -216,31 +218,22 @@ fn main() {
             ..default()
         }),
         Material2dPlugin::<SingleMipLevelMaterial>::default(),
+        FeathersPlugins,
     ))
     .init_resource::<AppStatus>()
     .init_resource::<AppAssets>()
+    .insert_resource(UiTheme(create_dark_theme()))
     .add_message::<RegenerateImage>()
-    .add_message::<WidgetClickEvent<AppSetting>>()
     .add_systems(Startup, setup)
     .add_systems(Update, animate_image_scale)
     .add_systems(
         Update,
-        (
-            widgets::handle_ui_interactions::<AppSetting>,
-            update_radio_buttons,
-        )
-            .chain(),
-    )
-    .add_systems(
-        Update,
         (handle_window_resize_events, regenerate_image_when_requested).chain(),
     )
-    .add_systems(
-        Update,
-        handle_app_setting_change
-            .after(widgets::handle_ui_interactions::<AppSetting>)
-            .before(regenerate_image_when_requested),
-    );
+    .add_observer(radio_self_update)
+    .add_observer(handle_regenerate_top_mip_level_activate)
+    .add_observer(handle_enable_mip_generation_change)
+    .add_observer(handle_image_size_setting_change);
 
     // Because `MipGenerationJobs` is part of the render app, we need to add the
     // associated systems to that app, not the main one.
@@ -325,69 +318,64 @@ fn setup(
 
 /// Spawns the UI widgets at the bottom of the window.
 fn spawn_ui(commands: &mut Commands) {
-    commands.spawn((
-        widgets::main_ui_node(),
-        children![
+    commands.spawn_scene(bsn! {
+        main_ui_node_scene()
+        Children [
             // Spawn the "Regenerate Top Mip Level" button.
-            (
-                Button,
-                Node {
-                    border: BUTTON_BORDER,
-                    justify_content: JustifyContent::Center,
-                    align_items: AlignItems::Center,
-                    padding: BUTTON_PADDING,
-                    border_radius: BorderRadius::all(BUTTON_BORDER_RADIUS_SIZE),
-                    ..default()
-                },
-                BUTTON_BORDER_COLOR,
-                BackgroundColor(Color::BLACK),
-                WidgetClickSender(AppSetting::RegenerateTopMipLevel),
-                children![(
-                    widgets::ui_text("Regenerate Top Mip Level", Color::WHITE),
-                    WidgetClickSender(AppSetting::RegenerateTopMipLevel),
-                )],
-            ),
+            @FeathersButton {
+                @caption: bsn! { caption("Regenerate Top Mip Level") }
+            }
+            RegenerateTopMipLevelButton
+            Node {
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+            }
+            BackgroundColor(Color::BLACK)
+            ,
+
             // Spawn the "Mip Generation" switch that allows the user to toggle
             // mip generation on and off.
-            widgets::option_buttons(
+            feathers_option_buttons(
                 "Mip Generation",
                 &[
                     (
-                        AppSetting::EnableMipGeneration(EnableMipGeneration::On),
+                        EnableMipGeneration::On,
                         "On"
                     ),
                     (
-                        AppSetting::EnableMipGeneration(EnableMipGeneration::Off),
+                        EnableMipGeneration::Off,
                         "Off"
                     ),
-                ]
+                ], 0
             ),
             // Spawn the "Image Width" control that allows the user to set the
             // width of the image.
-            widgets::option_buttons(
+            feathers_option_buttons(
                 "Image Width",
                 &[
-                    (AppSetting::ImageWidth(ImageSize::Size240), "240"),
-                    (AppSetting::ImageWidth(ImageSize::Size480), "480"),
-                    (AppSetting::ImageWidth(ImageSize::Size640), "640"),
-                    (AppSetting::ImageWidth(ImageSize::Size1080), "1080"),
-                    (AppSetting::ImageWidth(ImageSize::Size1920), "1920"),
-                ]
+                    (ImageSizeSetting::ImageWidth(ImageSize::Size240), "240"),
+                    (ImageSizeSetting::ImageWidth(ImageSize::Size480), "480"),
+                    (ImageSizeSetting::ImageWidth(ImageSize::Size640), "640"),
+                    (ImageSizeSetting::ImageWidth(ImageSize::Size1080), "1080"),
+                    (ImageSizeSetting::ImageWidth(ImageSize::Size1920), "1920"),
+                ],
+                2
             ),
             // Spawn the "Image Height" control that allows the user to set the
             // height of the image.
-            widgets::option_buttons(
+            feathers_option_buttons(
                 "Image Height",
                 &[
-                    (AppSetting::ImageHeight(ImageSize::Size240), "240"),
-                    (AppSetting::ImageHeight(ImageSize::Size480), "480"),
-                    (AppSetting::ImageHeight(ImageSize::Size640), "640"),
-                    (AppSetting::ImageHeight(ImageSize::Size1080), "1080"),
-                    (AppSetting::ImageHeight(ImageSize::Size1920), "1920"),
-                ]
+                    (ImageSizeSetting::ImageHeight(ImageSize::Size240), "240"),
+                    (ImageSizeSetting::ImageHeight(ImageSize::Size480), "480"),
+                    (ImageSizeSetting::ImageHeight(ImageSize::Size640), "640"),
+                    (ImageSizeSetting::ImageHeight(ImageSize::Size1080), "1080"),
+                    (ImageSizeSetting::ImageHeight(ImageSize::Size1920), "1920"),
+                ],
+                1
             ),
-        ],
-    ));
+        ]
+    });
 }
 
 impl MipmapSizeIterator {
@@ -464,65 +452,50 @@ fn extract_mipmap_source_image(
     }
 }
 
-/// Updates the widgets at the bottom of the screen to reflect the settings that
-/// the user has chosen.
-fn update_radio_buttons(
-    mut widgets: Query<
-        (
-            Entity,
-            Option<&mut BackgroundColor>,
-            Has<Text>,
-            &WidgetClickSender<AppSetting>,
-        ),
-        Or<(With<RadioButton>, With<RadioButtonText>)>,
-    >,
-    app_status: Res<AppStatus>,
-    mut writer: TextUiWriter,
-) {
-    for (entity, image, has_text, sender) in widgets.iter_mut() {
-        let selected = match **sender {
-            AppSetting::RegenerateTopMipLevel => continue,
-            AppSetting::EnableMipGeneration(enable_mip_generation) => {
-                enable_mip_generation == app_status.enable_mip_generation
-            }
-            AppSetting::ImageWidth(image_width) => image_width == app_status.image_width,
-            AppSetting::ImageHeight(image_height) => image_height == app_status.image_height,
-        };
-
-        if let Some(mut bg_color) = image {
-            widgets::update_ui_radio_button(&mut bg_color, selected);
-        }
-        if has_text {
-            widgets::update_ui_radio_button_text(entity, &mut writer, selected);
-        }
-    }
-}
-
-/// Handles a request from the user to change application settings via the UI.
-///
-/// This also handles clicks on the "Regenerate Top Mip Level" button.
-fn handle_app_setting_change(
-    mut events: MessageReader<WidgetClickEvent<AppSetting>>,
-    mut app_status: ResMut<AppStatus>,
+/// Handles the button activation of the `RegenerateTopMipLevelButton`.
+fn handle_regenerate_top_mip_level_activate(
+    event: On<Activate>,
+    q: Query<(), With<RegenerateTopMipLevelButton>>,
     mut regenerate_image_message_writer: MessageWriter<RegenerateImage>,
 ) {
-    for event in events.read() {
-        // If this is a setting, update the setting. Fall through if, in
-        // addition to updating the setting, we need to regenerate the image.
-        match **event {
-            AppSetting::EnableMipGeneration(enable_mip_generation) => {
-                app_status.enable_mip_generation = enable_mip_generation;
-                continue;
-            }
-
-            AppSetting::RegenerateTopMipLevel => {}
-            AppSetting::ImageWidth(image_size) => app_status.image_width = image_size,
-            AppSetting::ImageHeight(image_size) => app_status.image_height = image_size,
-        }
-
+    if q.contains(event.entity) {
         // Schedule the image to be regenerated.
         regenerate_image_message_writer.write(RegenerateImage);
     }
+}
+
+/// Handles a request from the user to change the enable mip generation setting via the UI.
+fn handle_enable_mip_generation_change(
+    event: On<ValueChange<Entity>>,
+    new_value_query: Query<&RadioButtonOptionValue<EnableMipGeneration>>,
+    mut app_status: ResMut<AppStatus>,
+) {
+    let Ok(RadioButtonOptionValue(enable_mip)) = new_value_query.get(event.value) else {
+        return;
+    };
+    app_status.enable_mip_generation = *enable_mip;
+
+    // Enabling mip generation does not trigger a request to regenerate the image.
+}
+
+/// Handles a request from the user to change the image size via the UI.
+fn handle_image_size_setting_change(
+    event: On<ValueChange<Entity>>,
+    new_value_query: Query<&RadioButtonOptionValue<ImageSizeSetting>>,
+    mut app_status: ResMut<AppStatus>,
+    mut regenerate_image_message_writer: MessageWriter<RegenerateImage>,
+) {
+    let Ok(RadioButtonOptionValue(size_setting)) = new_value_query.get(event.value) else {
+        return;
+    };
+
+    match *size_setting {
+        ImageSizeSetting::ImageWidth(image_size) => app_status.image_width = image_size,
+        ImageSizeSetting::ImageHeight(image_size) => app_status.image_height = image_size,
+    }
+
+    // Schedule the image to be regenerated.
+    regenerate_image_message_writer.write(RegenerateImage);
 }
 
 /// Handles resize events for the window.

--- a/examples/3d/clustered_decals.rs
+++ b/examples/3d/clustered_decals.rs
@@ -233,7 +233,7 @@ fn spawn_buttons(commands: &mut Commands) {
                 (Selection::Camera, "Camera"),
                 (Selection::DecalA, "Decal A"),
                 (Selection::DecalB, "Decal B"),
-            ]),
+            ], 0),
             number_input("Scale Multiplier", 1.0, 0.05..10., AppNumberInput::Scale),
             number_input("Roll (-π to π)", 0.0, -PI..PI, AppNumberInput::Roll),
         ]

--- a/examples/3d/light_probe_blending.rs
+++ b/examples/3d/light_probe_blending.rs
@@ -334,18 +334,21 @@ fn spawn_buttons(commands: &mut Commands) {
         Children [
             feathers_option_buttons(
                 "Gizmos",
-                &[(GizmosEnabled::On, "On"), (GizmosEnabled::Off, "Off"),]
+                &[(GizmosEnabled::On, "On"), (GizmosEnabled::Off, "Off"),],
+                0,
             ),
             feathers_option_buttons(
                 "Object to Show",
                 &[
                     (ObjectToShow::Sphere, "Sphere"),
                     (ObjectToShow::Prism, "Prism"),
-                ]
+                ],
+                0,
             ),
             feathers_option_buttons(
                 "Camera Mode",
-                &[(CameraMode::Orbit, "Orbit"), (CameraMode::Free, "Free"),]
+                &[(CameraMode::Orbit, "Orbit"), (CameraMode::Free, "Free"),],
+                0,
             ),
         ]
     });

--- a/examples/3d/light_textures.rs
+++ b/examples/3d/light_textures.rs
@@ -283,6 +283,7 @@ fn spawn_buttons(commands: &mut Commands) {
                     (Selection::PointLight, "Point Light"),
                     (Selection::DirectionalLight, "Directional Light"),
                 ],
+                0,
             ),
 
             // Camera's visibility cannot be toggled.
@@ -293,6 +294,7 @@ fn spawn_buttons(commands: &mut Commands) {
                     (Visibility::Inherited, "Show"),
                     (Visibility::Hidden, "Hide"),
                 ],
+                0,
             ),
 
             // The number inputs start off hidden because Camera is selected first.

--- a/examples/3d/mirror.rs
+++ b/examples/3d/mirror.rs
@@ -331,6 +331,7 @@ fn spawn_buttons(commands: &mut Commands) {
                 (DragAction::MoveCamera, "Move Camera"),
                 (DragAction::MoveFox, "Move Fox"),
             ],
+            0,
         )]
     });
 }

--- a/examples/3d/pccm.rs
+++ b/examples/3d/pccm.rs
@@ -164,6 +164,7 @@ fn spawn_buttons(commands: &mut Commands) {
                     (PccmEnableStatus::Enabled, "On"),
                     (PccmEnableStatus::Disabled, "Off"),
                 ],
+                0,
             )
         ]
     });

--- a/examples/3d/pcss.rs
+++ b/examples/3d/pcss.rs
@@ -209,6 +209,7 @@ fn spawn_buttons(commands: &mut Commands) {
                     (LightType::Point, "Point"),
                     (LightType::Spot, "Spot"),
                 ],
+                0,
             ),
             radio::feathers_option_buttons(
                 "Shadow Filter",
@@ -219,6 +220,7 @@ fn spawn_buttons(commands: &mut Commands) {
                     ),
                     (ShadowFilter::Temporal, "Temporal"),
                 ],
+                0,
             ),
             radio::feathers_option_buttons(
                 "Soft Shadows",
@@ -226,6 +228,7 @@ fn spawn_buttons(commands: &mut Commands) {
                     (SoftShadows(true), "On"),
                     (SoftShadows(false), "Off"),
                 ],
+                0,
             ),
         ]
     });

--- a/examples/3d/specular_tint.rs
+++ b/examples/3d/specular_tint.rs
@@ -188,6 +188,7 @@ fn spawn_buttons(commands: &mut Commands) {
                     (TintType::Solid, "SOLID"),
                     (TintType::Map,   "MAP"),
                 ],
+                0,
             )
         ]
     });

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -470,6 +470,7 @@ fn spawn_buttons(commands: &mut Commands, app_settings: &AppSettings) {
                     (SsrOn(true), "On"),
                     (SsrOn(false), "Off"),
                 ],
+                0,
             ),
             feathers_option_buttons(
                 "Model",
@@ -481,6 +482,7 @@ fn spawn_buttons(commands: &mut Commands, app_settings: &AppSettings) {
                     ),
                     (DisplayedModel::Capsules, "Capsules"),
                 ],
+                0,
             ),
             feathers_option_buttons(
                 "Base",
@@ -489,6 +491,7 @@ fn spawn_buttons(commands: &mut Commands, app_settings: &AppSettings) {
                     (DisplayedBase::Metallic, "Metallic"),
                     (DisplayedBase::RedPlane, "Red Plane"),
                 ],
+                0,
             ),
             range_row(
                 "Min Roughness",

--- a/examples/helpers/radio.rs
+++ b/examples/helpers/radio.rs
@@ -33,8 +33,7 @@ pub fn main_ui_node_scene() -> impl Scene {
 
 /// Spawns the radio buttons that allow configuration of a setting.
 ///
-/// The first option in the `options` list is always marked as selected.
-/// Ensure options is in the correct ordering with how your app is initialized.
+/// The option at index `selected_option` in the `options` list is marked as selected.
 ///
 /// To react to changes in value, create an observer that listens to
 /// `ValueChange<Entity>>`. Query for the value entity's `RadioButtonOptionValue`
@@ -42,7 +41,11 @@ pub fn main_ui_node_scene() -> impl Scene {
 ///
 /// Ensure the radio button self updates its own state by adding the
 /// `ui_widgets::radio_self_update` observer to the app.
-pub fn feathers_option_buttons<T>(title: &'static str, options: &[(T, &str)]) -> impl Scene
+pub fn feathers_option_buttons<T>(
+    title: &'static str,
+    options: &[(T, &str)],
+    selected_option: usize,
+) -> impl Scene
 where
     T: Clone + Default + Send + Sync + Unpin + 'static,
 {
@@ -51,7 +54,7 @@ where
         .cloned()
         .enumerate()
         .map(|(option_index, (option_value, option_name))| {
-            feathers_option_button(option_value, option_name, option_index == 0)
+            feathers_option_button(option_value, option_name, option_index == selected_option)
         })
         .collect::<Vec<_>>();
     // Add the parent node for the row.


### PR DESCRIPTION
# Objective

- Part of #24112 

## Solution

- Straightforward port of using `FeathersRadio` and `FeathersButton`.
- Had to update the `radio.rs` helper to accept an argument that specifies the selected option. It makes sense here since the image sizes should stay in order from lowest to highest.

## Testing

- `cargo run --example dynamic_mip_generation --features=“bevy_feathers”` should work like it did on main

---

## Showcase

<img width="1270" height="742" alt="Screenshot 2026-07-21 at 1 28 15 PM" src="https://github.com/user-attachments/assets/f410119e-d459-471c-9966-365f3e782dc9" />
