### PR TITLE
Migrate ```specular_tint``` to use ```FeathersRadio```

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5207,7 +5207,7 @@ wasm = true
 name = "specular_tint"
 path = "examples/3d/specular_tint.rs"
 doc-scrape-examples = true
-required-features = ["pbr_specular_textures"]
+required-features = ["pbr_specular_textures", "bevy_feathers"]
 
 [package.metadata.example.specular_tint]
 name = "Specular Tint"

--- a/examples/3d/specular_tint.rs
+++ b/examples/3d/specular_tint.rs
@@ -1,16 +1,31 @@
 //! Demonstrates specular tints and maps.
 
-use std::f32::consts::PI;
+use std::{
+    f32::consts::PI,
+    fmt::{self, Formatter},
+};
 
-use bevy::{camera::Hdr, color::palettes::css::WHITE, light::Skybox, prelude::*};
+use bevy::{
+    camera::Hdr,
+    color::palettes::css::WHITE,
+    feathers::{theme::UiTheme, FeathersPlugins},
+    light::Skybox,
+    prelude::*,
+    ui_widgets::{radio_self_update, ValueChange},
+};
+
+use radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptionValue};
+
+#[path = "../helpers/radio.rs"]
+mod radio;
+
+#[path = "../helpers/theme.rs"]
+mod theme;
 
 /// The camera rotation speed in radians per frame.
 const ROTATION_SPEED: f32 = 0.005;
 /// The rate at which the specular tint hue changes in degrees per frame.
 const HUE_SHIFT_SPEED: f32 = 0.2;
-
-static SWITCH_TO_MAP_HELP_TEXT: &str = "Press Space to switch to a specular map";
-static SWITCH_TO_SOLID_TINT_HELP_TEXT: &str = "Press Space to switch to a solid specular tint";
 
 /// The current settings the user has chosen.
 #[derive(Resource, Default)]
@@ -38,13 +53,22 @@ impl FromWorld for AppAssets {
 }
 
 /// The type of specular tint that the user has selected.
-#[derive(Clone, Copy, PartialEq, Default)]
+#[derive(Clone, Copy, PartialEq, Default, Debug)]
 enum TintType {
     /// A solid color.
     #[default]
     Solid,
     /// A Perlin noise texture.
     Map,
+}
+
+impl fmt::Display for TintType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            TintType::Map => f.write_str("MAP"),
+            TintType::Solid => f.write_str("SOLID"),
+        }
+    }
 }
 
 /// The entry point.
@@ -57,6 +81,8 @@ fn main() {
             }),
             ..default()
         }))
+        .add_plugins(FeathersPlugins)
+        .insert_resource(UiTheme(theme::basic_example_theme(Color::WHITE)))
         .init_resource::<AppAssets>()
         .init_resource::<AppStatus>()
         .insert_resource(GlobalAmbientLight {
@@ -66,8 +92,8 @@ fn main() {
         })
         .add_systems(Startup, setup)
         .add_systems(Update, rotate_camera)
-        .add_systems(Update, (toggle_specular_map, update_text).chain())
-        .add_systems(Update, shift_hue.after(toggle_specular_map))
+        .add_observer(toggle_specular_map)
+        .add_observer(radio_self_update)
         .run();
 }
 
@@ -119,16 +145,7 @@ fn setup(
         })),
     ));
 
-    // Spawn the help text.
-    commands.spawn((
-        Node {
-            position_type: PositionType::Absolute,
-            bottom: px(12),
-            left: px(12),
-            ..default()
-        },
-        app_status.create_text(),
-    ));
+    spawn_buttons(&mut commands);
 }
 
 /// Rotates the camera a bit every frame.
@@ -160,36 +177,38 @@ fn shift_hue(
     }
 }
 
-impl AppStatus {
-    /// Returns appropriate help text that reflects the current app status.
-    fn create_text(&self) -> Text {
-        let tint_map_help_text = match self.tint_type {
-            TintType::Solid => SWITCH_TO_MAP_HELP_TEXT,
-            TintType::Map => SWITCH_TO_SOLID_TINT_HELP_TEXT,
-        };
-
-        Text::new(tint_map_help_text)
-    }
+/// Spawns the radio buttons in the bottom left corner of the screen.
+fn spawn_buttons(commands: &mut Commands) {
+    commands.spawn_scene(bsn! {
+        main_ui_node_scene()
+        Children [
+            feathers_option_buttons(
+                "Toggle specular tint",
+                &[
+                    (TintType::Solid, "SOLID"),
+                    (TintType::Map,   "MAP"),
+                ],
+            )
+        ]
+    });
 }
 
-/// Changes the specular tint to a solid color or map when the user presses
-/// Space.
+/// Changes the specular tint to a solid color or map when the user checks
+/// a radio button.
 fn toggle_specular_map(
-    keyboard: Res<ButtonInput<KeyCode>>,
+    event: On<ValueChange<Entity>>,
+    new_value_query: Query<&RadioButtonOptionValue<TintType>>,
     mut app_status: ResMut<AppStatus>,
     app_assets: Res<AppAssets>,
     objects_with_materials: Query<&MeshMaterial3d<StandardMaterial>>,
     mut standard_materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    if !keyboard.just_pressed(KeyCode::Space) {
+    let Ok(RadioButtonOptionValue(selection)) = new_value_query.get(event.value) else {
         return;
-    }
-
-    // Swap tint type.
-    app_status.tint_type = match app_status.tint_type {
-        TintType::Solid => TintType::Map,
-        TintType::Map => TintType::Solid,
     };
+
+    // Set the specular map value in `AppStatus`.
+    app_status.tint_type = *selection;
 
     for material_handle in objects_with_materials.iter() {
         let Some(mut material) = standard_materials.get_mut(material_handle) else {
@@ -213,12 +232,6 @@ fn toggle_specular_map(
             }
         };
     }
-}
 
-/// Updates the help text at the bottom of the screen to reflect the current app
-/// status.
-fn update_text(mut text_query: Query<&mut Text>, app_status: Res<AppStatus>) {
-    for mut text in text_query.iter_mut() {
-        *text = app_status.create_text();
-    }
+    shift_hue(app_status, objects_with_materials, standard_materials);
 }


### PR DESCRIPTION
# Objective
Addresses one item in #25032 
Supersedes #25103 

## Solution
This is essentially identical to #25091: a straightforward drop-in replacement of a spacebar control with FeathersRadio buttons. 

## Testing
- ```cargo run ---example specular_tint --features="bevy_feathers pbr_specular_textures"``` There shouldn't be any differences functionally or visually between the examples. 

## Showcase
<img width="1876" height="1005" alt="image" src="https://github.com/user-attachments/assets/13662aaf-a690-4cdb-ab05-2657b89466a8" />

<img width="1876" height="1005" alt="image" src="https://github.com/user-attachments/assets/85e72f81-ed81-4bc7-92fd-8180e2d04601" />