### PR TITLE
Migrate `context_menu` to use bsn! and `ui_widgets::ListBox` (Phase 3 Item 2)

### DIFF
--- a/examples/usage/context_menu.rs
+++ b/examples/usage/context_menu.rs
@@ -19,15 +19,15 @@ struct OpenContextMenu {
 struct CloseContextMenus;
 
 /// marker component identifying root of a context menu
-#[derive(Component)]
+#[derive(Component, Clone, Default)]
 struct ContextMenu;
 
 /// context menu item data storing what background color `Srgba` it activates
-#[derive(Component, PartialEq)]
+#[derive(Component, Clone, Default, PartialEq)]
 struct ContextMenuItem(Srgba);
 
 /// marker component for context item text
-#[derive(Component)]
+#[derive(Component, Clone, Default)]
 struct ContextMenuItemText;
 
 fn main() {
@@ -66,8 +66,9 @@ fn text_color_on_hover<T: Debug + Clone + Reflect>(
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 
-    commands.spawn(background_and_button()).observe(
-        |event: On<Pointer<Press>>, query: Query<(), With<ContextMenu>>, mut commands: Commands| {
+    commands.spawn_scene(bsn! {
+        background()
+        on(|event: On<Pointer<Press>>, query: Query<(), With<ContextMenu>>, mut commands: Commands| {
             debug!("click: {}", event.pointer_location.position);
 
             if query.is_empty() {
@@ -79,8 +80,8 @@ fn setup(mut commands: Commands) {
                 // Close the context menu if it exists
                 commands.trigger(CloseContextMenus);
             }
-        },
-    );
+        })
+    });
 }
 
 fn on_trigger_close_menus(
@@ -100,34 +101,30 @@ fn on_trigger_menu(event: On<OpenContextMenu>, mut commands: Commands) {
 
     debug!("open context menu at: {pos}");
 
-    commands
-        .spawn((
-            Name::new("context menu"),
-            ContextMenu,
-            Node {
-                position_type: PositionType::Absolute,
-                left: px(pos.x),
-                top: px(pos.y),
-                flex_direction: FlexDirection::Column,
-                border_radius: BorderRadius::all(px(4)),
-                ..default()
-            },
-            BorderColor::all(Color::BLACK),
-            BackgroundColor(Color::linear_rgb(0.1, 0.1, 0.1)),
-            ListBox,
-            children![
-                context_item("fuchsia", basic::FUCHSIA),
-                context_item("gray", basic::GRAY),
-                context_item("maroon", basic::MAROON),
-                context_item("purple", basic::PURPLE),
-                context_item("teal", basic::TEAL),
-            ],
-        ))
-        .observe(
-            |event: On<ValueChange<Entity>>,
-             menu_items: Query<&ContextMenuItem, With<ListItem>>,
-             mut clear_col: ResMut<ClearColor>,
-             mut commands: Commands| {
+    commands.spawn_scene(bsn! {
+        Name::new("context menu")
+        ContextMenu
+        Node {
+            position_type: PositionType::Absolute,
+            left: px(pos.x),
+            top: px(pos.y),
+            flex_direction: FlexDirection::Column,
+            border_radius: BorderRadius::all(px(4)),
+        }
+        BorderColor::all(Color::BLACK)
+        BackgroundColor(Color::linear_rgb(0.1, 0.1, 0.1))
+        ListBox
+        Children [
+            context_item("fuchsia", basic::FUCHSIA),
+            context_item("gray", basic::GRAY),
+            context_item("maroon", basic::MAROON),
+            context_item("purple", basic::PURPLE),
+            context_item("teal", basic::TEAL),
+        ]
+        on(|event: On<ValueChange<Entity>>,
+            menu_items: Query<&ContextMenuItem, With<ListItem>>,
+            mut clear_col: ResMut<ClearColor>,
+            mut commands: Commands| {
                 let Ok(selected) = menu_items.get(event.value) else {
                     return;
                 };
@@ -136,53 +133,46 @@ fn on_trigger_menu(event: On<OpenContextMenu>, mut commands: Commands) {
 
                 // We do not set the `Selected` state of any of the items because the menu
                 // will be despawned.
-            },
-        );
+        })
+    });
 }
 
-fn context_item(text: &str, col: Srgba) -> impl Bundle {
-    (
-        Name::new(format!("item-{text}")),
-        ListItem,
-        ContextMenuItem(col),
+fn context_item(text: &'static str, col: Srgba) -> impl Scene {
+    bsn! {
+        Name::new(format!("item-{text}"))
+        ListItem
+        ContextMenuItem(col)
         Node {
             padding: UiRect::all(px(5)),
-            ..default()
-        },
-        children![(
-            ContextMenuItemText,
-            Pickable::IGNORE,
-            Text::new(text),
+        }
+        Children [
+            ContextMenuItemText
+            Pickable::IGNORE
+            Text::new(text)
             TextFont {
                 font_size: FontSize::Px(24.0),
-                ..default()
-            },
-            TextColor(Color::WHITE),
-        )],
-    )
+            }
+            TextColor(Color::WHITE)
+        ]
+    }
 }
 
-fn background_and_button() -> impl Bundle {
-    (
-        Name::new("background"),
+fn background() -> impl Scene {
+    bsn! {
+        Name::new("background")
         Node {
             width: percent(100),
             height: percent(100),
             align_items: AlignItems::Center,
             justify_content: JustifyContent::Center,
-            ..default()
-        },
-        ZIndex(-10),
-        Children::spawn(SpawnWith(|parent: &mut RelatedSpawner<ChildOf>| {
-            parent
-                .spawn((
-                    Text::new("Click anywhere to spawn a Context Menu.\nYour selection will change the background color."),
-                    TextFont {
-                        font_size: FontSize::Px(28.0),
-                        ..default()
-                    },
-                    TextColor(Color::WHITE),
-                ));
-        })),
-    )
+        }
+        ZIndex({-10})
+        Children [
+            Text::new("Click anywhere to spawn a Context Menu.\nYour selection will change the background color.")
+            TextFont {
+                font_size: FontSize::Px(28.0),
+            }
+            TextColor(Color::WHITE)
+        ]
+    }
 }

--- a/examples/usage/context_menu.rs
+++ b/examples/usage/context_menu.rs
@@ -4,7 +4,7 @@ use bevy::{
     color::palettes::basic,
     ecs::{relationship::RelatedSpawner, spawn::SpawnWith},
     prelude::*,
-    ui_widgets::{observe, Activate, Button},
+    ui_widgets::{Button, ListBox, ListItem, ValueChange},
 };
 use std::fmt::Debug;
 
@@ -23,7 +23,7 @@ struct CloseContextMenus;
 struct ContextMenu;
 
 /// context menu item data storing what background color `Srgba` it activates
-#[derive(Component)]
+#[derive(Component, PartialEq)]
 struct ContextMenuItem(Srgba);
 
 fn main() {
@@ -86,34 +86,51 @@ fn on_trigger_menu(event: On<OpenContextMenu>, mut commands: Commands) {
 
     debug!("open context menu at: {pos}");
 
-    commands.spawn((
-        Name::new("context menu"),
-        ContextMenu,
-        Node {
-            position_type: PositionType::Absolute,
-            left: px(pos.x),
-            top: px(pos.y),
-            flex_direction: FlexDirection::Column,
-            border_radius: BorderRadius::all(px(4)),
-            ..default()
-        },
-        BorderColor::all(Color::BLACK),
-        BackgroundColor(Color::linear_rgb(0.1, 0.1, 0.1)),
-        children![
-            context_item("fuchsia", basic::FUCHSIA),
-            context_item("gray", basic::GRAY),
-            context_item("maroon", basic::MAROON),
-            context_item("purple", basic::PURPLE),
-            context_item("teal", basic::TEAL),
-        ],
-    ));
+    commands
+        .spawn((
+            Name::new("context menu"),
+            ContextMenu,
+            Node {
+                position_type: PositionType::Absolute,
+                left: px(pos.x),
+                top: px(pos.y),
+                flex_direction: FlexDirection::Column,
+                border_radius: BorderRadius::all(px(4)),
+                ..default()
+            },
+            BorderColor::all(Color::BLACK),
+            BackgroundColor(Color::linear_rgb(0.1, 0.1, 0.1)),
+            ListBox,
+            children![
+                context_item("fuchsia", basic::FUCHSIA),
+                context_item("gray", basic::GRAY),
+                context_item("maroon", basic::MAROON),
+                context_item("purple", basic::PURPLE),
+                context_item("teal", basic::TEAL),
+            ],
+        ))
+        .observe(
+            |event: On<ValueChange<Entity>>,
+             menu_items: Query<&ContextMenuItem, With<ListItem>>,
+             mut clear_col: ResMut<ClearColor>,
+             mut commands: Commands| {
+                let Ok(selected) = menu_items.get(event.value) else {
+                    return;
+                };
+                clear_col.0 = selected.0.into();
+                commands.trigger(CloseContextMenus);
+
+                // We do not set the `Selected` state of any of the items because the menu
+                // will be despawned.
+            },
+        );
 }
 
 fn context_item(text: &str, col: Srgba) -> impl Bundle {
     (
         Name::new(format!("item-{text}")),
+        ListItem,
         ContextMenuItem(col),
-        Button,
         Node {
             padding: UiRect::all(px(5)),
             ..default()
@@ -127,18 +144,6 @@ fn context_item(text: &str, col: Srgba) -> impl Bundle {
             },
             TextColor(Color::WHITE),
         )],
-        // Activating an item sets the `ClearColor` and then closes the context menu
-        observe(
-            |event: On<Activate>,
-             menu_items: Query<&ContextMenuItem>,
-             mut clear_col: ResMut<ClearColor>,
-             mut commands: Commands| {
-                if let Ok(item) = menu_items.get(event.entity) {
-                    clear_col.0 = item.0.into();
-                    commands.trigger(CloseContextMenus);
-                }
-            },
-        ),
     )
 }
 

--- a/examples/usage/context_menu.rs
+++ b/examples/usage/context_menu.rs
@@ -4,6 +4,7 @@ use bevy::{
     color::palettes::basic,
     ecs::{relationship::RelatedSpawner, spawn::SpawnWith},
     prelude::*,
+    ui_widgets::{observe, Activate, Button},
 };
 use std::fmt::Debug;
 
@@ -85,41 +86,27 @@ fn on_trigger_menu(event: On<OpenContextMenu>, mut commands: Commands) {
 
     debug!("open context menu at: {pos}");
 
-    commands
-        .spawn((
-            Name::new("context menu"),
-            ContextMenu,
-            Node {
-                position_type: PositionType::Absolute,
-                left: px(pos.x),
-                top: px(pos.y),
-                flex_direction: FlexDirection::Column,
-                border_radius: BorderRadius::all(px(4)),
-                ..default()
-            },
-            BorderColor::all(Color::BLACK),
-            BackgroundColor(Color::linear_rgb(0.1, 0.1, 0.1)),
-            children![
-                context_item("fuchsia", basic::FUCHSIA),
-                context_item("gray", basic::GRAY),
-                context_item("maroon", basic::MAROON),
-                context_item("purple", basic::PURPLE),
-                context_item("teal", basic::TEAL),
-            ],
-        ))
-        .observe(
-            |event: On<Pointer<Press>>,
-             menu_items: Query<&ContextMenuItem>,
-             mut clear_col: ResMut<ClearColor>,
-             mut commands: Commands| {
-                let target = event.original_event_target();
-
-                if let Ok(item) = menu_items.get(target) {
-                    clear_col.0 = item.0.into();
-                    commands.trigger(CloseContextMenus);
-                }
-            },
-        );
+    commands.spawn((
+        Name::new("context menu"),
+        ContextMenu,
+        Node {
+            position_type: PositionType::Absolute,
+            left: px(pos.x),
+            top: px(pos.y),
+            flex_direction: FlexDirection::Column,
+            border_radius: BorderRadius::all(px(4)),
+            ..default()
+        },
+        BorderColor::all(Color::BLACK),
+        BackgroundColor(Color::linear_rgb(0.1, 0.1, 0.1)),
+        children![
+            context_item("fuchsia", basic::FUCHSIA),
+            context_item("gray", basic::GRAY),
+            context_item("maroon", basic::MAROON),
+            context_item("purple", basic::PURPLE),
+            context_item("teal", basic::TEAL),
+        ],
+    ));
 }
 
 fn context_item(text: &str, col: Srgba) -> impl Bundle {
@@ -140,6 +127,18 @@ fn context_item(text: &str, col: Srgba) -> impl Bundle {
             },
             TextColor(Color::WHITE),
         )],
+        // Activating an item sets the `ClearColor` and then closes the context menu
+        observe(
+            |event: On<Activate>,
+             menu_items: Query<&ContextMenuItem>,
+             mut clear_col: ResMut<ClearColor>,
+             mut commands: Commands| {
+                if let Ok(item) = menu_items.get(event.entity) {
+                    clear_col.0 = item.0.into();
+                    commands.trigger(CloseContextMenus);
+                }
+            },
+        ),
     )
 }
 

--- a/examples/usage/context_menu.rs
+++ b/examples/usage/context_menu.rs
@@ -2,7 +2,6 @@
 
 use bevy::{
     color::palettes::basic,
-    ecs::{relationship::RelatedSpawner, spawn::SpawnWith},
     prelude::*,
     ui_widgets::{ListBox, ListItem, ValueChange},
 };

--- a/examples/usage/context_menu.rs
+++ b/examples/usage/context_menu.rs
@@ -4,7 +4,7 @@ use bevy::{
     color::palettes::basic,
     ecs::{relationship::RelatedSpawner, spawn::SpawnWith},
     prelude::*,
-    ui_widgets::{Button, ListBox, ListItem, ValueChange},
+    ui_widgets::{ListBox, ListItem, ValueChange},
 };
 use std::fmt::Debug;
 
@@ -26,6 +26,10 @@ struct ContextMenu;
 #[derive(Component, PartialEq)]
 struct ContextMenuItem(Srgba);
 
+/// marker component for context item text
+#[derive(Component)]
+struct ContextMenuItemText;
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -40,9 +44,10 @@ fn main() {
 /// helper function to reduce code duplication when generating almost identical observers for the hover text color change effect
 fn text_color_on_hover<T: Debug + Clone + Reflect>(
     color: Color,
-) -> impl FnMut(On<Pointer<T>>, Query<&mut TextColor>, Query<&Children>) {
+) -> impl FnMut(On<Pointer<T>>, Query<&mut TextColor, With<ContextMenuItemText>>, Query<&Children>)
+{
     move |mut event: On<Pointer<T>>,
-          mut text_color: Query<&mut TextColor>,
+          mut text_color: Query<&mut TextColor, With<ContextMenuItemText>>,
           children: Query<&Children>| {
         let Ok(children) = children.get(event.original_event_target()) else {
             return;
@@ -62,9 +67,18 @@ fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 
     commands.spawn(background_and_button()).observe(
-        // any click bubbling up here should lead to closing any open menu
-        |_: On<Pointer<Press>>, mut commands: Commands| {
-            commands.trigger(CloseContextMenus);
+        |event: On<Pointer<Press>>, query: Query<(), With<ContextMenu>>, mut commands: Commands| {
+            debug!("click: {}", event.pointer_location.position);
+
+            if query.is_empty() {
+                // Open the context menu at the pointer location if one does not exist
+                commands.trigger(OpenContextMenu {
+                    pos: event.pointer_location.position,
+                });
+            } else {
+                // Close the context menu if it exists
+                commands.trigger(CloseContextMenus);
+            }
         },
     );
 }
@@ -136,6 +150,7 @@ fn context_item(text: &str, col: Srgba) -> impl Bundle {
             ..default()
         },
         children![(
+            ContextMenuItemText,
             Pickable::IGNORE,
             Text::new(text),
             TextFont {
@@ -161,41 +176,13 @@ fn background_and_button() -> impl Bundle {
         Children::spawn(SpawnWith(|parent: &mut RelatedSpawner<ChildOf>| {
             parent
                 .spawn((
-                    Name::new("button"),
-                    Button,
-                    Node {
-                        width: px(250),
-                        height: px(65),
-                        border: UiRect::all(px(5)),
-                        justify_content: JustifyContent::Center,
-                        align_items: AlignItems::Center,
-                        border_radius: BorderRadius::MAX,
+                    Text::new("Click anywhere to spawn a Context Menu.\nYour selection will change the background color."),
+                    TextFont {
+                        font_size: FontSize::Px(28.0),
                         ..default()
                     },
-                    BorderColor::all(Color::BLACK),
-                    BackgroundColor(Color::BLACK),
-                    children![(
-                        Pickable::IGNORE,
-                        Text::new("Context Menu"),
-                        TextFont {
-                            font_size: FontSize::Px(28.0),
-                            ..default()
-                        },
-                        TextColor(Color::WHITE),
-                        TextShadow::default(),
-                    )],
-                ))
-                .observe(|mut event: On<Pointer<Press>>, mut commands: Commands| {
-                    // by default this event would bubble up further leading to the `CloseContextMenus`
-                    // event being triggered and undoing the opening of one here right away.
-                    event.propagate(false);
-
-                    debug!("click: {}", event.pointer_location.position);
-
-                    commands.trigger(OpenContextMenu {
-                        pos: event.pointer_location.position,
-                    });
-                });
+                    TextColor(Color::WHITE),
+                ));
         })),
     )
 }


### PR DESCRIPTION
# Objective

- Part of #24112

## Solution

- A straightforward port of using a `ListBox` to react to a color selection.
- I wasn’t very fond of the button being used to spawn the context menu, because then that sorta leads me to think that you should be using `Popover` to position the menu relative to the button. To remove any such ideas and to make the example more free form (since I imagine a context menu is intended to be able to be spawned anywhere on the screen), I removed the limitation to spawning near the button. It doesn’t look pretty in every location spawned (since it doesn’t adapt to the borders of the window for example), but I think it makes more sense like this and introduces the concept a bit clearer.

## Testing

- `cargo run --example context_menu`. It works differently than it does on `main`, but I think it’s to its improvement.

---

## Showcase

<img width="1277" height="751" alt="Screenshot 2026-07-24 at 3 40 31 PM" src="https://github.com/user-attachments/assets/1289d67e-0b2d-4d0f-9d87-6a02e34e2812" />
