### PR TITLE
Migrate `ghost_nodes` to use `ui_widgets::Button` and `bsn!` (Phase 1 Item 5)

### DIFF
--- a/examples/ui/layout/ghost_nodes.rs
+++ b/examples/ui/layout/ghost_nodes.rs
@@ -9,7 +9,7 @@
 //!
 //! In order to use [`GhostNode`]s you must enable the `ghost_nodes` feature flag.
 
-use bevy::{prelude::*, ui::experimental::GhostNode};
+use bevy::{prelude::*, ui::experimental::GhostNode, ui::Pressed, ui_widgets::Button};
 
 fn main() {
     App::new()
@@ -101,17 +101,15 @@ fn create_label(text: &str, font: Handle<Font>) -> (Text, TextFont, TextColor) {
 }
 
 fn button_system(
-    mut interaction_query: Query<(&Interaction, &ChildOf), (Changed<Interaction>, With<Button>)>,
+    buttons: Query<&ChildOf, (With<Button>, Added<Pressed>)>,
     labels_query: Query<(&Children, &ChildOf), With<Button>>,
     mut text_query: Query<&mut Text>,
     mut counter_query: Query<&mut Counter>,
 ) {
     // Update parent counter on click
-    for (interaction, child_of) in &mut interaction_query {
-        if matches!(interaction, Interaction::Pressed) {
-            let mut counter = counter_query.get_mut(child_of.parent()).unwrap();
-            counter.0 += 1;
-        }
+    for child_of in &buttons {
+        let mut counter = counter_query.get_mut(child_of.parent()).unwrap();
+        counter.0 += 1;
     }
 
     // Update button labels to match their parent counter

--- a/examples/ui/layout/ghost_nodes.rs
+++ b/examples/ui/layout/ghost_nodes.rs
@@ -9,114 +9,121 @@
 //!
 //! In order to use [`GhostNode`]s you must enable the `ghost_nodes` feature flag.
 
-use bevy::{prelude::*, ui::experimental::GhostNode, ui::Pressed, ui_widgets::Button};
+use bevy::{
+    prelude::*,
+    text::FontSourceTemplate,
+    ui::experimental::GhostNode,
+    ui_widgets::{Activate, Button},
+};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_systems(Startup, setup)
-        .add_systems(Update, button_system)
+        .add_systems(Startup, scene.spawn())
         .run();
 }
 
-#[derive(Component)]
+#[derive(Component, Clone, Default)]
 struct Counter(i32);
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font_handle = asset_server.load("fonts/FiraSans-Bold.ttf");
+fn scene() -> impl SceneList {
+    bsn_list![Camera2d, ghost_root(), normal_root()]
+}
 
-    commands.spawn(Camera2d);
+/// Ghost UI root
+fn ghost_root() -> impl Scene {
+    bsn! {
+        GhostNode
+        Children [(
+            Node
+            Children [ label("This text node is rendered under a ghost root") ]
+        )]
+    }
+}
 
-    // Ghost UI root
-    commands.spawn(GhostNode).with_children(|ghost_root| {
-        ghost_root.spawn(Node::default()).with_child(create_label(
-            "This text node is rendered under a ghost root",
-            font_handle.clone(),
-        ));
-    });
-
-    // Normal UI root
-    commands
-        .spawn(Node {
+/// Normal UI root
+fn normal_root() -> impl Scene {
+    bsn! {
+        Node {
             width: percent(100),
             height: percent(100),
             align_items: AlignItems::Center,
             justify_content: JustifyContent::Center,
-            ..default()
-        })
-        .with_children(|parent| {
-            parent
-                .spawn((Node::default(), Counter(0)))
-                .with_children(|layout_parent| {
-                    layout_parent
-                        .spawn((GhostNode, Counter(0)))
-                        .with_children(|ghost_parent| {
-                            // Ghost children using a separate counter state
-                            // These buttons are being treated as children of layout_parent in the context of UI
-                            ghost_parent
-                                .spawn(create_button())
-                                .with_child(create_label("0", font_handle.clone()));
-                            ghost_parent
-                                .spawn(create_button())
-                                .with_child(create_label("0", font_handle.clone()));
-                        });
-
-                    // A normal child using the layout parent counter
-                    layout_parent
-                        .spawn(create_button())
-                        .with_child(create_label("0", font_handle.clone()));
-                });
-        });
+        }
+        Children [(
+            Node Counter(0)
+            Children [
+                // Ghost children using a separate counter state.
+                // These buttons are being treated as children of the layout parent
+                // in the context of UI, but they share the ghost node's counter.
+                (
+                    GhostNode Counter(0)
+                    Children [ button(), button() ]
+                ),
+                // A normal child using the layout parent counter
+                button(),
+            ]
+        )]
+    }
 }
 
-fn create_button() -> impl Bundle {
-    (
-        Button,
+fn button() -> impl Scene {
+    bsn! {
+        Button
+        // Bump the counter belonging to this button's parent, then refresh every
+        // label under that parent. Buttons sharing a parent share a counter, so
+        // pressing either ghost child updates both of their labels.
+        on(|activate: On<Activate>,
+            child_of_query: Query<&ChildOf>,
+            children_query: Query<&Children>,
+            mut counter_query: Query<&mut Counter>,
+            mut text_query: Query<&mut Text>| {
+            let Ok(parent) = child_of_query.get(activate.entity).map(ChildOf::parent) else {
+                return;
+            };
+            let Ok(mut counter) = counter_query.get_mut(parent) else {
+                return;
+            };
+            counter.0 += 1;
+            let value = counter.0.to_string();
+
+            let Ok(siblings) = children_query.get(parent) else {
+                return;
+            };
+            for &sibling in siblings {
+                let Ok(labels) = children_query.get(sibling) else {
+                    continue;
+                };
+                for &label in labels {
+                    if let Ok(mut text) = text_query.get_mut(label) {
+                        **text = value.clone();
+                    }
+                }
+            }
+        })
         Node {
             width: px(150),
             height: px(65),
-            border: UiRect::all(px(5)),
+            border: px(5),
             // horizontally center child text
             justify_content: JustifyContent::Center,
             // vertically center child text
             align_items: AlignItems::Center,
             border_radius: BorderRadius::MAX,
-            ..default()
-        },
-        BorderColor::all(Color::BLACK),
-        BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
-    )
-}
-
-fn create_label(text: &str, font: Handle<Font>) -> (Text, TextFont, TextColor) {
-    (
-        Text::new(text),
-        TextFont {
-            font: font.into(),
-            font_size: FontSize::Px(33.0),
-            ..default()
-        },
-        TextColor(Color::srgb(0.9, 0.9, 0.9)),
-    )
-}
-
-fn button_system(
-    buttons: Query<&ChildOf, (With<Button>, Added<Pressed>)>,
-    labels_query: Query<(&Children, &ChildOf), With<Button>>,
-    mut text_query: Query<&mut Text>,
-    mut counter_query: Query<&mut Counter>,
-) {
-    // Update parent counter on click
-    for child_of in &buttons {
-        let mut counter = counter_query.get_mut(child_of.parent()).unwrap();
-        counter.0 += 1;
+        }
+        BorderColor::from(Color::BLACK)
+        BackgroundColor(Color::srgb(0.15, 0.15, 0.15))
+        Children [ label("0") ]
     }
+}
 
-    // Update button labels to match their parent counter
-    for (children, child_of) in &labels_query {
-        let counter = counter_query.get(child_of.parent()).unwrap();
-        let mut text = text_query.get_mut(children[0]).unwrap();
-
-        **text = counter.0.to_string();
+fn label(text: &str) -> impl Scene {
+    bsn! {
+        Text(text)
+        TextFont {
+            font: FontSourceTemplate::Handle("fonts/FiraSans-Bold.ttf"),
+            font_size: px(33.0),
+        }
+        TextColor(Color::srgb(0.9, 0.9, 0.9))
     }
 }


### PR DESCRIPTION
# Objective

Part of #24112

## Solution

- Migrate from the Marker Button component to `bevy_ui_widgets::Button`
- use `bsn!` to render the template in the example

## Testing

- Did you test these changes? If so, how?
I ran the `ghost_nodes` example before and after my changes to ensure behavioral parity. 