### PR TITLE
Migrate `size_constraints` to bsn! and `ui_widgets::RadioButton` (Phase 3 Item 5)

### DIFF
--- a/examples/ui/layout/size_constraints.rs
+++ b/examples/ui/layout/size_constraints.rs
@@ -1,13 +1,18 @@
 //! Demonstrates how the to use the size constraints to control the size of a UI node.
 
-use bevy::{color::palettes::css::*, prelude::*};
+use bevy::{
+    color::palettes::css::*,
+    prelude::*,
+    text::FontSourceTemplate,
+    ui::Checked,
+    ui_widgets::{RadioButton, RadioGroup, ValueChange},
+};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_message::<ButtonActivated>()
         .add_systems(Startup, setup)
-        .add_systems(Update, (update_buttons, update_radio_buttons_colors))
+        .add_observer(on_value_change_constraints)
         .run();
 }
 
@@ -21,9 +26,11 @@ const ACTIVE_TEXT_COLOR: Color = Color::BLACK;
 const HOVERED_TEXT_COLOR: Color = Color::WHITE;
 const UNHOVERED_TEXT_COLOR: Color = Color::srgb(0.5, 0.5, 0.5);
 
-#[derive(Component)]
+/// A marker component for the UI Node which will be resized by user input.
+#[derive(Component, Clone, Default)]
 struct Bar;
 
+/// The four properties on the `Node` of the `Bar` entity that can be changed.
 #[derive(Copy, Clone, Debug, Component, PartialEq)]
 enum Constraint {
     FlexBasis,
@@ -32,115 +39,101 @@ enum Constraint {
     MaxWidth,
 }
 
-#[derive(Copy, Clone, Component)]
-struct ButtonValue(Val);
+#[derive(Copy, Clone, Component, Default, PartialEq)]
+struct RadioButtonValue(Val);
 
-#[derive(Message)]
-struct ButtonActivated(Entity);
-
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // ui camera
+fn setup(mut commands: Commands) {
+    // UI Camera
     commands.spawn(Camera2d);
 
-    let text_font = (
-        TextFont {
-            font: asset_server.load("fonts/FiraSans-Bold.ttf").into(),
-            font_size: FontSize::Px(33.0),
-            ..Default::default()
-        },
-        TextColor(Color::srgb(0.9, 0.9, 0.9)),
-    );
-
-    commands
-        .spawn((
+    commands.spawn_scene(bsn! {
+        // Background Node
+        Node {
+            width: percent(100),
+            height: percent(100),
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+        }
+        BackgroundColor(Color::BLACK)
+        Children [
+            // Centered column that contains all the content of the example.
             Node {
-                width: percent(100),
-                height: percent(100),
-                justify_content: JustifyContent::Center,
+                flex_direction: FlexDirection::Column,
                 align_items: AlignItems::Center,
-                ..default()
-            },
-            BackgroundColor(Color::BLACK),
-        ))
-        .with_children(|parent| {
-            parent
-                .spawn(Node {
+                justify_content: JustifyContent::Center,
+            }
+            Children [
+                Text::new("Size Constraints Example")
+                font_style_scene()
+                Node {
+                    margin: UiRect::bottom(px(25)),
+                },
+
+                bar_scene(),
+
+                // Controls (radio buttons)
+                Node {
                     flex_direction: FlexDirection::Column,
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::Center,
-                    ..default()
-                })
-                .with_children(|parent| {
-                    parent.spawn((
-                        Text::new("Size Constraints Example"),
-                        text_font.clone(),
-                        Node {
-                            margin: UiRect::bottom(px(25)),
-                            ..Default::default()
-                        },
-                    ));
-
-                    spawn_bar(parent);
-
-                    parent
-                        .spawn((
-                            Node {
-                                flex_direction: FlexDirection::Column,
-                                align_items: AlignItems::Stretch,
-                                padding: UiRect::all(px(10)),
-                                margin: UiRect::top(px(50)),
-                                ..default()
-                            },
-                            BackgroundColor(YELLOW.into()),
-                        ))
-                        .with_children(|parent| {
-                            for constraint in [
-                                Constraint::MinWidth,
-                                Constraint::FlexBasis,
-                                Constraint::Width,
-                                Constraint::MaxWidth,
-                            ] {
-                                spawn_button_row(parent, constraint, text_font.clone());
-                            }
-                        });
-                });
-        });
+                    align_items: AlignItems::Stretch,
+                    padding: UiRect::all(px(10)),
+                    margin: UiRect::top(px(50)),
+                }
+                BackgroundColor(YELLOW)
+                Children [
+                    {
+                        [
+                            Constraint::MinWidth,
+                            Constraint::FlexBasis,
+                            Constraint::Width,
+                            Constraint::MaxWidth,
+                        ].into_iter().map(|constraint| {
+                            radio_group_scene(constraint)
+                        })
+                        .collect::<Vec<_>>()
+                    }
+                ]
+            ]
+        ]
+    });
 }
 
