### PR TITLE
Manually implement FromTemplate for WindowRef

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -101,14 +101,18 @@ impl FromTemplate for WindowRef {
     type Template = WindowRefTemplate;
 }
 
-#[derive(Default)]
+/// A [`Template`] that produces a [`WindowRef`].
+#[derive(Debug, Default)]
 pub enum WindowRefTemplate {
+    /// See [`WindowRef::Primary`].
     #[default]
     Primary,
+    /// See [`WindowRef::Entity`].
     Entity(EntityTemplate),
 }
 
 impl WindowRefTemplate {
+    /// Default value of the [`WindowRefTemplate::Entity`] variant.
     pub fn default_entity() -> Self {
         Self::Entity(Default::default())
     }

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -5,7 +5,8 @@ use core::num::NonZero;
 
 use bevy_ecs::{
     entity::{ContainsEntity, Entity},
-    prelude::Component,
+    prelude::{BevyError, Component},
+    template::{EntityTemplate, FromTemplate, SpecializeFromTemplate, Template, TemplateContext},
 };
 use bevy_math::{CompassOctant, DVec2, IVec2, UVec2, Vec2};
 use bevy_platform::sync::LazyLock;
@@ -82,6 +83,7 @@ pub enum WindowRef {
     /// then you can use that entity here for usage in cameras.
     Entity(Entity),
 }
+impl Unpin for WindowRef where for<'a> [()]: SpecializeFromTemplate {}
 
 impl WindowRef {
     /// Normalize the window reference so that it can be compared to other window references.
@@ -92,6 +94,41 @@ impl WindowRef {
         };
 
         entity.map(NormalizedWindowRef)
+    }
+}
+
+impl FromTemplate for WindowRef {
+    type Template = WindowRefTemplate;
+}
+
+#[derive(Default)]
+pub enum WindowRefTemplate {
+    #[default]
+    Primary,
+    Entity(EntityTemplate),
+}
+
+impl WindowRefTemplate {
+    pub fn default_entity() -> Self {
+        Self::Entity(Default::default())
+    }
+}
+
+impl Template for WindowRefTemplate {
+    type Output = WindowRef;
+
+    fn build_template(&self, context: &mut TemplateContext) -> Result<Self::Output, BevyError> {
+        Ok(match self {
+            WindowRefTemplate::Primary => WindowRef::Primary,
+            WindowRefTemplate::Entity(entity) => WindowRef::Entity(entity.build_template(context)?),
+        })
+    }
+
+    fn clone_template(&self) -> Self {
+        match self {
+            WindowRefTemplate::Primary => WindowRefTemplate::Primary,
+            WindowRefTemplate::Entity(entity) => WindowRefTemplate::Entity(*entity),
+        }
     }
 }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -118,6 +118,15 @@ impl WindowRefTemplate {
     }
 }
 
+impl From<WindowRef> for WindowRefTemplate {
+    fn from(value: WindowRef) -> Self {
+        match value {
+            WindowRef::Primary => WindowRefTemplate::Primary,
+            WindowRef::Entity(entity) => WindowRefTemplate::Entity(EntityTemplate::Entity(entity)),
+        }
+    }
+}
+
 impl Template for WindowRefTemplate {
     type Output = WindowRef;
 


### PR DESCRIPTION
# Objective

RenderTarget::Window cannot be instantiated within the bsn macro because WindowRef does not implement FromTemplate.

## Solution

Create a custom Template type for WindowRef and manually implement FromTemplate. This requires specializing WindowRef, which may be controversial? I'm not sure.

This PR is for my goal outlined at the end of #25113.