### PR TITLE
Change `Pressed` to be a newtype bool to take advantage of Change Detection

### DIFF
--- a/_release-content/migration-guides/pressed_newtype_bool.md
+++ b/_release-content/migration-guides/pressed_newtype_bool.md
@@ -1,6 +1,6 @@
 ---
 title: "`Pressed` Component is now a newtype bool component"
-pull_requests: [24636, 24701]
+pull_requests: [25154]
 ---
 
 Previously, the `Pressed` component was a marker component without any fields. Now, it is a marker component with a single boolean field signifying whether the entity is being pressed. This was done to enable usage of change detection of the `Pressed` component in regular systems. The `Pressed` component is still removed from entities, but only after one whole frame of staying in the `false` state.

--- a/_release-content/migration-guides/pressed_newtype_bool.md
+++ b/_release-content/migration-guides/pressed_newtype_bool.md
@@ -1,0 +1,36 @@
+---
+title: "`Pressed` Component is now a newtype bool component"
+pull_requests: [24636, 24701]
+---
+
+Previously, the `Pressed` component was a marker component without any fields. Now, it is a marker component with a single boolean field signifying whether the entity is being pressed. This was done to enable usage of change detection of the `Pressed` component in regular systems. The `Pressed` component is still removed from entities, but only after one whole frame of staying in the `false` state.
+
+To check whether an entity is being pressed, the `Pressed` component must be present on the entity **and** its boolean field must be true. A convenience trait for `Option<&Pressed>` and `Option<Mut<'_, Pressed>>` types is available at `ui::interaction_states::OptionPressedExt` to make this check easier to reference.
+
+```rust
+// Before
+fn system(
+  query: Query<Has<Pressed>>
+) {
+  for is_pressed in query {
+    if is_pressed {
+      // ...
+    }
+  }
+}
+
+// After
+use bevy::ui::interaction_states::OptionPressedExt;
+
+fn system(
+  query: Query<Option<&Pressed>>
+) {
+  for maybe_pressed in query {
+    if maybe_pressed.is_pressed() {
+      // ...
+    }
+  }
+}
+```
+
+If you were using `bevy::ecs::lifecycle::RemovedComponents` in systems to check for the removal of `Pressed`, you can now filter queries with `Changed<Pressed>` and check for `!maybe_pressed.is_pressed()` to change your app's behavior based on press release.

--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -16,7 +16,7 @@ use bevy_picking::{hover::Hovered, PickingSystems};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::prelude::*;
 use bevy_text::FontWeight;
