### PR TITLE
Migrate `ui_transform` to use `ui_widgets::Button` (Phase 3 Item 4)

### DIFF
--- a/examples/ui/ui_transform.rs
+++ b/examples/ui/ui_transform.rs
@@ -2,7 +2,11 @@
 use bevy::color::palettes::css::DARK_GRAY;
 use bevy::color::palettes::css::RED;
 use bevy::color::palettes::css::YELLOW;
+use bevy::picking::hover::Hovered;
+use bevy::platform::collections::HashSet;
 use bevy::prelude::*;
+use bevy::ui::Pressed;
+use bevy::ui_widgets::Button;
 use core::f32::consts::FRAC_PI_8;
 
 fn main() {
@@ -32,39 +36,49 @@ pub struct TargetNode;
 
 /// Handles button interactions
 fn button_system(
-    mut interaction_query: Query<
+    mut button_query: Query<
         (
-            &Interaction,
+            Entity,
             &mut BackgroundColor,
+            Ref<Hovered>,
+            Option<Ref<Pressed>>,
             Option<&RotateButton>,
             Option<&ScaleButton>,
         ),
-        (Changed<Interaction>, With<Button>),
+        With<Button>,
     >,
+    mut removed_pressed: RemovedComponents<Pressed>,
     mut rotator_query: Query<&mut UiTransform, With<TargetNode>>,
 ) {
-    for (interaction, mut color, maybe_rotate, maybe_scale) in &mut interaction_query {
-        match *interaction {
-            Interaction::Pressed => {
-                *color = PRESSED_BUTTON.into();
-                if let Some(step) = maybe_rotate {
-                    for mut transform in rotator_query.iter_mut() {
-                        transform.rotation *= step.0;
+    // Buttons that had `Pressed` removed this frame; change detection does not report removals.
+    let just_unpressed: HashSet<Entity> = removed_pressed.read().collect();
+    for (entity, mut color, hovered, pressed, maybe_rotate, maybe_scale) in &mut button_query {
+        let changed = hovered.is_changed()
+            || pressed.as_ref().is_some_and(Ref::is_changed)
+            || just_unpressed.contains(&entity);
+        if changed {
+            match (pressed, hovered.get()) {
+                (Some(_), _) => {
+                    *color = PRESSED_BUTTON.into();
+                    if let Some(step) = maybe_rotate {
+                        for mut transform in rotator_query.iter_mut() {
+                            transform.rotation *= step.0;
+                        }
+                    }
+                    if let Some(step) = maybe_scale {
+                        for mut transform in rotator_query.iter_mut() {
+                            transform.scale += step.0;
+                            transform.scale =
+                                transform.scale.clamp(Vec2::splat(0.25), Vec2::splat(3.0));
+                        }
                     }
                 }
-                if let Some(step) = maybe_scale {
-                    for mut transform in rotator_query.iter_mut() {
-                        transform.scale += step.0;
-                        transform.scale =
-                            transform.scale.clamp(Vec2::splat(0.25), Vec2::splat(3.0));
-                    }
+                (_, true) => {
+                    *color = HOVERED_BUTTON.into();
                 }
-            }
-            Interaction::Hovered => {
-                *color = HOVERED_BUTTON.into();
-            }
-            Interaction::None => {
-                *color = NORMAL_BUTTON.into();
+                _ => {
+                    *color = NORMAL_BUTTON.into();
+                }
             }
         }
     }
@@ -137,6 +151,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     children![
                         (
                             Button,
+                            Hovered::default(),
                             Node {
                                 height: px(50),
                                 width: px(50),
@@ -150,6 +165,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ),
                         (
                             Button,
+                            Hovered::default(),
                             Node {
                                 height: px(50),
                                 width: px(50),
@@ -178,6 +194,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     children![
                         (
                             Button,
+                            Hovered::default(),
                             Node {
                                 width: px(80),
                                 height: px(80),
@@ -198,6 +215,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             children![
                                 (
                                     Button,
+                                    Hovered::default(),
                                     Node {
                                         width: px(80),
                                         height: px(80),
@@ -225,6 +243,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 ),
                                 (
                                     Button,
+                                    Hovered::default(),
                                     Node {
                                         width: px(80),
                                         height: px(80),
@@ -242,6 +261,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ),
                         (
                             Button,
+                            Hovered::default(),
                             Node {
                                 width: px(80),
                                 height: px(80),
@@ -270,6 +290,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     children![
                         (
                             Button,
+                            Hovered::default(),
                             Node {
                                 height: px(50),
                                 width: px(50),
@@ -283,6 +304,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ),
                         (
                             Button,
+                            Hovered::default(),
                             Node {
                                 height: px(50),
                                 width: px(50),


### PR DESCRIPTION
# Objective

- Part of #24112 

## Solution

- A straightforward port (phew) to using `ui_widgets::Button`, `Hovered`, and `Pressed` to replace the logic that used Interactions. The port is very similar to `ui_texture_atlas_slice`.

## Testing

- `cargo run --example ui_transform` There should be no difference from main.