### PR TITLE
Fix: Added "scale all 3 axis" option for scale gizmo.

### DIFF
--- a/crates/bevy_gizmos/src/transform_gizmo.rs
+++ b/crates/bevy_gizmos/src/transform_gizmo.rs
@@ -385,7 +385,14 @@ fn transform_gizmo_hover(
                 VIEW_RING_MAJOR * scale,
             )
         }
-        TransformGizmoMode::Scale => f32::MAX, // no view handle for scale
+        TransformGizmoMode::Scale => {
+            // View handle: uniform scale via a center handle
+            if let Ok(center_screen) = camera.world_to_viewport(cam_tf, gizmo_pos) {
+                (cursor_pos - center_screen).length()
+            } else {
+                f32::MAX
+            }
+        }
     };
 
     if view_dist < threshold && view_dist < best_dist {
@@ -429,7 +436,7 @@ fn transform_gizmo_drag(
             };
 
             let drag_start_world = match settings.mode {
-                TransformGizmoMode::Translate => {
+                TransformGizmoMode::Translate | TransformGizmoMode::Scale => {
                     if axis == TransformGizmoAxis::View {
                         // View-plane translate: use camera forward as normal
                         let plane_normal = cam_tf.forward().as_vec3();
@@ -447,14 +454,6 @@ fn transform_gizmo_drag(
                         let cursor_vec = intersection - gizmo_pos;
                         cursor_vec.dot(axis_dir.normalize()) * axis_dir.normalize() + gizmo_pos
                     }
-                }
-                TransformGizmoMode::Scale => {
-                    let plane_normal = translation_plane_normal(ray, axis_dir);
-                    let Some(intersection) = intersect_plane(ray, plane_normal, gizmo_pos) else {
-                        return;
-                    };
-                    let cursor_vec = intersection - gizmo_pos;
-                    cursor_vec.dot(axis_dir.normalize()) * axis_dir.normalize() + gizmo_pos
                 }
                 TransformGizmoMode::Rotate => {
                     let rot_axis = if axis == TransformGizmoAxis::View {
@@ -567,13 +566,24 @@ fn transform_gizmo_drag(
                 transform.rotation = rotation_delta * state.start_transform.rotation;
             }
             TransformGizmoMode::Scale => {
-                let plane_normal = translation_plane_normal(ray, axis_dir);
+                let (plane_normal, projection_dir) = if axis == TransformGizmoAxis::View {
+                    let start_vec = state.drag_start_world - gizmo_origin;
+                    let len = start_vec.length();
+                    if len <= f32::EPSILON {
+                        return;
+                    }
+                    (cam_tf.forward().as_vec3(), start_vec / len)
+                } else {
+                    (
+                        translation_plane_normal(ray, axis_dir),
+                        axis_dir.normalize(),
+                    )
+                };
                 let Some(intersection) = intersect_plane(ray, plane_normal, gizmo_origin) else {
                     return;
                 };
-                let axis_norm = axis_dir.normalize();
-                let cursor_projected = (intersection - gizmo_origin).dot(axis_norm);
-                let start_projected = (state.drag_start_world - gizmo_origin).dot(axis_norm);
+                let cursor_projected = (intersection - gizmo_origin).dot(projection_dir);
+                let start_projected = (state.drag_start_world - gizmo_origin).dot(projection_dir);
 
                 let scale_factor = if start_projected.abs() > f32::EPSILON {
                     cursor_projected / start_projected

--- a/crates/bevy_gizmos/src/transform_gizmo.rs
+++ b/crates/bevy_gizmos/src/transform_gizmo.rs
@@ -156,6 +156,8 @@ pub struct TransformGizmoSettings {
     pub confine_cursor: bool,
     /// Screen-space scale factor. Set to 0.0 to disable constant-size behavior.
     pub screen_scale_factor: f32,
+    /// Scale sensitivity factor for the scale handle.
+    pub scale_sensitivity: f32,
 }
 
 impl Default for TransformGizmoSettings {
@@ -171,6 +173,7 @@ impl Default for TransformGizmoSettings {
             snap_scale: None,
             confine_cursor: true,
             screen_scale_factor: 0.1,
+            scale_sensitivity: 1.0,
         }
     }
 }
@@ -386,7 +389,6 @@ fn transform_gizmo_hover(
             )
         }
         TransformGizmoMode::Scale => {
-            // View handle: uniform scale via a center handle
             if let Ok(center_screen) = camera.world_to_viewport(cam_tf, gizmo_pos) {
                 (cursor_pos - center_screen).length()
             } else {
@@ -585,10 +587,19 @@ fn transform_gizmo_drag(
                 let cursor_projected = (intersection - gizmo_origin).dot(projection_dir);
                 let start_projected = (state.drag_start_world - gizmo_origin).dot(projection_dir);
 
-                let scale_factor = if start_projected.abs() > f32::EPSILON {
-                    cursor_projected / start_projected
-                } else {
-                    1.0
+                let scale_factor = match axis {
+                    TransformGizmoAxis::X | TransformGizmoAxis::Y | TransformGizmoAxis::Z => {
+                        if start_projected.abs() > f32::EPSILON {
+                            let ratio = cursor_projected / start_projected;
+                            1.0 + (ratio - 1.0) * settings.scale_sensitivity
+                        } else {
+                            1.0
+                        }
+                    }
+                    TransformGizmoAxis::View => {
+                        let delta = cursor_projected - start_projected;
+                        (delta * settings.scale_sensitivity).exp()
+                    }
                 };
 
                 let mut new_scale = state.start_transform.scale;

--- a/crates/bevy_gizmos/src/transform_gizmo.rs
+++ b/crates/bevy_gizmos/src/transform_gizmo.rs
@@ -598,7 +598,7 @@ fn transform_gizmo_drag(
                     }
                     TransformGizmoAxis::View => {
                         let delta = cursor_projected - start_projected;
-                        (delta * settings.scale_sensitivity).exp()
+                        bevy_math::ops::exp(delta * settings.scale_sensitivity)
                     }
                 };
 

--- a/crates/bevy_gizmos/src/transform_gizmo.rs
+++ b/crates/bevy_gizmos/src/transform_gizmo.rs
@@ -156,7 +156,7 @@ pub struct TransformGizmoSettings {
     pub confine_cursor: bool,
     /// Screen-space scale factor. Set to 0.0 to disable constant-size behavior.
     pub screen_scale_factor: f32,
-    /// Scale sensitivity factor for the scale handle.
+    /// Controls how fast objects change scale when the scale handle is used.
     pub scale_sensitivity: f32,
 }
 

--- a/crates/bevy_gizmos_render/src/transform_gizmo_render.rs
+++ b/crates/bevy_gizmos_render/src/transform_gizmo_render.rs
@@ -201,6 +201,15 @@ fn spawn_gizmo_meshes(
         .mesh()
         .build(),
     );
+    let view_scale_mesh = meshes.add(
+        Cuboid::new(
+            SCALE_CUBE_SIZE * 1.5,
+            SCALE_CUBE_SIZE * 1.5,
+            SCALE_CUBE_SIZE * 1.5,
+        )
+        .mesh()
+        .build(),
+    );
 
     // Axis rotations: cylinder default is Y-up
     let axis_rotation = |axis: TransformGizmoAxis| -> Quat {
@@ -334,6 +343,16 @@ fn spawn_gizmo_meshes(
             TransformGizmoMode::Scale,
         );
     }
+
+    // View-axis cube (scale)
+    spawn_child(
+        &mut commands,
+        view_scale_mesh,
+        make_mat(TransformGizmoAxis::View),
+        Transform::IDENTITY,
+        TransformGizmoAxis::View,
+        TransformGizmoMode::Scale,
+    );
 
     // --- Overlay camera ---
     // This camera renders only the gizmo layer, after the main camera (order: 1),

--- a/examples/gizmos/transform_gizmo.rs
+++ b/examples/gizmos/transform_gizmo.rs
@@ -156,6 +156,14 @@ fn gizmo_mode_keys(
             TransformGizmoSpace::Local => TransformGizmoSpace::World,
         };
     }
+    if settings.mode == TransformGizmoMode::Scale {
+        if keyboard.just_pressed(KeyCode::ArrowUp) {
+            settings.scale_sensitivity = (settings.scale_sensitivity + 0.1).min(2.0);
+        }
+        if keyboard.just_pressed(KeyCode::ArrowDown) {
+            settings.scale_sensitivity = (settings.scale_sensitivity - 0.1).max(0.1);
+        }
+    }
 }
 
 #[derive(Component)]
@@ -174,7 +182,15 @@ fn update_instructions(
         TransformGizmoSpace::World => "World",
         TransformGizmoSpace::Local => "Local",
     };
-    text.0 = format!(
+    let base = format!(
         "Click an object to select it\n1: Translate | 2: Rotate | 3: Scale | X: World/Local space\nMode: {mode_str} | Space: {space_str}"
     );
+    text.0 = if settings.mode == TransformGizmoMode::Scale {
+        format!(
+            "{base}\nArrowUp or ArrowDown: Scale sensitivity {:.2}",
+            settings.scale_sensitivity
+        )
+    } else {
+        base
+    };
 }


### PR DESCRIPTION
# Objective
- Fixes #24435
- Currently, the scale gizmo only supports scaling along individual axes (X, Y, Z). 
- This PR adds a uniform scale handle to allow scaling all 3 axes simultaneously.

## Solution
### `crates/bevy_gizmos_render/src/transform_gizmo_render.rs`
- `spawn_gizmo_meshes`: Added a central cuboid mesh rendered for `TransformGizmoMode::Scale` on the `TransformGizmoAxis::View` handle.

### `crates/bevy_gizmos/src/transform_gizmo.rs`
- `transform_gizmo_hover`: Added screen-space hover checking for the central scale view handle.
- `transform_gizmo_drag`: Added uniform scaling logic when dragging the `TransformGizmoAxis::View` handle in `TransformGizmoMode::Scale`.

## Testing
- Tested manually using `cargo run --example transform_gizmo --features="free_camera"`.

---

## Showcase

https://github.com/user-attachments/assets/6e1c7ce9-3643-4ea6-8cf3-4759e9693336