-fn spawn_bar(parent: &mut ChildSpawnerCommands) {
-    parent
-        .spawn((
+fn font_style_scene() -> impl Scene {
+    bsn! {
+        TextFont {
+            font: FontSourceTemplate::Handle("fonts/FiraSans-Bold.ttf"),
+            font_size: FontSize::Px(33.0),
+        }
+        TextColor(Color::srgb(0.9, 0.9, 0.9))
+    }
+}
+
+fn bar_scene() -> impl Scene {
+    bsn! {
+        Node {
+            flex_basis: percent(100),
+            align_self: AlignSelf::Stretch,
+            padding: UiRect::all(px(10)),
+        }
+        BackgroundColor(YELLOW)
+        Children [
             Node {
-                flex_basis: percent(100),
-                align_self: AlignSelf::Stretch,
-                padding: UiRect::all(px(10)),
-                ..default()
-            },
-            BackgroundColor(YELLOW.into()),
-        ))
-        .with_children(|parent| {
-            parent
-                .spawn((
-                    Node {
-                        align_items: AlignItems::Stretch,
-                        width: percent(100),
-                        height: px(100),
-                        padding: UiRect::all(px(4)),
-                        ..default()
-                    },
-                    BackgroundColor(Color::BLACK),
-                ))
-                .with_children(|parent| {
-                    parent.spawn((Node::default(), BackgroundColor(Color::WHITE), Bar));
-                });
-        });
+                align_items: AlignItems::Stretch,
+                width: percent(100),
+                height: px(100),
+                padding: UiRect::all(px(4)),
+            }
+            BackgroundColor(Color::BLACK)
+            Children [
+                // This bar will grow and shrink as the constraints are tinkered with.
+                Bar
+                Node
+                BackgroundColor(Color::WHITE)
+            ]
+        ]
+    }
 }
 
