### PR TITLE
Migrate clearcoat to use ```FeathersRadio```

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4919,7 +4919,7 @@ wasm = true
 name = "clearcoat"
 path = "examples/3d/clearcoat.rs"
 doc-scrape-examples = true
-required-features = ["pbr_multi_layer_material_textures"]
+required-features = ["pbr_multi_layer_material_textures", "bevy_feathers"]
 
 [package.metadata.example.clearcoat]
 name = "Clearcoat"

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -21,28 +21,28 @@ use std::f32::consts::PI;
 
 use bevy::{
     camera::Hdr,
-    input_focus::{tab_navigation::TabGroup},
     color::palettes::css::{BLUE, GOLD, WHITE},
     core_pipeline::tonemapping::Tonemapping::AcesFitted,
+    feathers::{
+        containers::*,
+        controls::*,
+        dark_theme::create_dark_theme,
+        display::label_small,
+        theme::{ThemedText, UiTheme},
+        FeathersPlugins,
+    },
     image::ImageLoaderSettings,
+    input_focus::tab_navigation::TabGroup,
     light::Skybox,
     math::vec3,
     prelude::*,
-    feathers::{
-        controls::*, 
-        containers::*, 
-        dark_theme::create_dark_theme,
-        theme::{ThemedText, UiTheme},
-        FeathersPlugins,
-        display::{label_small},
-    },
+    ui::Checked,
     ui_widgets::{
-        slider_self_update, SliderStep, SliderValue, RadioGroup, 
-        SliderPrecision, ValueChange, checkbox_self_update, radio_self_update, 
+        checkbox_self_update, radio_self_update, slider_self_update, RadioGroup, SliderPrecision,
+        SliderStep, SliderValue, ValueChange,
     },
-    ui::Checked, 
 };
-use bevy_ecs::{system::SystemParam, VariantDefaults}; 
+use bevy_ecs::{system::SystemParam, VariantDefaults};
 
 /// The size of each sphere.
 const SPHERE_SCALE: f32 = 0.9;
