### PR TITLE
Migrate `box_shadow` to use `FeathersRadio` `FeathersNumberInput` `FeathersButton` and full `bsn!` (Phase 6 Item 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3814,6 +3814,7 @@ wasm = true
 name = "box_shadow"
 path = "examples/ui/styling/box_shadow.rs"
 doc-scrape-examples = true
+required-features = ["bevy_feathers"]
 
 [package.metadata.example.box_shadow]
 name = "Box Shadow"

--- a/examples/3d/clustered_decals.rs
+++ b/examples/3d/clustered_decals.rs
@@ -28,10 +28,10 @@ use ops::{acos, cos, sin};
 #[path = "../helpers/radio.rs"]
 mod radio;
 
-#[path = "../helpers/number_input.rs"]
-mod number_input;
+#[path = "../helpers/number_input_f32.rs"]
+mod number_input_f32;
 
-use number_input::number_input_f32;
+use number_input_f32::number_input_f32;
 
 /// The custom material shader that we use to demonstrate how to use the decal
 /// `tag` field.

--- a/examples/3d/light_textures.rs
+++ b/examples/3d/light_textures.rs
@@ -21,15 +21,15 @@ use bevy::{
     ui_widgets::ValueChange,
 };
 use light_consts::lux::{AMBIENT_DAYLIGHT, CLEAR_SUNRISE};
-use number_input::number_input_f32;
+use number_input_f32::number_input_f32;
 use ops::{acos, cos, sin};
 use radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptionValue};
 
 #[path = "../helpers/radio.rs"]
 mod radio;
 
-#[path = "../helpers/number_input.rs"]
-mod number_input;
+#[path = "../helpers/number_input_f32.rs"]
+mod number_input_f32;
 
 #[path = "../helpers/theme.rs"]
 mod theme;

--- a/examples/helpers/number_input.rs
+++ b/examples/helpers/number_input.rs
@@ -78,3 +78,74 @@ where
         })
     }
 }
+
+/// Creates an i32 number input.
+///
+/// `number_input_identifier` should be a component that will distinguish this
+/// number input from any others if needed.
+///
+/// Examples that use this to create a number input should handle its `ValueChange<i32>` events.
+/// If there is a need to identify the number input that originated the value change,
+/// query which `number_input_identifier` with the `FeathersNumberInput` is
+/// the value change's source entity.
+pub fn number_input_i32<T>(
+    name: &'static str,
+    number_input_identifier: Option<T>,
+    value: i32,
+    precision: NumberInputPrecision,
+    limits: core::ops::Range<i32>,
+) -> Box<dyn Scene>
+where
+    T: Template<Output: Component> + Send + Sync + Unpin + 'static,
+{
+    if let Some(identifier) = number_input_identifier {
+        Box::new(bsn! {
+            Node {
+                align_items: AlignItems::Center,
+                column_gap: px(5),
+            }
+            Children [
+                Node {
+                    align_items: AlignItems::Center,
+                    width: px(150),
+                }
+                Children [
+                    label(name)
+                ],
+
+                Node {
+                    align_items: AlignItems::Center,
+                }
+                template_value(identifier)
+                @FeathersNumberInput
+                template_value(NumberInputValue::I32(value))
+                template_value(precision)
+                HardLimit::i32(limits)
+            ]
+        })
+    } else {
+        Box::new(bsn! {
+            Node {
+                align_items: AlignItems::Center,
+                column_gap: px(5),
+            }
+            Children [
+                Node {
+                    align_items: AlignItems::Center,
+                    width: px(150),
+                }
+                Children [
+                    label(name)
+                ],
+
+                Node {
+                    align_items: AlignItems::Center,
+                }
+                @FeathersNumberInput
+                template_value(NumberInputValue::I32(value))
+                template_value(precision)
+                HardLimit::i32(limits)
+            ]
+        })
+    }
+}

--- a/examples/helpers/number_input_f32.rs
+++ b/examples/helpers/number_input_f32.rs
@@ -1,0 +1,80 @@
+/// Helpers to create a basic f32 number input using `FeathersNumberInput`
+/// Using these helpers requires the `bevy_feathers` feature to be enabled.
+use bevy::{
+    feathers::{
+        controls::{FeathersNumberInput, HardLimit, NumberInputPrecision, NumberInputValue},
+        display::label,
+    },
+    prelude::*,
+};
+
+/// Creates an f32 number input.
+///
+/// `number_input_identifier` should be a component that will distinguish this
+/// number input from any others if needed.
+///
+/// Examples that use this to create a number input should handle its `ValueChange<f32>` events.
+/// If there is a need to identify the number input that originated the value change,
+/// query which `number_input_identifier` with the `FeathersNumberInput` is
+/// the value change's source entity.
+pub fn number_input_f32<T>(
+    name: &'static str,
+    number_input_identifier: Option<T>,
+    value: f32,
+    precision: NumberInputPrecision,
+    limits: core::ops::Range<f32>,
+) -> Box<dyn Scene>
+where
+    T: Template<Output: Component> + Send + Sync + Unpin + 'static,
+{
+    if let Some(identifier) = number_input_identifier {
+        Box::new(bsn! {
+            Node {
+                align_items: AlignItems::Center,
+                column_gap: px(5),
+            }
+            Children [
+                Node {
+                    align_items: AlignItems::Center,
+                    width: px(150),
+                }
+                Children [
+                    label(name)
+                ],
+
+                Node {
+                    align_items: AlignItems::Center,
+                }
+                template_value(identifier)
+                @FeathersNumberInput
+                template_value(NumberInputValue::F32(value))
+                template_value(precision)
+                HardLimit::f32(limits)
+            ]
+        })
+    } else {
+        Box::new(bsn! {
+            Node {
+                align_items: AlignItems::Center,
+                column_gap: px(5),
+            }
+            Children [
+                Node {
+                    align_items: AlignItems::Center,
+                    width: px(150),
+                }
+                Children [
+                    label(name)
+                ],
+
+                Node {
+                    align_items: AlignItems::Center,
+                }
+                @FeathersNumberInput
+                template_value(NumberInputValue::F32(value))
+                template_value(precision)
+                HardLimit::f32(limits)
+            ]
+        })
+    }
+}

--- a/examples/helpers/number_input_i32.rs
+++ b/examples/helpers/number_input_i32.rs
@@ -1,4 +1,4 @@
-/// Helpers to create a basic number input using `FeathersNumberInput`
+/// Helpers to create a basic i32 number input using `FeathersNumberInput`
 /// Using these helpers requires the `bevy_feathers` feature to be enabled.
 use bevy::{
     feathers::{
@@ -7,77 +7,6 @@ use bevy::{
     },
     prelude::*,
 };
-
-/// Creates an f32 number input.
-///
-/// `number_input_identifier` should be a component that will distinguish this
-/// number input from any others if needed.
-///
-/// Examples that use this to create a number input should handle its `ValueChange<f32>` events.
-/// If there is a need to identify the number input that originated the value change,
-/// query which `number_input_identifier` with the `FeathersNumberInput` is
-/// the value change's source entity.
-pub fn number_input_f32<T>(
-    name: &'static str,
-    number_input_identifier: Option<T>,
-    value: f32,
-    precision: NumberInputPrecision,
-    limits: core::ops::Range<f32>,
-) -> Box<dyn Scene>
-where
-    T: Template<Output: Component> + Send + Sync + Unpin + 'static,
-{
-    if let Some(identifier) = number_input_identifier {
-        Box::new(bsn! {
-            Node {
-                align_items: AlignItems::Center,
-                column_gap: px(5),
-            }
-            Children [
-                Node {
-                    align_items: AlignItems::Center,
-                    width: px(150),
-                }
-                Children [
-                    label(name)
-                ],
-
-                Node {
-                    align_items: AlignItems::Center,
-                }
-                template_value(identifier)
-                @FeathersNumberInput
-                template_value(NumberInputValue::F32(value))
-                template_value(precision)
-                HardLimit::f32(limits)
-            ]
-        })
-    } else {
-        Box::new(bsn! {
-            Node {
-                align_items: AlignItems::Center,
-                column_gap: px(5),
-            }
-            Children [
-                Node {
-                    align_items: AlignItems::Center,
-                    width: px(150),
-                }
-                Children [
-                    label(name)
-                ],
-
-                Node {
-                    align_items: AlignItems::Center,
-                }
-                @FeathersNumberInput
-                template_value(NumberInputValue::F32(value))
-                template_value(precision)
-                HardLimit::f32(limits)
-            ]
-        })
-    }
-}
 
 /// Creates an i32 number input.
 ///

--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -1,32 +1,28 @@
 //! This example shows how to create a node with a shadow and adjust its settings interactively.
 
+use crate::number_input::{number_input_f32, number_input_i32};
 use crate::radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptionValue};
 use bevy::{
     color::palettes::css::*,
-    feathers::{dark_theme::create_dark_theme, theme::UiTheme, FeathersPlugins},
+    feathers::{
+        controls::{FeathersNumberInput, NumberInputPrecision, NumberInputValue},
+        dark_theme::create_dark_theme,
+        theme::UiTheme,
+        FeathersPlugins,
+    },
     prelude::*,
-    time::Time,
-    ui_widgets::{radio_self_update, ValueChange},
-    window::RequestRedraw,
+    ui_widgets::{radio_self_update, Button, ValueChange},
 };
