### PR TITLE
Migrate `display_and_visibility` to use a `FeathersSelect` (Phase 3 Item 6)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3859,6 +3859,7 @@ wasm = true
 name = "display_and_visibility"
 path = "examples/ui/layout/display_and_visibility.rs"
 doc-scrape-examples = true
+required-features = ["bevy_feathers"]
 
 [package.metadata.example.display_and_visibility]
 name = "Display and Visibility"

--- a/examples/helpers/theme.rs
+++ b/examples/helpers/theme.rs
@@ -72,6 +72,54 @@ pub fn basic_example_theme(text_color: Color) -> ThemeProps {
         bevy::feathers::palette::TRANSPARENT,
     );
 
+    // Feathers Button / Select
+    color.insert(
+        bevy::feathers::tokens::BUTTON_BG,
+        bevy::feathers::palette::TRANSPARENT,
+    );
+    color.insert(
+        bevy::feathers::tokens::BUTTON_BG_HOVER,
+        bevy::feathers::palette::TRANSPARENT,
+    );
+    color.insert(
+        bevy::feathers::tokens::BUTTON_BG_PRESSED,
+        bevy::feathers::palette::TRANSPARENT,
+    );
+    color.insert(
+        bevy::feathers::tokens::MENU_BG,
+        bevy::feathers::palette::GRAY_0,
+    );
+    color.insert(
+        bevy::feathers::tokens::MENU_BORDER,
+        bevy::feathers::palette::GRAY_0,
+    );
+    color.insert(
+        bevy::feathers::tokens::MENUITEM_BG_HOVER,
+        bevy::feathers::palette::TRANSPARENT,
+    );
+    color.insert(
+        bevy::feathers::tokens::MENUITEM_BG_PRESSED,
+        bevy::feathers::palette::TRANSPARENT,
+    );
+    color.insert(
+        bevy::feathers::tokens::MENUITEM_BG_FOCUSED,
+        bevy::feathers::palette::TRANSPARENT,
+    );
+    color.insert(
+        bevy::feathers::tokens::LISTROW_BG,
+        bevy::feathers::palette::TRANSPARENT,
+    );
+    color.insert(
+        bevy::feathers::tokens::LISTROW_BG_HOVER,
+        bevy::feathers::palette::BLACK,
+    );
+    color.insert(
+        bevy::feathers::tokens::LISTROW_BG_SELECTED,
+        bevy::feathers::palette::BLACK,
+    );
+    color.insert(bevy::feathers::tokens::BUTTON_TEXT, text_color);
+    color.insert(bevy::feathers::tokens::LISTROW_TEXT, text_color);
+
     // Main text color
     color.insert(bevy::feathers::tokens::TEXT_MAIN, text_color);
     ThemeProps { color }

--- a/examples/ui/layout/display_and_visibility.rs
+++ b/examples/ui/layout/display_and_visibility.rs
@@ -1,33 +1,39 @@
 //! Demonstrates how Display and Visibility work in the UI.
 
 use bevy::{
-    color::palettes::css::{DARK_CYAN, DARK_GRAY, YELLOW},
+    color::palettes::css::{DARK_CYAN, DARK_GRAY},
     ecs::{component::Mutable, template::EntityTemplate},
+    feathers::{
+        controls::{FeathersListRow, FeathersSelect, OptionIndex},
+        display::caption,
+        theme::UiTheme,
+        FeathersPlugins,
+    },
     prelude::*,
-    text::FontSourceTemplate,
+    ui::Selected,
+    ui_widgets::ValueChange,
 };
+
+#[path = "../../helpers/theme.rs"]
+mod theme;
 
 const PALETTE: [&str; 4] = ["27496D", "466B7A", "669DB3", "ADCBE3"];
 const HIDDEN_COLOR: Color = Color::srgb(1.0, 0.7, 0.7);
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins((DefaultPlugins, FeathersPlugins))
+        .insert_resource(UiTheme(theme::basic_example_theme(Color::WHITE)))
         .add_systems(Startup, setup)
-        .add_systems(
-            Update,
-            (
-                buttons_handler::<Display>,
-                buttons_handler::<Visibility>,
-                text_hover,
-            ),
-        )
+        .add_observer(on_value_change::<NodeDisplaySetting>)
+        .add_observer(on_value_change::<NodeVisibilitySetting>)
         .run();
 }
 
-/// A component attached to a button that implements `TargetUpdate`.
-/// Activating the button will alter the target entity's
-/// `T` component.
+/// A component attached to an option select that will change the target entity
+/// with a given setting `T`.
+/// The way the change is implemented is via the `TargetUpdate<T>` trait. Changing the
+/// value of the option select will alter the target entity.
 #[derive(Component, Clone, Default)]
 struct Target<T> {
     id: Option<Entity>,
@@ -43,35 +49,49 @@ impl<T> Target<T> {
     }
 }
 
