### PR TITLE
Declare `bevy_input_focus/bevy_picking` in `bevy_ui_widgets`

### DIFF
--- a/crates/bevy_ui_widgets/Cargo.toml
+++ b/crates/bevy_ui_widgets/Cargo.toml
@@ -15,7 +15,9 @@ bevy_a11y = { path = "../bevy_a11y", version = "0.20.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.20.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.20.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.20.0-dev" }
-bevy_input_focus = { path = "../bevy_input_focus", version = "0.20.0-dev", features = ["bevy_picking"] }
+bevy_input_focus = { path = "../bevy_input_focus", version = "0.20.0-dev", features = [
+  "bevy_picking",
+] }
 bevy_log = { path = "../bevy_log", version = "0.20.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.20.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.20.0-dev" }

--- a/crates/bevy_ui_widgets/Cargo.toml
+++ b/crates/bevy_ui_widgets/Cargo.toml
@@ -15,7 +15,7 @@ bevy_a11y = { path = "../bevy_a11y", version = "0.20.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.20.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.20.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.20.0-dev" }
-bevy_input_focus = { path = "../bevy_input_focus", version = "0.20.0-dev" }
+bevy_input_focus = { path = "../bevy_input_focus", version = "0.20.0-dev", features = ["bevy_picking"] }
 bevy_log = { path = "../bevy_log", version = "0.20.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.20.0-dev" }
 bevy_picking = { path = "../bevy_picking", version = "0.20.0-dev" }


### PR DESCRIPTION
# Objective

`bevy_ui_widgets` fails to build standalone on main:

cargo check -p bevy_ui_widgets
error[E0432]: unresolved import `bevy_input_focus::pointer_focus`
  --> crates/bevy_ui_widgets/src/lib.rs:64:23
   |
64 | use bevy_input_focus::pointer_focus::PointerFocusPlugin;
   |                       ^^^^^^^^^^^^^ could not find `pointer_focus` in `bevy_input_focus`
   |

`lib.rs` unconditionally imports `pointer_focus`, which is gated behind
`bevy_input_focus`'s `bevy_picking` feature — but the Cargo.toml
dependency doesn't enable it. Workspace and facade builds mask this
through feature unification (another crate in the graph enables the
feature), so CI doesn't catch it; any standalone build or test of the
crate fails.

# Solution

Declare the feature the code already requires:

```toml
bevy_input_focus = { path = "../bevy_input_focus", version = "0.20.0-dev", features = ["bevy_picking"] }
```

`bevy_ui_widgets` already depends on `bevy_picking` directly and uses it
unconditionally, so this enables no new functionality — it just makes
the declared dependencies match the code.

# Testing

- `cargo check -p bevy_ui_widgets` — fails on main, passes with this change.
- `cargo test -p bevy_ui_widgets` — same.