+
+#[path = "../../helpers/number_input.rs"]
+mod number_input;
 
 #[path = "../../helpers/radio.rs"]
 mod radio;
 
 const NORMAL_BUTTON: Color = Color::srgb(0.15, 0.15, 0.15);
-const HOVERED_BUTTON: Color = Color::srgb(0.25, 0.25, 0.25);
-const PRESSED_BUTTON: Color = Color::srgb(0.35, 0.75, 0.35);
 
-const SHADOW_DEFAULT_SETTINGS: ShadowSettings = ShadowSettings {
-    x_offset: 20.0,
-    y_offset: 20.0,
-    blur: 10.0,
-    spread: 15.0,
-    count: 1,
-    samples: 6,
-};
-
-/// The current shape displayed on the screen
+/// Shapes that the node displayed on the screen can be.
 #[derive(Component, Clone, Copy, Default, PartialEq)]
 enum Shape {
     #[default]
@@ -70,7 +66,7 @@ impl Shape {
     }
 
     /// Returns the name of the shape as a string.
-    fn name(&self) -> &'static str {
+    fn label(&self) -> &'static str {
         match *self {
             Shape::Square => "Square",
             Shape::RoundedSquare => "Rounded Square",
@@ -81,19 +77,35 @@ impl Shape {
     }
 }
 
-#[derive(Resource, Default)]
+/// Settings that the user can modify within the example.
+#[derive(Resource)]
 struct AppSettings {
     shape: Shape,
-}
-
-#[derive(Resource, Default)]
-struct ShadowSettings {
+    // Refer to `ShadowStyle` for information on x_offset, y_offset,
+    // blur (radius), and spread (radius)
     x_offset: f32,
     y_offset: f32,
     blur: f32,
     spread: f32,
+    /// The number of `BoxShadow`s created
     count: usize,
+    /// The number of samples used in `BoxShadowSamples`
     samples: u32,
+}
+
+/// The example initializes with these default settings.
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            shape: Shape::default(),
+            x_offset: 20.0,
+            y_offset: 20.0,
+            blur: 10.0,
+            spread: 15.0,
+            count: 1,
+            samples: 6,
+        }
+    }
 }
 
 #[derive(Component)]
@@ -102,52 +114,43 @@ struct ShadowNode;
 #[derive(Component, PartialEq, Clone, Copy, Default)]
 enum SettingsButton {
     #[default]
-    XOffsetInc,
-    XOffsetDec,
-    YOffsetInc,
-    YOffsetDec,
-    BlurInc,
-    BlurDec,
-    SpreadInc,
-    SpreadDec,
-    CountInc,
-    CountDec,
     Reset,
-    SamplesInc,
-    SamplesDec,
 }
 
 #[derive(Component, Clone, Copy, Default, PartialEq, Eq, Debug)]