-fn spawn_button_row(
-    parent: &mut ChildSpawnerCommands,
-    constraint: Constraint,
-    text_style: (TextFont, TextColor),
-) {
+fn radio_group_scene(constraint: Constraint) -> impl Scene {
     let label = match constraint {
         Constraint::FlexBasis => "flex_basis",
         Constraint::Width => "size",
@@ -148,212 +141,195 @@ fn spawn_button_row(
         Constraint::MaxWidth => "max_size",
     };
 
-    parent
-        .spawn((
-            Node {
-                flex_direction: FlexDirection::Column,
-                padding: UiRect::all(px(2)),
-                align_items: AlignItems::Stretch,
-                ..default()
-            },
-            BackgroundColor(Color::BLACK),
-        ))
-        .with_children(|parent| {
-            parent
-                .spawn(Node {
-                    flex_direction: FlexDirection::Row,
-                    justify_content: JustifyContent::End,
-                    padding: UiRect::all(px(2)),
-                    ..default()
-                })
-                .with_children(|parent| {
-                    // spawn row label
-                    parent
-                        .spawn((Node {
-                            min_width: px(200),
-                            max_width: px(200),
-                            justify_content: JustifyContent::Center,
-                            align_items: AlignItems::Center,
-                            ..default()
-                        },))
-                        .with_child((Text::new(label), text_style.clone()));
-
-                    // spawn row buttons
-                    parent.spawn(Node::default()).with_children(|parent| {
-                        spawn_button(
-                            parent,
-                            constraint,
-                            ButtonValue(auto()),
-                            "Auto".to_string(),
-                            text_style.clone(),
-                            true,
-                        );
-                        for percent_value in [0, 25, 50, 75, 100, 125] {
-                            spawn_button(
-                                parent,
-                                constraint,
-                                ButtonValue(percent(percent_value)),
-                                format!("{percent_value}%"),
-                                text_style.clone(),
-                                false,
-                            );
-                        }
-                    });
-                });
-        });
-}
-
-fn spawn_button(
-    parent: &mut ChildSpawnerCommands,
-    constraint: Constraint,
-    action: ButtonValue,
-    label: String,
-    text_style: (TextFont, TextColor),
-    active: bool,
-) {
-    parent
-        .spawn((
-            Button,
-            Node {
-                align_items: AlignItems::Center,
-                justify_content: JustifyContent::Center,
-                border: UiRect::all(px(2)),
-                margin: UiRect::horizontal(px(2)),
-                ..Default::default()
-            },
-            BorderColor::all(if active {
-                ACTIVE_BORDER_COLOR
-            } else {
-                INACTIVE_BORDER_COLOR
-            }),
-            constraint,
-            action,
-        ))
-        .with_children(|parent| {
-            parent
-                .spawn((
-                    Node {
-                        width: px(100),
-                        justify_content: JustifyContent::Center,
-                        ..default()
-                    },
-                    BackgroundColor(if active {
-                        ACTIVE_INNER_COLOR
-                    } else {
-                        INACTIVE_INNER_COLOR
-                    }),
-                ))
-                .with_child((
-                    Text::new(label),
-                    text_style.0,
-                    TextColor(if active {
-                        ACTIVE_TEXT_COLOR
-                    } else {
-                        UNHOVERED_TEXT_COLOR
-                    }),
-                    TextLayout::justify(Justify::Center),
-                ));
-        });
-}
-
-fn update_buttons(
-    mut button_query: Query<
-        (Entity, &Interaction, &Constraint, &ButtonValue),
-        Changed<Interaction>,
-    >,
-    mut bar_node: Single<&mut Node, With<Bar>>,
-    mut text_query: Query<&mut TextColor>,
-    children_query: Query<&Children>,
-    mut button_activated_writer: MessageWriter<ButtonActivated>,
-) {
-    for (button_id, interaction, constraint, value) in button_query.iter_mut() {
-        match interaction {
-            Interaction::Pressed => {
-                button_activated_writer.write(ButtonActivated(button_id));
-                match constraint {
-                    Constraint::FlexBasis => {
-                        bar_node.flex_basis = value.0;
-                    }
-                    Constraint::Width => {
-                        bar_node.width = value.0;
-                    }
-                    Constraint::MinWidth => {
-                        bar_node.min_width = value.0;
-                    }
-                    Constraint::MaxWidth => {
-                        bar_node.max_width = value.0;
-                    }
-                }
-            }
-            Interaction::Hovered => {
-                if let Ok(children) = children_query.get(button_id) {
-                    for &child in children {
-                        if let Ok(grand_children) = children_query.get(child) {
-                            for &grandchild in grand_children {
-                                if let Ok(mut text_color) = text_query.get_mut(grandchild)
-                                    && text_color.0 != ACTIVE_TEXT_COLOR
-                                {
-                                    text_color.0 = HOVERED_TEXT_COLOR;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            Interaction::None => {
-                if let Ok(children) = children_query.get(button_id) {
-                    for &child in children {
-                        if let Ok(grand_children) = children_query.get(child) {
-                            for &grandchild in grand_children {
-                                if let Ok(mut text_color) = text_query.get_mut(grandchild)
-                                    && text_color.0 != ACTIVE_TEXT_COLOR
-                                {
-                                    text_color.0 = UNHOVERED_TEXT_COLOR;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+    bsn! {
+        Node {
+            flex_direction: FlexDirection::Column,
+            padding: UiRect::all(px(2)),
+            align_items: AlignItems::Stretch,
         }
+        BackgroundColor(Color::BLACK)
+        Children [
+            Node {
+                flex_direction: FlexDirection::Row,
+                justify_content: JustifyContent::End,
+                padding: UiRect::all(px(2)),
+            }
+            Children [
+                // Row Label
+                Node {
+                    min_width: px(200),
+                    max_width: px(200),
+                    justify_content: JustifyContent::Center,
+                    align_items: AlignItems::Center,
+                }
+                Children [
+                    Text::new(label)
+                    font_style_scene()
+                ],
+
+                // Row Buttons
+                Node
+                RadioGroup
+                Children [
+                    Checked
+                    radio_button_scene(
+                        constraint,
+                        RadioButtonValue(auto()),
+                        "Auto".to_string(),
+                        true,
+                    ),
+
+                    {
+                        [0, 25, 50, 75, 100, 125].into_iter().map(|percent_value| {
+                            radio_button_scene(
+                                constraint,
+                                RadioButtonValue(percent(percent_value)),
+                                format!("{percent_value}%"),
+                                false,
+                            )
+                        }).collect::<Vec<_>>()
+                    },
+                ],
+            ]
+        ]
     }
 }
 
-fn update_radio_buttons_colors(
-    mut button_activated_reader: MessageReader<ButtonActivated>,
-    button_query: Query<(Entity, &Constraint, &Interaction)>,
-    mut border_query: Query<&mut BorderColor>,
-    mut color_query: Query<&mut BackgroundColor>,
-    mut text_query: Query<&mut TextColor>,
-    children_query: Query<&Children>,
-) {
-    for &ButtonActivated(button_id) in button_activated_reader.read() {
-        let (_, target_constraint, _) = button_query.get(button_id).unwrap();
-        for (id, constraint, interaction) in button_query.iter() {
-            if target_constraint == constraint {
-                let (border_color, inner_color, label_color) = if id == button_id {
-                    (ACTIVE_BORDER_COLOR, ACTIVE_INNER_COLOR, ACTIVE_TEXT_COLOR)
+fn radio_button_scene(
+    constraint: Constraint,
+    action: RadioButtonValue,
+    label: String,
+    active: bool,
+) -> impl Scene {
+    bsn! {
+        RadioButton
+        Node {
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+            border: UiRect::all(px(2)),
+            margin: UiRect::horizontal(px(2)),
+        }
+        BorderColor::all(if active {
+            ACTIVE_BORDER_COLOR
+        } else {
+            INACTIVE_BORDER_COLOR
+        })
+        template_value(constraint)
+        template_value(action)
+        Children [
+            Node {
+                width: px(100),
+                justify_content: JustifyContent::Center,
+            }
+            BackgroundColor({if active {
+                ACTIVE_INNER_COLOR
+            } else {
+                INACTIVE_INNER_COLOR
+            }})
+            Children [
+                Text::new(label)
+                font_style_scene()
+                TextColor({if active {
+                    ACTIVE_TEXT_COLOR
                 } else {
-                    (
-                        INACTIVE_BORDER_COLOR,
-                        INACTIVE_INNER_COLOR,
-                        if matches!(interaction, Interaction::Hovered) {
-                            HOVERED_TEXT_COLOR
-                        } else {
-                            UNHOVERED_TEXT_COLOR
-                        },
-                    )
-                };
+                    UNHOVERED_TEXT_COLOR
+                }})
+                TextLayout::justify(Justify::Center)
+            ]
+        ]
+        // Observers for updating text on hover/leave
+        on(|event: On<Pointer<Over>>,
+            has_checked_query: Query<&Checked>,
+            child_q: Query<&Children>,
+            mut commands: Commands| {
+            if has_checked_query.contains(event.entity) {
+                return;
+            }
 
-                *border_query.get_mut(id).unwrap() = BorderColor::all(border_color);
-                for &child in children_query.get(id).into_iter().flatten() {
-                    color_query.get_mut(child).unwrap().0 = inner_color;
-                    for &grandchild in children_query.get(child).into_iter().flatten() {
-                        if let Ok(mut text_color) = text_query.get_mut(grandchild) {
-                            text_color.0 = label_color;
-                        }
-                    }
+            for text_entity in child_q.iter_leaves(event.entity) {
+                commands.entity(text_entity).insert(TextColor(HOVERED_TEXT_COLOR));
+            }
+        })
+        on(|event: On<Pointer<Out>>,
+            has_checked_query: Query<&Checked>,
+            child_q: Query<&Children>,
+            mut commands: Commands| {
+            if has_checked_query.contains(event.entity) {
+                return;
+            }
+
+            for text_entity in child_q.iter_leaves(event.entity) {
+                commands.entity(text_entity).insert(TextColor(UNHOVERED_TEXT_COLOR));
+            }
+        })
+    }
+}
+
+/// This system updates the Bar when a new value for a constraint is selected, and marks
+/// the radio button as the one currently selected
+fn on_value_change_constraints(
+    event: On<ValueChange<Entity>>,
+    new_setting_query: Query<
+        (&Constraint, &RadioButtonValue, Entity, &Children),
+        (With<RadioButton>, Without<Checked>),
+    >,
+    previous_query: Query<
+        (&Constraint, &RadioButtonValue, Entity, &Children),
+        (With<RadioButton>, With<Checked>),
+    >,
+    child_q: Query<&Children>,
+    mut commands: Commands,
+    mut bar_node: Single<&mut Node, With<Bar>>,
+) {
+    if let Ok((constraint, value, entity, children)) = new_setting_query.get(event.value) {
+        for (previous_constraint, previous_value, previous_entity, previous_children) in
+            previous_query.iter()
+        {
+            if constraint == previous_constraint && value == previous_value {
+                // There is no change in constraint. We can exit out early.
+                return;
+            } else if constraint == previous_constraint {
+                commands.entity(previous_entity).remove::<Checked>();
+                commands
+                    .entity(previous_entity)
+                    .insert(BorderColor::all(INACTIVE_BORDER_COLOR));
+                // radio button entities only have one child which contains the inner background color.
+                commands
+                    .entity(*previous_children.first().unwrap())
+                    .insert(BackgroundColor(INACTIVE_INNER_COLOR));
+                for text_entity in child_q.iter_leaves(previous_entity) {
+                    commands
+                        .entity(text_entity)
+                        .insert(TextColor(UNHOVERED_TEXT_COLOR));
                 }
+
+                commands.entity(entity).insert(Checked);
+                commands
+                    .entity(entity)
+                    .insert(BorderColor::all(ACTIVE_BORDER_COLOR));
+                commands
+                    .entity(*children.first().unwrap())
+                    .insert(BackgroundColor(ACTIVE_INNER_COLOR));
+                for text_entity in child_q.iter_leaves(entity) {
+                    commands
+                        .entity(text_entity)
+                        .insert(TextColor(ACTIVE_TEXT_COLOR));
+                }
+            }
+        }
+
+        match constraint {
+            Constraint::FlexBasis => {
+                bar_node.flex_basis = value.0;
+            }
+            Constraint::Width => {
+                bar_node.width = value.0;
+            }
+            Constraint::MinWidth => {
+                bar_node.min_width = value.0;
+            }
+            Constraint::MaxWidth => {
+                bar_node.max_width = value.0;
             }
         }
     }


### PR DESCRIPTION
# Objective

- Part of #24112 

## Solution

- Migrate the Buttons to become `RadioButton`s and `RadioGroup`. The look of the example stays exactly the same.
- bsn!-ify the thing for readability.

## Testing

- `cargo run --example size_constraints` It should look and function exactly the same as the example on main.