-trait TargetUpdate {
+/// The trait to be used in conjunction with the `Target` struct.
+/// This trait specifies the `TargetComponent` which will be modified.
+/// `T` is a setting option type that will influence how the `TargetComponent` is updated.
+trait TargetUpdate<T: Component + Clone + Default + PartialEq> {
     type TargetComponent: Component<Mutability = Mutable>;
-    const NAME: &'static str;
-    fn update_target(&self, target: &mut Self::TargetComponent) -> String;
+    fn update_target(&self, target: &mut Self::TargetComponent, value: &T);
 }
 
-impl TargetUpdate for Target<Display> {
+#[derive(Component, Clone, Debug, Default, PartialEq)]
+enum NodeDisplaySetting {
+    #[default]
+    Flex,
+    None,
+}
+
+#[derive(Component, Clone, Debug, Default, PartialEq)]
+enum NodeVisibilitySetting {
+    #[default]
+    Inherited,
+    Visible,
+    Hidden,
+}
+
+/// For `Display`, this impl of `TargetUpdate` will affect this entity's `Node` component's display property.
+impl TargetUpdate<NodeDisplaySetting> for Target<NodeDisplaySetting> {
     type TargetComponent = Node;
-    const NAME: &'static str = "Display";
-    fn update_target(&self, node: &mut Self::TargetComponent) -> String {
-        node.display = match node.display {
-            Display::Flex => Display::None,
-            Display::None => Display::Flex,
-            Display::Block | Display::Grid => unreachable!(),
+    fn update_target(&self, node: &mut Self::TargetComponent, value: &NodeDisplaySetting) {
+        node.display = match value {
+            NodeDisplaySetting::Flex => Display::Flex,
+            NodeDisplaySetting::None => Display::None,
         };
-        format!("{}::{:?} ", Self::NAME, node.display)
     }
 }
 
-impl TargetUpdate for Target<Visibility> {
+/// For `Visibility`, this impl of `TargetUpdate` will affect this entity's `Visibility` component.`
+impl TargetUpdate<NodeVisibilitySetting> for Target<NodeVisibilitySetting> {
     type TargetComponent = Visibility;
-    const NAME: &'static str = "Visibility";
-    fn update_target(&self, visibility: &mut Self::TargetComponent) -> String {
-        *visibility = match *visibility {
-            Visibility::Inherited => Visibility::Visible,
-            Visibility::Visible => Visibility::Hidden,
-            Visibility::Hidden => Visibility::Inherited,
+    fn update_target(&self, visibility: &mut Self::TargetComponent, value: &NodeVisibilitySetting) {
+        *visibility = match value {
+            NodeVisibilitySetting::Inherited => Visibility::Inherited,
+            NodeVisibilitySetting::Visible => Visibility::Visible,
+            NodeVisibilitySetting::Hidden => Visibility::Hidden,
         };
-        format!("{}::{visibility:?}", Self::NAME)
     }
 }
 
@@ -85,9 +105,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     commands.spawn(Camera2d);
 
-    let panels_child = commands
-        .spawn_scene(panels("fonts/FiraSans-Bold.ttf", &palette))
-        .id();
+    let panels_child = commands.spawn_scene(panels(&palette)).id();
 
     commands
         .spawn((
@@ -147,7 +165,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 /// Returns the main interactable of the example as a scene.
 /// The left panel changes Display and Visibility based on actions taken
 /// in the right panel.
-fn panels(text_font: &'static str, palette: &[Color; 4]) -> impl Scene {
+fn panels(palette: &[Color; 4]) -> impl Scene {
     let left_panel_node_base = |height_px: i32, palette_index: usize| {
         bsn! {
             Node {
@@ -261,26 +279,26 @@ fn panels(text_font: &'static str, palette: &[Color; 4]) -> impl Scene {
                         offset: px(10),
                     }
                     Children [
-                        button_scene::<Display>(text_font, #LeftGrandParent),
-                        button_scene::<Visibility>(text_font, #LeftGrandParent),
+                        feathers_select_display(#LeftGrandParent),
+                        feathers_select_visibility(#LeftGrandParent),
 
                         #RightParent
                         right_panel_node_base(400, 1)
                         Children [
-                            button_scene::<Display>(text_font, #LeftParent),
-                            button_scene::<Visibility>(text_font, #LeftParent),
+                            feathers_select_display(#LeftParent),
+                            feathers_select_visibility(#LeftParent),
 
                             #RightChild
                             right_panel_node_base(300, 2)
                             Children [
-                                button_scene::<Display>(text_font, #LeftChild),
-                                button_scene::<Visibility>(text_font, #LeftChild),
+                                feathers_select_display(#LeftChild),
+                                feathers_select_visibility(#LeftChild),
 
                                 #RightGrandChild
                                 right_panel_node_base(200, 3)
                                 Children [
-                                    button_scene::<Display>(text_font, #LeftGrandChild),
-                                    button_scene::<Visibility>(text_font, #LeftGrandChild),
+                                    feathers_select_display(#LeftGrandChild),
+                                    feathers_select_visibility(#LeftGrandChild),
 
                                     Node {
                                         width: px(100),
@@ -296,15 +314,82 @@ fn panels(text_font: &'static str, palette: &[Color; 4]) -> impl Scene {
     }
 }
 
-/// A button that, when pressed, will execute up a target action on the provided `target`.
-/// The target action is applied to the `T` component on the `target.`
-fn button_scene<T>(text_font: &'static str, target: EntityTemplate) -> impl Scene
+/// A dropdown select that will execute a target action on the provided `target` via `on_value_change`.
+/// This select will update the display property on the Node of the target.
+fn feathers_select_display(target: EntityTemplate) -> impl Scene {
+    bsn! {
+        select_base::<NodeDisplaySetting>(target)
+        @FeathersSelect {
+            @options: {
+                bsn_list! {
+                    @FeathersListRow Selected OptionIndex(0) template_value(NodeDisplaySetting::Flex) Children[caption(format!("Display::{:?}", Display::Flex))],
+                    @FeathersListRow OptionIndex(1) template_value(NodeDisplaySetting::None) Children[caption(format!("Display::{:?}", Display::None))],
+                }
+            }
+        }
+    }
+}
+
+/// A dropdown select that will execute a target action on the provided `target` via `on_value_change`.
+/// This select will update the Visibility component directly on the target.
+fn feathers_select_visibility(target: EntityTemplate) -> impl Scene {
+    bsn! {
+        select_base::<NodeVisibilitySetting>(target)
+        @FeathersSelect {
+            @options: {
+                bsn_list! {
+                    @FeathersListRow Selected OptionIndex(0) template_value(NodeVisibilitySetting::Inherited) Children[caption(format!("Visibility::{:?}", Visibility::Inherited))],
+                    @FeathersListRow OptionIndex(1) template_value(NodeVisibilitySetting::Visible) Children[caption(format!("Visibility::{:?}", Visibility::Visible))],
+                    @FeathersListRow OptionIndex(2) template_value(NodeVisibilitySetting::Hidden) Children[caption(format!("Visibility::{:?}", Visibility::Hidden))],
+                }
+            }
+        }
+    }
+}
+
+/// Observer that reacts to value changes of a FeathersSelect for the `T` setting,
+/// and updates the target entity accordingly.
+fn on_value_change<T: Component + Default + Clone + PartialEq + Send + Sync>(
+    event: On<ValueChange<Entity>>,
+    setting_value_q: Query<&T>,
+    list_box_q: Query<(&Children, &Target<T>), With<FeathersSelect>>,
+    mut target_component_query: Query<&mut <Target<T> as TargetUpdate<T>>::TargetComponent>,
+    mut commands: Commands,
+) where
+    Target<T>: TargetUpdate<T>,
+{
+    let Ok(value) = setting_value_q.get(event.value) else {
+        return;
+    };
+    let Ok((children, target)) = list_box_q.get(event.source) else {
+        return;
+    };
+
+    let Ok(mut target_value) = target_component_query.get_mut(target.id.unwrap()) else {
+        return;
+    };
+
+    target.update_target(target_value.as_mut(), value);
+
+    // Update selected status of children
+    for child in children {
+        if let Ok(child_value) = setting_value_q.get(*child)
+            && *child_value == *value
+        {
+            commands.entity(*child).insert(Selected);
+        } else {
+            commands.entity(*child).remove::<Selected>();
+        }
+    }
+}
+
+/// A scene of the Node, BackgroundColor, and `Target<T>` for the given target.
+fn select_base<T: Component + Clone + Default + PartialEq>(target: EntityTemplate) -> impl Scene
 where
     T: Default + Clone + Unpin + std::fmt::Debug + Send + Sync + 'static,
-    Target<T>: TargetUpdate,
+    Target<T>: TargetUpdate<T>,
 {
     bsn! {
-        Button
         Node {
             align_self: AlignSelf::FlexStart,
             padding: UiRect::axes(px(5), px(1)),
@@ -315,69 +400,5 @@ where
             EntityTemplate::SceneEntityReference(scene_entity_reference) => Ok(Target::<T>::new(ctx.get_entity(scene_entity_reference))),
             EntityTemplate::None => Err(BevyError::error("Did not set up example correctly!"))
         })
-        Children [
-            Text(format!("{}::{:?}", Target::<T>::NAME, T::default()))
-            TextFont {
-                font: FontSourceTemplate::Handle(text_font)
-            }
-            TextLayout::justify(Justify::Center)
-        ]
-    }
-}
-
-fn buttons_handler<T>(
-    mut left_panel_query: Query<&mut <Target<T> as TargetUpdate>::TargetComponent>,
-    mut visibility_button_query: Query<(&Target<T>, &Interaction, &Children), Changed<Interaction>>,
-    mut text_query: Query<(&mut Text, &mut TextColor)>,
-) where
-    T: Send + Sync,
-    Target<T>: TargetUpdate + Component,
-{
-    for (target, interaction, children) in visibility_button_query.iter_mut() {
-        if matches!(interaction, Interaction::Pressed) {
-            let mut target_value = left_panel_query.get_mut(target.id.unwrap()).unwrap();
-            for &child in children {
-                if let Ok((mut text, mut text_color)) = text_query.get_mut(child) {
-                    **text = target.update_target(target_value.as_mut());
-                    text_color.0 = if text.contains("None") || text.contains("Hidden") {
-                        Color::srgb(1.0, 0.7, 0.7)
-                    } else {
-                        Color::WHITE
-                    };
-                }
-            }
-        }
-    }
-}
-
-fn text_hover(
-    mut button_query: Query<(&Interaction, &mut BackgroundColor, &Children), Changed<Interaction>>,
-    mut text_query: Query<(&Text, &mut TextColor)>,
-) {
-    for (interaction, mut color, children) in button_query.iter_mut() {
-        match interaction {
-            Interaction::Hovered => {
-                *color = Color::BLACK.with_alpha(0.6).into();
-                for &child in children {
-                    if let Ok((_, mut text_color)) = text_query.get_mut(child) {
-                        // Bypass change detection to avoid recomputation of the text when only changing the color
-                        text_color.bypass_change_detection().0 = YELLOW.into();
-                    }
-                }
-            }
-            _ => {
-                *color = Color::BLACK.with_alpha(0.5).into();
-                for &child in children {
-                    if let Ok((text, mut text_color)) = text_query.get_mut(child) {
-                        text_color.bypass_change_detection().0 =
-                            if text.contains("None") || text.contains("Hidden") {
-                                HIDDEN_COLOR
-                            } else {
-                                Color::WHITE
-                            };
-                    }
-                }
-            }
-        }
     }
 }

--- a/examples/ui/layout/display_and_visibility.rs
+++ b/examples/ui/layout/display_and_visibility.rs
@@ -34,6 +34,8 @@ fn main() {
 /// with a given setting `T`.
 /// The way the change is implemented is via the `TargetUpdate<T>` trait. Changing the
 /// value of the option select will alter the target entity.
+/// id is an `Option` in order for this to derive `Default` for usage in bsn!,
+/// but the id should always be present.
 #[derive(Component, Clone, Default)]
 struct Target<T> {
     id: Option<Entity>,
@@ -163,7 +165,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 /// Returns the main interactable of the example as a scene.
-/// The left panel changes Display and Visibility based on actions taken
+/// The left panel changes `Display` and `Visibility` based on actions taken
 /// in the right panel.
 fn panels(palette: &[Color; 4]) -> impl Scene {
     let left_panel_node_base = |height_px: i32, palette_index: usize| {
@@ -352,7 +354,7 @@ fn feathers_select_visibility(target: EntityTemplate) -> impl Scene {
 fn on_value_change<T: Component + Default + Clone + PartialEq + Send + Sync>(
     event: On<ValueChange<Entity>>,
     setting_value_q: Query<&T>,
-    list_box_q: Query<(&Children, &Target<T>), With<FeathersSelect>>,
+    select_q: Query<(&Children, &Target<T>), With<FeathersSelect>>,
     mut target_component_query: Query<&mut <Target<T> as TargetUpdate<T>>::TargetComponent>,
     mut commands: Commands,
 ) where
@@ -361,7 +363,7 @@ fn on_value_change<T: Component + Default + Clone + PartialEq + Send + Sync>(
     let Ok(value) = setting_value_q.get(event.value) else {
         return;
     };
-    let Ok((children, target)) = list_box_q.get(event.source) else {
+    let Ok((children, target)) = select_q.get(event.source) else {
         return;
     };
 

--- a/examples/ui/layout/display_and_visibility.rs
+++ b/examples/ui/layout/display_and_visibility.rs
@@ -85,7 +85,7 @@ impl TargetUpdate<NodeDisplaySetting> for Target<NodeDisplaySetting> {
     }
 }
 
-/// For `Visibility`, this impl of `TargetUpdate` will affect this entity's `Visibility` component.`
+/// For `Visibility`, this impl of `TargetUpdate` will affect this entity's `Visibility` component.
 impl TargetUpdate<NodeVisibilitySetting> for Target<NodeVisibilitySetting> {
     type TargetComponent = Visibility;
     fn update_target(&self, visibility: &mut Self::TargetComponent, value: &NodeVisibilitySetting) {
@@ -349,7 +349,7 @@ fn feathers_select_visibility(target: EntityTemplate) -> impl Scene {
     }
 }
 
-/// Observer that reacts to value changes of a FeathersSelect for the `T` setting,
+/// Observer that reacts to value changes of a `FeathersSelect` for the `T` setting,
 /// and updates the target entity accordingly.
 fn on_value_change<T: Component + Default + Clone + PartialEq + Send + Sync>(
     event: On<ValueChange<Entity>>,
@@ -385,10 +385,10 @@ fn on_value_change<T: Component + Default + Clone + PartialEq + Send + Sync>(
     }
 }
 
-/// A scene of the Node, BackgroundColor, and `Target<T>` for the given target.
-fn select_base<T: Component + Clone + Default + PartialEq>(target: EntityTemplate) -> impl Scene
+/// A scene of the `Node`, `BackgroundColor`, and `Target<T>` for the given target.
+fn select_base<T>(target: EntityTemplate) -> impl Scene
 where
-    T: Default + Clone + Unpin + std::fmt::Debug + Send + Sync + 'static,
+    T: Default + Clone + Component + PartialEq + Unpin + Send + Sync + 'static,
     Target<T>: TargetUpdate<T>,
 {
     bsn! {

--- a/examples/ui/layout/display_and_visibility.rs
+++ b/examples/ui/layout/display_and_visibility.rs
@@ -2,8 +2,9 @@
 
 use bevy::{
     color::palettes::css::{DARK_CYAN, DARK_GRAY, YELLOW},
-    ecs::{component::Mutable, hierarchy::ChildSpawnerCommands},
+    ecs::{component::Mutable, template::EntityTemplate},
     prelude::*,
+    text::FontSourceTemplate,
 };
 
 const PALETTE: [&str; 4] = ["27496D", "466B7A", "669DB3", "ADCBE3"];
@@ -24,16 +25,19 @@ fn main() {
         .run();
 }
 
-#[derive(Component)]
+/// A component attached to a button that implements `TargetUpdate`.
+/// Activating the button will alter the target entity's
+/// `T` component.
+#[derive(Component, Clone, Default)]
 struct Target<T> {
-    id: Entity,
+    id: Option<Entity>,
     phantom: std::marker::PhantomData<T>,
 }
 
 impl<T> Target<T> {
     fn new(id: Entity) -> Self {
         Self {
-            id,
+            id: Some(id),
             phantom: std::marker::PhantomData,
         }
     }
@@ -80,6 +84,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     };
 
     commands.spawn(Camera2d);
+
+    let panels_child = commands
+        .spawn_scene(panels("fonts/FiraSans-Bold.ttf", &palette))
+        .id();
+
     commands
         .spawn((
             Node {
@@ -92,6 +101,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
             BackgroundColor(Color::BLACK),
         ))
+        .add_child(panels_child)
         .with_children(|parent| {
             parent.spawn((
                 Text::new("Use the panel on the right to change the Display and Visibility properties for the respective nodes of the panel on the left"),
@@ -102,35 +112,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     ..Default::default()
                 },
             ));
-
-            parent
-                .spawn(Node {
-                    width: percent(100),
-                    ..default()
-                })
-                .with_children(|parent| {
-                    let mut target_ids = vec![];
-                    parent
-                        .spawn(Node {
-                            width: percent(50),
-                            height: px(520),
-                            justify_content: JustifyContent::Center,
-                            ..default()
-                        })
-                        .with_children(|parent| {
-                            target_ids = spawn_left_panel(parent, &palette);
-                        });
-
-                    parent
-                        .spawn(Node {
-                            width: percent(50),
-                            justify_content: JustifyContent::Center,
-                            ..default()
-                        })
-                        .with_children(|parent| {
-                            spawn_right_panel(parent, text_font, &palette, target_ids);
-                        });
-                });
 
             parent
                 .spawn(Node {
@@ -163,239 +144,185 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         });
 }
 
-fn spawn_left_panel(builder: &mut ChildSpawnerCommands, palette: &[Color; 4]) -> Vec<Entity> {
-    let mut target_ids = vec![];
-    builder
-        .spawn((
+/// Returns the main interactable of the example as a scene.
+/// The left panel changes Display and Visibility based on actions taken
+/// in the right panel.
+fn panels(text_font: &'static str, palette: &[Color; 4]) -> impl Scene {
+    let left_panel_node_base = |height_px: i32, palette_index: usize| {
+        bsn! {
             Node {
-                padding: UiRect::all(px(10)),
-                ..default()
-            },
-            BackgroundColor(Color::WHITE),
-        ))
-        .with_children(|parent| {
-            parent
-                .spawn((Node::default(), BackgroundColor(Color::BLACK)))
-                .with_children(|parent| {
-                    let id = parent
-                        .spawn((
+                height: px(height_px),
+                align_items: AlignItems::FlexEnd,
+                justify_content: JustifyContent::FlexEnd,
+            }
+            BackgroundColor(palette[palette_index])
+        }
+    };
+
+    let right_panel_node_base = |width_height_px: i32, palette_index: usize| {
+        bsn! {
+            Node {
+                width: px(width_height_px),
+                height: px(width_height_px),
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::FlexEnd,
+                justify_content: JustifyContent::SpaceBetween,
+                padding: UiRect {
+                    left: px(5),
+                    top: px(5),
+                },
+            }
+            BackgroundColor(palette[palette_index])
+        }
+    };
+
+    // This must be defined as a big scene because
+    // the right panel has entity references to affect look of the left panel.
+    // The entity references must exist in the same `bsn!` block in order to be valid.
+    bsn! {
+        Node {
+            width: percent(100)
+        }
+        Children [
+            #LeftPanel
+            Node {
+                width: percent(50),
+                height: px(520),
+                justify_content: JustifyContent::Center,
+            }
+            Children [
+                Node {
+                    padding: UiRect::all(px(10)),
+                }
+                BackgroundColor(Color::WHITE)
+                Children [
+                    Node
+                    BackgroundColor(Color::BLACK)
+                    Children [
+                        #LeftGrandParent
+                        left_panel_node_base(500, 0)
+                        Outline {
+                            width: px(4),
+                            color: DARK_CYAN,
+                            offset: px(10),
+                        }
+                        Children [
                             Node {
-                                align_items: AlignItems::FlexEnd,
-                                justify_content: JustifyContent::FlexEnd,
-                                ..default()
-                            },
-                            BackgroundColor(palette[0]),
-                            Outline {
-                                width: px(4),
-                                color: DARK_CYAN.into(),
-                                offset: px(10),
-                            },
-                        ))
-                        .with_children(|parent| {
-                            parent.spawn(Node {
                                 width: px(100),
                                 height: px(500),
-                                ..default()
-                            });
+                            },
 
-                            let id = parent
-                                .spawn((
+                            #LeftParent
+                            left_panel_node_base(400, 1)
+                            Children [
+                                Node {
+                                    width: px(100),
+                                    height: px(400),
+                                },
+
+                                #LeftChild
+                                left_panel_node_base(300, 2)
+                                Children [
                                     Node {
-                                        height: px(400),
-                                        align_items: AlignItems::FlexEnd,
-                                        justify_content: JustifyContent::FlexEnd,
-                                        ..default()
-                                    },
-                                    BackgroundColor(palette[1]),
-                                ))
-                                .with_children(|parent| {
-                                    parent.spawn(Node {
                                         width: px(100),
-                                        height: px(400),
-                                        ..default()
-                                    });
+                                        height: px(300),
+                                    },
 
-                                    let id = parent
-                                        .spawn((
-                                            Node {
-                                                height: px(300),
-                                                align_items: AlignItems::FlexEnd,
-                                                justify_content: JustifyContent::FlexEnd,
-                                                ..default()
-                                            },
-                                            BackgroundColor(palette[2]),
-                                        ))
-                                        .with_children(|parent| {
-                                            parent.spawn(Node {
-                                                width: px(100),
-                                                height: px(300),
-                                                ..default()
-                                            });
+                                    #LeftGrandChild
+                                    Node {
+                                        width: px(200),
+                                        height: px(200),
 
-                                            let id = parent
-                                                .spawn((
-                                                    Node {
-                                                        width: px(200),
-                                                        height: px(200),
-                                                        ..default()
-                                                    },
-                                                    BackgroundColor(palette[3]),
-                                                ))
-                                                .id();
-                                            target_ids.push(id);
-                                        })
-                                        .id();
-                                    target_ids.push(id);
-                                })
-                                .id();
-                            target_ids.push(id);
-                        })
-                        .id();
-                    target_ids.push(id);
-                });
-        });
-    target_ids
-}
+                                    }
+                                    BackgroundColor(palette[3])
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ],
 
-fn spawn_right_panel(
-    parent: &mut ChildSpawnerCommands,
-    text_font: TextFont,
-    palette: &[Color; 4],
-    mut target_ids: Vec<Entity>,
-) {
-    let spawn_buttons = |parent: &mut ChildSpawnerCommands, target_id| {
-        spawn_button::<Display>(parent, text_font.clone(), target_id);
-        spawn_button::<Visibility>(parent, text_font.clone(), target_id);
-    };
-    parent
-        .spawn((
+            #RightPanel
             Node {
-                padding: UiRect::all(px(10)),
-                ..default()
-            },
-            BackgroundColor(Color::WHITE),
-        ))
-        .with_children(|parent| {
-            parent
-                .spawn((
-                    Node {
-                        width: px(500),
-                        height: px(500),
-                        flex_direction: FlexDirection::Column,
-                        align_items: AlignItems::FlexEnd,
-                        justify_content: JustifyContent::SpaceBetween,
-                        padding: UiRect {
-                            left: px(5),
-                            top: px(5),
-                            ..default()
-                        },
-                        ..default()
-                    },
-                    BackgroundColor(palette[0]),
+                width: percent(50),
+                justify_content: JustifyContent::Center,
+            }
+            Children [
+                Node {
+                    padding: UiRect::all(px(10)),
+                }
+                BackgroundColor(Color::WHITE)
+                Children [
+                    #RightGrandParent
+                    right_panel_node_base(500, 0)
                     Outline {
                         width: px(4),
-                        color: DARK_CYAN.into(),
+                        color: DARK_CYAN,
                         offset: px(10),
-                    },
-                ))
-                .with_children(|parent| {
-                    spawn_buttons(parent, target_ids.pop().unwrap());
+                    }
+                    Children [
+                        button_scene::<Display>(text_font, #LeftGrandParent),
+                        button_scene::<Visibility>(text_font, #LeftGrandParent),
 
-                    parent
-                        .spawn((
-                            Node {
-                                width: px(400),
-                                height: px(400),
-                                flex_direction: FlexDirection::Column,
-                                align_items: AlignItems::FlexEnd,
-                                justify_content: JustifyContent::SpaceBetween,
-                                padding: UiRect {
-                                    left: px(5),
-                                    top: px(5),
-                                    ..default()
-                                },
-                                ..default()
-                            },
-                            BackgroundColor(palette[1]),
-                        ))
-                        .with_children(|parent| {
-                            spawn_buttons(parent, target_ids.pop().unwrap());
+                        #RightParent
+                        right_panel_node_base(400, 1)
+                        Children [
+                            button_scene::<Display>(text_font, #LeftParent),
+                            button_scene::<Visibility>(text_font, #LeftParent),
 
-                            parent
-                                .spawn((
+                            #RightChild
+                            right_panel_node_base(300, 2)
+                            Children [
+                                button_scene::<Display>(text_font, #LeftChild),
+                                button_scene::<Visibility>(text_font, #LeftChild),
+
+                                #RightGrandChild
+                                right_panel_node_base(200, 3)
+                                Children [
+                                    button_scene::<Display>(text_font, #LeftGrandChild),
+                                    button_scene::<Visibility>(text_font, #LeftGrandChild),
+
                                     Node {
-                                        width: px(300),
-                                        height: px(300),
-                                        flex_direction: FlexDirection::Column,
-                                        align_items: AlignItems::FlexEnd,
-                                        justify_content: JustifyContent::SpaceBetween,
-                                        padding: UiRect {
-                                            left: px(5),
-                                            top: px(5),
-                                            ..default()
-                                        },
-                                        ..default()
-                                    },
-                                    BackgroundColor(palette[2]),
-                                ))
-                                .with_children(|parent| {
-                                    spawn_buttons(parent, target_ids.pop().unwrap());
-
-                                    parent
-                                        .spawn((
-                                            Node {
-                                                width: px(200),
-                                                height: px(200),
-                                                align_items: AlignItems::FlexStart,
-                                                justify_content: JustifyContent::SpaceBetween,
-                                                flex_direction: FlexDirection::Column,
-                                                padding: UiRect {
-                                                    left: px(5),
-                                                    top: px(5),
-                                                    ..default()
-                                                },
-                                                ..default()
-                                            },
-                                            BackgroundColor(palette[3]),
-                                        ))
-                                        .with_children(|parent| {
-                                            spawn_buttons(parent, target_ids.pop().unwrap());
-
-                                            parent.spawn(Node {
-                                                width: px(100),
-                                                height: px(100),
-                                                ..default()
-                                            });
-                                        });
-                                });
-                        });
-                });
-        });
+                                        width: px(100),
+                                        height: px(100),
+                                    }
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+        ]
+    }
 }
 
-fn spawn_button<T>(parent: &mut ChildSpawnerCommands, text_font: TextFont, target: Entity)
+/// A button that, when pressed, will execute up a target action on the provided `target`.
+/// The target action is applied to the `T` component on the `target.`
+fn button_scene<T>(text_font: &'static str, target: EntityTemplate) -> impl Scene
 where
-    T: Default + std::fmt::Debug + Send + Sync + 'static,
+    T: Default + Clone + Unpin + std::fmt::Debug + Send + Sync + 'static,
     Target<T>: TargetUpdate,
 {
-    parent
-        .spawn((
-            Button,
-            Node {
-                align_self: AlignSelf::FlexStart,
-                padding: UiRect::axes(px(5), px(1)),
-                ..default()
-            },
-            BackgroundColor(Color::BLACK.with_alpha(0.5)),
-            Target::<T>::new(target),
-        ))
-        .with_children(|builder| {
-            builder.spawn((
-                Text(format!("{}::{:?}", Target::<T>::NAME, T::default())),
-                text_font,
-                TextLayout::justify(Justify::Center),
-            ));
-        });
+    bsn! {
+        Button
+        Node {
+            align_self: AlignSelf::FlexStart,
+            padding: UiRect::axes(px(5), px(1)),
+        }
+        BackgroundColor({Color::BLACK.with_alpha(0.5)})
+        template(move |ctx| match target {
+            EntityTemplate::Entity(ent) => Ok(Target::<T>::new(ent)),
+            EntityTemplate::SceneEntityReference(scene_entity_reference) => Ok(Target::<T>::new(ctx.get_entity(scene_entity_reference))),
+            EntityTemplate::None => Err(BevyError::error("Did not set up example correctly!"))
+        })
+        Children [
+            Text(format!("{}::{:?}", Target::<T>::NAME, T::default()))
+            TextFont {
+                font: FontSourceTemplate::Handle(text_font)
+            }
+            TextLayout::justify(Justify::Center)
+        ]
+    }
 }
 
 fn buttons_handler<T>(
@@ -408,7 +335,7 @@ fn buttons_handler<T>(
 {
     for (target, interaction, children) in visibility_button_query.iter_mut() {
         if matches!(interaction, Interaction::Pressed) {
-            let mut target_value = left_panel_query.get_mut(target.id).unwrap();
+            let mut target_value = left_panel_query.get_mut(target.id.unwrap()).unwrap();
             for &child in children {
                 if let Ok((mut text, mut text_color)) = text_query.get_mut(child) {
                     **text = target.update_target(target_value.as_mut());


### PR DESCRIPTION
# Objective

- Part of #24112 
- It was under a “ui_widgets” migration phase, but the buttons used are not necessary to understanding the point of the example, which is to demonstrate the differences between `Display` and `Visibility`. After interacting with the example on `main`, I decided that it would be best to use a `FeathersSelect`. Plus, I would have to worry less about hand crafting a menu popup from scratch.

## Solution
- The logic to set up the example panels was very….. involved, so I decided to port it to bsn! instead. I think it becomes a really cool example showing the usage of using Entity References to do something neat as a side effect.
- Replaced the button/interaction logic with a `FeathersSelect`. I think the only thing that’s lost is that the text color doesn’t change to a tinted red when selecting “Hidden” or “None”, but I hope that’s not a blocker.

## Testing

- `cargo run --example display_and_visibility --features=“bevy_feathers"`

---

## Showcase

<details>
  <summary>Before and After Screenshots</summary>

Before
<img width="1271" height="746" alt="Screenshot 2026-07-23 at 7 11 22 PM" src="https://github.com/user-attachments/assets/16d28f10-bd57-41ae-84dc-b2963c4452d6" />

After
<img width="1270" height="744" alt="Screenshot 2026-07-23 at 7 06 40 PM" src="https://github.com/user-attachments/assets/f57d06ab-e377-4ba8-a054-930b7f399018" />

<img width="1271" height="744" alt="Screenshot 2026-07-23 at 7 06 53 PM" src="https://github.com/user-attachments/assets/1f9ca271-ec1e-4bce-8f2a-7065b114db6d" />

</details>
