### PR TITLE
Solari support on metal backends

### DIFF
--- a/_release-content/release-notes/solari_metal.md
+++ b/_release-content/release-notes/solari_metal.md
@@ -8,7 +8,7 @@ Ray tracing on Metal has been available since wgpu 29, and with bindless storage
 
 Run the Solari example on a compatible Mac:
 
-```
+```sh
 cargo run --example solari --features bevy_solari,https,free_camera
 ```
 

--- a/_release-content/release-notes/solari_metal.md
+++ b/_release-content/release-notes/solari_metal.md
@@ -1,0 +1,15 @@
+---
+title: Solari on Metal
+authors: ["@mate-h"]
+pull_requests: [25123]
+---
+
+Ray tracing on Metal has been available since wgpu 29, and with bindless storage buffers landing in wgpu 30, Solari now runs on Apple Silicon Macs.
+
+Run the Solari example on a compatible Mac:
+
+```
+cargo run --example solari --features bevy_solari,https,free_camera
+```
+
+Denoising is not available on Metal yet, DLSS is NVIDIA-only. MetalFX Ray Reconstruction or Open Image Denoise 3.0 are promising paths for cross-platform denoising in the future.

--- a/crates/bevy_solari/src/realtime/node.rs
+++ b/crates/bevy_solari/src/realtime/node.rs
@@ -1,4 +1,7 @@
-use super::prepare::{SolariLightingResources, LIGHT_TILE_BLOCKS, WORLD_CACHE_SIZE};
+use super::prepare::{
+    SolariLightingResources, LIGHT_TILE_BLOCKS, WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET,
+    WORLD_CACHE_SIZE,
+};
 use crate::scene::RaytracingSceneBindings;
 #[cfg(all(feature = "dlss", not(feature = "force_disable_dlss")))]
 use bevy_anti_alias::dlss::ViewDlssRayReconstructionTextures;
@@ -179,16 +182,7 @@ pub fn solari_lighting(
             previous_depth_buffer,
             view_uniforms_binding,
             previous_view_uniforms_binding,
-            s.world_cache_checksums.as_entire_binding(),
-            s.world_cache_life.as_entire_binding(),
-            s.world_cache_radiance.as_entire_binding(),
-            s.world_cache_geometry_data.as_entire_binding(),
-            s.world_cache_luminance_deltas.as_entire_binding(),
-            s.world_cache_active_cells_new_radiance.as_entire_binding(),
-            s.world_cache_a.as_entire_binding(),
-            s.world_cache_b.as_entire_binding(),
-            s.world_cache_active_cell_indices.as_entire_binding(),
-            s.world_cache_active_cells_count.as_entire_binding(),
+            s.world_cache.as_entire_binding(),
             s.constants.as_entire_binding(),
         )),
     );
@@ -317,7 +311,9 @@ pub fn solari_lighting(
 
     diagnostics.record_u32(
         ctx.command_encoder(),
-        &s.world_cache_active_cells_count.slice(..),
+        &s.world_cache.slice(
+            WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET..WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET + 4,
+        ),
         "solari_lighting/world_cache_active_cells_count",
     );
 }
@@ -346,15 +342,6 @@ pub fn init_solari_lighting_pipelines(
                 texture_depth_2d(),
                 uniform_buffer::<ViewUniform>(true),
                 uniform_buffer::<PreviousViewData>(true),
-                storage_buffer_sized(false, None),
-                storage_buffer_sized(false, None),
-                storage_buffer_sized(false, None),
-                storage_buffer_sized(false, None),
-                storage_buffer_sized(false, None),
-                storage_buffer_sized(false, None),
-                storage_buffer_sized(false, None),
-                storage_buffer_sized(false, None),
-                storage_buffer_sized(false, None),
                 storage_buffer_sized(false, None),
                 uniform_buffer_sized(false, None),
             ),

--- a/crates/bevy_solari/src/realtime/node.rs
+++ b/crates/bevy_solari/src/realtime/node.rs
@@ -309,7 +309,7 @@ pub fn solari_lighting(
 
     drop(pass);
 
-    // Active cell count readback from the packed world cache buffer.
+    // Active cell count readback.
     diagnostics.record_u32(
         ctx.command_encoder(),
         &s.world_cache.slice(

--- a/crates/bevy_solari/src/realtime/node.rs
+++ b/crates/bevy_solari/src/realtime/node.rs
@@ -309,10 +309,12 @@ pub fn solari_lighting(
 
     drop(pass);
 
+    // Active cell count readback from the packed world cache buffer.
     diagnostics.record_u32(
         ctx.command_encoder(),
         &s.world_cache.slice(
-            WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET..WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET + 4,
+            WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET
+                ..WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET + size_of::<u32>() as u64,
         ),
         "solari_lighting/world_cache_active_cells_count",
     );

--- a/crates/bevy_solari/src/realtime/prepare.rs
+++ b/crates/bevy_solari/src/realtime/prepare.rs
@@ -42,7 +42,47 @@ pub const LIGHT_TILE_BLOCKS: u64 = 128;
 pub const LIGHT_TILE_SAMPLES_PER_BLOCK: u64 = 1024;
 
 /// Amount of entries in the world cache (must be a power of 2, and >= 2^10)
-pub const WORLD_CACHE_SIZE: u64 = 2u64.pow(20);
+pub const WORLD_CACHE_SIZE: u64 = 1 << 20;
+
+/// Layout constants for the packed `WorldCache` buffer.
+///
+/// The `ShaderType` mirror lives in this module and is intentionally private so it cannot be
+/// constructed, because it would be too large.
+mod world_cache_layout {
+    use bevy_math::{Vec3, Vec4};
+    use bevy_render::render_resource::ShaderType;
+
+    const WORLD_CACHE_LEN: usize = super::WORLD_CACHE_SIZE as usize;
+
+    #[derive(ShaderType)]
+    struct GeometryData {
+        world_position: Vec3,
+        padding_a: u32,
+        world_normal: Vec3,
+        padding_b: u32,
+    }
+
+    #[derive(ShaderType)]
+    struct WorldCache {
+        checksums: [u32; WORLD_CACHE_LEN],
+        life: [u32; WORLD_CACHE_LEN],
+        radiance: [Vec4; WORLD_CACHE_LEN],
+        geometry_data: [GeometryData; WORLD_CACHE_LEN],
+        luminance_deltas: [f32; WORLD_CACHE_LEN],
+        active_cells_new_radiance: [Vec3; WORLD_CACHE_LEN],
+        a: [u32; WORLD_CACHE_LEN],
+        b: [u32; 1024],
+        active_cell_indices: [u32; WORLD_CACHE_LEN],
+        active_cells_count: u32,
+    }
+
+    /// `active_cells_count` is field index 9 in `WorldCache`.
+    pub const ACTIVE_CELLS_COUNT_OFFSET: u64 = WorldCache::METADATA.offset(9);
+    pub const BUFFER_SIZE: u64 = WorldCache::METADATA.min_size().get();
+}
+
+pub const WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET: u64 =
+    world_cache_layout::ACTIVE_CELLS_COUNT_OFFSET;
 
 /// GPU representation of the user-configurable [`SolariLighting`] settings, plus
 /// per-frame state.
@@ -93,16 +133,7 @@ pub struct SolariLightingResources {
     pub light_tile_resolved_samples: Buffer,
     pub reservoirs_a: Buffer,
     pub reservoirs_b: Buffer,
-    pub world_cache_checksums: Buffer,
-    pub world_cache_life: Buffer,
-    pub world_cache_radiance: Buffer,
-    pub world_cache_geometry_data: Buffer,
-    pub world_cache_luminance_deltas: Buffer,
-    pub world_cache_active_cells_new_radiance: Buffer,
-    pub world_cache_a: Buffer,
-    pub world_cache_b: Buffer,
-    pub world_cache_active_cell_indices: Buffer,
-    pub world_cache_active_cells_count: Buffer,
+    pub world_cache: Buffer,
     pub world_cache_active_cells_dispatch: Buffer,
     pub view_size: UVec2,
 }
@@ -196,72 +227,9 @@ pub fn prepare_solari_lighting_resources(
         let reservoirs_a = reservoirs_buffer("solari_lighting_reservoirs_a");
         let reservoirs_b = reservoirs_buffer("solari_lighting_reservoirs_b");
 
-        let world_cache_checksums = render_device.create_buffer(&BufferDescriptor {
-            label: Some("solari_lighting_world_cache_checksums"),
-            size: WORLD_CACHE_SIZE * size_of::<u32>() as u64,
-            usage: BufferUsages::STORAGE,
-            mapped_at_creation: false,
-        });
-
-        let world_cache_life = render_device.create_buffer(&BufferDescriptor {
-            label: Some("solari_lighting_world_cache_life"),
-            size: WORLD_CACHE_SIZE * size_of::<u32>() as u64,
-            usage: BufferUsages::STORAGE,
-            mapped_at_creation: false,
-        });
-
-        let world_cache_radiance = render_device.create_buffer(&BufferDescriptor {
-            label: Some("solari_lighting_world_cache_radiance"),
-            size: WORLD_CACHE_SIZE * size_of::<[f32; 4]>() as u64,
-            usage: BufferUsages::STORAGE,
-            mapped_at_creation: false,
-        });
-
-        let world_cache_geometry_data = render_device.create_buffer(&BufferDescriptor {
-            label: Some("solari_lighting_world_cache_geometry_data"),
-            size: WORLD_CACHE_SIZE * size_of::<[f32; 8]>() as u64,
-            usage: BufferUsages::STORAGE,
-            mapped_at_creation: false,
-        });
-
-        let world_cache_luminance_deltas = render_device.create_buffer(&BufferDescriptor {
-            label: Some("solari_lighting_world_cache_luminance_deltas"),
-            size: WORLD_CACHE_SIZE * size_of::<f32>() as u64,
-            usage: BufferUsages::STORAGE,
-            mapped_at_creation: false,
-        });
-
-        let world_cache_active_cells_new_radiance =
-            render_device.create_buffer(&BufferDescriptor {
-                label: Some("solari_lighting_world_cache_active_cells_new_radiance"),
-                size: WORLD_CACHE_SIZE * size_of::<[f32; 4]>() as u64,
-                usage: BufferUsages::STORAGE,
-                mapped_at_creation: false,
-            });
-
-        let world_cache_a = render_device.create_buffer(&BufferDescriptor {
-            label: Some("solari_lighting_world_cache_a"),
-            size: WORLD_CACHE_SIZE * size_of::<u32>() as u64,
-            usage: BufferUsages::STORAGE,
-            mapped_at_creation: false,
-        });
-        let world_cache_b = render_device.create_buffer(&BufferDescriptor {
-            label: Some("solari_lighting_world_cache_b"),
-            size: 1024 * size_of::<u32>() as u64,
-            usage: BufferUsages::STORAGE,
-            mapped_at_creation: false,
-        });
-
-        let world_cache_active_cell_indices = render_device.create_buffer(&BufferDescriptor {
-            label: Some("solari_lighting_world_cache_active_cell_indices"),
-            size: WORLD_CACHE_SIZE * size_of::<u32>() as u64,
-            usage: BufferUsages::STORAGE,
-            mapped_at_creation: false,
-        });
-
-        let world_cache_active_cells_count = render_device.create_buffer(&BufferDescriptor {
-            label: Some("solari_lighting_world_cache_active_cells_count"),
-            size: size_of::<u32>() as u64,
+        let world_cache = render_device.create_buffer(&BufferDescriptor {
+            label: Some("solari_lighting_world_cache"),
+            size: world_cache_layout::BUFFER_SIZE,
             usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
             mapped_at_creation: false,
         });
@@ -279,16 +247,7 @@ pub fn prepare_solari_lighting_resources(
             light_tile_resolved_samples,
             reservoirs_a,
             reservoirs_b,
-            world_cache_checksums,
-            world_cache_life,
-            world_cache_radiance,
-            world_cache_geometry_data,
-            world_cache_luminance_deltas,
-            world_cache_active_cells_new_radiance,
-            world_cache_a,
-            world_cache_b,
-            world_cache_active_cell_indices,
-            world_cache_active_cells_count,
+            world_cache,
             world_cache_active_cells_dispatch,
             view_size,
         });

--- a/crates/bevy_solari/src/realtime/prepare.rs
+++ b/crates/bevy_solari/src/realtime/prepare.rs
@@ -42,7 +42,7 @@ pub const LIGHT_TILE_BLOCKS: u64 = 128;
 pub const LIGHT_TILE_SAMPLES_PER_BLOCK: u64 = 1024;
 
 /// Amount of entries in the world cache (must be a power of 2, and >= 2^10)
-pub const WORLD_CACHE_SIZE: u64 = 1 << 20;
+pub const WORLD_CACHE_SIZE: u64 = 2u64.pow(20);
 
 /// Layout constants for the packed `WorldCache` buffer.
 ///
@@ -71,13 +71,15 @@ mod world_cache_layout {
         luminance_deltas: [f32; WORLD_CACHE_LEN],
         active_cells_new_radiance: [Vec3; WORLD_CACHE_LEN],
         a: [u32; WORLD_CACHE_LEN],
-        b: [u32; 1024],
+        b: [u32; WORLD_CACHE_LEN / 1024],
         active_cell_indices: [u32; WORLD_CACHE_LEN],
         active_cells_count: u32,
     }
 
-    /// `active_cells_count` is field index 9 in `WorldCache`.
-    pub const ACTIVE_CELLS_COUNT_OFFSET: u64 = WorldCache::METADATA.offset(9);
+    // `ShaderType::METADATA` is internal, but we need the field offset and size without
+    // constructing this large layout type.
+    pub const ACTIVE_CELLS_COUNT_OFFSET: u64 = WorldCache::METADATA.last_offset();
+    /// Must stay under wgpu's default `max_storage_buffer_binding_size` (128 MiB or 2^27 bytes).
     pub const BUFFER_SIZE: u64 = WorldCache::METADATA.min_size().get();
 }
 

--- a/crates/bevy_solari/src/realtime/prepare.rs
+++ b/crates/bevy_solari/src/realtime/prepare.rs
@@ -44,23 +44,16 @@ pub const LIGHT_TILE_SAMPLES_PER_BLOCK: u64 = 1024;
 /// Amount of entries in the world cache (must be a power of 2, and >= 2^10)
 pub const WORLD_CACHE_SIZE: u64 = 2u64.pow(20);
 
-/// Bytes contributed by each world-cache cell in the packed SoA buffer, excluding the fixed-size
-/// `b` array that sits between `a` and `active_cell_indices`.
-///
-/// Keep in sync with `WorldCache` in `realtime_bindings.wgsl`:
-/// `checksums` (4) + `life` (4) + `radiance` (16) + `geometry_data` (32) + `luminance_deltas` (4)
-/// + `active_cells_new_radiance` (16; `vec3` array stride) + `a` (4) + `active_cell_indices` (4).
+/// Sum of per-cell field sizes in `WorldCache`. Keep in sync with `realtime_bindings.wgsl`.
 const WORLD_CACHE_ENTRY_SIZE: u64 = 84;
 
-/// Size of the fixed `b` array (`array<u32, WORLD_CACHE_SIZE / 1024>`) in the packed buffer.
+/// Size of the fixed `b` array (`array<u32, WORLD_CACHE_SIZE / 1024>`).
 const WORLD_CACHE_B_SIZE: u64 = (WORLD_CACHE_SIZE / 1024) * size_of::<u32>() as u64;
 
-/// Offset of `active_cells_count` in the packed world cache buffer.
+/// Offset of `active_cells_count`.
 pub const WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET: u64 =
     WORLD_CACHE_SIZE * WORLD_CACHE_ENTRY_SIZE + WORLD_CACHE_B_SIZE;
 
-/// Total size of the packed world cache buffer.
-///
 /// Must stay under wgpu's default `max_storage_buffer_binding_size` (128 MiB or 2^27 bytes).
 pub const WORLD_CACHE_BUFFER_SIZE: u64 =
     WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET + size_of::<u32>() as u64;

--- a/crates/bevy_solari/src/realtime/prepare.rs
+++ b/crates/bevy_solari/src/realtime/prepare.rs
@@ -43,17 +43,13 @@ pub const LIGHT_TILE_SAMPLES_PER_BLOCK: u64 = 1024;
 
 /// Amount of entries in the world cache (must be a power of 2, and >= 2^10)
 pub const WORLD_CACHE_SIZE: u64 = 2u64.pow(20);
-
 /// Sum of per-cell field sizes in `WorldCache`. Keep in sync with `realtime_bindings.wgsl`.
 const WORLD_CACHE_ENTRY_SIZE: u64 = 84;
-
 /// Size of the fixed `b` array (`array<u32, WORLD_CACHE_SIZE / 1024>`).
 const WORLD_CACHE_B_SIZE: u64 = (WORLD_CACHE_SIZE / 1024) * size_of::<u32>() as u64;
-
 /// Offset of `active_cells_count`.
 pub const WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET: u64 =
     WORLD_CACHE_SIZE * WORLD_CACHE_ENTRY_SIZE + WORLD_CACHE_B_SIZE;
-
 /// Must stay under wgpu's default `max_storage_buffer_binding_size` (128 MiB or 2^27 bytes).
 pub const WORLD_CACHE_BUFFER_SIZE: u64 =
     WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET + size_of::<u32>() as u64;

--- a/crates/bevy_solari/src/realtime/prepare.rs
+++ b/crates/bevy_solari/src/realtime/prepare.rs
@@ -44,47 +44,26 @@ pub const LIGHT_TILE_SAMPLES_PER_BLOCK: u64 = 1024;
 /// Amount of entries in the world cache (must be a power of 2, and >= 2^10)
 pub const WORLD_CACHE_SIZE: u64 = 2u64.pow(20);
 
-/// Layout constants for the packed `WorldCache` buffer.
+/// Bytes contributed by each world-cache cell in the packed SoA buffer, excluding the fixed-size
+/// `b` array that sits between `a` and `active_cell_indices`.
 ///
-/// The `ShaderType` mirror lives in this module and is intentionally private so it cannot be
-/// constructed, because it would be too large.
-mod world_cache_layout {
-    use bevy_math::{Vec3, Vec4};
-    use bevy_render::render_resource::ShaderType;
+/// Keep in sync with `WorldCache` in `realtime_bindings.wgsl`:
+/// `checksums` (4) + `life` (4) + `radiance` (16) + `geometry_data` (32) + `luminance_deltas` (4)
+/// + `active_cells_new_radiance` (16; `vec3` array stride) + `a` (4) + `active_cell_indices` (4).
+const WORLD_CACHE_ENTRY_SIZE: u64 = 84;
 
-    const WORLD_CACHE_LEN: usize = super::WORLD_CACHE_SIZE as usize;
+/// Size of the fixed `b` array (`array<u32, WORLD_CACHE_SIZE / 1024>`) in the packed buffer.
+const WORLD_CACHE_B_SIZE: u64 = (WORLD_CACHE_SIZE / 1024) * size_of::<u32>() as u64;
 
-    #[derive(ShaderType)]
-    struct GeometryData {
-        world_position: Vec3,
-        padding_a: u32,
-        world_normal: Vec3,
-        padding_b: u32,
-    }
-
-    #[derive(ShaderType)]
-    struct WorldCache {
-        checksums: [u32; WORLD_CACHE_LEN],
-        life: [u32; WORLD_CACHE_LEN],
-        radiance: [Vec4; WORLD_CACHE_LEN],
-        geometry_data: [GeometryData; WORLD_CACHE_LEN],
-        luminance_deltas: [f32; WORLD_CACHE_LEN],
-        active_cells_new_radiance: [Vec3; WORLD_CACHE_LEN],
-        a: [u32; WORLD_CACHE_LEN],
-        b: [u32; WORLD_CACHE_LEN / 1024],
-        active_cell_indices: [u32; WORLD_CACHE_LEN],
-        active_cells_count: u32,
-    }
-
-    // `ShaderType::METADATA` is internal, but we need the field offset and size without
-    // constructing this large layout type.
-    pub const ACTIVE_CELLS_COUNT_OFFSET: u64 = WorldCache::METADATA.last_offset();
-    /// Must stay under wgpu's default `max_storage_buffer_binding_size` (128 MiB or 2^27 bytes).
-    pub const BUFFER_SIZE: u64 = WorldCache::METADATA.min_size().get();
-}
-
+/// Offset of `active_cells_count` in the packed world cache buffer.
 pub const WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET: u64 =
-    world_cache_layout::ACTIVE_CELLS_COUNT_OFFSET;
+    WORLD_CACHE_SIZE * WORLD_CACHE_ENTRY_SIZE + WORLD_CACHE_B_SIZE;
+
+/// Total size of the packed world cache buffer.
+///
+/// Must stay under wgpu's default `max_storage_buffer_binding_size` (128 MiB or 2^27 bytes).
+pub const WORLD_CACHE_BUFFER_SIZE: u64 =
+    WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET + size_of::<u32>() as u64;
 
 /// GPU representation of the user-configurable [`SolariLighting`] settings, plus
 /// per-frame state.
@@ -231,7 +210,7 @@ pub fn prepare_solari_lighting_resources(
 
         let world_cache = render_device.create_buffer(&BufferDescriptor {
             label: Some("solari_lighting_world_cache"),
-            size: world_cache_layout::BUFFER_SIZE,
+            size: WORLD_CACHE_BUFFER_SIZE,
             usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
             mapped_at_creation: false,
         });

--- a/crates/bevy_solari/src/realtime/prepare.rs
+++ b/crates/bevy_solari/src/realtime/prepare.rs
@@ -52,7 +52,7 @@ pub const WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET: u64 =
     WORLD_CACHE_SIZE * WORLD_CACHE_ENTRY_SIZE + WORLD_CACHE_B_SIZE;
 /// Must stay under wgpu's default `max_storage_buffer_binding_size` (128 MiB or 2^27 bytes).
 pub const WORLD_CACHE_BUFFER_SIZE: u64 =
-    WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET + size_of::<u32>() as u64;
+    (WORLD_CACHE_ACTIVE_CELLS_COUNT_OFFSET + size_of::<u32>() as u64).next_multiple_of(16);
 
 /// GPU representation of the user-configurable [`SolariLighting`] settings, plus
 /// per-frame state.

--- a/crates/bevy_solari/src/realtime/realtime_bindings.wgsl
+++ b/crates/bevy_solari/src/realtime/realtime_bindings.wgsl
@@ -19,21 +19,24 @@ enable wgpu_ray_query;
 @group(1) @binding(10) var<uniform> view: View;
 @group(1) @binding(11) var<uniform> previous_view: PreviousViewUniforms;
 
-@group(1) @binding(12) var<storage, read_write> world_cache_checksums: array<atomic<u32>, #{WORLD_CACHE_SIZE}>;
+struct WorldCache {
+    checksums: array<atomic<u32>, #{WORLD_CACHE_SIZE}>,
 #ifdef WORLD_CACHE_NON_ATOMIC_LIFE_BUFFER
-@group(1) @binding(13) var<storage, read_write> world_cache_life: array<u32, #{WORLD_CACHE_SIZE}>;
+    life: array<u32, #{WORLD_CACHE_SIZE}>,
 #else
-@group(1) @binding(13) var<storage, read_write> world_cache_life: array<atomic<u32>, #{WORLD_CACHE_SIZE}>;
+    life: array<atomic<u32>, #{WORLD_CACHE_SIZE}>,
 #endif
-@group(1) @binding(14) var<storage, read_write> world_cache_radiance: array<vec4<f32>, #{WORLD_CACHE_SIZE}>;
-@group(1) @binding(15) var<storage, read_write> world_cache_geometry_data: array<WorldCacheGeometryData, #{WORLD_CACHE_SIZE}>;
-@group(1) @binding(16) var<storage, read_write> world_cache_luminance_deltas: array<f32, #{WORLD_CACHE_SIZE}>;
-@group(1) @binding(17) var<storage, read_write> world_cache_active_cells_new_radiance: array<vec3<f32>, #{WORLD_CACHE_SIZE}>;
-@group(1) @binding(18) var<storage, read_write> world_cache_a: array<u32, #{WORLD_CACHE_SIZE}>;
-@group(1) @binding(19) var<storage, read_write> world_cache_b: array<u32, 1024u>;
-@group(1) @binding(20) var<storage, read_write> world_cache_active_cell_indices: array<u32, #{WORLD_CACHE_SIZE}>;
-@group(1) @binding(21) var<storage, read_write> world_cache_active_cells_count: u32;
-@group(1) @binding(22) var<uniform> constants: SolariLightingSettings;
+    radiance: array<vec4<f32>, #{WORLD_CACHE_SIZE}>,
+    geometry_data: array<WorldCacheGeometryData, #{WORLD_CACHE_SIZE}>,
+    luminance_deltas: array<f32, #{WORLD_CACHE_SIZE}>,
+    active_cells_new_radiance: array<vec3<f32>, #{WORLD_CACHE_SIZE}>,
+    a: array<u32, #{WORLD_CACHE_SIZE}>,
+    b: array<u32, 1024u>,
+    active_cell_indices: array<u32, #{WORLD_CACHE_SIZE}>,
+    active_cells_count: u32,
+}
+@group(1) @binding(12) var<storage, read_write> world_cache: WorldCache;
+@group(1) @binding(13) var<uniform> constants: SolariLightingSettings;
 
 #ifdef DLSS_RR_GUIDE_BUFFERS
 @group(2) @binding(0) var diffuse_albedo: texture_storage_2d<rgba8unorm, write>;

--- a/crates/bevy_solari/src/realtime/realtime_bindings.wgsl
+++ b/crates/bevy_solari/src/realtime/realtime_bindings.wgsl
@@ -19,6 +19,7 @@ enable wgpu_ray_query;
 @group(1) @binding(10) var<uniform> view: View;
 @group(1) @binding(11) var<uniform> previous_view: PreviousViewUniforms;
 
+// Keep in sync with `world_cache_layout::WorldCache` in `prepare.rs`.
 struct WorldCache {
     checksums: array<atomic<u32>, #{WORLD_CACHE_SIZE}>,
 #ifdef WORLD_CACHE_NON_ATOMIC_LIFE_BUFFER

--- a/crates/bevy_solari/src/realtime/realtime_bindings.wgsl
+++ b/crates/bevy_solari/src/realtime/realtime_bindings.wgsl
@@ -18,24 +18,6 @@ enable wgpu_ray_query;
 @group(1) @binding(9) var previous_depth_buffer: texture_depth_2d;
 @group(1) @binding(10) var<uniform> view: View;
 @group(1) @binding(11) var<uniform> previous_view: PreviousViewUniforms;
-
-// Keep in sync with `world_cache_layout::WorldCache` in `prepare.rs`.
-struct WorldCache {
-    checksums: array<atomic<u32>, #{WORLD_CACHE_SIZE}>,
-#ifdef WORLD_CACHE_NON_ATOMIC_LIFE_BUFFER
-    life: array<u32, #{WORLD_CACHE_SIZE}>,
-#else
-    life: array<atomic<u32>, #{WORLD_CACHE_SIZE}>,
-#endif
-    radiance: array<vec4<f32>, #{WORLD_CACHE_SIZE}>,
-    geometry_data: array<WorldCacheGeometryData, #{WORLD_CACHE_SIZE}>,
-    luminance_deltas: array<f32, #{WORLD_CACHE_SIZE}>,
-    active_cells_new_radiance: array<vec3<f32>, #{WORLD_CACHE_SIZE}>,
-    a: array<u32, #{WORLD_CACHE_SIZE}>,
-    b: array<u32, 1024u>,
-    active_cell_indices: array<u32, #{WORLD_CACHE_SIZE}>,
-    active_cells_count: u32,
-}
 @group(1) @binding(12) var<storage, read_write> world_cache: WorldCache;
 @group(1) @binding(13) var<uniform> constants: SolariLightingSettings;
 
@@ -99,4 +81,22 @@ struct WorldCacheGeometryData {
     padding_a: u32,
     world_normal: vec3<f32>,
     padding_b: u32,
+}
+
+// Keep in sync with the packed world-cache layout constants in `prepare.rs`.
+struct WorldCache {
+    checksums: array<atomic<u32>, #{WORLD_CACHE_SIZE}>,
+#ifdef WORLD_CACHE_NON_ATOMIC_LIFE_BUFFER
+    life: array<u32, #{WORLD_CACHE_SIZE}>,
+#else
+    life: array<atomic<u32>, #{WORLD_CACHE_SIZE}>,
+#endif
+    radiance: array<vec4<f32>, #{WORLD_CACHE_SIZE}>,
+    geometry_data: array<WorldCacheGeometryData, #{WORLD_CACHE_SIZE}>,
+    luminance_deltas: array<f32, #{WORLD_CACHE_SIZE}>,
+    active_cells_new_radiance: array<vec3<f32>, #{WORLD_CACHE_SIZE}>,
+    a: array<u32, #{WORLD_CACHE_SIZE}>,
+    b: array<u32, 1024u>,
+    active_cell_indices: array<u32, #{WORLD_CACHE_SIZE}>,
+    active_cells_count: u32,
 }

--- a/crates/bevy_solari/src/realtime/world_cache_compact.wgsl
+++ b/crates/bevy_solari/src/realtime/world_cache_compact.wgsl
@@ -1,16 +1,7 @@
 enable wgpu_ray_query;
 
 #import bevy_solari::world_cache::WORLD_CACHE_EMPTY_CELL
-#import bevy_solari::realtime_bindings::{
-    world_cache_life,
-    world_cache_checksums,
-    world_cache_radiance,
-    world_cache_luminance_deltas,
-    world_cache_a,
-    world_cache_b,
-    world_cache_active_cell_indices,
-    world_cache_active_cells_count,
-}
+#import bevy_solari::realtime_bindings::world_cache
 
 @group(2) @binding(0) var<storage, read_write> world_cache_active_cells_dispatch: vec3<u32>;
 
@@ -19,15 +10,15 @@ var<workgroup> w2: array<u32, 1024u>;
 
 @compute @workgroup_size(1024, 1, 1)
 fn decay_world_cache(@builtin(global_invocation_id) global_id: vec3<u32>) {
-    var life = world_cache_life[global_id.x];
+    var life = world_cache.life[global_id.x];
     if life > 0u {
         life -= 1u;
-        world_cache_life[global_id.x] = life;
+        world_cache.life[global_id.x] = life;
 
         if life == 0u {
-            world_cache_checksums[global_id.x] = WORLD_CACHE_EMPTY_CELL;
-            world_cache_radiance[global_id.x] = vec4(0.0);
-            world_cache_luminance_deltas[global_id.x] = 0.0;
+            world_cache.checksums[global_id.x] = WORLD_CACHE_EMPTY_CELL;
+            world_cache.radiance[global_id.x] = vec4(0.0);
+            world_cache.luminance_deltas[global_id.x] = 0.0;
         }
     }
 }
@@ -37,7 +28,7 @@ fn compact_world_cache_single_block(
     @builtin(global_invocation_id) cell_id: vec3<u32>,
     @builtin(local_invocation_index) t: u32,
 ) {
-    if t == 0u { w1[0u] = 0u; } else { w1[t] = u32(world_cache_life[cell_id.x - 1u] != 0u); }; workgroupBarrier();
+    if t == 0u { w1[0u] = 0u; } else { w1[t] = u32(world_cache.life[cell_id.x - 1u] != 0u); }; workgroupBarrier();
     if t < 1u { w2[t] = w1[t]; } else { w2[t] = w1[t] + w1[t - 1u]; } workgroupBarrier();
     if t < 2u { w1[t] = w2[t]; } else { w1[t] = w2[t] + w2[t - 2u]; } workgroupBarrier();
     if t < 4u { w2[t] = w1[t]; } else { w2[t] = w1[t] + w1[t - 4u]; } workgroupBarrier();
@@ -47,12 +38,12 @@ fn compact_world_cache_single_block(
     if t < 64u { w2[t] = w1[t]; } else { w2[t] = w1[t] + w1[t - 64u]; } workgroupBarrier();
     if t < 128u { w1[t] = w2[t]; } else { w1[t] = w2[t] + w2[t - 128u]; } workgroupBarrier();
     if t < 256u { w2[t] = w1[t]; } else { w2[t] = w1[t] + w1[t - 256u]; } workgroupBarrier();
-    if t < 512u { world_cache_a[cell_id.x] = w2[t]; } else { world_cache_a[cell_id.x] = w2[t] + w2[t - 512u]; }
+    if t < 512u { world_cache.a[cell_id.x] = w2[t]; } else { world_cache.a[cell_id.x] = w2[t] + w2[t - 512u]; }
 }
 
 @compute @workgroup_size(1024, 1, 1)
 fn compact_world_cache_blocks(@builtin(local_invocation_index) t: u32) {
-    if t == 0u { w1[0u] = 0u; } else { w1[t] = world_cache_a[t * 1024u - 1u]; }; workgroupBarrier();
+    if t == 0u { w1[0u] = 0u; } else { w1[t] = world_cache.a[t * 1024u - 1u]; }; workgroupBarrier();
     if t < 1u { w2[t] = w1[t]; } else { w2[t] = w1[t] + w1[t - 1u]; } workgroupBarrier();
     if t < 2u { w1[t] = w2[t]; } else { w1[t] = w2[t] + w2[t - 2u]; } workgroupBarrier();
     if t < 4u { w2[t] = w1[t]; } else { w2[t] = w1[t] + w1[t - 4u]; } workgroupBarrier();
@@ -62,7 +53,7 @@ fn compact_world_cache_blocks(@builtin(local_invocation_index) t: u32) {
     if t < 64u { w2[t] = w1[t]; } else { w2[t] = w1[t] + w1[t - 64u]; } workgroupBarrier();
     if t < 128u { w1[t] = w2[t]; } else { w1[t] = w2[t] + w2[t - 128u]; } workgroupBarrier();
     if t < 256u { w2[t] = w1[t]; } else { w2[t] = w1[t] + w1[t - 256u]; } workgroupBarrier();
-    if t < 512u { world_cache_b[t] = w2[t]; } else { world_cache_b[t] = w2[t] + w2[t - 512u]; }
+    if t < 512u { world_cache.b[t] = w2[t]; } else { world_cache.b[t] = w2[t] + w2[t - 512u]; }
 }
 
 @compute @workgroup_size(1024, 1, 1)
@@ -71,16 +62,16 @@ fn compact_world_cache_write_active_cells(
     @builtin(workgroup_id) workgroup_id: vec3<u32>,
     @builtin(local_invocation_index) thread_index: u32,
 ) {
-    let compacted_index = world_cache_a[cell_id.x] + world_cache_b[workgroup_id.x];
-    let cell_active = world_cache_life[cell_id.x] != 0u;
+    let compacted_index = world_cache.a[cell_id.x] + world_cache.b[workgroup_id.x];
+    let cell_active = world_cache.life[cell_id.x] != 0u;
 
     if cell_active {
-        world_cache_active_cell_indices[compacted_index] = cell_id.x;
+        world_cache.active_cell_indices[compacted_index] = cell_id.x;
     }
 
     if thread_index == 1023u && workgroup_id.x == 1023u {
         let active_cell_count = compacted_index + u32(cell_active);
-        world_cache_active_cells_count = active_cell_count;
+        world_cache.active_cells_count = active_cell_count;
         world_cache_active_cells_dispatch = vec3((active_cell_count + 63u) / 64u, 1u, 1u);
     }
 }

--- a/crates/bevy_solari/src/realtime/world_cache_query.wgsl
+++ b/crates/bevy_solari/src/realtime/world_cache_query.wgsl
@@ -5,10 +5,7 @@ enable wgpu_ray_query;
 #import bevy_pbr::utils::{rand_f, rand_vec2f}
 #import bevy_render::maths::orthonormalize
 #import bevy_solari::realtime_bindings::{
-    world_cache_life,
-    world_cache_checksums,
-    world_cache_radiance,
-    world_cache_geometry_data,
+    world_cache,
     constants,
 }
 
@@ -40,25 +37,25 @@ fn query_world_cache(world_position_in: vec3<f32>, world_normal: vec3<f32>, view
     let checksum = compute_checksum(world_position_quantized, world_normal_quantized);
 
     for (var i = 0u; i < WORLD_CACHE_MAX_SEARCH_STEPS; i++) {
-        let cas = atomicCompareExchangeWeak(&world_cache_checksums[key], WORLD_CACHE_EMPTY_CELL, checksum);
+        let cas = atomicCompareExchangeWeak(&world_cache.checksums[key], WORLD_CACHE_EMPTY_CELL, checksum);
         let existing_checksum = cas.old_value;
 
         // Cell already exists or is empty - reset lifetime
         if existing_checksum == checksum || existing_checksum == WORLD_CACHE_EMPTY_CELL {
 #ifndef WORLD_CACHE_QUERY_ATOMIC_MAX_LIFETIME
-            atomicStore(&world_cache_life[key], cell_lifetime);
+            atomicStore(&world_cache.life[key], cell_lifetime);
 #else
-            atomicMax(&world_cache_life[key], cell_lifetime);
+            atomicMax(&world_cache.life[key], cell_lifetime);
 #endif
         }
 
         if existing_checksum == checksum {
             // Cache entry already exists - get radiance
-            return world_cache_radiance[key].rgb;
+            return world_cache.radiance[key].rgb;
         } else if existing_checksum == WORLD_CACHE_EMPTY_CELL && cas.exchanged {
             // Cell is empty - initialize it
-            world_cache_geometry_data[key].world_position = world_position;
-            world_cache_geometry_data[key].world_normal = world_normal;
+            world_cache.geometry_data[key].world_position = world_position;
+            world_cache.geometry_data[key].world_normal = world_normal;
             return vec3(0.0);
         } else {
             // Collision - linear probe to next entry

--- a/crates/bevy_solari/src/realtime/world_cache_query.wgsl
+++ b/crates/bevy_solari/src/realtime/world_cache_query.wgsl
@@ -4,10 +4,7 @@ enable wgpu_ray_query;
 
 #import bevy_pbr::utils::{rand_f, rand_vec2f}
 #import bevy_render::maths::orthonormalize
-#import bevy_solari::realtime_bindings::{
-    world_cache,
-    constants,
-}
+#import bevy_solari::realtime_bindings::{world_cache, constants}
 
 /// Maximum amount of frames a cell can live for without being queried
 const WORLD_CACHE_CELL_LIFETIME: u32 = 10u;

--- a/crates/bevy_solari/src/realtime/world_cache_update.wgsl
+++ b/crates/bevy_solari/src/realtime/world_cache_update.wgsl
@@ -10,62 +10,56 @@ enable wgpu_ray_query;
     light_tile_resolved_samples,
     view,
     constants,
-    world_cache_active_cells_count,
-    world_cache_active_cell_indices,
-    world_cache_life,
-    world_cache_geometry_data,
-    world_cache_radiance,
-    world_cache_luminance_deltas,
-    world_cache_active_cells_new_radiance,
+    world_cache,
 }
 
 @compute @workgroup_size(64, 1, 1)
 fn sample_di(@builtin(workgroup_id) workgroup_id: vec3<u32>, @builtin(global_invocation_id) active_cell_id: vec3<u32>) {
-    if active_cell_id.x >= world_cache_active_cells_count { return; }
+    if active_cell_id.x >= world_cache.active_cells_count { return; }
 
-    let cell_index = world_cache_active_cell_indices[active_cell_id.x];
-    let geometry_data = world_cache_geometry_data[cell_index];
+    let cell_index = world_cache.active_cell_indices[active_cell_id.x];
+    let geometry_data = world_cache.geometry_data[cell_index];
     var rng = cell_index + constants.frame_rng;
 
-    if rand_f(&rng) >= f32(constants.world_cache_cell_updates_soft_target) / f32(world_cache_active_cells_count) { return; }
+    if rand_f(&rng) >= f32(constants.world_cache_cell_updates_soft_target) / f32(world_cache.active_cells_count) { return; }
 
     let new_radiance = sample_random_light_ris(geometry_data.world_position, geometry_data.world_normal, workgroup_id.xy, &rng);
 
-    world_cache_active_cells_new_radiance[active_cell_id.x] = new_radiance;
+    world_cache.active_cells_new_radiance[active_cell_id.x] = new_radiance;
 }
 
 @compute @workgroup_size(64, 1, 1)
 fn sample_gi(@builtin(workgroup_id) workgroup_id: vec3<u32>, @builtin(global_invocation_id) active_cell_id: vec3<u32>) {
-    if active_cell_id.x >= world_cache_active_cells_count { return; }
+    if active_cell_id.x >= world_cache.active_cells_count { return; }
 
-    let cell_index = world_cache_active_cell_indices[active_cell_id.x];
-    let geometry_data = world_cache_geometry_data[cell_index];
+    let cell_index = world_cache.active_cell_indices[active_cell_id.x];
+    let geometry_data = world_cache.geometry_data[cell_index];
     var rng = cell_index + constants.frame_rng;
 
-    if rand_f(&rng) >= f32(constants.world_cache_cell_updates_soft_target) / f32(world_cache_active_cells_count) { return; }
+    if rand_f(&rng) >= f32(constants.world_cache_cell_updates_soft_target) / f32(world_cache.active_cells_count) { return; }
 
     let ray_direction = sample_cosine_hemisphere(geometry_data.world_normal, &rng);
     let ray = trace_ray(geometry_data.world_position + (geometry_data.world_normal * RAY_T_MIN), ray_direction, RAY_T_MIN, constants.world_cache_max_gi_ray_distance, RAY_FLAG_NONE);
     if ray.kind != RAY_QUERY_INTERSECTION_NONE {
         let ray_hit = resolve_ray_hit_full(ray);
-        let cell_life = atomicLoad(&world_cache_life[cell_index]);
+        let cell_life = atomicLoad(&world_cache.life[cell_index]);
         let radiance = query_world_cache(ray_hit.world_position, ray_hit.geometric_world_normal, view.world_position, ray.t, cell_life, &rng);
-        world_cache_active_cells_new_radiance[active_cell_id.x] += ray_hit.material.base_color * radiance;
+        world_cache.active_cells_new_radiance[active_cell_id.x] += ray_hit.material.base_color * radiance;
     }
 }
 
 @compute @workgroup_size(64, 1, 1)
 fn blend_new_samples(@builtin(global_invocation_id) active_cell_id: vec3<u32>) {
-    if active_cell_id.x >= world_cache_active_cells_count { return; }
+    if active_cell_id.x >= world_cache.active_cells_count { return; }
 
-    let cell_index = world_cache_active_cell_indices[active_cell_id.x];
+    let cell_index = world_cache.active_cell_indices[active_cell_id.x];
     var rng = cell_index + constants.frame_rng;
 
-    if rand_f(&rng) >= f32(constants.world_cache_cell_updates_soft_target) / f32(world_cache_active_cells_count) { return; }
+    if rand_f(&rng) >= f32(constants.world_cache_cell_updates_soft_target) / f32(world_cache.active_cells_count) { return; }
 
-    let old_radiance = world_cache_radiance[cell_index];
-    let new_radiance = world_cache_active_cells_new_radiance[active_cell_id.x];
-    let luminance_delta = world_cache_luminance_deltas[cell_index];
+    let old_radiance = world_cache.radiance[cell_index];
+    let new_radiance = world_cache.active_cells_new_radiance[active_cell_id.x];
+    let luminance_delta = world_cache.luminance_deltas[cell_index];
 
     // https://bsky.app/profile/gboisse.bsky.social/post/3m5blga3ftk2a
     let sample_count = min(old_radiance.a + 1.0, constants.world_cache_max_temporal_samples);
@@ -79,8 +73,8 @@ fn blend_new_samples(@builtin(global_invocation_id) active_cell_id: vec3<u32>) {
     let blended_radiance = mix(old_radiance.rgb, new_radiance, blend_amount);
     let blended_luminance_delta = select(mix(luminance_delta, luminance(blended_radiance) - luminance(old_radiance.rgb), 1.0 / 8.0), 0.0, bool(constants.reset));
 
-    world_cache_radiance[cell_index] = vec4(blended_radiance, sample_count);
-    world_cache_luminance_deltas[cell_index] = blended_luminance_delta;
+    world_cache.radiance[cell_index] = vec4(blended_radiance, sample_count);
+    world_cache.luminance_deltas[cell_index] = blended_luminance_delta;
 }
 
 fn sample_random_light_ris(world_position: vec3<f32>, world_normal: vec3<f32>, workgroup_id: vec2<u32>, rng: ptr<function, u32>) -> vec3<f32> {


### PR DESCRIPTION
# Objective

[Ray tracing on Metal](https://github.com/gfx-rs/wgpu/pull/8071) has been available since wgpu 29.

I shipped a PR to wgpu for [implementing bindless storage buffers](https://github.com/gfx-rs/wgpu/pull/9081) for metal, which was released with wgpu 30. With the [wgpu 30 PR](https://github.com/bevyengine/bevy/pull/24841) in bevy merged, we are fully ready to add support to Solari on metal backends!

However because there is a limit of 31 buffer slots per shader stage. Running Solari on main on a raytracing compatible Mac results in a crash.

## Solution

I had combine the world cache into a single packed buffer. In theory this should not introduce performance regressions since it’s only reorganizing bindings and doesn’t introduce and copy or other passes. Tried keeping the diff fairly minimal and easy to review.

Getting the buffer layout for the world cache on the CPU with `ShaderType` was tricky. To avoid blowing up memory I put it in a private module so you can't construct it. 

## Testing

- Ran the Solari example on mac

```
cargo run --example solari --features bevy_solari,https,free_camera
```

Currently this PR needs a benchmark against main to ensure there's no perf regression. I could use some help with that! 

---

## Showcase

<img width="2566" height="1514" alt="shot" src="https://github.com/user-attachments/assets/691b9bd3-129f-47e6-8efe-313cbadd6ff5" />

## Known limitations

Tracing spans incorrectly report 0.0ms , tracking in https://github.com/gfx-rs/wgpu/issues/9414

No denoising support yet. Could theoretically use [MetalFX Ray Reconstruction](https://crates.io/crates/objc2-metal-fx) in place of DLSS for cross-platform denoising support in Solari. In the longer term we are also looking at Open Image Denoise 3.0 that promises temporal denoising support.