-enum SettingType {
+enum AppNumberInputF32 {
     #[default]
     XOffset,
     YOffset,
     Blur,
     Spread,
+}
+
+#[derive(Component, Clone, Copy, Default, PartialEq, Eq, Debug)]
+enum AppNumberInputI32 {
+    #[default]
     Count,
-    Shape,
     Samples,
 }
 
-impl SettingType {
+impl AppNumberInputF32 {
     fn label(&self) -> &str {
         match self {
-            SettingType::XOffset => "X Offset",
-            SettingType::YOffset => "Y Offset",
-            SettingType::Blur => "Blur",
-            SettingType::Spread => "Spread",
-            SettingType::Count => "Count",
-            SettingType::Shape => "Shape",
-            SettingType::Samples => "Samples",
+            AppNumberInputF32::XOffset => "X Offset",
+            AppNumberInputF32::YOffset => "Y Offset",
+            AppNumberInputF32::Blur => "Blur",
+            AppNumberInputF32::Spread => "Spread",
         }
     }
 }
 
-#[derive(Resource, Default)]
-struct HeldButton {
-    button: Option<SettingsButton>,
-    pressed_at: Option<f64>,
-    last_repeat: Option<f64>,
+impl AppNumberInputI32 {
+    fn label(&self) -> &str {
+        match self {
+            AppNumberInputI32::Count => "Count (1-3)",
+            AppNumberInputI32::Samples => "Samples (0-15)",
+        }
+    }
 }
 
 fn main() {
@@ -155,27 +158,17 @@ fn main() {
         .add_plugins((DefaultPlugins, FeathersPlugins))
         .insert_resource(UiTheme(create_dark_theme()))
         .init_resource::<AppSettings>()
-        .insert_resource(SHADOW_DEFAULT_SETTINGS)
-        .insert_resource(HeldButton::default())
         .add_systems(Startup, setup)
-        .add_systems(
-            Update,
-            (
-                button_system,
-                button_color_system,
-                update_shadow.run_if(resource_changed::<ShadowSettings>),
-                update_shadow_samples.run_if(resource_changed::<ShadowSettings>),
-                button_repeat_system,
-            ),
-        )
+        .add_observer(on_value_change_i32_update_shadow)
+        .add_observer(on_value_change_f32_update_shadow)
         .add_observer(on_value_change_update_shape)
         .add_observer(radio_self_update)
         .run();
 }
 
 // --- UI Setup ---
-fn setup(mut commands: Commands, shadow: Res<ShadowSettings>, app_settings: Res<AppSettings>) {
-    commands.spawn((Camera2d, BoxShadowSamples(shadow.samples)));
+fn setup(mut commands: Commands, app_settings: Res<AppSettings>) {
+    commands.spawn((Camera2d, BoxShadowSamples(app_settings.samples)));
     // Spawn shape node
     commands
         .spawn((
@@ -206,10 +199,10 @@ fn setup(mut commands: Commands, shadow: Res<ShadowSettings>, app_settings: Res<
                 BackgroundColor(Color::srgb(0.21, 0.21, 0.21)),
                 BoxShadow(vec![ShadowStyle {
                     color: Color::BLACK.with_alpha(0.8),
-                    x_offset: px(shadow.x_offset),
-                    y_offset: px(shadow.y_offset),
-                    spread_radius: px(shadow.spread),
-                    blur_radius: px(shadow.blur),
+                    x_offset: px(app_settings.x_offset),
+                    y_offset: px(app_settings.y_offset),
+                    spread_radius: px(app_settings.spread),
+                    blur_radius: px(app_settings.blur),
                 }]),
                 ShadowNode,
             )
@@ -223,49 +216,54 @@ fn setup(mut commands: Commands, shadow: Res<ShadowSettings>, app_settings: Res<
             feathers_option_buttons(
                 "Shape",
                 &[
-                    (Shape::Square, Shape::Square.name()),
-                    (Shape::RoundedSquare, Shape::RoundedSquare.name()),
-                    (Shape::Circle, Shape::Circle.name()),
-                    (Shape::LongRectangle, Shape::LongRectangle.name()),
-                    (Shape::TallRectangle, Shape::TallRectangle.name()),
+                    (Shape::Square, Shape::Square.label()),
+                    (Shape::RoundedSquare, Shape::RoundedSquare.label()),
+                    (Shape::Circle, Shape::Circle.label()),
+                    (Shape::LongRectangle, Shape::LongRectangle.label()),
+                    (Shape::TallRectangle, Shape::TallRectangle.label()),
                 ],
             ),
-            build_setting_row(
-                SettingType::XOffset,
-                SettingsButton::XOffsetDec,
-                SettingsButton::XOffsetInc,
-                shadow.x_offset,
+            number_input_f32(
+                AppNumberInputF32::XOffset.label(),
+                Some(AppNumberInputF32::XOffset),
+                app_settings.x_offset,
+                NumberInputPrecision(0),
+                0. ..200.
             ),
-            build_setting_row(
-                SettingType::YOffset,
-                SettingsButton::YOffsetDec,
-                SettingsButton::YOffsetInc,
-                shadow.y_offset,
+            number_input_f32(
+                AppNumberInputF32::YOffset.label(),
+                Some(AppNumberInputF32::YOffset),
+                app_settings.y_offset,
+                NumberInputPrecision(0),
+                0. ..200.
             ),
-            build_setting_row(
-                SettingType::Blur,
-                SettingsButton::BlurDec,
-                SettingsButton::BlurInc,
-                shadow.blur,
+            number_input_f32(
+                AppNumberInputF32::Blur.label(),
+                Some(AppNumberInputF32::Blur),
+                app_settings.blur,
+                NumberInputPrecision(0),
+                0. ..100.
             ),
-            build_setting_row(
-                SettingType::Spread,
-                SettingsButton::SpreadDec,
-                SettingsButton::SpreadInc,
-                shadow.spread,
+            number_input_f32(
+                AppNumberInputF32::Spread.label(),
+                Some(AppNumberInputF32::Spread),
+                app_settings.spread,
+                NumberInputPrecision(0),
+                0. ..100.
             ),
-            build_setting_row(
-                SettingType::Count,
-                SettingsButton::CountDec,
-                SettingsButton::CountInc,
-                shadow.count as f32,
+            number_input_i32(
+                AppNumberInputI32::Count.label(),
+                Some(AppNumberInputI32::Count),
+                app_settings.count as i32,
+                NumberInputPrecision(0),
+                1..3
             ),
-            // Add BoxShadowSamples as a setting row
-            build_setting_row(
-                SettingType::Samples,
-                SettingsButton::SamplesDec,
-                SettingsButton::SamplesInc,
-                shadow.samples as f32,
+            number_input_i32(
+                AppNumberInputI32::Samples.label(),
+                Some(AppNumberInputI32::Samples),
+                app_settings.samples as i32,
+                NumberInputPrecision(0),
+                0..15
             ),
             // Reset button
             Node {
@@ -293,164 +291,135 @@ fn setup(mut commands: Commands, shadow: Res<ShadowSettings>, app_settings: Res<
     });
 }
 
-// --- UI Helper Functions ---
-
-// Helper to return an input to the children! macro for a setting row
-fn build_setting_row(
-    setting_type: SettingType,
-    dec: SettingsButton,
-    inc: SettingsButton,
-    value: f32,
-) -> impl Scene {
-    let value_text = match setting_type {
-        SettingType::Shape => "TODO To Remove".to_string(),
-        SettingType::Count => format!("{}", value as usize),
-        _ => format!("{value:.1}"),
-    };
-
-    bsn! {
-        Node {
-            flex_direction: FlexDirection::Row,
-            align_items: AlignItems::Center,
-            height: px(32),
-        }
-        Children [
-            Node {
-                width: px(80),
-                justify_content: JustifyContent::FlexEnd,
-                align_items: AlignItems::Center,
-            }
-            // Attach SettingType to the value label node, not the parent row
-            Children [
-                Text::new(setting_type.label())
-            ],
-
-
-            Button
-            Node {
-                width: px(28),
-                height: px(28),
-                margin: UiRect::left(px(8)),
-                justify_content: JustifyContent::Center,
-                align_items: AlignItems::Center,
-                border_radius: BorderRadius::all(px(6)),
-            }
-            BackgroundColor(Color::WHITE)
-            template_value(dec)
-            Children [
-                Text::new("-")
-            ],
-
-            Node {
-                width: px(48),
-                height: px(28),
-                margin: UiRect::horizontal(px(8)),
-                justify_content: JustifyContent::Center,
-                align_items: AlignItems::Center,
-                border_radius: BorderRadius::all(px(6)),
-            }
-            Children [
-                Text::new(value_text)
-                template_value(setting_type)
-            ],
-            Button
-            Node {
-                width: px(28),
-                height: px(28),
-                justify_content: JustifyContent::Center,
-                align_items: AlignItems::Center,
-                border_radius: BorderRadius::all(px(6)),
-            }
-            BackgroundColor(Color::WHITE)
-            template_value(inc)
-            Children [
-                Text::new("+")
-            ],
-        ]
-    }
-}
-
 // --- SYSTEMS ---
 
-// Update the shadow node's BoxShadow on resource changes
-fn update_shadow(
-    shadow: Res<ShadowSettings>,
-    mut query: Query<&mut BoxShadow, With<ShadowNode>>,
-    mut label_query: Query<(&mut Text, &SettingType)>,
+/// Update the shadow node's `BoxShadow` or the camera's `BoxShadowSamples` on any change to the i32 number inputs.
+fn on_value_change_i32_update_shadow(
+    value_change: On<ValueChange<i32>>,
+    number_input_q: Query<&AppNumberInputI32, With<FeathersNumberInput>>,
+    mut commands: Commands,
+    mut app_settings: ResMut<AppSettings>,
+    mut box_shadow_q: Query<&mut BoxShadow, With<ShadowNode>>,
+    mut samples_q: Query<&mut BoxShadowSamples, With<Camera2d>>,
 ) {
-    for mut box_shadow in &mut query {
-        *box_shadow = BoxShadow(generate_shadows(&shadow));
+    if let Ok(app_number_input_i32) = number_input_q.get(value_change.source) {
+        match app_number_input_i32 {
+            AppNumberInputI32::Count => {
+                app_settings.count = value_change.value as usize;
+                for mut box_shadow in &mut box_shadow_q {
+                    *box_shadow = BoxShadow(generate_shadows(&app_settings));
+                }
+            }
+            AppNumberInputI32::Samples => {
+                app_settings.samples = value_change.value as u32;
+                for mut samples in &mut samples_q {
+                    samples.0 = app_settings.samples;
+                }
+            }
+        }
     }
-    // Update value labels for shadow settings
-    for (mut text, setting) in &mut label_query {
-        let value = match setting {
-            SettingType::XOffset => format!("{:.1}", shadow.x_offset),
-            SettingType::YOffset => format!("{:.1}", shadow.y_offset),
-            SettingType::Blur => format!("{:.1}", shadow.blur),
-            SettingType::Spread => format!("{:.1}", shadow.spread),
-            SettingType::Count => format!("{}", shadow.count),
-            SettingType::Shape => continue,
-            SettingType::Samples => format!("{}", shadow.samples),
-        };
-        *text = Text::new(value);
+
+    commands
+        .entity(value_change.source)
+        .insert(NumberInputValue::I32(value_change.value));
+}
+
+// Update the shadow node's `BoxShadow` on any change to the f32 number inputs.
+fn on_value_change_f32_update_shadow(
+    value_change: On<ValueChange<f32>>,
+    number_input_q: Query<&AppNumberInputF32, With<FeathersNumberInput>>,
+    mut commands: Commands,
+    mut app_settings: ResMut<AppSettings>,
+    mut box_shadow_q: Query<&mut BoxShadow, With<ShadowNode>>,
+) {
+    if let Ok(app_number_input_i32) = number_input_q.get(value_change.source) {
+        match app_number_input_i32 {
+            AppNumberInputF32::XOffset => {
+                app_settings.x_offset = value_change.value;
+            }
+            AppNumberInputF32::YOffset => {
+                app_settings.y_offset = value_change.value;
+            }
+            AppNumberInputF32::Blur => {
+                app_settings.blur = value_change.value;
+            }
+            AppNumberInputF32::Spread => {
+                app_settings.spread = value_change.value;
+            }
+        }
+        for mut box_shadow in &mut box_shadow_q {
+            *box_shadow = BoxShadow(generate_shadows(&app_settings));
+        }
+    }
+
+    commands
+        .entity(value_change.source)
+        .insert(NumberInputValue::F32(value_change.value));
+}
+
+// Update shape of `ShadowNode` if shape selection has changed
+fn on_value_change_update_shape(
+    event: On<ValueChange<Entity>>,
+    new_value_query: Query<&RadioButtonOptionValue<Shape>>,
+    mut app_settings: ResMut<AppSettings>,
+    mut query: Query<&mut Node, With<ShadowNode>>,
+) {
+    let Ok(RadioButtonOptionValue(shape)) = new_value_query.get(event.value) else {
+        return;
+    };
+    app_settings.shape = *shape;
+
+    for mut node in &mut query {
+        app_settings.shape.change_node(&mut node);
     }
 }
 
-fn update_shadow_samples(
-    shadow: Res<ShadowSettings>,
-    mut query: Query<&mut BoxShadowSamples, With<Camera2d>>,
-) {
-    for mut samples in &mut query {
-        samples.0 = shadow.samples;
-    }
-}
-
-fn generate_shadows(shadow: &ShadowSettings) -> Vec<ShadowStyle> {
-    match shadow.count {
+fn generate_shadows(app_settings: &AppSettings) -> Vec<ShadowStyle> {
+    match app_settings.count {
         1 => vec![make_shadow(
             BLACK.into(),
-            shadow.x_offset,
-            shadow.y_offset,
-            shadow.spread,
-            shadow.blur,
+            app_settings.x_offset,
+            app_settings.y_offset,
+            app_settings.spread,
+            app_settings.blur,
         )],
         2 => vec![
             make_shadow(
                 BLUE.into(),
-                shadow.x_offset,
-                shadow.y_offset,
-                shadow.spread,
-                shadow.blur,
+                app_settings.x_offset,
+                app_settings.y_offset,
+                app_settings.spread,
+                app_settings.blur,
             ),
             make_shadow(
                 YELLOW.into(),
-                -shadow.x_offset,
-                -shadow.y_offset,
-                shadow.spread,
-                shadow.blur,
+                -app_settings.x_offset,
+                -app_settings.y_offset,
+                app_settings.spread,
+                app_settings.blur,
             ),
         ],
         3 => vec![
             make_shadow(
                 BLUE.into(),
-                shadow.x_offset,
-                shadow.y_offset,
-                shadow.spread,
-                shadow.blur,
+                app_settings.x_offset,
+                app_settings.y_offset,
+                app_settings.spread,
+                app_settings.blur,
             ),
             make_shadow(
                 YELLOW.into(),
-                -shadow.x_offset,
-                -shadow.y_offset,
-                shadow.spread,
-                shadow.blur,
+                -app_settings.x_offset,
+                -app_settings.y_offset,
+                app_settings.spread,
+                app_settings.blur,
             ),
             make_shadow(
                 RED.into(),
-                shadow.y_offset,
-                -shadow.x_offset,
-                shadow.spread,
-                shadow.blur,
+                app_settings.y_offset,
+                -app_settings.x_offset,
+                app_settings.spread,
+                app_settings.blur,
             ),
         ],
         _ => vec![],
@@ -464,145 +433,5 @@ fn make_shadow(color: Color, x_offset: f32, y_offset: f32, spread: f32, blur: f3
         y_offset: px(y_offset),
         spread_radius: px(spread),
         blur_radius: px(blur),
-    }
-}
-
-// Update shape of ShadowNode if shape selection changed
-fn on_value_change_update_shape(
-    event: On<ValueChange<Entity>>,
-    new_value_query: Query<&RadioButtonOptionValue<Shape>>,
-    mut app_settings: ResMut<AppSettings>,
-    query: Query<&mut Node, With<ShadowNode>>,
-    label_query: Query<(&mut Text, &SettingType)>,
-) {
-    let Ok(RadioButtonOptionValue(shape)) = new_value_query.get(event.value) else {
-        return;
-    };
-    app_settings.shape = *shape;
-
-    update_shape(&app_settings, query, label_query);
-}
-
-fn update_shape(
-    app_settings: &AppSettings,
-    mut query: Query<&mut Node, With<ShadowNode>>,
-    mut label_query: Query<(&mut Text, &SettingType)>,
-) {
-    for mut node in &mut query {
-        app_settings.shape.change_node(&mut node);
-    }
-    for (mut text, kind) in &mut label_query {
-        if *kind == SettingType::Shape {
-            *text = Text::new(app_settings.shape.name());
-        }
-    }
-}
-
-// Handles button interactions for all settings
-fn button_system(
-    mut interaction_query: Query<
-        (&Interaction, &SettingsButton),
-        (Changed<Interaction>, With<Button>),
-    >,
-    mut shadow: ResMut<ShadowSettings>,
-    mut app_settings: ResMut<AppSettings>,
-    mut held: ResMut<HeldButton>,
-    time: Res<Time>,
-) {
-    let now = time.elapsed_secs_f64();
-    for (interaction, btn) in &mut interaction_query {
-        match *interaction {
-            Interaction::Pressed => {
-                trigger_button_action(btn, &mut shadow, &mut app_settings);
-                held.button = Some(*btn);
-                held.pressed_at = Some(now);
-                held.last_repeat = Some(now);
-            }
-            Interaction::None | Interaction::Hovered => {
-                if held.button == Some(*btn) {
-                    held.button = None;
-                    held.pressed_at = None;
-                    held.last_repeat = None;
-                }
-            }
-        }
-    }
-}
-
-fn trigger_button_action(
-    btn: &SettingsButton,
-    shadow: &mut ShadowSettings,
-    app_settings: &mut AppSettings,
-) {
-    match btn {
-        SettingsButton::XOffsetInc => shadow.x_offset += 1.0,
-        SettingsButton::XOffsetDec => shadow.x_offset -= 1.0,
-        SettingsButton::YOffsetInc => shadow.y_offset += 1.0,
-        SettingsButton::YOffsetDec => shadow.y_offset -= 1.0,
-        SettingsButton::BlurInc => shadow.blur = (shadow.blur + 1.0).max(0.0),
-        SettingsButton::BlurDec => shadow.blur = (shadow.blur - 1.0).max(0.0),
-        SettingsButton::SpreadInc => shadow.spread += 1.0,
-        SettingsButton::SpreadDec => shadow.spread -= 1.0,
-        SettingsButton::CountInc => {
-            if shadow.count < 3 {
-                shadow.count += 1;
-            }
-        }
-        SettingsButton::CountDec => {
-            if shadow.count > 1 {
-                shadow.count -= 1;
-            }
-        }
-        SettingsButton::Reset => {
-            *app_settings = AppSettings::default();
-            *shadow = SHADOW_DEFAULT_SETTINGS;
-        }
-        SettingsButton::SamplesInc => shadow.samples += 1,
-        SettingsButton::SamplesDec => {
-            if shadow.samples > 1 {
-                shadow.samples -= 1;
-            }
-        }
-    }
-}
-
-// System to repeat button action while held
-fn button_repeat_system(
-    time: Res<Time>,
-    mut held: ResMut<HeldButton>,
-    mut shadow: ResMut<ShadowSettings>,
-    mut app_settings: ResMut<AppSettings>,
-    mut request_redraw_writer: MessageWriter<RequestRedraw>,
-) {
-    if held.button.is_some() {
-        request_redraw_writer.write(RequestRedraw);
-    }
-    const INITIAL_DELAY: f64 = 0.15;
-    const REPEAT_RATE: f64 = 0.08;
-    if let (Some(btn), Some(pressed_at)) = (held.button, held.pressed_at) {
-        let now = time.elapsed_secs_f64();
-        let since_pressed = now - pressed_at;
-        let last_repeat = held.last_repeat.unwrap_or(pressed_at);
-        let since_last = now - last_repeat;
-        if since_pressed > INITIAL_DELAY && since_last > REPEAT_RATE {
-            trigger_button_action(&btn, &mut shadow, &mut app_settings);
-            held.last_repeat = Some(now);
-        }
-    }
-}
-
-// Changes color of button on hover and on pressed
-fn button_color_system(
-    mut query: Query<
-        (&Interaction, &mut BackgroundColor),
-        (Changed<Interaction>, With<Button>, With<SettingsButton>),
-    >,
-) {
-    for (interaction, mut color) in &mut query {
-        match *interaction {
-            Interaction::Pressed => *color = PRESSED_BUTTON.into(),
-            Interaction::Hovered => *color = HOVERED_BUTTON.into(),
-            Interaction::None => *color = NORMAL_BUTTON.into(),
-        }
     }
 }

--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -1,7 +1,7 @@
 //! This example shows how to create a node with a shadow and adjust its settings interactively.
 
 use crate::number_input::{number_input_f32, number_input_i32};
-use crate::radio::{feathers_option_buttons, RadioButtonOptionValue};
+use crate::radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptionValue};
 use bevy::{
     color::palettes::css::*,
     feathers::{
@@ -9,7 +9,8 @@ use bevy::{
         controls::{FeathersButton, FeathersNumberInput, NumberInputPrecision, NumberInputValue},
         dark_theme::create_dark_theme,
         display::caption,
-        theme::UiTheme,
+        theme::{ThemeProps, UiTheme},
+        tokens::PANE_BODY_BG,
         FeathersPlugins,
     },
     prelude::*,
@@ -161,7 +162,7 @@ impl AppNumberInputI32 {
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, FeathersPlugins))
-        .insert_resource(UiTheme(create_dark_theme()))
+        .insert_resource(UiTheme(get_example_theme()))
         .init_resource::<AppSettings>()
         .add_systems(Startup, setup)
         .add_observer(on_value_change_i32_update_shadow)
@@ -220,7 +221,7 @@ fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
     let selected_shape_index = SHAPE_OPTIONS
         .iter()
         .enumerate()
-        .find(|(index, (shape, _))| *shape == app_settings.shape)
+        .find(|(_, (shape, _))| *shape == app_settings.shape)
         // default is set to the length of the array, which will be interpreted as "no option is set"
         .map_or(SHAPE_OPTIONS.len(), |(index, _)| index);
 
@@ -228,11 +229,7 @@ fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
         SettingsPanel
         ZIndex(10)
         pane()
-        Node {
-            position_type: PositionType::Absolute,
-            left: px(0),
-            bottom: px(0),
-        }
+        main_ui_node_scene()
         Children [
             pane_body()
             Children [
@@ -291,6 +288,15 @@ fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
             ]
         ]
     }
+}
+
+fn get_example_theme() -> ThemeProps {
+    let mut props = create_dark_theme();
+    // Pane background color is made a little transparent to see the objects behind the setting controls.
+    if let Some(color) = props.color.get_mut(&PANE_BODY_BG) {
+        color.set_alpha(0.9);
+    }
+    props
 }
 
 // --- SYSTEMS ---

--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -108,7 +108,7 @@ impl Default for AppSettings {
     }
 }
 
-#[derive(Component)]
+#[derive(Component, Clone, Default)]
 struct ShadowNode;
 
 #[derive(Component, PartialEq, Clone, Copy, Default)]
@@ -147,8 +147,8 @@ impl AppNumberInputF32 {
 impl AppNumberInputI32 {
     fn label(&self) -> &str {
         match self {
-            AppNumberInputI32::Count => "Count (1-3)",
-            AppNumberInputI32::Samples => "Samples (0-15)",
+            AppNumberInputI32::Count => "Count (1 - 3)",
+            AppNumberInputI32::Samples => "Samples (0 - 15)",
         }
     }
 }
@@ -168,60 +168,65 @@ fn main() {
 
 // --- UI Setup ---
 fn setup(mut commands: Commands, app_settings: Res<AppSettings>) {
-    commands.spawn((Camera2d, BoxShadowSamples(app_settings.samples)));
-    // Spawn shape node
-    commands
-        .spawn((
-            Node {
-                width: percent(100),
-                height: percent(100),
-                align_items: AlignItems::Center,
-                justify_content: JustifyContent::Center,
-                ..default()
-            },
-            BackgroundColor(GRAY.into()),
-        ))
-        .insert(children![{
-            let mut node = Node {
-                width: px(164),
-                height: px(164),
-                border: UiRect::all(px(1)),
-                align_items: AlignItems::Center,
-                justify_content: JustifyContent::Center,
-                border_radius: BorderRadius::ZERO,
-                ..default()
-            };
-            app_settings.shape.change_node(&mut node);
+    // create shape node
+    let mut node = Node {
+        width: px(164),
+        height: px(164),
+        border: UiRect::all(px(1)),
+        align_items: AlignItems::Center,
+        justify_content: JustifyContent::Center,
+        border_radius: BorderRadius::ZERO,
+        ..default()
+    };
+    app_settings.shape.change_node(&mut node);
 
-            (
-                node,
-                BorderColor::all(WHITE),
-                BackgroundColor(Color::srgb(0.21, 0.21, 0.21)),
-                BoxShadow(vec![ShadowStyle {
-                    color: Color::BLACK.with_alpha(0.8),
-                    x_offset: px(app_settings.x_offset),
-                    y_offset: px(app_settings.y_offset),
-                    spread_radius: px(app_settings.spread),
-                    blur_radius: px(app_settings.blur),
-                }]),
-                ShadowNode,
-            )
-        }]);
+    let shape_options = [
+        (Shape::Square, Shape::Square.label()),
+        (Shape::RoundedSquare, Shape::RoundedSquare.label()),
+        (Shape::Circle, Shape::Circle.label()),
+        (Shape::LongRectangle, Shape::LongRectangle.label()),
+        (Shape::TallRectangle, Shape::TallRectangle.label()),
+    ];
 
-    // Settings Panel
-    commands.spawn_scene(bsn! {
+    commands.spawn_scene_list(bsn_list! {
+        // Camera
+        Camera2d
+        BoxShadowSamples({app_settings.samples}),
+
+        // Centered shape with shadow
+        Node {
+            width: percent(100),
+            height: percent(100),
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+        }
+        BackgroundColor(GRAY)
+        Children [
+            template_value(node)
+            BorderColor::all(WHITE)
+            BackgroundColor(Color::srgb(0.21, 0.21, 0.21))
+            BoxShadow(vec![ShadowStyle {
+                color: Color::BLACK.with_alpha(0.8),
+                x_offset: px(app_settings.x_offset),
+                y_offset: px(app_settings.y_offset),
+                spread_radius: px(app_settings.spread),
+                blur_radius: px(app_settings.blur),
+            }])
+            ShadowNode
+        ],
+
+        settings_panel_scene(&app_settings, &shape_options),
+    });
+}
+
+fn settings_panel_scene(app_settings: &AppSettings, shape_options: &[(Shape, &str)]) -> impl Scene {
+    bsn! {
         main_ui_node_scene()
         ZIndex(10)
         Children [
             feathers_option_buttons(
                 "Shape",
-                &[
-                    (Shape::Square, Shape::Square.label()),
-                    (Shape::RoundedSquare, Shape::RoundedSquare.label()),
-                    (Shape::Circle, Shape::Circle.label()),
-                    (Shape::LongRectangle, Shape::LongRectangle.label()),
-                    (Shape::TallRectangle, Shape::TallRectangle.label()),
-                ],
+                &shape_options,
             ),
             number_input_f32(
                 AppNumberInputF32::XOffset.label(),
@@ -288,7 +293,7 @@ fn setup(mut commands: Commands, app_settings: Res<AppSettings>) {
                 ],
             ],
         ]
-    });
+    }
 }
 
 // --- SYSTEMS ---

--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -230,14 +230,14 @@ fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
                 Some(AppNumberInputF32::XOffset),
                 app_settings.x_offset,
                 NumberInputPrecision(0),
-                0. ..200.
+                -200. ..200.
             ),
             number_input_f32(
                 AppNumberInputF32::YOffset.label(),
                 Some(AppNumberInputF32::YOffset),
                 app_settings.y_offset,
                 NumberInputPrecision(0),
-                0. ..200.
+                -200. ..200.
             ),
             number_input_f32(
                 AppNumberInputF32::Blur.label(),
@@ -251,7 +251,7 @@ fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
                 Some(AppNumberInputF32::Spread),
                 app_settings.spread,
                 NumberInputPrecision(0),
-                0. ..100.
+                -200. ..200.
             ),
             number_input_i32(
                 AppNumberInputI32::Count.label(),
@@ -265,7 +265,7 @@ fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
                 Some(AppNumberInputI32::Samples),
                 app_settings.samples as i32,
                 NumberInputPrecision(0),
-                0..15
+                1..15
             ),
             // Reset button
             @FeathersButton {
@@ -372,7 +372,8 @@ fn on_activate_reset(
 ) {
     *app_settings = AppSettings::default();
 
-    // Reset the settings panel.
+    // Reset the settings panel. It is quicker to do this
+    // than to go through every field and setting the fields correctly.
     commands.entity(settings_panel_q.entity()).despawn();
     commands.spawn_scene(settings_panel_scene(&app_settings));
 

--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -5,6 +5,7 @@ use crate::radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptio
 use bevy::{
     color::palettes::css::*,
     feathers::{
+        containers::{pane, pane_body},
         controls::{FeathersButton, FeathersNumberInput, NumberInputPrecision, NumberInputValue},
         dark_theme::create_dark_theme,
         display::caption,
@@ -218,60 +219,68 @@ fn setup(mut commands: Commands, app_settings: Res<AppSettings>) {
 fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
     bsn! {
         SettingsPanel
-        main_ui_node_scene()
         ZIndex(10)
+        pane()
+        Node {
+            position_type: PositionType::Absolute,
+            left: px(0),
+            bottom: px(0),
+        }
         Children [
-            feathers_option_buttons(
-                "Shape",
-                &SHAPE_OPTIONS,
-            ),
-            number_input_f32(
-                AppNumberInputF32::XOffset.label(),
-                Some(AppNumberInputF32::XOffset),
-                app_settings.x_offset,
-                NumberInputPrecision(0),
-                -200. ..200.
-            ),
-            number_input_f32(
-                AppNumberInputF32::YOffset.label(),
-                Some(AppNumberInputF32::YOffset),
-                app_settings.y_offset,
-                NumberInputPrecision(0),
-                -200. ..200.
-            ),
-            number_input_f32(
-                AppNumberInputF32::Blur.label(),
-                Some(AppNumberInputF32::Blur),
-                app_settings.blur,
-                NumberInputPrecision(0),
-                0. ..100.
-            ),
-            number_input_f32(
-                AppNumberInputF32::Spread.label(),
-                Some(AppNumberInputF32::Spread),
-                app_settings.spread,
-                NumberInputPrecision(0),
-                -200. ..200.
-            ),
-            number_input_i32(
-                AppNumberInputI32::Count.label(),
-                Some(AppNumberInputI32::Count),
-                app_settings.count as i32,
-                NumberInputPrecision(0),
-                1..3
-            ),
-            number_input_i32(
-                AppNumberInputI32::Samples.label(),
-                Some(AppNumberInputI32::Samples),
-                app_settings.samples as i32,
-                NumberInputPrecision(0),
-                1..15
-            ),
-            // Reset button
-            @FeathersButton {
-                @caption: bsn! { caption("Reset") }
-            }
-            on(on_activate_reset)
+            pane_body()
+            Children [
+                feathers_option_buttons(
+                    "Shape",
+                    &SHAPE_OPTIONS,
+                ),
+                number_input_f32(
+                    AppNumberInputF32::XOffset.label(),
+                    Some(AppNumberInputF32::XOffset),
+                    app_settings.x_offset,
+                    NumberInputPrecision(0),
+                    -200. ..200.
+                ),
+                number_input_f32(
+                    AppNumberInputF32::YOffset.label(),
+                    Some(AppNumberInputF32::YOffset),
+                    app_settings.y_offset,
+                    NumberInputPrecision(0),
+                    -200. ..200.
+                ),
+                number_input_f32(
+                    AppNumberInputF32::Blur.label(),
+                    Some(AppNumberInputF32::Blur),
+                    app_settings.blur,
+                    NumberInputPrecision(0),
+                    0. ..100.
+                ),
+                number_input_f32(
+                    AppNumberInputF32::Spread.label(),
+                    Some(AppNumberInputF32::Spread),
+                    app_settings.spread,
+                    NumberInputPrecision(0),
+                    -200. ..200.
+                ),
+                number_input_i32(
+                    AppNumberInputI32::Count.label(),
+                    Some(AppNumberInputI32::Count),
+                    app_settings.count as i32,
+                    NumberInputPrecision(0),
+                    1..3
+                ),
+                number_input_i32(
+                    AppNumberInputI32::Samples.label(),
+                    Some(AppNumberInputI32::Samples),
+                    app_settings.samples as i32,
+                    NumberInputPrecision(0),
+                    1..15
+                ),
+                // Reset button
+                @FeathersButton {
+                    @caption: bsn! { caption("Reset") }
+                }
+                on(on_activate_reset)
+            ]
         ]
     }
 }

--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -1,6 +1,7 @@
 //! This example shows how to create a node with a shadow and adjust its settings interactively.
 
-use crate::number_input::{number_input_f32, number_input_i32};
+use crate::number_input_f32::number_input_f32;
+use crate::number_input_i32::number_input_i32;
 use crate::radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptionValue};
 use bevy::{
     color::palettes::css::*,
@@ -17,8 +18,11 @@ use bevy::{
     ui_widgets::{radio_self_update, Activate, ValueChange},
 };
 
-#[path = "../../helpers/number_input.rs"]
-mod number_input;
+#[path = "../../helpers/number_input_f32.rs"]
+mod number_input_f32;
+
+#[path = "../../helpers/number_input_i32.rs"]
+mod number_input_i32;
 
 #[path = "../../helpers/radio.rs"]
 mod radio;

--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -5,13 +5,14 @@ use crate::radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptio
 use bevy::{
     color::palettes::css::*,
     feathers::{
-        controls::{FeathersNumberInput, NumberInputPrecision, NumberInputValue},
+        controls::{FeathersButton, FeathersNumberInput, NumberInputPrecision, NumberInputValue},
         dark_theme::create_dark_theme,
+        display::caption,
         theme::UiTheme,
         FeathersPlugins,
     },
     prelude::*,
-    ui_widgets::{radio_self_update, Button, ValueChange},
+    ui_widgets::{radio_self_update, Activate, ValueChange},
 };
 
 #[path = "../../helpers/number_input.rs"]
@@ -19,8 +20,6 @@ mod number_input;
 
 #[path = "../../helpers/radio.rs"]
 mod radio;
-
-const NORMAL_BUTTON: Color = Color::srgb(0.15, 0.15, 0.15);
 
 /// Shapes that the node displayed on the screen can be.
 #[derive(Component, Clone, Copy, Default, PartialEq)]
@@ -66,7 +65,7 @@ impl Shape {
     }
 
     /// Returns the name of the shape as a string.
-    fn label(&self) -> &'static str {
+    const fn label(&self) -> &'static str {
         match *self {
             Shape::Square => "Square",
             Shape::RoundedSquare => "Rounded Square",
@@ -76,6 +75,14 @@ impl Shape {
         }
     }
 }
+
+const SHAPE_OPTIONS: [(Shape, &str); 5] = [
+    (Shape::Square, Shape::Square.label()),
+    (Shape::RoundedSquare, Shape::RoundedSquare.label()),
+    (Shape::Circle, Shape::Circle.label()),
+    (Shape::LongRectangle, Shape::LongRectangle.label()),
+    (Shape::TallRectangle, Shape::TallRectangle.label()),
+];
 
 /// Settings that the user can modify within the example.
 #[derive(Resource)]
@@ -111,11 +118,8 @@ impl Default for AppSettings {
 #[derive(Component, Clone, Default)]
 struct ShadowNode;
 
-#[derive(Component, PartialEq, Clone, Copy, Default)]
-enum SettingsButton {
-    #[default]
-    Reset,
-}
+#[derive(Component, Clone, Default)]
+struct SettingsPanel;
 
 #[derive(Component, Clone, Copy, Default, PartialEq, Eq, Debug)]
 enum AppNumberInputF32 {
@@ -180,14 +184,6 @@ fn setup(mut commands: Commands, app_settings: Res<AppSettings>) {
     };
     app_settings.shape.change_node(&mut node);
 
-    let shape_options = [
-        (Shape::Square, Shape::Square.label()),
-        (Shape::RoundedSquare, Shape::RoundedSquare.label()),
-        (Shape::Circle, Shape::Circle.label()),
-        (Shape::LongRectangle, Shape::LongRectangle.label()),
-        (Shape::TallRectangle, Shape::TallRectangle.label()),
-    ];
-
     commands.spawn_scene_list(bsn_list! {
         // Camera
         Camera2d
@@ -215,18 +211,19 @@ fn setup(mut commands: Commands, app_settings: Res<AppSettings>) {
             ShadowNode
         ],
 
-        settings_panel_scene(&app_settings, &shape_options),
+        settings_panel_scene(&app_settings),
     });
 }
 
-fn settings_panel_scene(app_settings: &AppSettings, shape_options: &[(Shape, &str)]) -> impl Scene {
+fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
     bsn! {
+        SettingsPanel
         main_ui_node_scene()
         ZIndex(10)
         Children [
             feathers_option_buttons(
                 "Shape",
-                &shape_options,
+                &SHAPE_OPTIONS,
             ),
             number_input_f32(
                 AppNumberInputF32::XOffset.label(),
@@ -271,27 +268,10 @@ fn settings_panel_scene(app_settings: &AppSettings, shape_options: &[(Shape, &st
                 0..15
             ),
             // Reset button
-            Node {
-                flex_direction: FlexDirection::Row,
-                align_items: AlignItems::Center,
-                height: px(36),
-                margin: UiRect::top(px(12)),
+            @FeathersButton {
+                @caption: bsn! { caption("Reset") }
             }
-            Children [
-                Button
-                Node {
-                    width: px(90),
-                    height: px(32),
-                    justify_content: JustifyContent::Center,
-                    align_items: AlignItems::Center,
-                    border_radius: BorderRadius::all(px(8)),
-                }
-                BackgroundColor(NORMAL_BUTTON)
-                template_value(SettingsButton::Reset)
-                Children [
-                    Text::new("Reset")
-                ],
-            ],
+            on(on_activate_reset)
         ]
     }
 }
@@ -329,7 +309,7 @@ fn on_value_change_i32_update_shadow(
         .insert(NumberInputValue::I32(value_change.value));
 }
 
-// Update the shadow node's `BoxShadow` on any change to the f32 number inputs.
+/// Update the shadow node's `BoxShadow` on any change to the f32 number inputs.
 fn on_value_change_f32_update_shadow(
     value_change: On<ValueChange<f32>>,
     number_input_q: Query<&AppNumberInputF32, With<FeathersNumberInput>>,
@@ -362,20 +342,51 @@ fn on_value_change_f32_update_shadow(
         .insert(NumberInputValue::F32(value_change.value));
 }
 
-// Update shape of `ShadowNode` if shape selection has changed
+/// Update shape of `ShadowNode` if shape selection has changed
 fn on_value_change_update_shape(
     event: On<ValueChange<Entity>>,
     new_value_query: Query<&RadioButtonOptionValue<Shape>>,
     mut app_settings: ResMut<AppSettings>,
-    mut query: Query<&mut Node, With<ShadowNode>>,
+    mut node_q: Query<&mut Node, With<ShadowNode>>,
 ) {
     let Ok(RadioButtonOptionValue(shape)) = new_value_query.get(event.value) else {
         return;
     };
     app_settings.shape = *shape;
 
-    for mut node in &mut query {
+    for mut node in &mut node_q {
         app_settings.shape.change_node(&mut node);
+    }
+}
+
+/// If the reset button was activated, reset app settings to default values.
+/// This observer is placed directly on the reset button.
+fn on_activate_reset(
+    _event: On<Activate>,
+    mut commands: Commands,
+    mut app_settings: ResMut<AppSettings>,
+    settings_panel_q: Single<Entity, With<SettingsPanel>>,
+    mut node_q: Query<&mut Node, With<ShadowNode>>,
+    mut box_shadow_q: Query<&mut BoxShadow, With<ShadowNode>>,
+    mut samples_q: Query<&mut BoxShadowSamples, With<Camera2d>>,
+) {
+    *app_settings = AppSettings::default();
+
+    // Reset the settings panel.
+    commands.entity(settings_panel_q.entity()).despawn();
+    commands.spawn_scene(settings_panel_scene(&app_settings));
+
+    // Do a full refresh of the box and its shadows.
+    for mut node in &mut node_q {
+        app_settings.shape.change_node(&mut node);
+    }
+
+    for mut box_shadow in &mut box_shadow_q {
+        *box_shadow = BoxShadow(generate_shadows(&app_settings));
+    }
+
+    for mut samples in &mut samples_q {
+        samples.0 = app_settings.samples;
     }
 }
 

--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -1,12 +1,21 @@
 //! This example shows how to create a node with a shadow and adjust its settings interactively.
 
-use bevy::{color::palettes::css::*, prelude::*, time::Time, window::RequestRedraw};
+use crate::radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptionValue};
+use bevy::{
+    color::palettes::css::*,
+    feathers::{dark_theme::create_dark_theme, theme::UiTheme, FeathersPlugins},
+    prelude::*,
+    time::Time,
+    ui_widgets::{radio_self_update, ValueChange},
+    window::RequestRedraw,
+};
+
+#[path = "../../helpers/radio.rs"]
+mod radio;
 
 const NORMAL_BUTTON: Color = Color::srgb(0.15, 0.15, 0.15);
 const HOVERED_BUTTON: Color = Color::srgb(0.25, 0.25, 0.25);
 const PRESSED_BUTTON: Color = Color::srgb(0.35, 0.75, 0.35);
-
-const SHAPE_DEFAULT_SETTINGS: ShapeSettings = ShapeSettings { index: 0 };
 
 const SHADOW_DEFAULT_SETTINGS: ShadowSettings = ShadowSettings {
     x_offset: 20.0,
@@ -17,37 +26,64 @@ const SHADOW_DEFAULT_SETTINGS: ShadowSettings = ShadowSettings {
     samples: 6,
 };
 
-const SHAPES: &[(&str, fn(&mut Node))] = &[
-    ("1", |node| {
-        node.width = px(164);
-        node.height = px(164);
-        node.border_radius = BorderRadius::ZERO;
-    }),
-    ("2", |node| {
-        node.width = px(164);
-        node.height = px(164);
-        node.border_radius = BorderRadius::all(px(41));
-    }),
-    ("3", |node| {
-        node.width = px(164);
-        node.height = px(164);
-        node.border_radius = BorderRadius::MAX;
-    }),
-    ("4", |node| {
-        node.width = px(240);
-        node.height = px(80);
-        node.border_radius = BorderRadius::all(px(32));
-    }),
-    ("5", |node| {
-        node.width = px(80);
-        node.height = px(240);
-        node.border_radius = BorderRadius::all(px(32));
-    }),
-];
+/// The current shape displayed on the screen
+#[derive(Component, Clone, Copy, Default, PartialEq)]
+enum Shape {
+    #[default]
+    Square,
+    RoundedSquare,
+    Circle,
+    LongRectangle,
+    TallRectangle,
+}
+
+impl Shape {
+    /// Mutates the `node` to become the given shape.
+    fn change_node(&self, node: &mut Node) {
+        match *self {
+            Self::Square => {
+                node.width = px(164);
+                node.height = px(164);
+                node.border_radius = BorderRadius::ZERO;
+            }
+            Self::RoundedSquare => {
+                node.width = px(164);
+                node.height = px(164);
+                node.border_radius = BorderRadius::all(px(41));
+            }
+            Self::Circle => {
+                node.width = px(164);
+                node.height = px(164);
+                node.border_radius = BorderRadius::MAX;
+            }
+            Self::LongRectangle => {
+                node.width = px(240);
+                node.height = px(80);
+                node.border_radius = BorderRadius::all(px(32));
+            }
+            Self::TallRectangle => {
+                node.width = px(80);
+                node.height = px(240);
+                node.border_radius = BorderRadius::all(px(32));
+            }
+        }
+    }
+
+    /// Returns the name of the shape as a string.
+    fn name(&self) -> &'static str {
+        match *self {
+            Shape::Square => "Square",
+            Shape::RoundedSquare => "Rounded Square",
+            Shape::Circle => "Circle",
+            Shape::LongRectangle => "Long Rectangle",
+            Shape::TallRectangle => "Tall Rectangle",
+        }
+    }
+}
 
 #[derive(Resource, Default)]
-struct ShapeSettings {
-    index: usize,
+struct AppSettings {
+    shape: Shape,
 }
 
 #[derive(Resource, Default)]
@@ -63,8 +99,9 @@ struct ShadowSettings {
 #[derive(Component)]
 struct ShadowNode;
 
-#[derive(Component, PartialEq, Clone, Copy)]
+#[derive(Component, PartialEq, Clone, Copy, Default)]
 enum SettingsButton {
+    #[default]
     XOffsetInc,
     XOffsetDec,
     YOffsetInc,
@@ -75,15 +112,14 @@ enum SettingsButton {
     SpreadDec,
     CountInc,
     CountDec,
-    ShapePrev,
-    ShapeNext,
     Reset,
     SamplesInc,
     SamplesDec,
 }
 
-#[derive(Component, Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Component, Clone, Copy, Default, PartialEq, Eq, Debug)]
 enum SettingType {
+    #[default]
     XOffset,
     YOffset,
     Blur,
@@ -116,9 +152,10 @@ struct HeldButton {
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins((DefaultPlugins, FeathersPlugins))
+        .insert_resource(UiTheme(create_dark_theme()))
+        .init_resource::<AppSettings>()
         .insert_resource(SHADOW_DEFAULT_SETTINGS)
-        .insert_resource(SHAPE_DEFAULT_SETTINGS)
         .insert_resource(HeldButton::default())
         .add_systems(Startup, setup)
         .add_systems(
@@ -126,22 +163,18 @@ fn main() {
             (
                 button_system,
                 button_color_system,
-                update_shape.run_if(resource_changed::<ShapeSettings>),
                 update_shadow.run_if(resource_changed::<ShadowSettings>),
                 update_shadow_samples.run_if(resource_changed::<ShadowSettings>),
                 button_repeat_system,
             ),
         )
+        .add_observer(on_value_change_update_shape)
+        .add_observer(radio_self_update)
         .run();
 }
 
 // --- UI Setup ---
-fn setup(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-    shadow: Res<ShadowSettings>,
-    shape: Res<ShapeSettings>,
-) {
+fn setup(mut commands: Commands, shadow: Res<ShadowSettings>, app_settings: Res<AppSettings>) {
     commands.spawn((Camera2d, BoxShadowSamples(shadow.samples)));
     // Spawn shape node
     commands
@@ -165,7 +198,7 @@ fn setup(
                 border_radius: BorderRadius::ZERO,
                 ..default()
             };
-            SHAPES[shape.index % SHAPES.len()].1(&mut node);
+            app_settings.shape.change_node(&mut node);
 
             (
                 node,
@@ -183,64 +216,49 @@ fn setup(
         }]);
 
     // Settings Panel
-    commands
-        .spawn((
-            Node {
-                flex_direction: FlexDirection::Column,
-                position_type: PositionType::Absolute,
-                left: px(24),
-                bottom: px(24),
-                width: px(270),
-                padding: UiRect::all(px(16)),
-                border_radius: BorderRadius::all(px(12)),
-                ..default()
-            },
-            BackgroundColor(Color::srgb(0.12, 0.12, 0.12).with_alpha(0.85)),
-            BorderColor::all(Color::WHITE.with_alpha(0.15)),
-            ZIndex(10),
-        ))
-        .insert(children![
-            build_setting_row(
-                SettingType::Shape,
-                SettingsButton::ShapePrev,
-                SettingsButton::ShapeNext,
-                shape.index as f32,
-                &asset_server,
+    commands.spawn_scene(bsn! {
+        main_ui_node_scene()
+        ZIndex(10)
+        Children [
+            feathers_option_buttons(
+                "Shape",
+                &[
+                    (Shape::Square, Shape::Square.name()),
+                    (Shape::RoundedSquare, Shape::RoundedSquare.name()),
+                    (Shape::Circle, Shape::Circle.name()),
+                    (Shape::LongRectangle, Shape::LongRectangle.name()),
+                    (Shape::TallRectangle, Shape::TallRectangle.name()),
+                ],
             ),
             build_setting_row(
                 SettingType::XOffset,
                 SettingsButton::XOffsetDec,
                 SettingsButton::XOffsetInc,
                 shadow.x_offset,
-                &asset_server,
             ),
             build_setting_row(
                 SettingType::YOffset,
                 SettingsButton::YOffsetDec,
                 SettingsButton::YOffsetInc,
                 shadow.y_offset,
-                &asset_server,
             ),
             build_setting_row(
                 SettingType::Blur,
                 SettingsButton::BlurDec,
                 SettingsButton::BlurInc,
                 shadow.blur,
-                &asset_server,
             ),
             build_setting_row(
                 SettingType::Spread,
                 SettingsButton::SpreadDec,
                 SettingsButton::SpreadInc,
                 shadow.spread,
-                &asset_server,
             ),
             build_setting_row(
                 SettingType::Count,
                 SettingsButton::CountDec,
                 SettingsButton::CountInc,
                 shadow.count as f32,
-                &asset_server,
             ),
             // Add BoxShadowSamples as a setting row
             build_setting_row(
@@ -248,40 +266,31 @@ fn setup(
                 SettingsButton::SamplesDec,
                 SettingsButton::SamplesInc,
                 shadow.samples as f32,
-                &asset_server,
             ),
             // Reset button
-            (
+            Node {
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                height: px(36),
+                margin: UiRect::top(px(12)),
+            }
+            Children [
+                Button
                 Node {
-                    flex_direction: FlexDirection::Row,
+                    width: px(90),
+                    height: px(32),
+                    justify_content: JustifyContent::Center,
                     align_items: AlignItems::Center,
-                    height: px(36),
-                    margin: UiRect::top(px(12)),
-                    ..default()
-                },
-                children![(
-                    Button,
-                    Node {
-                        width: px(90),
-                        height: px(32),
-                        justify_content: JustifyContent::Center,
-                        align_items: AlignItems::Center,
-                        border_radius: BorderRadius::all(px(8)),
-                        ..default()
-                    },
-                    BackgroundColor(NORMAL_BUTTON),
-                    SettingsButton::Reset,
-                    children![(
-                        Text::new("Reset"),
-                        TextFont {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf").into(),
-                            font_size: FontSize::Px(16.0),
-                            ..default()
-                        },
-                    )],
-                )],
-            ),
-        ]);
+                    border_radius: BorderRadius::all(px(8)),
+                }
+                BackgroundColor(NORMAL_BUTTON)
+                template_value(SettingsButton::Reset)
+                Children [
+                    Text::new("Reset")
+                ],
+            ],
+        ]
+    });
 }
 
 // --- UI Helper Functions ---
@@ -292,114 +301,73 @@ fn build_setting_row(
     dec: SettingsButton,
     inc: SettingsButton,
     value: f32,
-    asset_server: &Res<AssetServer>,
-) -> impl Bundle {
+) -> impl Scene {
     let value_text = match setting_type {
-        SettingType::Shape => SHAPES[value as usize % SHAPES.len()].0.to_string(),
+        SettingType::Shape => "TODO To Remove".to_string(),
         SettingType::Count => format!("{}", value as usize),
         _ => format!("{value:.1}"),
     };
 
-    (
+    bsn! {
         Node {
             flex_direction: FlexDirection::Row,
             align_items: AlignItems::Center,
             height: px(32),
-            ..default()
-        },
-        children![
-            (
-                Node {
-                    width: px(80),
-                    justify_content: JustifyContent::FlexEnd,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                // Attach SettingType to the value label node, not the parent row
-                children![(
-                    Text::new(setting_type.label()),
-                    TextFont {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf").into(),
-                        font_size: FontSize::Px(16.0),
-                        ..default()
-                    },
-                )],
-            ),
-            (
-                Button,
-                Node {
-                    width: px(28),
-                    height: px(28),
-                    margin: UiRect::left(px(8)),
-                    justify_content: JustifyContent::Center,
-                    align_items: AlignItems::Center,
-                    border_radius: BorderRadius::all(px(6)),
-                    ..default()
-                },
-                BackgroundColor(Color::WHITE),
-                dec,
-                children![(
-                    Text::new(if setting_type == SettingType::Shape {
-                        "<"
-                    } else {
-                        "-"
-                    }),
-                    TextFont {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf").into(),
-                        font_size: FontSize::Px(18.0),
-                        ..default()
-                    },
-                )],
-            ),
-            (
-                Node {
-                    width: px(48),
-                    height: px(28),
-                    margin: UiRect::horizontal(px(8)),
-                    justify_content: JustifyContent::Center,
-                    align_items: AlignItems::Center,
-                    border_radius: BorderRadius::all(px(6)),
-                    ..default()
-                },
-                children![{
-                    (
-                        Text::new(value_text),
-                        TextFont {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf").into(),
-                            font_size: FontSize::Px(16.0),
-                            ..default()
-                        },
-                        setting_type,
-                    )
-                }],
-            ),
-            (
-                Button,
-                Node {
-                    width: px(28),
-                    height: px(28),
-                    justify_content: JustifyContent::Center,
-                    align_items: AlignItems::Center,
-                    border_radius: BorderRadius::all(px(6)),
-                    ..default()
-                },
-                BackgroundColor(Color::WHITE),
-                inc,
-                children![(
-                    Text::new(if setting_type == SettingType::Shape {
-                        ">"
-                    } else {
-                        "+"
-                    }),
-                    TextFont {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf").into(),
-                        font_size: FontSize::Px(18.0),
-                        ..default()
-                    },
-                )],
-            ),
-        ],
-    )
+        }
+        Children [
+            Node {
+                width: px(80),
+                justify_content: JustifyContent::FlexEnd,
+                align_items: AlignItems::Center,
+            }
+            // Attach SettingType to the value label node, not the parent row
+            Children [
+                Text::new(setting_type.label())
+            ],
+
+
+            Button
+            Node {
+                width: px(28),
+                height: px(28),
+                margin: UiRect::left(px(8)),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                border_radius: BorderRadius::all(px(6)),
+            }
+            BackgroundColor(Color::WHITE)
+            template_value(dec)
+            Children [
+                Text::new("-")
+            ],
+
+            Node {
+                width: px(48),
+                height: px(28),
+                margin: UiRect::horizontal(px(8)),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                border_radius: BorderRadius::all(px(6)),
+            }
+            Children [
+                Text::new(value_text)
+                template_value(setting_type)
+            ],
+            Button
+            Node {
+                width: px(28),
+                height: px(28),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                border_radius: BorderRadius::all(px(6)),
+            }
+            BackgroundColor(Color::WHITE)
+            template_value(inc)
+            Children [
+                Text::new("+")
+            ],
+        ]
+    }
 }
 
 // --- SYSTEMS ---
@@ -500,17 +468,32 @@ fn make_shadow(color: Color, x_offset: f32, y_offset: f32, spread: f32, blur: f3
 }
 
 // Update shape of ShadowNode if shape selection changed
+fn on_value_change_update_shape(
+    event: On<ValueChange<Entity>>,
+    new_value_query: Query<&RadioButtonOptionValue<Shape>>,
+    mut app_settings: ResMut<AppSettings>,
+    query: Query<&mut Node, With<ShadowNode>>,
+    label_query: Query<(&mut Text, &SettingType)>,
+) {
+    let Ok(RadioButtonOptionValue(shape)) = new_value_query.get(event.value) else {
+        return;
+    };
+    app_settings.shape = *shape;
+
+    update_shape(&app_settings, query, label_query);
+}
+
 fn update_shape(
-    shape: Res<ShapeSettings>,
+    app_settings: &AppSettings,
     mut query: Query<&mut Node, With<ShadowNode>>,
     mut label_query: Query<(&mut Text, &SettingType)>,
 ) {
     for mut node in &mut query {
-        SHAPES[shape.index % SHAPES.len()].1(&mut node);
+        app_settings.shape.change_node(&mut node);
     }
     for (mut text, kind) in &mut label_query {
         if *kind == SettingType::Shape {
-            *text = Text::new(SHAPES[shape.index % SHAPES.len()].0);
+            *text = Text::new(app_settings.shape.name());
         }
     }
 }
@@ -522,7 +505,7 @@ fn button_system(
         (Changed<Interaction>, With<Button>),
     >,
     mut shadow: ResMut<ShadowSettings>,
-    mut shape: ResMut<ShapeSettings>,
+    mut app_settings: ResMut<AppSettings>,
     mut held: ResMut<HeldButton>,
     time: Res<Time>,
 ) {
@@ -530,7 +513,7 @@ fn button_system(
     for (interaction, btn) in &mut interaction_query {
         match *interaction {
             Interaction::Pressed => {
-                trigger_button_action(btn, &mut shadow, &mut shape);
+                trigger_button_action(btn, &mut shadow, &mut app_settings);
                 held.button = Some(*btn);
                 held.pressed_at = Some(now);
                 held.last_repeat = Some(now);
@@ -549,7 +532,7 @@ fn button_system(
 fn trigger_button_action(
     btn: &SettingsButton,
     shadow: &mut ShadowSettings,
-    shape: &mut ShapeSettings,
+    app_settings: &mut AppSettings,
 ) {
     match btn {
         SettingsButton::XOffsetInc => shadow.x_offset += 1.0,
@@ -570,18 +553,8 @@ fn trigger_button_action(
                 shadow.count -= 1;
             }
         }
-        SettingsButton::ShapePrev => {
-            if shape.index == 0 {
-                shape.index = SHAPES.len() - 1;
-            } else {
-                shape.index -= 1;
-            }
-        }
-        SettingsButton::ShapeNext => {
-            shape.index = (shape.index + 1) % SHAPES.len();
-        }
         SettingsButton::Reset => {
-            *shape = SHAPE_DEFAULT_SETTINGS;
+            *app_settings = AppSettings::default();
             *shadow = SHADOW_DEFAULT_SETTINGS;
         }
         SettingsButton::SamplesInc => shadow.samples += 1,
@@ -598,7 +571,7 @@ fn button_repeat_system(
     time: Res<Time>,
     mut held: ResMut<HeldButton>,
     mut shadow: ResMut<ShadowSettings>,
-    mut shape: ResMut<ShapeSettings>,
+    mut app_settings: ResMut<AppSettings>,
     mut request_redraw_writer: MessageWriter<RequestRedraw>,
 ) {
     if held.button.is_some() {
@@ -612,7 +585,7 @@ fn button_repeat_system(
         let last_repeat = held.last_repeat.unwrap_or(pressed_at);
         let since_last = now - last_repeat;
         if since_pressed > INITIAL_DELAY && since_last > REPEAT_RATE {
-            trigger_button_action(&btn, &mut shadow, &mut shape);
+            trigger_button_action(&btn, &mut shadow, &mut app_settings);
             held.last_repeat = Some(now);
         }
     }

--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -1,7 +1,7 @@
 //! This example shows how to create a node with a shadow and adjust its settings interactively.
 
 use crate::number_input::{number_input_f32, number_input_i32};
-use crate::radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptionValue};
+use crate::radio::{feathers_option_buttons, RadioButtonOptionValue};
 use bevy::{
     color::palettes::css::*,
     feathers::{
@@ -217,6 +217,13 @@ fn setup(mut commands: Commands, app_settings: Res<AppSettings>) {
 }
 
 fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
+    let selected_shape_index = SHAPE_OPTIONS
+        .iter()
+        .enumerate()
+        .find(|(index, (shape, _))| *shape == app_settings.shape)
+        // default is set to the length of the array, which will be interpreted as "no option is set"
+        .map_or(SHAPE_OPTIONS.len(), |(index, _)| index);
+
     bsn! {
         SettingsPanel
         ZIndex(10)
@@ -232,6 +239,7 @@ fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
                 feathers_option_buttons(
                     "Shape",
                     &SHAPE_OPTIONS,
+                    selected_shape_index,
                 ),
                 number_input_f32(
                     AppNumberInputF32::XOffset.label(),


### PR DESCRIPTION
# Objective

- Part of #24112

## Solution

- A similar level of involvement as `color_grading`. This one is a full migration that touches everything I’ve done in various places at some point - Radio, NumberInput, and Button. Also includes a full bsn scene list spawn because it was trivial to do.

## Testing

- `cargo run --example box_shadow --features=“bevy_feathers”`

---

## Showcase

Before
<img width="1272" height="748" alt="Screenshot 2026-07-22 at 1 45 02 PM" src="https://github.com/user-attachments/assets/26f27996-66e2-4aac-95a6-a4e23919731c" />

After
<img width="1276" height="749" alt="Screenshot 2026-07-22 at 1 33 43 PM" src="https://github.com/user-attachments/assets/30b272d7-8a17-4db2-adc4-4e024e838903" />