-use bevy_ui::{px, AlignItems, InteractionDisabled, JustifyContent, Node, Pressed, UiRect};
+use bevy_ui::{px, AlignItems, InteractionDisabled, JustifyContent, Node, Pressed, UiRect, interaction_states::OptionPressedExt};
 use bevy_ui_widgets::Button;
 
 use crate::{
@@ -202,7 +202,7 @@ fn update_button_styles(
             Entity,
             &ButtonVariant,
             Has<InteractionDisabled>,
-            Has<Pressed>,
+            Option<&Pressed>,
             &Hovered,
             &ThemeBackgroundColor,
             &InheritableThemeTextColor,
@@ -210,7 +210,7 @@ fn update_button_styles(
         Or<(
             Changed<Hovered>,
             Changed<ButtonVariant>,
-            Added<Pressed>,
+            Changed<Pressed>,
             Added<InteractionDisabled>,
         )>,
     >,
@@ -222,7 +222,7 @@ fn update_button_styles(
             button_ent,
             variant,
             disabled,
-            pressed,
+            pressed.is_pressed(),
             hovered.0,
             bg_color,
             font_color,
@@ -236,18 +236,16 @@ fn update_button_styles_remove(
         Entity,
         &ButtonVariant,
         Has<InteractionDisabled>,
-        Has<Pressed>,
+        Option<&Pressed>,
         &Hovered,
         &ThemeBackgroundColor,
         &InheritableThemeTextColor,
     )>,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
-    mut removed_pressed: RemovedComponents<Pressed>,
     mut commands: Commands,
 ) {
     removed_disabled
         .read()
-        .chain(removed_pressed.read())
         .for_each(|ent| {
             if let Ok((button_ent, variant, disabled, pressed, hovered, bg_color, font_color)) =
                 q_buttons.get(ent)
@@ -256,7 +254,7 @@ fn update_button_styles_remove(
                     button_ent,
                     variant,
                     disabled,
-                    pressed,
+                    pressed.is_pressed(),
                     hovered.0,
                     bg_color,
                     font_color,

--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -16,7 +16,10 @@ use bevy_picking::{hover::Hovered, PickingSystems};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::prelude::*;
 use bevy_text::FontWeight;
-use bevy_ui::{px, AlignItems, InteractionDisabled, JustifyContent, Node, Pressed, UiRect, interaction_states::OptionPressedExt};
+use bevy_ui::{
+    interaction_states::OptionPressedExt, px, AlignItems, InteractionDisabled, JustifyContent,
+    Node, Pressed, UiRect,
+};
 use bevy_ui_widgets::Button;
 
 use crate::{
@@ -244,24 +247,22 @@ fn update_button_styles_remove(
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
     mut commands: Commands,
 ) {
-    removed_disabled
-        .read()
-        .for_each(|ent| {
-            if let Ok((button_ent, variant, disabled, pressed, hovered, bg_color, font_color)) =
-                q_buttons.get(ent)
-            {
-                set_button_styles(
-                    button_ent,
-                    variant,
-                    disabled,
-                    pressed.is_pressed(),
-                    hovered.0,
-                    bg_color,
-                    font_color,
-                    &mut commands,
-                );
-            }
-        });
+    removed_disabled.read().for_each(|ent| {
+        if let Ok((button_ent, variant, disabled, pressed, hovered, bg_color, font_color)) =
+            q_buttons.get(ent)
+        {
+            set_button_styles(
+                button_ent,
+                variant,
+                disabled,
+                pressed.is_pressed(),
+                hovered.0,
+                bg_color,
+                font_color,
+                &mut commands,
+            );
+        }
+    });
 }
 
 fn set_button_styles(

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -21,8 +21,9 @@ use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::prelude::*;
 use bevy_text::FontWeight;
 use bevy_ui::{
-    px, AlignItems, BorderRadius, Checked, Display, FlexDirection, InteractionDisabled,
-    JustifyContent, Node, PositionType, Pressed, UiRect, UiTransform, interaction_states::OptionPressedExt,
+    interaction_states::OptionPressedExt, px, AlignItems, BorderRadius, Checked, Display,
+    FlexDirection, InteractionDisabled, JustifyContent, Node, PositionType, Pressed, UiRect,
+    UiTransform,
 };
 use bevy_ui_widgets::{ActivateOnPress, Checkbox};
 

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -22,7 +22,7 @@ use bevy_scene::prelude::*;
 use bevy_text::FontWeight;
 use bevy_ui::{
     px, AlignItems, BorderRadius, Checked, Display, FlexDirection, InteractionDisabled,
-    JustifyContent, Node, PositionType, Pressed, UiRect, UiTransform,
+    JustifyContent, Node, PositionType, Pressed, UiRect, UiTransform, interaction_states::OptionPressedExt,
 };
 use bevy_ui_widgets::{ActivateOnPress, Checkbox};
 
@@ -215,7 +215,7 @@ fn update_checkbox_styles(
             Entity,
             Has<InteractionDisabled>,
             Has<Checked>,
-            Has<Pressed>,
+            Option<&Pressed>,
             Has<ActivateOnPress>,
             &Hovered,
             &InheritableThemeTextColor,
@@ -225,7 +225,7 @@ fn update_checkbox_styles(
             Or<(
                 Changed<Hovered>,
                 Added<Checked>,
-                Added<Pressed>,
+                Changed<Pressed>,
                 Added<InteractionDisabled>,
             )>,
         ),
@@ -258,7 +258,7 @@ fn update_checkbox_styles(
             mark_ent,
             disabled,
             checked,
-            pressed,
+            pressed.is_pressed(),
             hovered.0,
             activate_on_press,
             outline_bg,
@@ -276,7 +276,7 @@ fn update_checkbox_styles_remove(
             Entity,
             Has<InteractionDisabled>,
             Has<Checked>,
-            Has<Pressed>,
+            Option<&Pressed>,
             Has<ActivateOnPress>,
             &Hovered,
             &InheritableThemeTextColor,
@@ -288,14 +288,12 @@ fn update_checkbox_styles_remove(
     mut q_mark: Query<&ThemeBorderColor, With<CheckboxMark>>,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
     mut removed_checked: RemovedComponents<Checked>,
-    mut remove_pressed: RemovedComponents<Pressed>,
     mut remove_activate_on_press: RemovedComponents<ActivateOnPress>,
     mut commands: Commands,
 ) {
     removed_disabled
         .read()
         .chain(removed_checked.read())
-        .chain(remove_pressed.read())
         .chain(remove_activate_on_press.read())
         .for_each(|ent| {
             if let Ok((
@@ -328,7 +326,7 @@ fn update_checkbox_styles_remove(
                     mark_ent,
                     disabled,
                     checked,
-                    pressed,
+                    pressed.is_pressed(),
                     hovered.0,
                     activate_on_press,
                     outline_bg,

--- a/crates/bevy_feathers/src/controls/menu.rs
+++ b/crates/bevy_feathers/src/controls/menu.rs
@@ -20,9 +20,9 @@ use bevy_reflect::Reflect;
 use bevy_scene::prelude::*;
 use bevy_text::FontWeight;
 use bevy_ui::{
-    px, AlignItems, AlignSelf, BoxShadow, Display, FlexDirection, GlobalZIndex,
-    InteractionDisabled, JustifyContent, Node, OverrideClip, PositionType, Pressed, UiRect,
-    interaction_states::OptionPressedExt,
+    interaction_states::OptionPressedExt, px, AlignItems, AlignSelf, BoxShadow, Display,
+    FlexDirection, GlobalZIndex, InteractionDisabled, JustifyContent, Node, OverrideClip,
+    PositionType, Pressed, UiRect,
 };
 use bevy_ui_widgets::{
     popover::{Popover, PopoverAlign, PopoverPlacement, PopoverSide},
@@ -452,7 +452,11 @@ fn update_menuitem_styles(
         ),
         (
             With<FeathersMenuItem>,
-            Or<(Changed<Hovered>, Changed<Pressed>, Added<InteractionDisabled>)>,
+            Or<(
+                Changed<Hovered>,
+                Changed<Pressed>,
+                Added<InteractionDisabled>,
+            )>,
         ),
     >,
     mut commands: Commands,
@@ -490,24 +494,22 @@ fn update_menuitem_styles_remove(
     focus_visible: Res<InputFocusVisible>,
     mut commands: Commands,
 ) {
-    removed_disabled
-        .read()
-        .for_each(|ent| {
-            if let Ok((item_ent, disabled, pressed, hovered, bg_color, font_color)) =
-                q_menuitems.get(ent)
-            {
-                set_menuitem_colors(
-                    item_ent,
-                    disabled,
-                    pressed.is_pressed(),
-                    hovered.0,
-                    Some(item_ent) == focus.get() && focus_visible.0,
-                    bg_color,
-                    font_color,
-                    &mut commands,
-                );
-            }
-        });
+    removed_disabled.read().for_each(|ent| {
+        if let Ok((item_ent, disabled, pressed, hovered, bg_color, font_color)) =
+            q_menuitems.get(ent)
+        {
+            set_menuitem_colors(
+                item_ent,
+                disabled,
+                pressed.is_pressed(),
+                hovered.0,
+                Some(item_ent) == focus.get() && focus_visible.0,
+                bg_color,
+                font_color,
+                &mut commands,
+            );
+        }
+    });
 }
 
 fn update_menuitem_styles_focus_changed(

--- a/crates/bevy_feathers/src/controls/menu.rs
+++ b/crates/bevy_feathers/src/controls/menu.rs
@@ -22,6 +22,7 @@ use bevy_text::FontWeight;
 use bevy_ui::{
     px, AlignItems, AlignSelf, BoxShadow, Display, FlexDirection, GlobalZIndex,
     InteractionDisabled, JustifyContent, Node, OverrideClip, PositionType, Pressed, UiRect,
+    interaction_states::OptionPressedExt,
 };
 use bevy_ui_widgets::{
     popover::{Popover, PopoverAlign, PopoverPlacement, PopoverSide},
@@ -444,14 +445,14 @@ fn update_menuitem_styles(
         (
             Entity,
             Has<InteractionDisabled>,
-            Has<Pressed>,
+            Option<&Pressed>,
             &Hovered,
             &ThemeBackgroundColor,
             &InheritableThemeTextColor,
         ),
         (
             With<FeathersMenuItem>,
-            Or<(Changed<Hovered>, Added<Pressed>, Added<InteractionDisabled>)>,
+            Or<(Changed<Hovered>, Changed<Pressed>, Added<InteractionDisabled>)>,
         ),
     >,
     mut commands: Commands,
@@ -462,7 +463,7 @@ fn update_menuitem_styles(
         set_menuitem_colors(
             item_ent,
             disabled,
-            pressed,
+            pressed.is_pressed(),
             hovered.0,
             Some(item_ent) == focus.get() && focus_visible.0,
             bg_color,
@@ -477,7 +478,7 @@ fn update_menuitem_styles_remove(
         (
             Entity,
             Has<InteractionDisabled>,
-            Has<Pressed>,
+            Option<&Pressed>,
             &Hovered,
             &ThemeBackgroundColor,
             &InheritableThemeTextColor,
@@ -485,14 +486,12 @@ fn update_menuitem_styles_remove(
         With<FeathersMenuItem>,
     >,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
-    mut removed_pressed: RemovedComponents<Pressed>,
     focus: Res<InputFocus>,
     focus_visible: Res<InputFocusVisible>,
     mut commands: Commands,
 ) {
     removed_disabled
         .read()
-        .chain(removed_pressed.read())
         .for_each(|ent| {
             if let Ok((item_ent, disabled, pressed, hovered, bg_color, font_color)) =
                 q_menuitems.get(ent)
@@ -500,7 +499,7 @@ fn update_menuitem_styles_remove(
                 set_menuitem_colors(
                     item_ent,
                     disabled,
-                    pressed,
+                    pressed.is_pressed(),
                     hovered.0,
                     Some(item_ent) == focus.get() && focus_visible.0,
                     bg_color,
@@ -516,7 +515,7 @@ fn update_menuitem_styles_focus_changed(
         (
             Entity,
             Has<InteractionDisabled>,
-            Has<Pressed>,
+            Option<&Pressed>,
             &Hovered,
             &ThemeBackgroundColor,
             &InheritableThemeTextColor,
@@ -532,7 +531,7 @@ fn update_menuitem_styles_focus_changed(
             set_menuitem_colors(
                 item_ent,
                 disabled,
-                pressed,
+                pressed.is_pressed(),
                 hovered.0,
                 Some(item_ent) == focus.get() && focus_visible.0,
                 bg_color,

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -20,7 +20,7 @@ use bevy_scene::prelude::*;
 use bevy_text::FontWeight;
 use bevy_ui::{
     px, AlignItems, BorderRadius, Checked, Display, FlexDirection, InteractionDisabled,
-    JustifyContent, LayoutConfig, Node, Pressed, UiRect,
+    JustifyContent, LayoutConfig, Node, Pressed, UiRect, interaction_states::OptionPressedExt,
 };
 use bevy_ui_widgets::{ActivateOnPress, RadioButton};
 
@@ -201,7 +201,7 @@ fn update_radio_styles(
             Entity,
             Has<InteractionDisabled>,
             Has<Checked>,
-            Has<Pressed>,
+            Option<&Pressed>,
             Has<ActivateOnPress>,
             &Hovered,
             &InheritableThemeTextColor,
@@ -211,7 +211,7 @@ fn update_radio_styles(
             Or<(
                 Changed<Hovered>,
                 Added<Checked>,
-                Added<Pressed>,
+                Changed<Pressed>,
                 Added<InteractionDisabled>,
             )>,
         ),
@@ -244,7 +244,7 @@ fn update_radio_styles(
             mark_ent,
             disabled,
             checked,
-            pressed,
+            pressed.is_pressed(),
             hovered.0,
             activate_on_press,
             outline_border,
@@ -261,7 +261,7 @@ fn update_radio_styles_remove(
             Entity,
             Has<InteractionDisabled>,
             Has<Checked>,
-            Has<Pressed>,
+            Option<&Pressed>,
             Has<ActivateOnPress>,
             &Hovered,
             &InheritableThemeTextColor,
@@ -273,14 +273,12 @@ fn update_radio_styles_remove(
     mut q_mark: Query<&ThemeBackgroundColor, With<RadioMark>>,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
     mut removed_checked: RemovedComponents<Checked>,
-    mut remove_pressed: RemovedComponents<Pressed>,
     mut remove_activate_on_press: RemovedComponents<ActivateOnPress>,
     mut commands: Commands,
 ) {
     removed_disabled
         .read()
         .chain(removed_checked.read())
-        .chain(remove_pressed.read())
         .chain(remove_activate_on_press.read())
         .for_each(|ent| {
             if let Ok((
@@ -313,7 +311,7 @@ fn update_radio_styles_remove(
                     mark_ent,
                     disabled,
                     checked,
-                    pressed,
+                    pressed.is_pressed(),
                     hovered.0,
                     activate_on_press,
                     outline_border,

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -19,8 +19,8 @@ use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::prelude::*;
 use bevy_text::FontWeight;
 use bevy_ui::{
-    px, AlignItems, BorderRadius, Checked, Display, FlexDirection, InteractionDisabled,
-    JustifyContent, LayoutConfig, Node, Pressed, UiRect, interaction_states::OptionPressedExt,
+    interaction_states::OptionPressedExt, px, AlignItems, BorderRadius, Checked, Display,
+    FlexDirection, InteractionDisabled, JustifyContent, LayoutConfig, Node, Pressed, UiRect,
 };
 use bevy_ui_widgets::{ActivateOnPress, RadioButton};
 

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -21,9 +21,9 @@ use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::prelude::*;
 use bevy_text::FontWeight;
 use bevy_ui::{
-    percent, px, widget::Text, AlignItems, BackgroundGradient, ColorStop, Display, FlexDirection,
-    Gradient, InteractionDisabled, InterpolationColorSpace, JustifyContent, LinearGradient, Node,
-    PositionType, Pressed, UiRect, interaction_states::OptionPressedExt,
+    interaction_states::OptionPressedExt, percent, px, widget::Text, AlignItems,
+    BackgroundGradient, ColorStop, Display, FlexDirection, Gradient, InteractionDisabled,
+    InterpolationColorSpace, JustifyContent, LinearGradient, Node, PositionType, Pressed, UiRect,
 };
 use bevy_ui_widgets::{
     Slider, SliderOrientation, SliderPrecision, SliderRange, SliderValue, TrackClick,
@@ -252,24 +252,22 @@ fn update_slider_styles_remove(
     theme: Res<UiTheme>,
     mut commands: Commands,
 ) {
-    removed_disabled
-        .read()
-        .for_each(|ent| {
-            if let Ok((slider_ent, disabled, pressed, hovered, mut gradient, font_color)) =
-                q_sliders.get_mut(ent)
-            {
-                set_slider_styles(
-                    slider_ent,
-                    &theme,
-                    disabled,
-                    pressed.is_pressed(),
-                    hovered.0,
-                    gradient.as_mut(),
-                    font_color,
-                    &mut commands,
-                );
-            }
-        });
+    removed_disabled.read().for_each(|ent| {
+        if let Ok((slider_ent, disabled, pressed, hovered, mut gradient, font_color)) =
+            q_sliders.get_mut(ent)
+        {
+            set_slider_styles(
+                slider_ent,
+                &theme,
+                disabled,
+                pressed.is_pressed(),
+                hovered.0,
+                gradient.as_mut(),
+                font_color,
+                &mut commands,
+            );
+        }
+    });
 }
 
 /// Re-apply slider styles to every slider when the theme changes.

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -23,7 +23,7 @@ use bevy_text::FontWeight;
 use bevy_ui::{
     percent, px, widget::Text, AlignItems, BackgroundGradient, ColorStop, Display, FlexDirection,
     Gradient, InteractionDisabled, InterpolationColorSpace, JustifyContent, LinearGradient, Node,
-    PositionType, Pressed, UiRect,
+    PositionType, Pressed, UiRect, interaction_states::OptionPressedExt,
 };
 use bevy_ui_widgets::{
     Slider, SliderOrientation, SliderPrecision, SliderRange, SliderValue, TrackClick,
@@ -204,7 +204,7 @@ fn update_slider_styles(
         (
             Entity,
             Has<InteractionDisabled>,
-            Has<Pressed>,
+            Option<&Pressed>,
             &Hovered,
             &mut BackgroundGradient,
             &InheritableThemeTextColor,
@@ -215,7 +215,7 @@ fn update_slider_styles(
                 Spawned,
                 Added<InteractionDisabled>,
                 Changed<Hovered>,
-                Added<Pressed>,
+                Changed<Pressed>,
             )>,
         ),
     >,
@@ -227,7 +227,7 @@ fn update_slider_styles(
             slider_ent,
             &theme,
             disabled,
-            pressed,
+            pressed.is_pressed(),
             hovered.0,
             gradient.as_mut(),
             font_color,
@@ -241,7 +241,7 @@ fn update_slider_styles_remove(
         (
             Entity,
             Has<InteractionDisabled>,
-            Has<Pressed>,
+            Option<&Pressed>,
             &Hovered,
             &mut BackgroundGradient,
             &InheritableThemeTextColor,
@@ -249,13 +249,11 @@ fn update_slider_styles_remove(
         With<FeathersSlider>,
     >,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
-    mut remove_pressed: RemovedComponents<Pressed>,
     theme: Res<UiTheme>,
     mut commands: Commands,
 ) {
     removed_disabled
         .read()
-        .chain(remove_pressed.read())
         .for_each(|ent| {
             if let Ok((slider_ent, disabled, pressed, hovered, mut gradient, font_color)) =
                 q_sliders.get_mut(ent)
@@ -264,7 +262,7 @@ fn update_slider_styles_remove(
                     slider_ent,
                     &theme,
                     disabled,
-                    pressed,
+                    pressed.is_pressed(),
                     hovered.0,
                     gradient.as_mut(),
                     font_color,
@@ -280,7 +278,7 @@ fn update_slider_styles_theme(
         (
             Entity,
             Has<InteractionDisabled>,
-            Has<Pressed>,
+            Option<&Pressed>,
             &Hovered,
             &mut BackgroundGradient,
             &InheritableThemeTextColor,
@@ -298,7 +296,7 @@ fn update_slider_styles_theme(
             slider_ent,
             &theme,
             disabled,
-            pressed,
+            pressed.is_pressed(),
             hovered.0,
             gradient.as_mut(),
             font_color,

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -19,7 +19,7 @@ use bevy_picking::{hover::Hovered, PickingSystems};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::prelude::*;
 use bevy_ui::{
-    percent, px, BorderRadius, Checked, InteractionDisabled, Node, PositionType, Pressed, UiRect,
+    percent, px, BorderRadius, Checked, InteractionDisabled, Node, PositionType, Pressed, UiRect, interaction_states::OptionPressedExt
 };
 use bevy_ui_widgets::{ActivateOnPress, Checkbox};
 
@@ -141,7 +141,7 @@ fn update_switch_styles(
             Entity,
             Has<InteractionDisabled>,
             Has<Checked>,
-            Has<Pressed>,
+            Option<&Pressed>,
             Has<ActivateOnPress>,
             &Hovered,
             &ThemeBackgroundColor,
@@ -152,7 +152,7 @@ fn update_switch_styles(
             Or<(
                 Changed<Hovered>,
                 Added<Checked>,
-                Added<Pressed>,
+                Changed<Pressed>,
                 Added<InteractionDisabled>,
             )>,
         ),
@@ -189,7 +189,7 @@ fn update_switch_styles(
             slide_ent,
             disabled,
             checked,
-            pressed,
+            pressed.is_pressed(),
             hovered.0,
             activate_on_press,
             outline_bg,
@@ -208,7 +208,7 @@ fn update_switch_styles_remove(
             Entity,
             Has<InteractionDisabled>,
             Has<Checked>,
-            Has<Pressed>,
+            Option<&Pressed>,
             Has<ActivateOnPress>,
             &Hovered,
             &ThemeBackgroundColor,
@@ -230,7 +230,6 @@ fn update_switch_styles_remove(
     removed_disabled
         .read()
         .chain(removed_checked.read())
-        .chain(remove_pressed.read())
         .chain(remove_activate_on_press.read())
         .for_each(|ent| {
             if let Ok((
@@ -258,7 +257,7 @@ fn update_switch_styles_remove(
                     slide_ent,
                     disabled,
                     checked,
-                    pressed,
+                    pressed.is_pressed(),
                     hovered.0,
                     activate_on_press,
                     outline_bg,

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -19,7 +19,8 @@ use bevy_picking::{hover::Hovered, PickingSystems};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::prelude::*;
 use bevy_ui::{
-    percent, px, BorderRadius, Checked, InteractionDisabled, Node, PositionType, Pressed, UiRect, interaction_states::OptionPressedExt
+    interaction_states::OptionPressedExt, percent, px, BorderRadius, Checked, InteractionDisabled,
+    Node, PositionType, Pressed, UiRect,
 };
 use bevy_ui_widgets::{ActivateOnPress, Checkbox};
 
@@ -223,7 +224,6 @@ fn update_switch_styles_remove(
     >,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
     mut removed_checked: RemovedComponents<Checked>,
-    mut remove_pressed: RemovedComponents<Pressed>,
     mut remove_activate_on_press: RemovedComponents<ActivateOnPress>,
     mut commands: Commands,
 ) {

--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -50,6 +50,9 @@ pub(crate) fn on_remove_disabled(
 ///
 /// If the component's value is false for one whole frame, the [`remove_pressed_on_next_frame()`]
 /// system that runs in the `Last` schedule removes the `Pressed` component from the entity.
+/// 
+/// [`OptionPressedExt`] is an easy extension to make working with `Option<&Pressed>` or `Option<&mut Pressed>`
+/// easier from queries.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component, Default, Clone)]
 pub struct Pressed(pub bool);
@@ -67,8 +70,8 @@ impl Default for Pressed {
     }
 }
 
-/// Extension trait for `Option<&Pressed>` for a convenience method
-/// to more easily checked the pressed state.
+/// Extension trait for `Option<&Pressed>` and `Option<Mut<'_, Pressed>>`. 
+/// Provides a convenience method to concisely checked the pressed state.
 pub trait OptionPressedExt {
     fn is_pressed(&self) -> bool;
 }

--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -1,12 +1,7 @@
 /// This module contains components that are used to track the interaction state of UI widgets.
 use bevy_a11y::AccessibilityNode;
 use bevy_ecs::{
-    change_detection::Mut,
-    component::Component,
-    lifecycle::{Add, Remove},
-    observer::On,
-    reflect::ReflectComponent,
-    world::DeferredWorld,
+    change_detection::{DetectChanges, Mut, Ref}, component::Component, entity::Entity, lifecycle::{Add, Remove}, observer::On, reflect::ReflectComponent, system::{Commands, Local, Query}, world::DeferredWorld,
 };
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
@@ -43,10 +38,11 @@ pub(crate) fn on_remove_disabled(
 /// Component that indicates whether a button or widget is currently in a pressed or "held down"
 /// state.
 ///
-/// When this component is first inserted into a button or widget, its value is true.
-/// When this button or widget is no longer being pressed, its value is false for a frame
-/// before being removed from the entity. This enables change detection for when
-/// this entity has transitioned from being pressed to not being pressed.
+/// When this component is first inserted into a button or widget, its value should be set to true.
+/// When this button or widget is no longer being pressed, its value should be set to false. 
+/// 
+/// If the component's value is false for one whole frame, the [`remove_pressed_on_next_frame()`]
+/// system that runs in the `Last` schedule removes the `Pressed` component from the entity.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component, Default, Clone)]
 pub struct Pressed(pub bool);
@@ -80,6 +76,31 @@ impl OptionPressedExt for Option<Mut<'_, Pressed>> {
     fn is_pressed(&self) -> bool {
         self.as_ref().is_some_and(|pressed| pressed.get())
     }
+}
+
+/// System that removes the `Pressed` component after all possible systems could have reacted
+/// to its changing to false via change detection. It runs in the `Last` schedule.
+pub fn remove_pressed_on_next_frame(
+    mut presses_to_clear: Local<Vec<Entity>>,
+    pressed_false_q: Query<(Entity, Ref<Pressed>)>,
+    mut commands: Commands,
+) {
+    for button_entity in presses_to_clear.drain(..) {
+        // If the button has stayed false for a whole frame, remove its component.
+        if let Ok((_, pressed)) = pressed_false_q.get(button_entity)
+            && !pressed.is_changed() && !pressed.get()
+        {
+            commands.entity(button_entity).remove::<Pressed>();
+        }
+    }
+
+    // Queue up the next buttons that will have `Pressed` remove on the next frame.
+    for (button_entity, pressed) in pressed_false_q {
+        if !pressed.get() {
+            presses_to_clear.push(button_entity);
+        }
+    }
+    presses_to_clear.shrink_to_fit();
 }
 
 /// Component that indicates that a widget can be checked.

--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -1,6 +1,7 @@
 /// This module contains components that are used to track the interaction state of UI widgets.
 use bevy_a11y::AccessibilityNode;
 use bevy_ecs::{
+    change_detection::Mut,
     component::Component,
     lifecycle::{Add, Remove},
     observer::On,
@@ -41,9 +42,45 @@ pub(crate) fn on_remove_disabled(
 
 /// Component that indicates whether a button or widget is currently in a pressed or "held down"
 /// state.
-#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
+///
+/// When this component is first inserted into a button or widget, its value is true.
+/// When this button or widget is no longer being pressed, its value is false for a frame
+/// before being removed from the entity. This enables change detection for when
+/// this entity has transitioned from being pressed to not being pressed.
+#[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component, Default, Clone)]
-pub struct Pressed;
+pub struct Pressed(pub bool);
+
+impl Pressed {
+    /// Get whether the entity is currently being pressed.
+    pub fn get(&self) -> bool {
+        self.0
+    }
+}
+
+impl Default for Pressed {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+/// Extension trait for `Option<&Pressed>` for a convenience method
+/// to more easily checked the pressed state.
+pub trait OptionPressedExt {
+    fn is_pressed(&self) -> bool;
+}
+
+impl OptionPressedExt for Option<&Pressed> {
+    fn is_pressed(&self) -> bool {
+        self.is_some_and(|pressed| pressed.get())
+    }
+}
+
+impl OptionPressedExt for Option<Mut<'_, Pressed>> {
+    fn is_pressed(&self) -> bool {
+        self.as_ref().is_some_and(|pressed| pressed.get())
+    }
+}
 
 /// Component that indicates that a widget can be checked.
 #[derive(Component, Debug, Clone, Copy, Default, Reflect)]

--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -102,7 +102,7 @@ pub fn remove_pressed_on_next_frame(
             && !pressed.is_changed()
             && !pressed.get()
         {
-            commands.entity(entity).remove::<Pressed>();
+            commands.entity(entity).try_remove::<Pressed>();
         }
     }
 

--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -1,7 +1,14 @@
 /// This module contains components that are used to track the interaction state of UI widgets.
 use bevy_a11y::AccessibilityNode;
 use bevy_ecs::{
-    change_detection::{DetectChanges, Mut, Ref}, component::Component, entity::Entity, lifecycle::{Add, Remove}, observer::On, reflect::ReflectComponent, system::{Commands, Local, Query}, world::DeferredWorld,
+    change_detection::{DetectChanges, Mut, Ref},
+    component::Component,
+    entity::Entity,
+    lifecycle::{Add, Remove},
+    observer::On,
+    reflect::ReflectComponent,
+    system::{Commands, Local, Query},
+    world::DeferredWorld,
 };
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
@@ -39,8 +46,8 @@ pub(crate) fn on_remove_disabled(
 /// state.
 ///
 /// When this component is first inserted into a button or widget, its value should be set to true.
-/// When this button or widget is no longer being pressed, its value should be set to false. 
-/// 
+/// When this button or widget is no longer being pressed, its value should be set to false.
+///
 /// If the component's value is false for one whole frame, the [`remove_pressed_on_next_frame()`]
 /// system that runs in the `Last` schedule removes the `Pressed` component from the entity.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
@@ -88,7 +95,8 @@ pub fn remove_pressed_on_next_frame(
     for button_entity in presses_to_clear.drain(..) {
         // If the button has stayed false for a whole frame, remove its component.
         if let Ok((_, pressed)) = pressed_false_q.get(button_entity)
-            && !pressed.is_changed() && !pressed.get()
+            && !pressed.is_changed()
+            && !pressed.get()
         {
             commands.entity(button_entity).remove::<Pressed>();
         }

--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -78,7 +78,7 @@ pub trait OptionPressedExt {
 
 impl OptionPressedExt for Option<&Pressed> {
     fn is_pressed(&self) -> bool {
-        self.is_some_and(|pressed| pressed.get())
+        self.is_some_and(Pressed::get)
     }
 }
 
@@ -97,7 +97,7 @@ pub fn remove_pressed_on_next_frame(
 ) {
     let previous_length = presses_to_clear.len();
     for entity in presses_to_clear.drain(..) {
-        // If the button has stayed false for a whole frame, remove its component.
+        // If `Pressed` has stayed false for a whole frame, remove it.
         if let Ok((_, pressed)) = pressed_false_q.get(entity)
             && !pressed.is_changed()
             && !pressed.get()
@@ -106,7 +106,8 @@ pub fn remove_pressed_on_next_frame(
         }
     }
 
-    // Queue up the next buttons that will have `Pressed` remove on the next frame.
+    // Queue up the next entities that should have `Pressed` removed on the next execution
+    // of this system.
     for (entity, pressed) in pressed_false_q {
         if !pressed.get() {
             presses_to_clear.push(entity);

--- a/crates/bevy_ui/src/interaction_states.rs
+++ b/crates/bevy_ui/src/interaction_states.rs
@@ -50,7 +50,7 @@ pub(crate) fn on_remove_disabled(
 ///
 /// If the component's value is false for one whole frame, the [`remove_pressed_on_next_frame()`]
 /// system that runs in the `Last` schedule removes the `Pressed` component from the entity.
-/// 
+///
 /// [`OptionPressedExt`] is an easy extension to make working with `Option<&Pressed>` or `Option<&mut Pressed>`
 /// easier from queries.
 #[derive(Component, Debug, Clone, Copy, Reflect)]
@@ -70,7 +70,7 @@ impl Default for Pressed {
     }
 }
 
-/// Extension trait for `Option<&Pressed>` and `Option<Mut<'_, Pressed>>`. 
+/// Extension trait for `Option<&Pressed>` and `Option<Mut<'_, Pressed>>`.
 /// Provides a convenience method to concisely checked the pressed state.
 pub trait OptionPressedExt {
     fn is_pressed(&self) -> bool;
@@ -95,23 +95,26 @@ pub fn remove_pressed_on_next_frame(
     pressed_false_q: Query<(Entity, Ref<Pressed>)>,
     mut commands: Commands,
 ) {
-    for button_entity in presses_to_clear.drain(..) {
+    let previous_length = presses_to_clear.len();
+    for entity in presses_to_clear.drain(..) {
         // If the button has stayed false for a whole frame, remove its component.
-        if let Ok((_, pressed)) = pressed_false_q.get(button_entity)
+        if let Ok((_, pressed)) = pressed_false_q.get(entity)
             && !pressed.is_changed()
             && !pressed.get()
         {
-            commands.entity(button_entity).remove::<Pressed>();
+            commands.entity(entity).remove::<Pressed>();
         }
     }
 
     // Queue up the next buttons that will have `Pressed` remove on the next frame.
-    for (button_entity, pressed) in pressed_false_q {
+    for (entity, pressed) in pressed_false_q {
         if !pressed.get() {
-            presses_to_clear.push(button_entity);
+            presses_to_clear.push(entity);
         }
     }
-    presses_to_clear.shrink_to_fit();
+    if previous_length > presses_to_clear.len() {
+        presses_to_clear.shrink_to_fit();
+    }
 }
 
 /// Component that indicates that a widget can be checked.

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -217,6 +217,8 @@ impl Plugin for UiPlugin {
             ),
         );
 
+        app.add_systems(Last, interaction_states::remove_pressed_on_next_frame);
+
         app.add_plugins(accessibility::AccessibilityPlugin);
 
         app.add_observer(interaction_states::on_add_disabled)

--- a/crates/bevy_ui_widgets/src/button.rs
+++ b/crates/bevy_ui_widgets/src/button.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     observer::On,
     query::With,
     reflect::ReflectComponent,
-    system::{Commands, Local, Query},
+    system::{Commands, Query},
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
 use bevy_input::ButtonState;

--- a/crates/bevy_ui_widgets/src/button.rs
+++ b/crates/bevy_ui_widgets/src/button.rs
@@ -1,6 +1,6 @@
 use accesskit::Role;
 use bevy_a11y::AccessibilityNode;
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Last, Plugin};
 use bevy_ecs::query::Has;
 use bevy_ecs::{
     component::Component,
@@ -8,14 +8,14 @@ use bevy_ecs::{
     observer::On,
     query::With,
     reflect::ReflectComponent,
-    system::{Commands, Query},
+    system::{Commands, Local, Query},
 };
 use bevy_input::keyboard::{KeyCode, KeyboardInput};
 use bevy_input::ButtonState;
 use bevy_input_focus::FocusedInput;
 use bevy_picking::events::{Cancel, Click, DragEnd, Pointer, Press, Release};
 use bevy_reflect::Reflect;
-use bevy_ui::{InteractionDisabled, Pressed};
+use bevy_ui::{interaction_states::OptionPressedExt, InteractionDisabled, Pressed};
 
 use crate::Activate;
 
@@ -58,14 +58,18 @@ fn button_on_key_event(
 fn button_on_pointer_click(
     mut click: On<Pointer<Click>>,
     mut q_state: Query<
-        (Has<Pressed>, Has<InteractionDisabled>, Has<ActivateOnPress>),
+        (
+            Option<&Pressed>,
+            Has<InteractionDisabled>,
+            Has<ActivateOnPress>,
+        ),
         With<Button>,
     >,
     mut commands: Commands,
 ) {
     if let Ok((pressed, disabled, activate_on_press)) = q_state.get_mut(click.entity) {
         click.propagate(false);
-        if pressed && !disabled && !activate_on_press {
+        if pressed.is_pressed() && !disabled && !activate_on_press {
             commands.trigger(Activate {
                 entity: click.entity,
             });
@@ -79,7 +83,7 @@ fn button_on_pointer_down(
         (
             Entity,
             Has<InteractionDisabled>,
-            Has<Pressed>,
+            Option<&Pressed>,
             Has<ActivateOnPress>,
         ),
         With<Button>,
@@ -88,8 +92,8 @@ fn button_on_pointer_down(
 ) {
     if let Ok((button, disabled, pressed, activate_on_press)) = q_state.get_mut(press.entity) {
         press.propagate(false);
-        if !disabled && !pressed {
-            commands.entity(button).insert(Pressed);
+        if !disabled && !pressed.is_pressed() {
+            commands.entity(button).insert(Pressed::default());
             if activate_on_press {
                 commands.trigger(Activate { entity: button });
             }
@@ -99,41 +103,72 @@ fn button_on_pointer_down(
 
 fn button_on_pointer_up(
     mut release: On<Pointer<Release>>,
-    mut q_state: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<Button>>,
-    mut commands: Commands,
+    mut q_state: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<Button>>,
 ) {
-    if let Ok((button, disabled, pressed)) = q_state.get_mut(release.entity) {
+    if let Ok((disabled, pressed)) = q_state.get_mut(release.entity) {
         release.propagate(false);
-        if !disabled && pressed {
-            commands.entity(button).remove::<Pressed>();
+        if !disabled
+            && pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }
 
 fn button_on_pointer_drag_end(
     mut drag_end: On<Pointer<DragEnd>>,
-    mut q_state: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<Button>>,
-    mut commands: Commands,
+    mut q_state: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<Button>>,
 ) {
-    if let Ok((button, disabled, pressed)) = q_state.get_mut(drag_end.entity) {
+    if let Ok((disabled, pressed)) = q_state.get_mut(drag_end.entity) {
         drag_end.propagate(false);
-        if !disabled && pressed {
-            commands.entity(button).remove::<Pressed>();
+        if !disabled
+            && pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }
 
 fn button_on_pointer_cancel(
     mut cancel: On<Pointer<Cancel>>,
-    mut q_state: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<Button>>,
-    mut commands: Commands,
+    mut q_state: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<Button>>,
 ) {
-    if let Ok((button, disabled, pressed)) = q_state.get_mut(cancel.entity) {
+    if let Ok((disabled, pressed)) = q_state.get_mut(cancel.entity) {
         cancel.propagate(false);
-        if !disabled && pressed {
-            commands.entity(button).remove::<Pressed>();
+        if !disabled
+            && pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
+}
+
+/// System that removes the `Pressed` component after all possible systems could have reacted
+/// to its changing to false via change detection.
+fn remove_pressed_on_next_frame(
+    mut presses_to_clear: Local<Vec<Entity>>,
+    pressed_false_q: Query<(Entity, &Pressed), With<Button>>,
+    mut commands: Commands,
+) {
+    for button_entity in presses_to_clear.drain(..) {
+        // If the button has stayed false for the whole frame, remove its component.
+        if let Ok((_, pressed)) = pressed_false_q.get(button_entity)
+            && !pressed.get()
+        {
+            commands.entity(button_entity).remove::<Pressed>();
+        }
+    }
+
+    // Queue up the next buttons that will have `Pressed` remove on the next frame.
+    for (button_entity, pressed) in pressed_false_q {
+        if !pressed.get() {
+            presses_to_clear.push(button_entity);
+        }
+    }
+    presses_to_clear.shrink_to_fit();
 }
 
 /// Plugin that adds the observers for the [`Button`] widget.
@@ -146,6 +181,7 @@ impl Plugin for ButtonPlugin {
             .add_observer(button_on_pointer_up)
             .add_observer(button_on_pointer_click)
             .add_observer(button_on_pointer_drag_end)
-            .add_observer(button_on_pointer_cancel);
+            .add_observer(button_on_pointer_cancel)
+            .add_systems(Last, remove_pressed_on_next_frame);
     }
 }

--- a/crates/bevy_ui_widgets/src/button.rs
+++ b/crates/bevy_ui_widgets/src/button.rs
@@ -1,6 +1,6 @@
 use accesskit::Role;
 use bevy_a11y::AccessibilityNode;
-use bevy_app::{App, Last, Plugin};
+use bevy_app::{App, Plugin};
 use bevy_ecs::query::Has;
 use bevy_ecs::{
     component::Component,
@@ -146,31 +146,6 @@ fn button_on_pointer_cancel(
     }
 }
 
-/// System that removes the `Pressed` component after all possible systems could have reacted
-/// to its changing to false via change detection.
-fn remove_pressed_on_next_frame(
-    mut presses_to_clear: Local<Vec<Entity>>,
-    pressed_false_q: Query<(Entity, &Pressed), With<Button>>,
-    mut commands: Commands,
-) {
-    for button_entity in presses_to_clear.drain(..) {
-        // If the button has stayed false for the whole frame, remove its component.
-        if let Ok((_, pressed)) = pressed_false_q.get(button_entity)
-            && !pressed.get()
-        {
-            commands.entity(button_entity).remove::<Pressed>();
-        }
-    }
-
-    // Queue up the next buttons that will have `Pressed` remove on the next frame.
-    for (button_entity, pressed) in pressed_false_q {
-        if !pressed.get() {
-            presses_to_clear.push(button_entity);
-        }
-    }
-    presses_to_clear.shrink_to_fit();
-}
-
 /// Plugin that adds the observers for the [`Button`] widget.
 pub struct ButtonPlugin;
 
@@ -181,7 +156,6 @@ impl Plugin for ButtonPlugin {
             .add_observer(button_on_pointer_up)
             .add_observer(button_on_pointer_click)
             .add_observer(button_on_pointer_drag_end)
-            .add_observer(button_on_pointer_cancel)
-            .add_systems(Last, remove_pressed_on_next_frame);
+            .add_observer(button_on_pointer_cancel);
     }
 }

--- a/crates/bevy_ui_widgets/src/checkbox.rs
+++ b/crates/bevy_ui_widgets/src/checkbox.rs
@@ -15,7 +15,9 @@ use bevy_input::ButtonState;
 use bevy_input_focus::{FocusCause, FocusedInput, InputFocus, InputFocusVisible};
 use bevy_picking::events::{Cancel, Click, DragEnd, Pointer, Press, Release};
 use bevy_reflect::Reflect;
-use bevy_ui::{Checkable, Checked, InteractionDisabled, Pressed};
+use bevy_ui::{
+    interaction_states::OptionPressedExt, Checkable, Checked, InteractionDisabled, Pressed,
+};
 
 use crate::{ActivateOnPress, ValueChange};
 use bevy_ecs::entity::Entity;
@@ -89,7 +91,7 @@ fn checkbox_on_pointer_down(
             Entity,
             Has<InteractionDisabled>,
             Has<Checked>,
-            Has<Pressed>,
+            Option<&Pressed>,
             Has<ActivateOnPress>,
         ),
         With<Checkbox>,
@@ -111,8 +113,8 @@ fn checkbox_on_pointer_down(
         }
 
         press.propagate(false);
-        if !disabled && !pressed {
-            commands.entity(checkbox).insert(Pressed);
+        if !disabled && !pressed.is_pressed() {
+            commands.entity(checkbox).insert(Pressed::default());
             if activate_on_press {
                 commands.trigger(ValueChange {
                     source: press.entity,
@@ -126,39 +128,45 @@ fn checkbox_on_pointer_down(
 
 fn checkbox_on_pointer_up(
     mut release: On<Pointer<Release>>,
-    mut q_checkbox: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<Checkbox>>,
-    mut commands: Commands,
+    mut q_checkbox: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<Checkbox>>,
 ) {
-    if let Ok((checkbox, disabled, pressed)) = q_checkbox.get_mut(release.entity) {
+    if let Ok((disabled, pressed)) = q_checkbox.get_mut(release.entity) {
         release.propagate(false);
-        if !disabled && pressed {
-            commands.entity(checkbox).remove::<Pressed>();
+        if !disabled
+            && pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }
 
 fn checkbox_on_pointer_drag_end(
     mut drag_end: On<Pointer<DragEnd>>,
-    mut q_checkbox: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<Checkbox>>,
-    mut commands: Commands,
+    mut q_checkbox: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<Checkbox>>,
 ) {
-    if let Ok((checkbox, disabled, pressed)) = q_checkbox.get_mut(drag_end.entity) {
+    if let Ok((disabled, pressed)) = q_checkbox.get_mut(drag_end.entity) {
         drag_end.propagate(false);
-        if !disabled && pressed {
-            commands.entity(checkbox).remove::<Pressed>();
+        if !disabled
+            && pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }
 
 fn checkbox_on_pointer_cancel(
     mut cancel: On<Pointer<Cancel>>,
-    mut q_checkbox: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<Checkbox>>,
-    mut commands: Commands,
+    mut q_checkbox: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<Checkbox>>,
 ) {
-    if let Ok((checkbox, disabled, pressed)) = q_checkbox.get_mut(cancel.entity) {
+    if let Ok((disabled, pressed)) = q_checkbox.get_mut(cancel.entity) {
         cancel.propagate(false);
-        if !disabled && pressed {
-            commands.entity(checkbox).remove::<Pressed>();
+        if !disabled
+            && pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }

--- a/crates/bevy_ui_widgets/src/menu.rs
+++ b/crates/bevy_ui_widgets/src/menu.rs
@@ -54,7 +54,9 @@ use bevy_input_focus::{
 use bevy_log::warn;
 use bevy_picking::events::{Cancel, Click, DragEnd, Pointer, Press, Release};
 use bevy_reflect::Reflect;
-use bevy_ui::{widget::Button, InteractionDisabled, Pressed, UiSystems};
+use bevy_ui::{
+    interaction_states::OptionPressedExt, widget::Button, InteractionDisabled, Pressed, UiSystems,
+};
 
 use crate::{text_input::text_input_autoscroll_system, Activate, ActivateOnPress};
 
@@ -330,12 +332,12 @@ fn menu_on_key_event(
 
 fn menu_item_on_pointer_click(
     mut ev: On<Pointer<Click>>,
-    mut q_state: Query<(Has<Pressed>, Has<InteractionDisabled>), With<MenuItem>>,
+    mut q_state: Query<(Option<&Pressed>, Has<InteractionDisabled>), With<MenuItem>>,
     mut commands: Commands,
 ) {
     if let Ok((pressed, disabled)) = q_state.get_mut(ev.entity) {
         ev.propagate(false);
-        if pressed && !disabled {
+        if pressed.is_pressed() && !disabled {
             // Trigger the menu action.
             commands.trigger(Activate { entity: ev.entity });
             // Set the focus to the menu button.
@@ -354,52 +356,58 @@ fn menu_item_on_pointer_click(
 
 fn menu_item_on_pointer_down(
     mut ev: On<Pointer<Press>>,
-    mut q_state: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<MenuItem>>,
+    mut q_state: Query<(Entity, Has<InteractionDisabled>, Option<&Pressed>), With<MenuItem>>,
     mut commands: Commands,
 ) {
     if let Ok((item, disabled, pressed)) = q_state.get_mut(ev.entity) {
         ev.propagate(false);
-        if !disabled && !pressed {
-            commands.entity(item).insert(Pressed);
+        if !disabled && !pressed.is_pressed() {
+            commands.entity(item).insert(Pressed::default());
         }
     }
 }
 
 fn menu_item_on_pointer_up(
     mut ev: On<Pointer<Release>>,
-    mut q_state: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<MenuItem>>,
-    mut commands: Commands,
+    mut q_state: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<MenuItem>>,
 ) {
-    if let Ok((item, disabled, pressed)) = q_state.get_mut(ev.entity) {
+    if let Ok((disabled, pressed)) = q_state.get_mut(ev.entity) {
         ev.propagate(false);
-        if !disabled && pressed {
-            commands.entity(item).remove::<Pressed>();
+        if !disabled
+            && !pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }
 
 fn menu_item_on_pointer_drag_end(
     mut ev: On<Pointer<DragEnd>>,
-    mut q_state: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<MenuItem>>,
-    mut commands: Commands,
+    mut q_state: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<MenuItem>>,
 ) {
-    if let Ok((item, disabled, pressed)) = q_state.get_mut(ev.entity) {
+    if let Ok((disabled, pressed)) = q_state.get_mut(ev.entity) {
         ev.propagate(false);
-        if !disabled && pressed {
-            commands.entity(item).remove::<Pressed>();
+        if !disabled
+            && !pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }
 
 fn menu_item_on_pointer_cancel(
     mut ev: On<Pointer<Cancel>>,
-    mut q_state: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<MenuItem>>,
-    mut commands: Commands,
+    mut q_state: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<MenuItem>>,
 ) {
-    if let Ok((item, disabled, pressed)) = q_state.get_mut(ev.entity) {
+    if let Ok((disabled, pressed)) = q_state.get_mut(ev.entity) {
         ev.propagate(false);
-        if !disabled && pressed {
-            commands.entity(item).remove::<Pressed>();
+        if !disabled
+            && !pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }

--- a/crates/bevy_ui_widgets/src/radio.rs
+++ b/crates/bevy_ui_widgets/src/radio.rs
@@ -15,7 +15,9 @@ use bevy_input::ButtonState;
 use bevy_input_focus::FocusedInput;
 use bevy_picking::events::{Cancel, Click, DragEnd, Pointer, Press, Release};
 use bevy_reflect::Reflect;
-use bevy_ui::{Checkable, Checked, InteractionDisabled, Pressed};
+use bevy_ui::{
+    interaction_states::OptionPressedExt, Checkable, Checked, InteractionDisabled, Pressed,
+};
 
 use crate::{ActivateOnPress, ValueChange};
 
@@ -233,7 +235,7 @@ fn radio_button_on_pointer_down(
             Entity,
             Has<InteractionDisabled>,
             Has<Checked>,
-            Has<Pressed>,
+            Option<&Pressed>,
             Has<ActivateOnPress>,
         ),
         With<RadioButton>,
@@ -245,8 +247,8 @@ fn radio_button_on_pointer_down(
         q_radio.get_mut(press.entity)
     {
         press.propagate(false);
-        if !disabled && !pressed {
-            commands.entity(radio).insert(Pressed);
+        if !disabled && !pressed.is_pressed() {
+            commands.entity(radio).insert(Pressed::default());
             if activate_on_press && !checked {
                 trigger_radio_button_and_radio_group_value_change(
                     press.entity,
@@ -261,39 +263,45 @@ fn radio_button_on_pointer_down(
 
 fn radio_button_on_pointer_up(
     mut release: On<Pointer<Release>>,
-    mut q_radio: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<RadioButton>>,
-    mut commands: Commands,
+    mut q_radio: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<RadioButton>>,
 ) {
-    if let Ok((radio, disabled, pressed)) = q_radio.get_mut(release.entity) {
+    if let Ok((disabled, pressed)) = q_radio.get_mut(release.entity) {
         release.propagate(false);
-        if !disabled && pressed {
-            commands.entity(radio).remove::<Pressed>();
+        if !disabled
+            && !pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }
 
 fn radio_button_on_pointer_drag_end(
     mut drag_end: On<Pointer<DragEnd>>,
-    mut q_radio: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<RadioButton>>,
-    mut commands: Commands,
+    mut q_radio: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<RadioButton>>,
 ) {
-    if let Ok((radio, disabled, pressed)) = q_radio.get_mut(drag_end.entity) {
+    if let Ok((disabled, pressed)) = q_radio.get_mut(drag_end.entity) {
         drag_end.propagate(false);
-        if !disabled && pressed {
-            commands.entity(radio).remove::<Pressed>();
+        if !disabled
+            && !pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }
 
 fn radio_button_on_pointer_cancel(
     mut cancel: On<Pointer<Cancel>>,
-    mut q_radio: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<RadioButton>>,
-    mut commands: Commands,
+    mut q_radio: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<RadioButton>>,
 ) {
-    if let Ok((radio, disabled, pressed)) = q_radio.get_mut(cancel.entity) {
+    if let Ok((disabled, pressed)) = q_radio.get_mut(cancel.entity) {
         cancel.propagate(false);
-        if !disabled && pressed {
-            commands.entity(radio).remove::<Pressed>();
+        if !disabled
+            && !pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }

--- a/crates/bevy_ui_widgets/src/slider.rs
+++ b/crates/bevy_ui_widgets/src/slider.rs
@@ -24,8 +24,8 @@ use bevy_math::ops;
 use bevy_picking::events::{Cancel, Drag, DragEnd, DragStart, Pointer, Press, Release};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{
-    ComputedNode, ComputedUiRenderTargetInfo, InteractionDisabled, Pressed, UiGlobalTransform,
-    UiScale,
+    interaction_states::OptionPressedExt, ComputedNode, ComputedUiRenderTargetInfo,
+    InteractionDisabled, Pressed, UiGlobalTransform, UiScale,
 };
 
 use crate::ValueChange;
@@ -301,7 +301,7 @@ pub(crate) fn slider_on_pointer_down(
             return;
         }
 
-        commands.entity(slider_ent).insert(Pressed);
+        commands.entity(slider_ent).insert(Pressed::default());
 
         let is_vertical = slider.orientation.is_vertical(node);
 
@@ -438,13 +438,13 @@ pub(crate) fn slider_on_drag_end(
     mut drag_end: On<Pointer<DragEnd>>,
     mut q_slider: Query<
         (
-            Entity,
             &Slider,
             &ComputedNode,
             &SliderRange,
             Option<&SliderPrecision>,
             &UiGlobalTransform,
             &mut SliderDragState,
+            &mut Pressed,
             Has<InteractionDisabled>,
         ),
         With<Slider>,
@@ -454,7 +454,7 @@ pub(crate) fn slider_on_drag_end(
     mut commands: Commands,
     ui_scale: Res<UiScale>,
 ) {
-    if let Ok((slider_ent, slider, node, range, precision, transform, mut drag, disabled)) =
+    if let Ok((slider, node, range, precision, transform, mut drag, mut pressed, disabled)) =
         q_slider.get_mut(drag_end.entity)
     {
         drag_end.propagate(false);
@@ -476,7 +476,7 @@ pub(crate) fn slider_on_drag_end(
                     true,
                 );
             }
-            commands.entity(slider_ent).remove::<Pressed>();
+            pressed.0 = false;
             drag.dragging = false;
         }
     }
@@ -546,26 +546,30 @@ fn emit_slider_drag_value_change(
 
 fn slider_on_pointer_up(
     mut release: On<Pointer<Release>>,
-    mut q_slider: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<Slider>>,
-    mut commands: Commands,
+    mut q_slider: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<Slider>>,
 ) {
-    if let Ok((slider, disabled, pressed)) = q_slider.get_mut(release.entity) {
+    if let Ok((disabled, pressed)) = q_slider.get_mut(release.entity) {
         release.propagate(false);
-        if !disabled && pressed {
-            commands.entity(slider).remove::<Pressed>();
+        if !disabled
+            && !pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }
 
 fn slider_on_pointer_cancel(
     mut release: On<Pointer<Cancel>>,
-    mut q_slider: Query<(Entity, Has<InteractionDisabled>, Has<Pressed>), With<Slider>>,
-    mut commands: Commands,
+    mut q_slider: Query<(Has<InteractionDisabled>, Option<&mut Pressed>), With<Slider>>,
 ) {
-    if let Ok((slider, disabled, pressed)) = q_slider.get_mut(release.entity) {
+    if let Ok((disabled, pressed)) = q_slider.get_mut(release.entity) {
         release.propagate(false);
-        if !disabled && pressed {
-            commands.entity(slider).remove::<Pressed>();
+        if !disabled
+            && !pressed.is_pressed()
+            && let Some(mut pressed) = pressed
+        {
+            pressed.0 = false;
         }
     }
 }

--- a/examples/ui/images/ui_texture_atlas_slice.rs
+++ b/examples/ui/images/ui_texture_atlas_slice.rs
@@ -4,9 +4,8 @@
 use bevy::{
     color::palettes::css::{GOLD, ORANGE},
     picking::hover::Hovered,
-    platform::collections::HashSet,
     prelude::*,
-    ui::{widget::NodeImageMode, Pressed},
+    ui::{interaction_states::OptionPressedExt, widget::NodeImageMode, Pressed},
     ui_widgets::Button,
 };
 
@@ -20,39 +19,21 @@ fn main() {
 
 /// Updates each button label whenever its `Pressed` or `Hovered` state changes.
 /// The image node, defined from a spritesheet, will also update upon pressing the button.
-///
-/// `Hovered` always exists on the button, so `Ref::is_changed` catches hover transitions and
-/// the insertion of `Pressed`. Removal of `Pressed` is not reported by change detection, so we
-/// also restyle any button that just had `Pressed` removed this frame.
 fn button_system(
     mut buttons: Query<
-        (
-            Entity,
-            Option<Ref<Pressed>>,
-            Ref<Hovered>,
-            &mut ImageNode,
-            &Children,
-        ),
-        With<Button>,
+        (Option<&Pressed>, &Hovered, &mut ImageNode, &Children),
+        (Or<(Changed<Hovered>, Changed<Pressed>)>, With<Button>),
     >,
-    mut removed_pressed: RemovedComponents<Pressed>,
     mut text_query: Query<&mut Text>,
 ) {
-    // Buttons that had `Pressed` removed this frame; change detection does not report removals.
-    let just_unpressed: HashSet<Entity> = removed_pressed.read().collect();
-    for (entity, pressed, hovered, mut image, children) in &mut buttons {
-        let changed = hovered.is_changed()
-            || pressed.as_ref().is_some_and(Ref::is_changed)
-            || just_unpressed.contains(&entity);
-        if changed {
-            set_button_style(
-                pressed.is_some(),
-                hovered.get(),
-                &mut image,
-                children,
-                &mut text_query,
-            );
-        }
+    for (pressed, hovered, mut image, children) in &mut buttons {
+        set_button_style(
+            pressed.is_pressed(),
+            hovered.get(),
+            &mut image,
+            children,
+            &mut text_query,
+        );
     }
 }
 

--- a/examples/ui/images/ui_texture_slice.rs
+++ b/examples/ui/images/ui_texture_slice.rs
@@ -8,9 +8,8 @@
 use bevy::{
     color::palettes::css::{GOLD, ORANGE},
     picking::hover::Hovered,
-    platform::collections::HashSet,
     prelude::*,
-    ui::{widget::NodeImageMode, Pressed},
+    ui::{interaction_states::OptionPressedExt, widget::NodeImageMode, Pressed},
     ui_widgets::Button,
 };
 
@@ -30,18 +29,12 @@ fn main() {
 /// also restyle any button that just had `Pressed` removed this frame.
 fn button_system(
     mut buttons: Query<
-        (
-            Entity,
-            Option<&Pressed>,
-            &Hovered,
-            &mut ImageNode,
-            &Children,
-        ),
+        (Option<&Pressed>, &Hovered, &mut ImageNode, &Children),
         (Or<(Changed<Hovered>, Changed<Pressed>)>, With<Button>),
     >,
     mut text_query: Query<&mut Text>,
 ) {
-    for (entity, pressed, hovered, mut image, children) in &mut buttons {
+    for (pressed, hovered, mut image, children) in &mut buttons {
         set_button_style(
             pressed.is_pressed(),
             hovered.get(),

--- a/examples/ui/images/ui_texture_slice.rs
+++ b/examples/ui/images/ui_texture_slice.rs
@@ -32,31 +32,23 @@ fn button_system(
     mut buttons: Query<
         (
             Entity,
-            Option<Ref<Pressed>>,
-            Ref<Hovered>,
+            Option<&Pressed>,
+            &Hovered,
             &mut ImageNode,
             &Children,
         ),
-        With<Button>,
+        (Or<(Changed<Hovered>, Changed<Pressed>)>, With<Button>),
     >,
-    mut removed_pressed: RemovedComponents<Pressed>,
     mut text_query: Query<&mut Text>,
 ) {
-    // Buttons that had `Pressed` removed this frame; change detection does not report removals.
-    let just_unpressed: HashSet<Entity> = removed_pressed.read().collect();
     for (entity, pressed, hovered, mut image, children) in &mut buttons {
-        let changed = hovered.is_changed()
-            || pressed.as_ref().is_some_and(Ref::is_changed)
-            || just_unpressed.contains(&entity);
-        if changed {
-            set_button_style(
-                pressed.is_some(),
-                hovered.get(),
-                &mut image,
-                children,
-                &mut text_query,
-            );
-        }
+        set_button_style(
+            pressed.is_pressed(),
+            hovered.get(),
+            &mut image,
+            children,
+            &mut text_query,
+        );
     }
 }
 

--- a/examples/ui/widgets/button.rs
+++ b/examples/ui/widgets/button.rs
@@ -26,7 +26,7 @@ use bevy::{
     color::palettes::basic::*,
     picking::hover::Hovered,
     prelude::*,
-    ui::Pressed,
+    ui::{Pressed, interaction_states::OptionPressedExt},
     ui_widgets::{observe, Activate, Button},
 };
 
@@ -112,7 +112,7 @@ fn update_button_appearance(
     mut buttons: Query<
         (
             &Hovered,
-            Has<Pressed>,
+            Option<&Pressed>,
             &mut BackgroundColor,
             &mut BorderColor,
             &Children,
@@ -126,7 +126,7 @@ fn update_button_appearance(
             continue;
         };
 
-        match (hovered.get(), pressed) {
+        match (hovered.get(), pressed.is_pressed()) {
             // Pressed (and, since you can only press what you're hovering, also hovered).
             (_, true) => {
                 **text = "Press".to_string();

--- a/examples/ui/widgets/button.rs
+++ b/examples/ui/widgets/button.rs
@@ -26,7 +26,7 @@ use bevy::{
     color::palettes::basic::*,
     picking::hover::Hovered,
     prelude::*,
-    ui::{Pressed, interaction_states::OptionPressedExt},
+    ui::{interaction_states::OptionPressedExt, Pressed},
     ui_widgets::{observe, Activate, Button},
 };
 

--- a/examples/ui/widgets/standard_widgets.rs
+++ b/examples/ui/widgets/standard_widgets.rs
@@ -14,7 +14,7 @@ use bevy::{
     },
     picking::hover::Hovered,
     prelude::*,
-    ui::{Checked, InteractionDisabled, Pressed},
+    ui::{Checked, InteractionDisabled, Pressed, interaction_states::OptionPressedExt},
     ui_widgets::{
         checkbox_self_update, observe,
         popover::{Popover, PopoverAlign, PopoverPlacement, PopoverSide},
@@ -270,7 +270,7 @@ fn menu_button(asset_server: &AssetServer) -> impl Bundle {
 fn update_button_style(
     mut buttons: Query<
         (
-            Has<Pressed>,
+            Option<&Pressed>,
             &Hovered,
             Has<InteractionDisabled>,
             &mut BackgroundColor,
@@ -293,7 +293,7 @@ fn update_button_style(
         set_button_style(
             disabled,
             hovered.get(),
-            pressed,
+            pressed.is_pressed(),
             &mut color,
             &mut border_color,
             &mut text,
@@ -305,7 +305,7 @@ fn update_button_style(
 fn update_button_style2(
     mut buttons: Query<
         (
-            Has<Pressed>,
+            Option<&Pressed>,
             &Hovered,
             Has<InteractionDisabled>,
             &mut BackgroundColor,
@@ -314,13 +314,11 @@ fn update_button_style2(
         ),
         With<DemoButton>,
     >,
-    mut removed_depressed: RemovedComponents<Pressed>,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
     mut text_query: Query<&mut Text>,
 ) {
-    removed_depressed
-        .read()
-        .chain(removed_disabled.read())
+    removed_disabled.
+        read()
         .for_each(|entity| {
             if let Ok((pressed, hovered, disabled, mut color, mut border_color, children)) =
                 buttons.get_mut(entity)
@@ -329,7 +327,7 @@ fn update_button_style2(
                 set_button_style(
                     disabled,
                     hovered.get(),
-                    pressed,
+                    pressed.is_pressed(),
                     &mut color,
                     &mut border_color,
                     &mut text,
@@ -895,7 +893,7 @@ fn menu_item(asset_server: &AssetServer) -> impl Bundle {
 fn update_menu_item_style(
     mut buttons: Query<
         (
-            Has<Pressed>,
+            Option<&Pressed>,
             &Hovered,
             Has<InteractionDisabled>,
             &mut BackgroundColor,
@@ -911,7 +909,7 @@ fn update_menu_item_style(
     >,
 ) {
     for (pressed, hovered, disabled, mut color) in &mut buttons {
-        set_menu_item_style(disabled, hovered.get(), pressed, &mut color);
+        set_menu_item_style(disabled, hovered.get(), pressed.is_pressed(), &mut color);
     }
 }
 
@@ -919,22 +917,20 @@ fn update_menu_item_style(
 fn update_menu_item_style2(
     mut buttons: Query<
         (
-            Has<Pressed>,
+            Option<&Pressed>,
             &Hovered,
             Has<InteractionDisabled>,
             &mut BackgroundColor,
         ),
         With<DemoMenuItem>,
     >,
-    mut removed_depressed: RemovedComponents<Pressed>,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
 ) {
-    removed_depressed
+    removed_disabled
         .read()
-        .chain(removed_disabled.read())
         .for_each(|entity| {
             if let Ok((pressed, hovered, disabled, mut color)) = buttons.get_mut(entity) {
-                set_menu_item_style(disabled, hovered.get(), pressed, &mut color);
+                set_menu_item_style(disabled, hovered.get(), pressed.is_pressed(), &mut color);
             }
         });
 }

--- a/examples/ui/widgets/standard_widgets.rs
+++ b/examples/ui/widgets/standard_widgets.rs
@@ -14,7 +14,7 @@ use bevy::{
     },
     picking::hover::Hovered,
     prelude::*,
-    ui::{Checked, InteractionDisabled, Pressed, interaction_states::OptionPressedExt},
+    ui::{interaction_states::OptionPressedExt, Checked, InteractionDisabled, Pressed},
     ui_widgets::{
         checkbox_self_update, observe,
         popover::{Popover, PopoverAlign, PopoverPlacement, PopoverSide},
@@ -317,23 +317,21 @@ fn update_button_style2(
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
     mut text_query: Query<&mut Text>,
 ) {
-    removed_disabled.
-        read()
-        .for_each(|entity| {
-            if let Ok((pressed, hovered, disabled, mut color, mut border_color, children)) =
-                buttons.get_mut(entity)
-            {
-                let mut text = text_query.get_mut(children[0]).unwrap();
-                set_button_style(
-                    disabled,
-                    hovered.get(),
-                    pressed.is_pressed(),
-                    &mut color,
-                    &mut border_color,
-                    &mut text,
-                );
-            }
-        });
+    removed_disabled.read().for_each(|entity| {
+        if let Ok((pressed, hovered, disabled, mut color, mut border_color, children)) =
+            buttons.get_mut(entity)
+        {
+            let mut text = text_query.get_mut(children[0]).unwrap();
+            set_button_style(
+                disabled,
+                hovered.get(),
+                pressed.is_pressed(),
+                &mut color,
+                &mut border_color,
+                &mut text,
+            );
+        }
+    });
 }
 
 fn set_button_style(
@@ -926,13 +924,11 @@ fn update_menu_item_style2(
     >,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
 ) {
-    removed_disabled
-        .read()
-        .for_each(|entity| {
-            if let Ok((pressed, hovered, disabled, mut color)) = buttons.get_mut(entity) {
-                set_menu_item_style(disabled, hovered.get(), pressed.is_pressed(), &mut color);
-            }
-        });
+    removed_disabled.read().for_each(|entity| {
+        if let Ok((pressed, hovered, disabled, mut color)) = buttons.get_mut(entity) {
+            set_menu_item_style(disabled, hovered.get(), pressed.is_pressed(), &mut color);
+        }
+    });
 }
 
 fn set_menu_item_style(disabled: bool, hovered: bool, pressed: bool, color: &mut BackgroundColor) {

--- a/examples/ui/widgets/standard_widgets_observers.rs
+++ b/examples/ui/widgets/standard_widgets_observers.rs
@@ -10,7 +10,7 @@ use bevy::{
     picking::hover::Hovered,
     prelude::*,
     reflect::Is,
-    ui::{Checked, InteractionDisabled, Pressed},
+    ui::{Checked, InteractionDisabled, Pressed, interaction_states::OptionPressedExt},
     ui_widgets::{
         checkbox_self_update, observe, Activate, Button, Checkbox, Slider, SliderRange,
         SliderThumb, SliderValue, ValueChange,
@@ -156,7 +156,7 @@ fn button_on_interaction<E: EntityEvent, C: Component>(
         (
             &Hovered,
             Has<InteractionDisabled>,
-            Has<Pressed>,
+            Option<&Pressed>,
             &mut BackgroundColor,
             &mut BorderColor,
             &Children,
@@ -177,7 +177,7 @@ fn button_on_interaction<E: EntityEvent, C: Component>(
         let hovered = hovered.get();
         // These "removal event checks" exist because the `Remove` event is triggered _before_ the component is actually
         // removed, meaning it still shows up in the query. We're investigating the best way to improve this scenario.
-        let pressed = pressed && !(E::is::<Remove>() && C::is::<Pressed>());
+        let pressed = pressed.is_pressed() && !(E::is::<Remove>() && C::is::<Pressed>());
         let disabled = disabled && !(E::is::<Remove>() && C::is::<InteractionDisabled>());
         match (disabled, hovered, pressed) {
             // Disabled button

--- a/examples/ui/widgets/standard_widgets_observers.rs
+++ b/examples/ui/widgets/standard_widgets_observers.rs
@@ -10,7 +10,7 @@ use bevy::{
     picking::hover::Hovered,
     prelude::*,
     reflect::Is,
-    ui::{Checked, InteractionDisabled, Pressed, interaction_states::OptionPressedExt},
+    ui::{interaction_states::OptionPressedExt, Checked, InteractionDisabled, Pressed},
     ui_widgets::{
         checkbox_self_update, observe, Activate, Button, Checkbox, Slider, SliderRange,
         SliderThumb, SliderValue, ValueChange,


### PR DESCRIPTION
# Objective

- Make the `Pressed` component more usable in regular systems. Observers for `Pointer<Press>` and `Pointer<Release>` are there of course, but sometimes you may want to use `Pressed` in a system. To detect a `Pressed` removal, you have to dip into `RemovedComponents`, which is a bit of a detour. 
- Preserve the “Marker Component” quality `Pressed` currently has despite any changes.

## Solution

- `Pressed` is now a newtype bool that is inserted as `true` when the press starts.
- When the entity is not being `Pressed` anymore, its value is set to false.
- There is now a system that runs in `Last` called `remove_pressed_on_next_frame()` that queues up any entities with a  `Pressed` component set to false. On the next run, if the `Pressed` component has not changed at all, it will remove the `Pressed` component on the entity, thus preserving the “Marker Component” nature of `Pressed`.

For reviewers, you should start with the `bevy_ui/src/interaction_states.rs` file first. Then I’d review the `examples` to see what this means in practice for the end user, and then the `widgets` and `feathers` changes.

This came out of an idea I had at 1AM, so apologies if this is a bad idea. But, I do see the potential in removing those `..._remove()` systems in feathers if all of the subsequent components were ported to use this approach. I still think it’s a little clever!

This is more of an exploratory PR, although polished enough to merge if we so wish.

## Testing

- `cargo run --example ui_texture_slice` and `cargo run --example ui_texture_atlas_slice` are two simple examples that showcase the simplification on the user side with this approach.