### PR TITLE
Migrate `cooldown` to use `ui_widgets::Button` and `bsn!` (Phase 3 Item 1)

### DIFF
--- a/examples/usage/cooldown.rs
+++ b/examples/usage/cooldown.rs
@@ -3,7 +3,12 @@
 //! You might want a system like this for abilities, buffs or consumables.
 //! We create four food buttons to eat with 2, 1, 10, and 4 seconds cooldown.
 
-use bevy::{color::palettes::tailwind, ecs::spawn::SpawnIter, prelude::*};
+use bevy::{
+    color::palettes::tailwind,
+    ecs::spawn::SpawnIter,
+    prelude::*,
+    ui_widgets::{Activate, Button},
+};
 
 fn main() {
     App::new()
@@ -11,11 +16,9 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(
             Update,
-            (
-                activate_ability,
-                animate_cooldowns.run_if(any_with_component::<ActiveCooldown>),
-            ),
+            animate_cooldowns.run_if(any_with_component::<ActiveCooldown>),
         )
+        .add_observer(on_activate_start_cooldown)
         .run();
 }
 
@@ -126,32 +129,26 @@ struct Cooldown(Timer);
 #[component(storage = "SparseSet")]
 struct ActiveCooldown;
 
-fn activate_ability(
+/// Observer that starts the cooldown whenever a food item button is activated.
+fn on_activate_start_cooldown(
+    event: On<Activate>,
     mut commands: Commands,
     mut interaction_query: Query<
-        (
-            Entity,
-            &Interaction,
-            &mut Cooldown,
-            &Name,
-            Option<&ActiveCooldown>,
-        ),
-        (Changed<Interaction>, With<Button>),
+        (Entity, &mut Cooldown, &Name, Option<&ActiveCooldown>),
+        With<Button>,
     >,
     mut text: Query<&mut Text>,
 ) -> Result {
-    for (entity, interaction, mut cooldown, name, on_cooldown) in &mut interaction_query {
-        if *interaction == Interaction::Pressed {
-            if on_cooldown.is_none() {
-                cooldown.0.reset();
-                commands.entity(entity).insert(ActiveCooldown);
-                **text.single_mut()? = format!("You ate {name}");
-            } else {
-                **text.single_mut()? = format!(
-                    "You can eat {name} again in {} seconds.",
-                    cooldown.0.remaining_secs().ceil()
-                );
-            }
+    if let Ok((entity, mut cooldown, name, on_cooldown)) = interaction_query.get_mut(event.entity) {
+        if on_cooldown.is_none() {
+            cooldown.0.reset();
+            commands.entity(entity).insert(ActiveCooldown);
+            **text.single_mut()? = format!("You ate {name}");
+        } else {
+            **text.single_mut()? = format!(
+                "You can eat {name} again in {} seconds.",
+                cooldown.0.remaining_secs().ceil()
+            );
         }
     }
 

--- a/examples/usage/cooldown.rs
+++ b/examples/usage/cooldown.rs
@@ -4,8 +4,8 @@
 //! We create four food buttons to eat with 2, 1, 10, and 4 seconds cooldown.
 
 use bevy::{
-    color::palettes::tailwind,
-    ecs::spawn::SpawnIter,
+    color::palettes::tailwind::{SLATE_400, SLATE_50},
+    image::TextureAtlasTemplate,
     prelude::*,
     ui_widgets::{Activate, Button},
 };
@@ -22,60 +22,74 @@ fn main() {
         .run();
 }
 
-fn setup(
-    mut commands: Commands,
-    mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>,
-    asset_server: Res<AssetServer>,
-) {
-    commands.spawn(Camera2d);
-    let texture = asset_server.load("textures/food_kenney.png");
+fn setup(mut commands: Commands, mut texture_atlas_layouts: ResMut<Assets<TextureAtlasLayout>>) {
     let layout = TextureAtlasLayout::from_grid(UVec2::splat(64), 7, 7, None, None);
     let texture_atlas_layout = texture_atlas_layouts.add(layout);
-    commands.spawn((
+
+    commands.spawn(Camera2d);
+
+    // The food items
+    commands.spawn_scene(bsn! {
         Node {
             width: percent(100),
             height: percent(100),
             align_items: AlignItems::Center,
             justify_content: JustifyContent::Center,
             column_gap: px(15),
-            ..default()
-        },
-        Children::spawn(SpawnIter(
-            [
-                FoodItem {
-                    name: "an apple",
-                    cooldown: 2.,
-                    index: 2,
-                },
-                FoodItem {
-                    name: "a burger",
-                    cooldown: 1.,
-                    index: 23,
-                },
-                FoodItem {
-                    name: "chocolate",
-                    cooldown: 10.,
-                    index: 32,
-                },
-                FoodItem {
-                    name: "cherries",
-                    cooldown: 4.,
-                    index: 41,
-                },
-            ]
-            .into_iter()
-            .map(move |food| build_ability(food, texture.clone(), texture_atlas_layout.clone())),
-        )),
-    ));
-    commands.spawn((
-        Text::new("*Click some food to eat it*"),
+        }
+        Children [
+            { food_items_scene_list(texture_atlas_layout) }
+        ]
+    });
+
+    // Status text
+    commands.spawn_scene(bsn! {
         Node {
             position_type: PositionType::Absolute,
             top: px(12),
             left: px(12),
-            ..default()
+        }
+        Children [
+            Text::new("*Click some food to eat it*")
+        ]
+    });
+}
+
+// Returns the scene list of food items.
+fn food_items_scene_list(texture_atlas_layout: Handle<TextureAtlasLayout>) -> impl SceneList {
+    let foods = [
+        FoodItem {
+            name: "an apple",
+            cooldown: 2.,
+            index: 2,
         },
-    ));
+        FoodItem {
+            name: "a burger",
+            cooldown: 1.,
+            index: 23,
+        },
+        FoodItem {
+            name: "chocolate",
+            cooldown: 10.,
+            index: 32,
+        },
+        FoodItem {
+            name: "cherries",
+            cooldown: 4.,
+            index: 41,
+        },
+    ];
+
+    foods
+        .into_iter()
+        .map(|food| {
+            build_ability(
+                food,
+                "textures/food_kenney.png".into(),
+                texture_atlas_layout.clone(),
+            )
+        })
+        .collect::<Vec<_>>()
 }
 
 struct FoodItem {
@@ -84,45 +98,57 @@ struct FoodItem {
     index: usize,
 }
 
+// Returns a scene of this food item as a button.
 fn build_ability(
     food: FoodItem,
-    texture: Handle<Image>,
+    texture: String,
     layout: Handle<TextureAtlasLayout>,
-) -> impl Bundle {
+) -> impl Scene {
     let FoodItem {
         name,
         cooldown,
         index,
     } = food;
-    let name = Name::new(name);
 
     // Every food item is a button with a child node.
     // The child node's height will be animated to be at 100% at the beginning
     // of a cooldown, effectively graying out the whole button, and then getting smaller over time.
-    (
+    bsn! {
         Node {
             width: px(80),
             height: px(80),
             flex_direction: FlexDirection::ColumnReverse,
-            ..default()
-        },
-        BackgroundColor(tailwind::SLATE_400.into()),
-        Button,
-        ImageNode::from_atlas_image(texture, TextureAtlas { layout, index }),
-        Cooldown(Timer::from_seconds(cooldown, TimerMode::Once)),
-        name,
-        children![(
+        }
+        BackgroundColor(SLATE_400)
+        Button
+        ImageNode {
+            image: texture,
+            texture_atlas: {Some(texture_atlas_template(layout, index))}
+        }
+        Cooldown(Timer::from_seconds(cooldown, TimerMode::Once))
+        Name::new(name)
+        Children [
             Node {
                 width: percent(100),
                 height: percent(0),
-                ..default()
-            },
-            BackgroundColor(tailwind::SLATE_50.with_alpha(0.5).into()),
-        )],
-    )
+            }
+            BackgroundColor({SLATE_50.with_alpha(0.5)})
+        ]
+    }
 }
 
-#[derive(Component)]
+// Ensure the texture_atlas in the ImageNode can be set correctly.
+fn texture_atlas_template(
+    layout: Handle<TextureAtlasLayout>,
+    index: usize,
+) -> TextureAtlasTemplate {
+    TextureAtlasTemplate {
+        layout: layout.into(),
+        index,
+    }
+}
+
+#[derive(Component, Clone, Default)]
 struct Cooldown(Timer);
 
 #[derive(Component)]

--- a/examples/usage/cooldown.rs
+++ b/examples/usage/cooldown.rs
@@ -123,7 +123,7 @@ fn build_ability(
         Button
         ImageNode {
             image: texture,
-            texture_atlas: {Some(texture_atlas_template(layout, index))}
+            texture_atlas: texture_atlas_template(layout, index),
         }
         Cooldown(Timer::from_seconds(cooldown, TimerMode::Once))
         Name::new(name)


### PR DESCRIPTION
# Objective

- Part of #24112 

## Solution

- Straightforward migration of using `ui_widgets::Button`
- The migration to `bsn!` was mostly painless minus this existing problem: #24889 . I used a small workaround function that @mnmaita mentioned. Preferably we remove the passing of the `Handle<TextureAtlasLayout>` whenever that bug is fixed. I haven’t written a TODO in the example code since it seems weird to do that, but I also felt it was valuable to document how to make an `ImageNode` like that in `bsn!` for now.

## Testing

- `cargo run --example cooldown` should look and function exactly like it did.