@@ -64,10 +64,10 @@ pub fn main() {
     App::new()
         .init_resource::<LightMode>()
         .insert_resource(UiTheme(create_dark_theme()))
-        .insert_resource(TweakableKnobState { 
-            illuminance: 10000.0, 
-            intensity: 1000.0, 
-            rotation_speed: 0.8, 
+        .insert_resource(TweakableKnobState {
+            illuminance: 10000.0,
+            intensity: 1000.0,
+            rotation_speed: 0.8,
         })
         .add_plugins((DefaultPlugins, FeathersPlugins))
         .add_systems(Startup, (scene.spawn(), hide_control_pane).chain())
@@ -83,7 +83,7 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    states: Res<TweakableKnobState>, 
+    states: Res<TweakableKnobState>,
     asset_server: Res<AssetServer>,
 ) {
     let sphere = create_sphere_mesh(&mut meshes);
@@ -214,8 +214,7 @@ fn spawn_scratched_gold_ball(
 }
 
 /// Spawns a light.
-fn spawn_light(commands: &mut Commands, 
-    states: Res<TweakableKnobState>) {
+fn spawn_light(commands: &mut Commands, states: Res<TweakableKnobState>) {
     commands.spawn(create_directional_light(states.intensity));
 }
 
@@ -262,8 +261,11 @@ fn animate_light(
 }
 
 /// Rotates the spheres.
-fn animate_spheres(mut spheres: Query<&mut Transform, With<ExampleSphere>>, time: Res<Time>, 
-    ui: SharedUiState) {
+fn animate_spheres(
+    mut spheres: Query<&mut Transform, With<ExampleSphere>>,
+    time: Res<Time>,
+    ui: SharedUiState,
+) {
     let now = time.elapsed_secs();
     for mut transform in spheres.iter_mut() {
         transform.rotation = Quat::from_rotation_y(ui.knobs.rotation_speed * now);
@@ -274,7 +276,7 @@ fn animate_spheres(mut spheres: Query<&mut Transform, With<ExampleSphere>>, time
 fn create_point_light(intensity: f32) -> PointLight {
     PointLight {
         color: WHITE.into(),
-        intensity: intensity,
+        intensity,
         ..default()
     }
 }
@@ -283,39 +285,38 @@ fn create_point_light(intensity: f32) -> PointLight {
 fn create_directional_light(illuminance: f32) -> DirectionalLight {
     DirectionalLight {
         color: WHITE.into(),
-        illuminance: illuminance, 
+        illuminance,
         ..default()
     }
 }
 
-#[derive(SystemParam)] 
-struct SharedUiState<'w, 's> { 
-    light_mode: ResMut<'w, LightMode>, 
+#[derive(SystemParam)]
+struct SharedUiState<'w, 's> {
+    light_mode: ResMut<'w, LightMode>,
     light_query: Query<'w, 's, Entity, Or<(With<PointLight>, With<DirectionalLight>)>>,
-    commands: Commands<'w, 's>, 
+    commands: Commands<'w, 's>,
     knobs: ResMut<'w, TweakableKnobState>,
-    speed_query: Query<'w, 's, Entity, With<RotationSpeedScalarField>>, 
+    speed_query: Query<'w, 's, Entity, With<RotationSpeedScalarField>>,
 }
 
-#[derive(Resource)] 
+#[derive(Resource)]
 struct TweakableKnobState {
-    illuminance: f32, 
-    intensity: f32, 
+    illuminance: f32,
+    intensity: f32,
     rotation_speed: f32,
 }
 
-#[derive(Component, Clone, Copy, Default)] 
-struct RotationSpeedScalarField; 
+#[derive(Component, Clone, Copy, Default)]
+struct RotationSpeedScalarField;
 
-#[derive(Component, Clone, Copy, Default, VariantDefaults)] 
+#[derive(Component, Clone, Copy, Default, VariantDefaults)]
 enum RadioLightMode {
-    #[default] 
-    Point, 
-    Directional,  
+    #[default]
+    Point,
+    Directional,
 }
 
-
-#[derive(Component, Clone, Copy, Default)] 
+#[derive(Component, Clone, Copy, Default)]
 struct UiControlsPaneBody;
 
 fn scene() -> impl SceneList {
@@ -332,7 +333,7 @@ fn ui() -> impl Scene {
             display: Display::Flex,
             flex_direction: FlexDirection::Row,
             column_gap: px(8),
-        } 
+        }
         Pickable::IGNORE
         TabGroup
         Children[
@@ -341,179 +342,179 @@ fn ui() -> impl Scene {
     }
 }
 
-
-/// Sets the illuminance of the directional light source to the slider's current value. 
-fn update_illuminance(new_value: f32, mut ui: SharedUiState) { 
-        ui.knobs.illuminance = new_value; 
-        for light in ui.light_query.iter_mut() { 
-            match *(ui.light_mode) { 
-                LightMode::Point => { }, // PointLight has no illuminance field  
-                LightMode::Directional => { 
-                    ui.commands 
-                        .entity(light)
-                        .insert(create_directional_light(ui.knobs.illuminance)); 
-                }
+/// Sets the illuminance of the directional light source to the slider's current value.
+fn update_illuminance(new_value: f32, mut ui: SharedUiState) {
+    ui.knobs.illuminance = new_value;
+    for light in ui.light_query.iter_mut() {
+        match *(ui.light_mode) {
+            LightMode::Point => {} // PointLight has no illuminance field
+            LightMode::Directional => {
+                ui.commands
+                    .entity(light)
+                    .insert(create_directional_light(ui.knobs.illuminance));
             }
         }
-}
-
-/// Sets the intensity of the point light source to the slider's current value. 
-fn update_intensity(new_value: f32, mut ui: SharedUiState) {  
-        ui.knobs.intensity = new_value; 
-        for light in ui.light_query.iter_mut() { 
-            match *(ui.light_mode) { 
-                LightMode::Point => { 
-                    ui.commands 
-                        .entity(light) 
-                        .insert(create_point_light(ui.knobs.intensity)); 
-                }, 
-                LightMode::Directional => { }, // DirectionalLight has no intensity field  
-            }
-        }
-}
-
-/// Sets the rotation speed of the spheres to the scalar input field's current value. 
-fn update_rotation_speed(new_value: f32, mut ui: SharedUiState) {
-    ui.knobs.rotation_speed = new_value;
-    for scalar_input_ent in ui.speed_query.iter() {
-        ui.commands 
-            .entity(scalar_input_ent) 
-            .insert(NumberInputValue::F32(ui.knobs.rotation_speed)); 
     }
 }
 
-/// Toggles point light. 
-fn toggle_point_light(mut ui: SharedUiState) { 
-    for light in ui.light_query.iter_mut() { 
-        *(ui.light_mode) = LightMode::Point; 
-        ui.commands 
-            .entity(light) 
-            .remove::<DirectionalLight>() 
+/// Sets the intensity of the point light source to the slider's current value.
+fn update_intensity(new_value: f32, mut ui: SharedUiState) {
+    ui.knobs.intensity = new_value;
+    for light in ui.light_query.iter_mut() {
+        match *(ui.light_mode) {
+            LightMode::Point => {
+                ui.commands
+                    .entity(light)
+                    .insert(create_point_light(ui.knobs.intensity));
+            }
+            LightMode::Directional => {} // DirectionalLight has no intensity field
+        }
+    }
+}
+
+/// Sets the rotation speed of the spheres to the scalar input field's current value.
+fn update_rotation_speed(new_value: f32, mut ui: SharedUiState) {
+    ui.knobs.rotation_speed = new_value;
+    for scalar_input_ent in ui.speed_query.iter() {
+        ui.commands
+            .entity(scalar_input_ent)
+            .insert(NumberInputValue::F32(ui.knobs.rotation_speed));
+    }
+}
+
+/// Toggles point light.
+fn toggle_point_light(mut ui: SharedUiState) {
+    for light in ui.light_query.iter_mut() {
+        *(ui.light_mode) = LightMode::Point;
+        ui.commands
+            .entity(light)
+            .remove::<DirectionalLight>()
             .insert(create_point_light(ui.knobs.intensity));
     }
 }
 
-/// Toggles directional light. 
-fn toggle_directional_light(mut ui: SharedUiState) { 
-    for light in ui.light_query.iter_mut() { 
-        *(ui.light_mode) = LightMode::Directional; 
-        ui.commands 
-            .entity(light) 
-            .remove::<PointLight>() 
+/// Toggles directional light.
+fn toggle_directional_light(mut ui: SharedUiState) {
+    for light in ui.light_query.iter_mut() {
+        *(ui.light_mode) = LightMode::Directional;
+        ui.commands
+            .entity(light)
+            .remove::<PointLight>()
             .insert(create_directional_light(ui.knobs.illuminance));
     }
 }
 
-/// Sets the light type to the currently checked radio button. 
-fn hit_the_lights(ui: SharedUiState) { 
-    match *(ui.light_mode) {
-        LightMode::Point => { 
-            toggle_point_light(ui); 
-        }, 
-        LightMode::Directional => { 
-            toggle_directional_light(ui); 
+///
+
+/// Sets the light type to the currently checked radio button.
+fn hit_the_lights(checked: RadioLightMode, mut ui: SharedUiState) {
+    match checked {
+        RadioLightMode::Directional => {
+            *(ui.light_mode) = LightMode::Directional;
+            toggle_directional_light(ui);
+        }
+        RadioLightMode::Point => {
+            *(ui.light_mode) = LightMode::Point;
+            toggle_point_light(ui);
         }
     }
 }
 
 /// Collapses all active control panes.  
-fn collapse_control_panes(change: On<ValueChange<bool>>, 
-    mut panes: Query<&mut Node, With<UiControlsPaneBody>>) { 
-    for mut node in &mut panes { 
-        node.display = if change.value { Display::Flex} 
-            else { Display::None } 
+fn collapse_control_panes(
+    change: On<ValueChange<bool>>,
+    mut panes: Query<&mut Node, With<UiControlsPaneBody>>,
+) {
+    for mut node in &mut panes {
+        node.display = if change.value {
+            Display::Flex
+        } else {
+            Display::None
+        }
     }
 }
 
-/// A set of widget controls for tweaking light property knobs, grouped into a pane. 
-fn control_pane() -> impl Scene { 
+/// A set of widget controls for tweaking light property knobs, grouped into a pane.
+fn control_pane() -> impl Scene {
     bsn! {
-        Node { 
-            display: Display::Flex, 
-            width: percent(30), 
-            min_width: px(200), 
-            flex_direction: FlexDirection::Column, 
+        Node {
+            display: Display::Flex,
+            width: percent(30),
+            min_width: px(200),
+            flex_direction: FlexDirection::Column,
         }
-        pane() Children [ 
-            pane_header() Children [ 
-                (@FeathersDisclosureToggle  
-                    on(checkbox_self_update) 
-                    on(|change: On<ValueChange<bool>>, 
-                        panes: Query<&mut Node, 
-                        With<UiControlsPaneBody>> | { 
-                            collapse_control_panes(change, panes); 
+        pane() Children [
+            pane_header() Children [
+                (@FeathersDisclosureToggle
+                    on(checkbox_self_update)
+                    on(|change: On<ValueChange<bool>>,
+                        panes: Query<&mut Node,
+                        With<UiControlsPaneBody>> | {
+                            collapse_control_panes(change, panes);
                     })
                 ),
                 (Text("UI Controls Pane") ThemedText),
             ],
             (
-                UiControlsPaneBody 
-                pane_body() Children [ 
+                UiControlsPaneBody
+                pane_body() Children [
                     label_small("Illuminance"),
                     (
-                        @FeathersSlider { 
-                            @max: 10000.0, 
+                        @FeathersSlider {
+                            @max: 10000.0,
                         }
-                        SliderStep(100.) 
+                        SliderStep(100.)
                         SliderPrecision(2)
                         SliderValue(10000.0)
                         on(slider_self_update)
-                        on(|change: On<ValueChange<f32>>,ui: SharedUiState| { 
-                            update_illuminance(change.value, ui); 
+                        on(|change: On<ValueChange<f32>>,ui: SharedUiState| {
+                            update_illuminance(change.value, ui);
                         })
                     ),
                     label_small("Intensity"),
                     (
-                        @FeathersSlider { 
+                        @FeathersSlider {
                             @max: 100000.0,
-                        } 
+                        }
                         SliderStep(1000.)
                         SliderPrecision(2)
                         SliderValue(1000.0)
                         on(slider_self_update)
                         on(|change: On<ValueChange<f32>>, ui: SharedUiState| {
-                            update_intensity(change.value, ui); 
+                            update_intensity(change.value, ui);
                         })
-                    ), 
-                    label_small("Rotation Speed"), 
-                    ( 
+                    ),
+                    label_small("Rotation Speed"),
+                    (
                         @FeathersNumberInput
                         RotationSpeedScalarField
-                        Node { 
-                            flex_grow: 1.0, 
-                            max_width: px(100), 
+                        Node {
+                            flex_grow: 1.0,
+                            max_width: px(100),
                         }
-                        on(|change: On<ValueChange<f32>>, ui: SharedUiState| { 
+                        on(|change: On<ValueChange<f32>>, ui: SharedUiState| {
                             if change.is_final {
                                 update_rotation_speed(change.value, ui);
                             }
                         })
                     ),
-                    Node { 
+                    Node {
                         display: Display::Flex,
-                        flex_direction: FlexDirection::Column, 
-                        row_gap: px(4), 
+                        flex_direction: FlexDirection::Column,
+                        row_gap: px(4),
                     }
-                    RadioGroup 
-                    on(radio_self_update) 
-                    on(|change: On<ValueChange<Entity>>, 
-                        mut ui: SharedUiState, 
-                        q_light: Query<&RadioLightMode>| { 
+                    RadioGroup
+                    on(radio_self_update)
+                    on(|change: On<ValueChange<Entity>>,
+                        ui: SharedUiState,
+                        q_light: Query<&RadioLightMode>| {
                             if let Ok(&checked) = q_light.get(change.value) {
-                                match checked { 
-                                    RadioLightMode::Directional => { 
-                                        *(ui.light_mode) = LightMode::Directional; 
-                                    }, 
-                                    RadioLightMode::Point => { 
-                                        *(ui.light_mode) = LightMode::Point; 
-                                    }
-                                }
-                                hit_the_lights(ui); 
+                                hit_the_lights(checked, ui);
                             }
                     })
-                    Children [ 
-                        (@FeathersRadio { @caption: bsn!{ Text("Point Light") ThemedText } } Checked RadioLightMode::Point), 
-                        (@FeathersRadio { @caption: bsn!{ Text("Directional Light") ThemedText } }   RadioLightMode::Directional), 
+                    Children [
+                        (@FeathersRadio { @caption: bsn!{ Text("Point Light") ThemedText } } Checked RadioLightMode::Point),
+                        (@FeathersRadio { @caption: bsn!{ Text("Directional Light") ThemedText } }   RadioLightMode::Directional),
                     ]
                 ]
             )
@@ -522,17 +523,19 @@ fn control_pane() -> impl Scene {
 }
 
 fn init_rotation_speed(
-    mut commands: Commands, 
-    states: Res<TweakableKnobState>, 
-    q_scalar_input: Query<Entity, With<RotationSpeedScalarField>>) { 
+    mut commands: Commands,
+    states: Res<TweakableKnobState>,
+    q_scalar_input: Query<Entity, With<RotationSpeedScalarField>>,
+) {
     for scalar_input_ent in q_scalar_input.iter() {
-        commands.entity(scalar_input_ent)
-            .insert(NumberInputValue::F32(states.rotation_speed));  
+        commands
+            .entity(scalar_input_ent)
+            .insert(NumberInputValue::F32(states.rotation_speed));
     }
 }
 
-fn hide_control_pane(mut panes: Query<&mut Node, With<UiControlsPaneBody>>) { 
-    for mut node in &mut panes { 
-        node.display = Display::None; 
+fn hide_control_pane(mut panes: Query<&mut Node, With<UiControlsPaneBody>>) {
+    for mut node in &mut panes {
+        node.display = Display::None;
     }
 }

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -22,31 +22,28 @@ use std::f32::consts::PI;
 use bevy::{
     camera::Hdr,
     color::palettes::css::{BLUE, GOLD, WHITE},
-    core_pipeline::tonemapping::Tonemapping::AcesFitted, 
-    ecs::{system::{SystemParam}, VariantDefaults},
-    feathers::{
-        containers::*,
-        controls::*,
-        dark_theme::create_dark_theme,
-        display::label_small,
-        theme::{ThemedText, UiTheme},
-        FeathersPlugins,
-    },
+    core_pipeline::tonemapping::Tonemapping::AcesFitted,
+    feathers::{theme::UiTheme, FeathersPlugins},
     image::ImageLoaderSettings,
-    input_focus::tab_navigation::TabGroup,
     light::Skybox,
     math::vec3,
     prelude::*,
-    ui::Checked,
-    ui_widgets::{
-        checkbox_self_update, radio_self_update, slider_self_update, RadioGroup, SliderPrecision,
-        SliderStep, SliderValue, ValueChange,
-    },
+    ui_widgets::{radio_self_update, ValueChange},
 };
 
+use radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptionValue};
+
+#[path = "../helpers/radio.rs"]
+mod radio;
+
+#[path = "../helpers/theme.rs"]
+mod theme;
 
 /// The size of each sphere.
 const SPHERE_SCALE: f32 = 0.9;
+
+/// The speed at which the spheres rotate, in radians per second.
+const SPHERE_ROTATION_SPEED: f32 = 0.8;
 
 /// Which type of light we're using: a point light or a directional light.
 #[derive(Clone, Copy, PartialEq, Resource, Default)]
@@ -64,18 +61,14 @@ struct ExampleSphere;
 pub fn main() {
     App::new()
         .init_resource::<LightMode>()
-        .insert_resource(UiTheme(create_dark_theme()))
-        .insert_resource(TweakableKnobState {
-            illuminance: 10000.0,
-            intensity: 1000.0,
-            rotation_speed: 0.8,
-        })
-        .add_plugins((DefaultPlugins, FeathersPlugins))
-        .add_systems(Startup, (scene.spawn(), hide_control_pane).chain())
+        .add_plugins(DefaultPlugins)
+        .add_plugins(FeathersPlugins)
+        .insert_resource(UiTheme(theme::basic_example_theme(Color::WHITE)))
         .add_systems(Startup, setup)
-        .add_systems(Startup, init_rotation_speed)
         .add_systems(Update, animate_light)
         .add_systems(Update, animate_spheres)
+        .add_observer(handle_selection_change)
+        .add_observer(radio_self_update)
         .run();
 }
 
@@ -84,7 +77,6 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    states: Res<TweakableKnobState>,
     asset_server: Res<AssetServer>,
 ) {
     let sphere = create_sphere_mesh(&mut meshes);
@@ -93,8 +85,9 @@ fn setup(
     spawn_golf_ball(&mut commands, &asset_server);
     spawn_scratched_gold_ball(&mut commands, &mut materials, &asset_server, &sphere);
 
-    spawn_light(&mut commands, states);
+    spawn_light(&mut commands);
     spawn_camera(&mut commands, &asset_server);
+    spawn_buttons(&mut commands);
 }
 
 /// Generates a sphere.
@@ -215,8 +208,8 @@ fn spawn_scratched_gold_ball(
 }
 
 /// Spawns a light.
-fn spawn_light(commands: &mut Commands, states: Res<TweakableKnobState>) {
-    commands.spawn(create_directional_light(states.intensity));
+fn spawn_light(commands: &mut Commands) {
+    commands.spawn(create_point_light());
 }
 
 /// Spawns a camera with associated skybox and environment map.
@@ -262,279 +255,77 @@ fn animate_light(
 }
 
 /// Rotates the spheres.
-fn animate_spheres(
-    mut spheres: Query<&mut Transform, With<ExampleSphere>>,
-    time: Res<Time>,
-    ui: SharedUiState,
-) {
+fn animate_spheres(mut spheres: Query<&mut Transform, With<ExampleSphere>>, time: Res<Time>) {
     let now = time.elapsed_secs();
     for mut transform in spheres.iter_mut() {
-        transform.rotation = Quat::from_rotation_y(ui.knobs.rotation_speed * now);
+        transform.rotation = Quat::from_rotation_y(SPHERE_ROTATION_SPEED * now);
+    }
+}
+
+/// Spawns buttons at the bottom of the screen which allow the user to
+/// toggle occlusion culling on or off.
+fn spawn_buttons(commands: &mut Commands) {
+    commands.spawn_scene(bsn! {
+        main_ui_node_scene()
+            Children [
+            feathers_option_buttons(
+                "Toggle light type",
+                &[
+                    (LightMode::Directional, "Directional"),
+                    (LightMode::Point, "Point"),
+                ],
+                0,
+            )
+        ]
+    });
+}
+
+/// Updates the light mode when the user toggles a radio.
+fn handle_selection_change(
+    event: On<ValueChange<Entity>>,
+    mut commands: Commands,
+    mut light_query: Query<Entity, Or<(With<PointLight>, With<DirectionalLight>)>>,
+    new_value_query: Query<&RadioButtonOptionValue<LightMode>>,
+    mut light_mode: ResMut<LightMode>,
+) {
+    let Ok(RadioButtonOptionValue(_selection)) = new_value_query.get(event.value) else {
+        return;
+    };
+
+    for light in light_query.iter_mut() {
+        match *light_mode {
+            LightMode::Point => {
+                *light_mode = LightMode::Directional;
+                commands
+                    .entity(light)
+                    .remove::<PointLight>()
+                    .insert(create_directional_light());
+            }
+            LightMode::Directional => {
+                *light_mode = LightMode::Point;
+                commands
+                    .entity(light)
+                    .remove::<DirectionalLight>()
+                    .insert(create_point_light());
+            }
+        }
     }
 }
 
 /// Creates or recreates the moving point light.
-fn create_point_light(intensity: f32) -> PointLight {
+fn create_point_light() -> PointLight {
     PointLight {
         color: WHITE.into(),
-        intensity,
+        intensity: 100000.0,
         ..default()
     }
 }
 
 /// Creates or recreates the moving directional light.
-fn create_directional_light(illuminance: f32) -> DirectionalLight {
+fn create_directional_light() -> DirectionalLight {
     DirectionalLight {
         color: WHITE.into(),
-        illuminance,
+        illuminance: 1000.0,
         ..default()
-    }
-}
-
-#[derive(SystemParam)]
-struct SharedUiState<'w, 's> {
-    light_mode: ResMut<'w, LightMode>,
-    light_query: Query<'w, 's, Entity, Or<(With<PointLight>, With<DirectionalLight>)>>,
-    commands: Commands<'w, 's>,
-    knobs: ResMut<'w, TweakableKnobState>,
-    speed_query: Query<'w, 's, Entity, With<RotationSpeedScalarField>>,
-}
-
-#[derive(Resource)]
-struct TweakableKnobState {
-    illuminance: f32,
-    intensity: f32,
-    rotation_speed: f32,
-}
-
-#[derive(Component, Clone, Copy, Default)]
-struct RotationSpeedScalarField;
-
-#[derive(Component, Clone, Copy, Default, VariantDefaults)]
-enum RadioLightMode {
-    #[default]
-    Point,
-    Directional,
-}
-
-#[derive(Component, Clone, Copy, Default)]
-struct UiControlsPaneBody;
-
-fn scene() -> impl SceneList {
-    bsn_list![ui()]
-}
-
-fn ui() -> impl Scene {
-    bsn! {
-        Node {
-            width: percent(100),
-            height: percent(100),
-            align_items: AlignItems::Start,
-            justify_content: JustifyContent::Start,
-            display: Display::Flex,
-            flex_direction: FlexDirection::Row,
-            column_gap: px(8),
-        }
-        Pickable::IGNORE
-        TabGroup
-        Children[
-            control_pane(),
-        ]
-    }
-}
-
-/// Sets the illuminance of the directional light source to the slider's current value.
-fn update_illuminance(new_value: f32, mut ui: SharedUiState) {
-    ui.knobs.illuminance = new_value;
-    for light in ui.light_query.iter_mut() {
-        match *(ui.light_mode) {
-            LightMode::Point => {} // PointLight has no illuminance field
-            LightMode::Directional => {
-                ui.commands
-                    .entity(light)
-                    .insert(create_directional_light(ui.knobs.illuminance));
-            }
-        }
-    }
-}
-
-/// Sets the intensity of the point light source to the slider's current value.
-fn update_intensity(new_value: f32, mut ui: SharedUiState) {
-    ui.knobs.intensity = new_value;
-    for light in ui.light_query.iter_mut() {
-        match *(ui.light_mode) {
-            LightMode::Point => {
-                ui.commands
-                    .entity(light)
-                    .insert(create_point_light(ui.knobs.intensity));
-            }
-            LightMode::Directional => {} // DirectionalLight has no intensity field
-        }
-    }
-}
-
-/// Sets the rotation speed of the spheres to the scalar input field's current value.
-fn update_rotation_speed(new_value: f32, mut ui: SharedUiState) {
-    ui.knobs.rotation_speed = new_value;
-    for scalar_input_ent in ui.speed_query.iter() {
-        ui.commands
-            .entity(scalar_input_ent)
-            .insert(NumberInputValue::F32(ui.knobs.rotation_speed));
-    }
-}
-
-/// Toggles point light.
-fn toggle_point_light(mut ui: SharedUiState) {
-    for light in ui.light_query.iter_mut() {
-        *(ui.light_mode) = LightMode::Point;
-        ui.commands
-            .entity(light)
-            .remove::<DirectionalLight>()
-            .insert(create_point_light(ui.knobs.intensity));
-    }
-}
-
-/// Toggles directional light.
-fn toggle_directional_light(mut ui: SharedUiState) {
-    for light in ui.light_query.iter_mut() {
-        *(ui.light_mode) = LightMode::Directional;
-        ui.commands
-            .entity(light)
-            .remove::<PointLight>()
-            .insert(create_directional_light(ui.knobs.illuminance));
-    }
-}
-
-/// Sets the light type to the currently checked radio button.
-fn hit_the_lights(checked: RadioLightMode, mut ui: SharedUiState) {
-    match checked {
-        RadioLightMode::Directional => {
-            *(ui.light_mode) = LightMode::Directional;
-            toggle_directional_light(ui);
-        }
-        RadioLightMode::Point => {
-            *(ui.light_mode) = LightMode::Point;
-            toggle_point_light(ui);
-        }
-    }
-}
-
-/// Collapses all active control panes.  
-fn collapse_control_panes(
-    change: On<ValueChange<bool>>,
-    mut panes: Query<&mut Node, With<UiControlsPaneBody>>,
-) {
-    for mut node in &mut panes {
-        node.display = if change.value {
-            Display::Flex
-        } else {
-            Display::None
-        }
-    }
-}
-
-/// A set of widget controls for tweaking light property knobs, grouped into a pane.
-fn control_pane() -> impl Scene {
-    bsn! {
-        Node {
-            display: Display::Flex,
-            width: percent(30),
-            min_width: px(200),
-            flex_direction: FlexDirection::Column,
-        }
-        pane() Children [
-            pane_header() Children [
-                (@FeathersDisclosureToggle
-                    on(checkbox_self_update)
-                    on(|change: On<ValueChange<bool>>,
-                        panes: Query<&mut Node,
-                        With<UiControlsPaneBody>> | {
-                            collapse_control_panes(change, panes);
-                    })
-                ),
-                (Text("UI Controls Pane") ThemedText),
-            ],
-            (
-                UiControlsPaneBody
-                pane_body() Children [
-                    label_small("Illuminance"),
-                    (
-                        @FeathersSlider {
-                            @max: 10000.0,
-                        }
-                        SliderStep(100.)
-                        SliderPrecision(2)
-                        SliderValue(10000.0)
-                        on(slider_self_update)
-                        on(|change: On<ValueChange<f32>>,ui: SharedUiState| {
-                            update_illuminance(change.value, ui);
-                        })
-                    ),
-                    label_small("Intensity"),
-                    (
-                        @FeathersSlider {
-                            @max: 100000.0,
-                        }
-                        SliderStep(1000.)
-                        SliderPrecision(2)
-                        SliderValue(1000.0)
-                        on(slider_self_update)
-                        on(|change: On<ValueChange<f32>>, ui: SharedUiState| {
-                            update_intensity(change.value, ui);
-                        })
-                    ),
-                    label_small("Rotation Speed"),
-                    (
-                        @FeathersNumberInput
-                        RotationSpeedScalarField
-                        Node {
-                            flex_grow: 1.0,
-                            max_width: px(100),
-                        }
-                        on(|change: On<ValueChange<f32>>, ui: SharedUiState| {
-                            if change.is_final {
-                                update_rotation_speed(change.value, ui);
-                            }
-                        })
-                    ),
-                    Node {
-                        display: Display::Flex,
-                        flex_direction: FlexDirection::Column,
-                        row_gap: px(4),
-                    }
-                    RadioGroup
-                    on(radio_self_update)
-                    on(|change: On<ValueChange<Entity>>,
-                        ui: SharedUiState,
-                        q_light: Query<&RadioLightMode>| {
-                            if let Ok(&checked) = q_light.get(change.value) {
-                                hit_the_lights(checked, ui);
-                            }
-                    })
-                    Children [
-                        (@FeathersRadio { @caption: bsn!{ Text("Point Light") ThemedText } } Checked RadioLightMode::Point),
-                        (@FeathersRadio { @caption: bsn!{ Text("Directional Light") ThemedText } }   RadioLightMode::Directional),
-                    ]
-                ]
-            )
-        ]
-    }
-}
-
-fn init_rotation_speed(
-    mut commands: Commands,
-    states: Res<TweakableKnobState>,
-    q_scalar_input: Query<Entity, With<RotationSpeedScalarField>>,
-) {
-    for scalar_input_ent in q_scalar_input.iter() {
-        commands
-            .entity(scalar_input_ent)
-            .insert(NumberInputValue::F32(states.rotation_speed));
-    }
-}
-
-fn hide_control_pane(mut panes: Query<&mut Node, With<UiControlsPaneBody>>) {
-    for mut node in &mut panes {
-        node.display = Display::None;
     }
 }

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -22,7 +22,8 @@ use std::f32::consts::PI;
 use bevy::{
     camera::Hdr,
     color::palettes::css::{BLUE, GOLD, WHITE},
-    core_pipeline::tonemapping::Tonemapping::AcesFitted,
+    core_pipeline::tonemapping::Tonemapping::AcesFitted, 
+    ecs::{system::{SystemParam}, VariantDefaults},
     feathers::{
         containers::*,
         controls::*,
@@ -42,7 +43,7 @@ use bevy::{
         SliderStep, SliderValue, ValueChange,
     },
 };
-use bevy_ecs::{system::SystemParam, VariantDefaults};
+
 
 /// The size of each sphere.
 const SPHERE_SCALE: f32 = 0.9;
@@ -403,8 +404,6 @@ fn toggle_directional_light(mut ui: SharedUiState) {
             .insert(create_directional_light(ui.knobs.illuminance));
     }
 }
-
-///
 
 /// Sets the light type to the currently checked radio button.
 fn hit_the_lights(checked: RadioLightMode, mut ui: SharedUiState) {

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -21,19 +21,30 @@ use std::f32::consts::PI;
 
 use bevy::{
     camera::Hdr,
+    input_focus::{AutoFocus, tab_navigation::TabGroup},
     color::palettes::css::{BLUE, GOLD, WHITE},
     core_pipeline::tonemapping::Tonemapping::AcesFitted,
     image::ImageLoaderSettings,
     light::Skybox,
     math::vec3,
     prelude::*,
+    feathers::{
+        controls::*, 
+        containers::*, 
+        dark_theme::create_dark_theme,
+        theme::{ThemedText, ThemeBackgroundColor, UiTheme},
+        FeathersPlugins,
+        display::{label_small},
+        tokens, 
+    },
+    ui_widgets::{
+        Activate, slider_self_update, SliderStep, SliderValue,   
+        SliderPrecision, ValueChange, checkbox_self_update,  
+    },
 };
 
 /// The size of each sphere.
 const SPHERE_SCALE: f32 = 0.9;
-
-/// The speed at which the spheres rotate, in radians per second.
-const SPHERE_ROTATION_SPEED: f32 = 0.8;
 
 /// Which type of light we're using: a point light or a directional light.
 #[derive(Clone, Copy, PartialEq, Resource, Default)]
@@ -51,11 +62,18 @@ struct ExampleSphere;
 pub fn main() {
     App::new()
         .init_resource::<LightMode>()
-        .add_plugins(DefaultPlugins)
+        .insert_resource(UiTheme(create_dark_theme()))
+        .insert_resource(ControlWidgetStates { 
+            illuminance: 10000.0, 
+            intensity: 1000.0, 
+            rotation_speed: 0.8, 
+        })
+        .add_plugins((DefaultPlugins, FeathersPlugins))
+        .add_systems(Startup, (scene.spawn(), hide_control_pane).chain())
         .add_systems(Startup, setup)
+        .add_systems(Startup, init_rotation_speed)
         .add_systems(Update, animate_light)
         .add_systems(Update, animate_spheres)
-        .add_systems(Update, (handle_input, update_help_text).chain())
         .run();
 }
 
@@ -64,8 +82,8 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
+    states: Res<ControlWidgetStates>, 
     asset_server: Res<AssetServer>,
-    light_mode: Res<LightMode>,
 ) {
     let sphere = create_sphere_mesh(&mut meshes);
     spawn_car_paint_sphere(&mut commands, &mut materials, &asset_server, &sphere);
@@ -73,9 +91,8 @@ fn setup(
     spawn_golf_ball(&mut commands, &asset_server);
     spawn_scratched_gold_ball(&mut commands, &mut materials, &asset_server, &sphere);
 
-    spawn_light(&mut commands);
+    spawn_light(&mut commands, states);
     spawn_camera(&mut commands, &asset_server);
-    spawn_text(&mut commands, &light_mode);
 }
 
 /// Generates a sphere.
@@ -196,8 +213,9 @@ fn spawn_scratched_gold_ball(
 }
 
 /// Spawns a light.
-fn spawn_light(commands: &mut Commands) {
-    commands.spawn(create_point_light());
+fn spawn_light(commands: &mut Commands, 
+    states: Res<ControlWidgetStates>) {
+    commands.spawn(create_directional_light(states.intensity));
 }
 
 /// Spawns a camera with associated skybox and environment map.
@@ -226,19 +244,6 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer) {
         });
 }
 
-/// Spawns the help text.
-fn spawn_text(commands: &mut Commands, light_mode: &LightMode) {
-    commands.spawn((
-        light_mode.create_help_text(),
-        Node {
-            position_type: PositionType::Absolute,
-            bottom: px(12),
-            left: px(12),
-            ..default()
-        },
-    ));
-}
-
 /// Moves the light around.
 fn animate_light(
     mut lights: Query<&mut Transform, Or<(With<PointLight>, With<DirectionalLight>)>>,
@@ -256,78 +261,268 @@ fn animate_light(
 }
 
 /// Rotates the spheres.
-fn animate_spheres(mut spheres: Query<&mut Transform, With<ExampleSphere>>, time: Res<Time>) {
+fn animate_spheres(mut spheres: Query<&mut Transform, With<ExampleSphere>>, time: Res<Time>, 
+    states: Res<ControlWidgetStates>) {
     let now = time.elapsed_secs();
     for mut transform in spheres.iter_mut() {
-        transform.rotation = Quat::from_rotation_y(SPHERE_ROTATION_SPEED * now);
-    }
-}
-
-/// Handles the user pressing Space to change the type of light from point to
-/// directional and vice versa.
-fn handle_input(
-    mut commands: Commands,
-    mut light_query: Query<Entity, Or<(With<PointLight>, With<DirectionalLight>)>>,
-    keyboard: Res<ButtonInput<KeyCode>>,
-    mut light_mode: ResMut<LightMode>,
-) {
-    if !keyboard.just_pressed(KeyCode::Space) {
-        return;
-    }
-
-    for light in light_query.iter_mut() {
-        match *light_mode {
-            LightMode::Point => {
-                *light_mode = LightMode::Directional;
-                commands
-                    .entity(light)
-                    .remove::<PointLight>()
-                    .insert(create_directional_light());
-            }
-            LightMode::Directional => {
-                *light_mode = LightMode::Point;
-                commands
-                    .entity(light)
-                    .remove::<DirectionalLight>()
-                    .insert(create_point_light());
-            }
-        }
-    }
-}
-
-/// Updates the help text at the bottom of the screen.
-fn update_help_text(mut text_query: Query<&mut Text>, light_mode: Res<LightMode>) {
-    for mut text in text_query.iter_mut() {
-        *text = light_mode.create_help_text();
+        transform.rotation = Quat::from_rotation_y(states.rotation_speed * now);
     }
 }
 
 /// Creates or recreates the moving point light.
-fn create_point_light() -> PointLight {
+fn create_point_light(intensity: f32) -> PointLight {
     PointLight {
         color: WHITE.into(),
-        intensity: 100000.0,
+        intensity: intensity,
         ..default()
     }
 }
 
 /// Creates or recreates the moving directional light.
-fn create_directional_light() -> DirectionalLight {
+fn create_directional_light(illuminance: f32) -> DirectionalLight {
     DirectionalLight {
         color: WHITE.into(),
-        illuminance: 1000.0,
+        illuminance: illuminance, 
         ..default()
     }
 }
 
-impl LightMode {
-    /// Creates the help text at the bottom of the screen.
-    fn create_help_text(&self) -> Text {
-        let help_text = match *self {
-            LightMode::Point => "Press Space to switch to a directional light",
-            LightMode::Directional => "Press Space to switch to a point light",
-        };
+#[derive(Resource)] 
+struct ControlWidgetStates {
+    illuminance: f32, 
+    intensity: f32, 
+    rotation_speed: f32,
+}
 
-        Text::new(help_text)
+#[derive(Component, Clone, Copy, Default)] 
+struct RotationSpeedScalarField; 
+
+#[derive(Component, Clone, Copy, Default)] 
+struct UiControlsPaneBody;
+
+fn scene() -> impl SceneList {
+    bsn_list![ui()]
+}
+
+fn ui() -> impl Scene {
+    bsn! {
+        Node {
+            width: percent(100),
+            height: percent(100),
+            align_items: AlignItems::Start,
+            justify_content: JustifyContent::Start,
+            display: Display::Flex,
+            flex_direction: FlexDirection::Row,
+            column_gap: px(8),
+        } 
+        Pickable::IGNORE
+        TabGroup
+        Children[
+            control_pane(),
+        ]
+    }
+}
+
+
+fn control_pane() -> impl Scene { 
+    bsn! { 
+        Node { 
+            display: Display::Flex, 
+            flex_direction: FlexDirection::Column, 
+            align_items: AlignItems::Stretch, 
+            justify_content: JustifyContent::Start, 
+            padding: px(8), 
+            row_gap: px(8), 
+            width: percent(30), 
+            min_width: px(200), 
+        }
+        ThemeBackgroundColor(tokens::WINDOW_BG)
+        Children [
+            pane() Children [ 
+                    pane_header() Children [ 
+                        (@FeathersDisclosureToggle  
+                            on(checkbox_self_update) 
+                            on(|change: On<ValueChange<bool>>, 
+                                mut panes: Query<&mut Node, 
+                                With<UiControlsPaneBody>> | { 
+                                for mut node in &mut panes { 
+                                    node.display = if change.value { Display::Flex} else { Display::None }
+                                }
+                            })
+                        ),
+                        (Text("UI Controls Pane") ThemedText),
+                    ],
+                (
+                    UiControlsPaneBody 
+                    pane_body() Children [  
+                        subpane() Children [  
+                            subpane_body() Children [ 
+                                group()
+                                Children [ 
+                                    group_body() 
+                                    Children [ 
+                                        label_small("Illuminance"),
+                                        (
+                                            @FeathersSlider { 
+                                                @max: 10000.0, 
+                                            }
+                                            SliderStep(100.) 
+                                            SliderPrecision(2)
+                                            SliderValue(10000.0)
+                                            on(slider_self_update)
+                                            on(|change: On<ValueChange<f32>>,
+                                                mut commands: Commands, 
+                                                light_mode: Res<LightMode>, 
+                                                mut light_query: Query<Entity, Or<(With<PointLight>, With<DirectionalLight>)>>, 
+                                                mut states: ResMut<ControlWidgetStates>| { 
+                                                    states.illuminance = change.value; 
+                                                    for light in light_query.iter_mut() { 
+                                                        match *light_mode { 
+                                                            LightMode::Point => { 
+                                                                commands 
+                                                                    .entity(light) 
+                                                                    .insert(create_point_light(states.illuminance)); 
+                                                            }, 
+                                                            LightMode::Directional => { 
+                                                                commands 
+                                                                    .entity(light) 
+                                                                    .insert(create_directional_light(states.illuminance)); 
+                                                            }
+                                                    }
+                                                }
+                                            })
+                                        ),
+                                        label_small("Intensity"),
+                                        (
+                                            @FeathersSlider { 
+                                                @max: 100000.0,
+                                            } 
+                                            SliderStep(1000.)
+                                            SliderPrecision(2)
+                                            SliderValue(1000.0)
+                                            on(slider_self_update)
+                                            on(|change: On<ValueChange<f32>>,
+                                                mut commands: Commands,
+                                                light_mode: Res<LightMode>,
+                                                mut light_query: Query<Entity, Or<(With<PointLight>, With<DirectionalLight>)>>, 
+                                                mut states: ResMut<ControlWidgetStates>| {
+                                                    states.intensity = change.value;
+                                                    for light in light_query.iter_mut() { 
+                                                        match *light_mode { 
+                                                            LightMode::Point => { 
+                                                                commands 
+                                                                    .entity(light) 
+                                                                    .insert(create_point_light(states.intensity)); 
+                                                            }, 
+                                                            LightMode::Directional => { 
+                                                                commands 
+                                                                    .entity(light) 
+                                                                    .insert(create_directional_light(states.intensity)); 
+                                                            }
+                                                        }
+                                                    }
+                                            })
+                                        ), 
+                                        label_small("Rotation Speed"), 
+                                        ( 
+                                            @FeathersNumberInput
+                                            RotationSpeedScalarField
+                                            Node { 
+                                                flex_grow: 1.0, 
+                                                max_width: px(100), 
+                                            }
+                                            on(
+                                                |change: On<ValueChange<f32>>,
+                                                mut commands: Commands, 
+                                                q_scalar_input: Query<Entity, With<RotationSpeedScalarField>>, 
+                                                mut states: ResMut<ControlWidgetStates>| { 
+                                                    if change.is_final { 
+                                                        for scalar_input_ent in q_scalar_input.iter() {  
+                                                            commands 
+                                                                .entity(scalar_input_ent)
+                                                                .insert(NumberInputValue::F32(change.value));
+                                                        }
+                                                        states.rotation_speed = change.value; 
+                                                    }
+                                                })
+                                        ),
+                                        (
+                                            @FeathersButton { 
+                                                @caption: bsn! { Text("Point Light") ThemedText }
+                                            }
+                                            Node { 
+                                                flex_grow: 1.0, 
+                                            }
+                                            AccessibleLabel("Point Light") 
+                                            on(|_activate: On<Activate>, 
+                                                mut commands: Commands, 
+                                                mut light_query: Query<Entity, Or<(With<PointLight>, With<DirectionalLight>)>>, 
+                                                mut light_mode: ResMut<LightMode>, 
+                                                states: Res<ControlWidgetStates>| { 
+                                                for light in light_query.iter_mut() { 
+                                                    match *light_mode { 
+                                                        _ => { 
+                                                            *light_mode = LightMode::Point; 
+                                                            commands 
+                                                                .entity(light) 
+                                                                .remove::<DirectionalLight>() 
+                                                                .insert(create_point_light(states.intensity)); 
+                                                        } 
+                                                    }
+                                                }
+                                            })
+                                        AutoFocus 
+                                        ),
+                                        (
+                                            @FeathersButton { 
+                                                @caption: bsn! { Text("Directional Light") ThemedText } 
+                                            }
+                                            Node {
+                                                flex_grow: 1.0, 
+                                            }
+                                            AccessibleLabel("Directional Light") 
+                                            on(|_activate: On<Activate>, 
+                                                mut commands: Commands,
+                                                mut light_query: Query<Entity, Or<(With<PointLight>, With<DirectionalLight>)>>, 
+                                                mut light_mode: ResMut<LightMode>,
+                                                states: Res<ControlWidgetStates>| { 
+                                                for light in light_query.iter_mut() { 
+                                                    match *light_mode { 
+                                                       _ => { 
+                                                            *light_mode = LightMode::Directional; 
+                                                            commands 
+                                                                .entity(light) 
+                                                                .remove::<PointLight>() 
+                                                                .insert(create_directional_light(states.illuminance));  
+                                                        } 
+                                                    }
+                                                }
+                                            }) 
+                                            AutoFocus 
+                                        )
+                                    ]
+                                ] 
+                            ]
+                        ] 
+                    ] 
+                )
+            ] 
+        ] 
+    }
+}
+
+fn init_rotation_speed(
+    mut commands: Commands, 
+    states: Res<ControlWidgetStates>, 
+    q_scalar_input: Query<Entity, With<RotationSpeedScalarField>>) { 
+    for scalar_input_ent in q_scalar_input.iter() {
+        commands.entity(scalar_input_ent)
+            .insert(NumberInputValue::F32(states.rotation_speed));  
+    }
+}
+
+fn hide_control_pane(mut panes: Query<&mut Node, With<UiControlsPaneBody>>) { 
+    for mut node in &mut panes { 
+        node.display = Display::None; 
     }
 }

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -288,12 +288,12 @@ fn handle_selection_change(
     new_value_query: Query<&RadioButtonOptionValue<LightMode>>,
     mut light_mode: ResMut<LightMode>,
 ) {
-    let Ok(RadioButtonOptionValue(_selection)) = new_value_query.get(event.value) else {
+    let Ok(RadioButtonOptionValue(selection)) = new_value_query.get(event.value) else {
         return;
     };
 
     for light in light_query.iter_mut() {
-        match *light_mode {
+        match selection {
             LightMode::Point => {
                 *light_mode = LightMode::Directional;
                 commands

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -21,7 +21,7 @@ use std::f32::consts::PI;
 
 use bevy::{
     camera::Hdr,
-    input_focus::{AutoFocus, tab_navigation::TabGroup},
+    input_focus::{tab_navigation::TabGroup},
     color::palettes::css::{BLUE, GOLD, WHITE},
     core_pipeline::tonemapping::Tonemapping::AcesFitted,
     image::ImageLoaderSettings,
@@ -32,16 +32,17 @@ use bevy::{
         controls::*, 
         containers::*, 
         dark_theme::create_dark_theme,
-        theme::{ThemedText, ThemeBackgroundColor, UiTheme},
+        theme::{ThemedText, UiTheme},
         FeathersPlugins,
         display::{label_small},
-        tokens, 
     },
     ui_widgets::{
-        Activate, slider_self_update, SliderStep, SliderValue,   
-        SliderPrecision, ValueChange, checkbox_self_update,  
+        slider_self_update, SliderStep, SliderValue, RadioGroup, 
+        SliderPrecision, ValueChange, checkbox_self_update, radio_self_update, 
     },
+    ui::Checked, 
 };
+use bevy_ecs::{system::SystemParam, VariantDefaults}; 
 
 /// The size of each sphere.
 const SPHERE_SCALE: f32 = 0.9;
@@ -63,7 +64,7 @@ pub fn main() {
     App::new()
         .init_resource::<LightMode>()
         .insert_resource(UiTheme(create_dark_theme()))
-        .insert_resource(ControlWidgetStates { 
+        .insert_resource(TweakableKnobState { 
             illuminance: 10000.0, 
             intensity: 1000.0, 
             rotation_speed: 0.8, 
@@ -82,7 +83,7 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
-    states: Res<ControlWidgetStates>, 
+    states: Res<TweakableKnobState>, 
     asset_server: Res<AssetServer>,
 ) {
     let sphere = create_sphere_mesh(&mut meshes);
@@ -214,7 +215,7 @@ fn spawn_scratched_gold_ball(
 
 /// Spawns a light.
 fn spawn_light(commands: &mut Commands, 
-    states: Res<ControlWidgetStates>) {
+    states: Res<TweakableKnobState>) {
     commands.spawn(create_directional_light(states.intensity));
 }
 
@@ -262,10 +263,10 @@ fn animate_light(
 
 /// Rotates the spheres.
 fn animate_spheres(mut spheres: Query<&mut Transform, With<ExampleSphere>>, time: Res<Time>, 
-    states: Res<ControlWidgetStates>) {
+    ui: SharedUiState) {
     let now = time.elapsed_secs();
     for mut transform in spheres.iter_mut() {
-        transform.rotation = Quat::from_rotation_y(states.rotation_speed * now);
+        transform.rotation = Quat::from_rotation_y(ui.knobs.rotation_speed * now);
     }
 }
 
@@ -287,8 +288,17 @@ fn create_directional_light(illuminance: f32) -> DirectionalLight {
     }
 }
 
+#[derive(SystemParam)] 
+struct SharedUiState<'w, 's> { 
+    light_mode: ResMut<'w, LightMode>, 
+    light_query: Query<'w, 's, Entity, Or<(With<PointLight>, With<DirectionalLight>)>>,
+    commands: Commands<'w, 's>, 
+    knobs: ResMut<'w, TweakableKnobState>,
+    speed_query: Query<'w, 's, Entity, With<RotationSpeedScalarField>>, 
+}
+
 #[derive(Resource)] 
-struct ControlWidgetStates {
+struct TweakableKnobState {
     illuminance: f32, 
     intensity: f32, 
     rotation_speed: f32,
@@ -296,6 +306,14 @@ struct ControlWidgetStates {
 
 #[derive(Component, Clone, Copy, Default)] 
 struct RotationSpeedScalarField; 
+
+#[derive(Component, Clone, Copy, Default, VariantDefaults)] 
+enum RadioLightMode {
+    #[default] 
+    Point, 
+    Directional,  
+}
+
 
 #[derive(Component, Clone, Copy, Default)] 
 struct UiControlsPaneBody;
@@ -324,196 +342,188 @@ fn ui() -> impl Scene {
 }
 
 
+/// Sets the illuminance of the directional light source to the slider's current value. 
+fn update_illuminance(new_value: f32, mut ui: SharedUiState) { 
+        ui.knobs.illuminance = new_value; 
+        for light in ui.light_query.iter_mut() { 
+            match *(ui.light_mode) { 
+                LightMode::Point => { }, // PointLight has no illuminance field  
+                LightMode::Directional => { 
+                    ui.commands 
+                        .entity(light)
+                        .insert(create_directional_light(ui.knobs.illuminance)); 
+                }
+            }
+        }
+}
+
+/// Sets the intensity of the point light source to the slider's current value. 
+fn update_intensity(new_value: f32, mut ui: SharedUiState) {  
+        ui.knobs.intensity = new_value; 
+        for light in ui.light_query.iter_mut() { 
+            match *(ui.light_mode) { 
+                LightMode::Point => { 
+                    ui.commands 
+                        .entity(light) 
+                        .insert(create_point_light(ui.knobs.intensity)); 
+                }, 
+                LightMode::Directional => { }, // DirectionalLight has no intensity field  
+            }
+        }
+}
+
+/// Sets the rotation speed of the spheres to the scalar input field's current value. 
+fn update_rotation_speed(new_value: f32, mut ui: SharedUiState) {
+    ui.knobs.rotation_speed = new_value;
+    for scalar_input_ent in ui.speed_query.iter() {
+        ui.commands 
+            .entity(scalar_input_ent) 
+            .insert(NumberInputValue::F32(ui.knobs.rotation_speed)); 
+    }
+}
+
+/// Toggles point light. 
+fn toggle_point_light(mut ui: SharedUiState) { 
+    for light in ui.light_query.iter_mut() { 
+        *(ui.light_mode) = LightMode::Point; 
+        ui.commands 
+            .entity(light) 
+            .remove::<DirectionalLight>() 
+            .insert(create_point_light(ui.knobs.intensity));
+    }
+}
+
+/// Toggles directional light. 
+fn toggle_directional_light(mut ui: SharedUiState) { 
+    for light in ui.light_query.iter_mut() { 
+        *(ui.light_mode) = LightMode::Directional; 
+        ui.commands 
+            .entity(light) 
+            .remove::<PointLight>() 
+            .insert(create_directional_light(ui.knobs.illuminance));
+    }
+}
+
+/// Sets the light type to the currently checked radio button. 
+fn hit_the_lights(ui: SharedUiState) { 
+    match *(ui.light_mode) {
+        LightMode::Point => { 
+            toggle_point_light(ui); 
+        }, 
+        LightMode::Directional => { 
+            toggle_directional_light(ui); 
+        }
+    }
+}
+
+/// Collapses all active control panes.  
+fn collapse_control_panes(change: On<ValueChange<bool>>, 
+    mut panes: Query<&mut Node, With<UiControlsPaneBody>>) { 
+    for mut node in &mut panes { 
+        node.display = if change.value { Display::Flex} 
+            else { Display::None } 
+    }
+}
+
+/// A set of widget controls for tweaking light property knobs, grouped into a pane. 
 fn control_pane() -> impl Scene { 
-    bsn! { 
+    bsn! {
         Node { 
             display: Display::Flex, 
-            flex_direction: FlexDirection::Column, 
-            align_items: AlignItems::Stretch, 
-            justify_content: JustifyContent::Start, 
-            padding: px(8), 
-            row_gap: px(8), 
             width: percent(30), 
             min_width: px(200), 
+            flex_direction: FlexDirection::Column, 
         }
-        ThemeBackgroundColor(tokens::WINDOW_BG)
-        Children [
-            pane() Children [ 
-                    pane_header() Children [ 
-                        (@FeathersDisclosureToggle  
-                            on(checkbox_self_update) 
-                            on(|change: On<ValueChange<bool>>, 
-                                mut panes: Query<&mut Node, 
-                                With<UiControlsPaneBody>> | { 
-                                for mut node in &mut panes { 
-                                    node.display = if change.value { Display::Flex} else { Display::None }
+        pane() Children [ 
+            pane_header() Children [ 
+                (@FeathersDisclosureToggle  
+                    on(checkbox_self_update) 
+                    on(|change: On<ValueChange<bool>>, 
+                        panes: Query<&mut Node, 
+                        With<UiControlsPaneBody>> | { 
+                            collapse_control_panes(change, panes); 
+                    })
+                ),
+                (Text("UI Controls Pane") ThemedText),
+            ],
+            (
+                UiControlsPaneBody 
+                pane_body() Children [ 
+                    label_small("Illuminance"),
+                    (
+                        @FeathersSlider { 
+                            @max: 10000.0, 
+                        }
+                        SliderStep(100.) 
+                        SliderPrecision(2)
+                        SliderValue(10000.0)
+                        on(slider_self_update)
+                        on(|change: On<ValueChange<f32>>,ui: SharedUiState| { 
+                            update_illuminance(change.value, ui); 
+                        })
+                    ),
+                    label_small("Intensity"),
+                    (
+                        @FeathersSlider { 
+                            @max: 100000.0,
+                        } 
+                        SliderStep(1000.)
+                        SliderPrecision(2)
+                        SliderValue(1000.0)
+                        on(slider_self_update)
+                        on(|change: On<ValueChange<f32>>, ui: SharedUiState| {
+                            update_intensity(change.value, ui); 
+                        })
+                    ), 
+                    label_small("Rotation Speed"), 
+                    ( 
+                        @FeathersNumberInput
+                        RotationSpeedScalarField
+                        Node { 
+                            flex_grow: 1.0, 
+                            max_width: px(100), 
+                        }
+                        on(|change: On<ValueChange<f32>>, ui: SharedUiState| { 
+                            if change.is_final {
+                                update_rotation_speed(change.value, ui);
+                            }
+                        })
+                    ),
+                    Node { 
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Column, 
+                        row_gap: px(4), 
+                    }
+                    RadioGroup 
+                    on(radio_self_update) 
+                    on(|change: On<ValueChange<Entity>>, 
+                        mut ui: SharedUiState, 
+                        q_light: Query<&RadioLightMode>| { 
+                            if let Ok(&checked) = q_light.get(change.value) {
+                                match checked { 
+                                    RadioLightMode::Directional => { 
+                                        *(ui.light_mode) = LightMode::Directional; 
+                                    }, 
+                                    RadioLightMode::Point => { 
+                                        *(ui.light_mode) = LightMode::Point; 
+                                    }
                                 }
-                            })
-                        ),
-                        (Text("UI Controls Pane") ThemedText),
-                    ],
-                (
-                    UiControlsPaneBody 
-                    pane_body() Children [  
-                        subpane() Children [  
-                            subpane_body() Children [ 
-                                group()
-                                Children [ 
-                                    group_body() 
-                                    Children [ 
-                                        label_small("Illuminance"),
-                                        (
-                                            @FeathersSlider { 
-                                                @max: 10000.0, 
-                                            }
-                                            SliderStep(100.) 
-                                            SliderPrecision(2)
-                                            SliderValue(10000.0)
-                                            on(slider_self_update)
-                                            on(|change: On<ValueChange<f32>>,
-                                                mut commands: Commands, 
-                                                light_mode: Res<LightMode>, 
-                                                mut light_query: Query<Entity, Or<(With<PointLight>, With<DirectionalLight>)>>, 
-                                                mut states: ResMut<ControlWidgetStates>| { 
-                                                    states.illuminance = change.value; 
-                                                    for light in light_query.iter_mut() { 
-                                                        match *light_mode { 
-                                                            LightMode::Point => { 
-                                                                commands 
-                                                                    .entity(light) 
-                                                                    .insert(create_point_light(states.illuminance)); 
-                                                            }, 
-                                                            LightMode::Directional => { 
-                                                                commands 
-                                                                    .entity(light) 
-                                                                    .insert(create_directional_light(states.illuminance)); 
-                                                            }
-                                                    }
-                                                }
-                                            })
-                                        ),
-                                        label_small("Intensity"),
-                                        (
-                                            @FeathersSlider { 
-                                                @max: 100000.0,
-                                            } 
-                                            SliderStep(1000.)
-                                            SliderPrecision(2)
-                                            SliderValue(1000.0)
-                                            on(slider_self_update)
-                                            on(|change: On<ValueChange<f32>>,
-                                                mut commands: Commands,
-                                                light_mode: Res<LightMode>,
-                                                mut light_query: Query<Entity, Or<(With<PointLight>, With<DirectionalLight>)>>, 
-                                                mut states: ResMut<ControlWidgetStates>| {
-                                                    states.intensity = change.value;
-                                                    for light in light_query.iter_mut() { 
-                                                        match *light_mode { 
-                                                            LightMode::Point => { 
-                                                                commands 
-                                                                    .entity(light) 
-                                                                    .insert(create_point_light(states.intensity)); 
-                                                            }, 
-                                                            LightMode::Directional => { 
-                                                                commands 
-                                                                    .entity(light) 
-                                                                    .insert(create_directional_light(states.intensity)); 
-                                                            }
-                                                        }
-                                                    }
-                                            })
-                                        ), 
-                                        label_small("Rotation Speed"), 
-                                        ( 
-                                            @FeathersNumberInput
-                                            RotationSpeedScalarField
-                                            Node { 
-                                                flex_grow: 1.0, 
-                                                max_width: px(100), 
-                                            }
-                                            on(
-                                                |change: On<ValueChange<f32>>,
-                                                mut commands: Commands, 
-                                                q_scalar_input: Query<Entity, With<RotationSpeedScalarField>>, 
-                                                mut states: ResMut<ControlWidgetStates>| { 
-                                                    if change.is_final { 
-                                                        for scalar_input_ent in q_scalar_input.iter() {  
-                                                            commands 
-                                                                .entity(scalar_input_ent)
-                                                                .insert(NumberInputValue::F32(change.value));
-                                                        }
-                                                        states.rotation_speed = change.value; 
-                                                    }
-                                                })
-                                        ),
-                                        (
-                                            @FeathersButton { 
-                                                @caption: bsn! { Text("Point Light") ThemedText }
-                                            }
-                                            Node { 
-                                                flex_grow: 1.0, 
-                                            }
-                                            AccessibleLabel("Point Light") 
-                                            on(|_activate: On<Activate>, 
-                                                mut commands: Commands, 
-                                                mut light_query: Query<Entity, Or<(With<PointLight>, With<DirectionalLight>)>>, 
-                                                mut light_mode: ResMut<LightMode>, 
-                                                states: Res<ControlWidgetStates>| { 
-                                                for light in light_query.iter_mut() { 
-                                                    match *light_mode { 
-                                                        _ => { 
-                                                            *light_mode = LightMode::Point; 
-                                                            commands 
-                                                                .entity(light) 
-                                                                .remove::<DirectionalLight>() 
-                                                                .insert(create_point_light(states.intensity)); 
-                                                        } 
-                                                    }
-                                                }
-                                            })
-                                        AutoFocus 
-                                        ),
-                                        (
-                                            @FeathersButton { 
-                                                @caption: bsn! { Text("Directional Light") ThemedText } 
-                                            }
-                                            Node {
-                                                flex_grow: 1.0, 
-                                            }
-                                            AccessibleLabel("Directional Light") 
-                                            on(|_activate: On<Activate>, 
-                                                mut commands: Commands,
-                                                mut light_query: Query<Entity, Or<(With<PointLight>, With<DirectionalLight>)>>, 
-                                                mut light_mode: ResMut<LightMode>,
-                                                states: Res<ControlWidgetStates>| { 
-                                                for light in light_query.iter_mut() { 
-                                                    match *light_mode { 
-                                                       _ => { 
-                                                            *light_mode = LightMode::Directional; 
-                                                            commands 
-                                                                .entity(light) 
-                                                                .remove::<PointLight>() 
-                                                                .insert(create_directional_light(states.illuminance));  
-                                                        } 
-                                                    }
-                                                }
-                                            }) 
-                                            AutoFocus 
-                                        )
-                                    ]
-                                ] 
-                            ]
-                        ] 
-                    ] 
-                )
-            ] 
-        ] 
+                                hit_the_lights(ui); 
+                            }
+                    })
+                    Children [ 
+                        (@FeathersRadio { @caption: bsn!{ Text("Point Light") ThemedText } } Checked RadioLightMode::Point), 
+                        (@FeathersRadio { @caption: bsn!{ Text("Directional Light") ThemedText } }   RadioLightMode::Directional), 
+                    ]
+                ]
+            )
+        ]
     }
 }
 
 fn init_rotation_speed(
     mut commands: Commands, 
-    states: Res<ControlWidgetStates>, 
+    states: Res<TweakableKnobState>, 
     q_scalar_input: Query<Entity, With<RotationSpeedScalarField>>) { 
     for scalar_input_ent in q_scalar_input.iter() {
         commands.entity(scalar_input_ent)

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -78,6 +78,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     asset_server: Res<AssetServer>,
+    light_mode: Res<LightMode>,
 ) {
     let sphere = create_sphere_mesh(&mut meshes);
     spawn_car_paint_sphere(&mut commands, &mut materials, &asset_server, &sphere);
@@ -87,7 +88,7 @@ fn setup(
 
     spawn_light(&mut commands);
     spawn_camera(&mut commands, &asset_server);
-    spawn_buttons(&mut commands);
+    spawn_buttons(&mut commands, light_mode);
 }
 
 /// Generates a sphere.
@@ -264,7 +265,7 @@ fn animate_spheres(mut spheres: Query<&mut Transform, With<ExampleSphere>>, time
 
 /// Spawns buttons at the bottom of the screen which allow the user to
 /// toggle occlusion culling on or off.
-fn spawn_buttons(commands: &mut Commands) {
+fn spawn_buttons(commands: &mut Commands, light_mode: Res<LightMode>) {
     commands.spawn_scene(bsn! {
         main_ui_node_scene()
             Children [
@@ -274,7 +275,7 @@ fn spawn_buttons(commands: &mut Commands) {
                     (LightMode::Directional, "Directional"),
                     (LightMode::Point, "Point"),
                 ],
-                0,
+                if *light_mode == LightMode::Directional { 0 } else { 1 },
             )
         ]
     });
@@ -292,17 +293,16 @@ fn handle_selection_change(
         return;
     };
 
+    *light_mode = *selection;
     for light in light_query.iter_mut() {
-        match selection {
-            LightMode::Point => {
-                *light_mode = LightMode::Directional;
+        match *light_mode {
+            LightMode::Directional => {
                 commands
                     .entity(light)
                     .remove::<PointLight>()
                     .insert(create_directional_light());
             }
-            LightMode::Directional => {
-                *light_mode = LightMode::Point;
+            LightMode::Point => {
                 commands
                     .entity(light)
                     .remove::<DirectionalLight>()


### PR DESCRIPTION
# Objective
Migrates spacebar control in examples/3d/clearcoat.rs to use two radios. 
Addresses an item in  #25032. 

Supersedes #25062

## Testing
```cargo run --example clearcoat --features="bevy_feathers pbr_multi_layer_material_textures"```

<img width="1876" height="1005" alt="2026-07-22-224422_hyprshot" src="https://github.com/user-attachments/assets/f27f67a8-e123-4ee2-86ea-a387d6a47698" />
