### PR TITLE
Migrate `custom_transitions` to use `ui_widgets::Button` (Phase 2 Item 6)

### DIFF
--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -254,7 +254,7 @@ fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
             on(|event: On<Remove, Pressed>,
                 is_hovered: Query<&Hovered>,
                 mut commands: Commands| {
-                    if is_hovered.get(event.entity).is_ok_and(|hovered| hovered.get()) {
+                    if is_hovered.get(event.entity).is_ok_and(Hovered::get) {
                         commands.entity(event.entity).insert(BackgroundColor(HOVERED_BUTTON));
                     } else {
                         commands.entity(event.entity).insert(BackgroundColor(NORMAL_BUTTON));

--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -13,7 +13,13 @@
 
 use std::marker::PhantomData;
 
-use bevy::{dev_tools::states::*, ecs::schedule::ScheduleLabel, prelude::*};
+use bevy::{
+    dev_tools::states::*,
+    ecs::schedule::ScheduleLabel,
+    picking::hover::Hovered,
+    prelude::*,
+    ui_widgets::{Activate, ActivateOnPress, Button},
+};
 
 use custom_transitions::*;
 
@@ -34,15 +40,17 @@ fn main() {
         .init_state::<AppState>()
         .add_systems(Startup, setup)
         .add_systems(OnEnter(AppState::Menu), setup_menu)
-        .add_systems(Update, menu.run_if(in_state(AppState::Menu)))
+        .add_observer(on_activate_start_game.run_if(in_state(AppState::Menu)))
+        .add_systems(Update, hover_style)
         .add_systems(OnExit(AppState::Menu), cleanup_menu)
-        // We will restart the game progress every time we re-enter into it.
+        // We will restart the game progress every time we re-enter xinto it.
+        .add_observer(trigger_game_restart.run_if(in_state(AppState::InGame)))
         .add_systems(OnReenter(AppState::InGame), setup_game)
         .add_systems(OnReexit(AppState::InGame), teardown_game)
         // Doing it this way allows us to restart the game without any additional in-between states.
         .add_systems(
             Update,
-            ((movement, change_color, trigger_game_restart).run_if(in_state(AppState::InGame)),),
+            (movement, change_color).run_if(in_state(AppState::InGame)),
         )
         .add_systems(Update, log_transitions::<AppState>)
         .run();
@@ -139,25 +147,18 @@ mod custom_transitions {
     }
 }
 
-fn menu(
-    mut next_state: ResMut<NextState<AppState>>,
-    mut interaction_query: Query<
-        (&Interaction, &mut BackgroundColor),
-        (Changed<Interaction>, With<Button>),
-    >,
+fn on_activate_start_game(_: On<Activate>, mut next_state: ResMut<NextState<AppState>>) {
+    next_state.set(AppState::InGame);
+}
+
+fn hover_style(
+    mut button_query: Query<(&Hovered, &mut BackgroundColor), (Changed<Hovered>, With<Button>)>,
 ) {
-    for (interaction, mut color) in &mut interaction_query {
-        match *interaction {
-            Interaction::Pressed => {
-                *color = PRESSED_BUTTON.into();
-                next_state.set(AppState::InGame);
-            }
-            Interaction::Hovered => {
-                *color = HOVERED_BUTTON.into();
-            }
-            Interaction::None => {
-                *color = NORMAL_BUTTON.into();
-            }
+    for (hovered, mut color) in &mut button_query {
+        if hovered.get() {
+            *color = HOVERED_BUTTON.into();
+        } else {
+            *color = NORMAL_BUTTON.into();
         }
     }
 }
@@ -204,18 +205,13 @@ fn change_color(time: Res<Time>, mut query: Query<&mut Sprite>) {
     }
 }
 
-// We can restart the game by pressing "R".
+// We can restart the game by pressing the restart button.
 // This will trigger an [`AppState::InGame`] -> [`AppState::InGame`]
 // transition, which will run our custom schedules.
-fn trigger_game_restart(
-    input: Res<ButtonInput<KeyCode>>,
-    mut next_state: ResMut<NextState<AppState>>,
-) {
-    if input.just_pressed(KeyCode::KeyR) {
-        // Although we are already in this state setting it again will generate an identity transition.
-        // While default schedules ignore those kinds of transitions, our custom schedules will react to them.
-        next_state.set(AppState::InGame);
-    }
+fn trigger_game_restart(_: On<Activate>, mut next_state: ResMut<NextState<AppState>>) {
+    // Although we are already in this state setting it again will generate an identity transition.
+    // While default schedules ignore those kinds of transitions, our custom schedules will react to them.
+    next_state.set(AppState::InGame);
 }
 
 fn setup(mut commands: Commands) {
@@ -224,6 +220,42 @@ fn setup(mut commands: Commands) {
 
 fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Sprite::from_image(asset_server.load("branding/icon.png")));
+    commands.spawn_scene(bsn! {
+        Node {
+            width: percent(100),
+            height: percent(100),
+        }
+        Children [
+            Node {
+                position_type: PositionType::Absolute,
+                left: px(10),
+                top: px(10),
+            }
+            Children [
+                Text::new("Move with arrow keys.")
+            ],
+
+            Node {
+                position_type: PositionType::Absolute,
+                left: px(10),
+                bottom: px(10),
+                width: px(150),
+                height: px(65),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+            }
+            Button
+            Hovered::default()
+            BackgroundColor(NORMAL_BUTTON)
+            Children [
+                Text::new("Restart")
+                TextFont {
+                        font_size: FontSize::Px(33.0),
+                }
+                TextColor(Color::srgb(0.9, 0.9, 0.9)),
+            ],
+        ]
+    });
     info!("Setup game");
 }
 
@@ -239,7 +271,6 @@ struct MenuData {
 
 const NORMAL_BUTTON: Color = Color::srgb(0.15, 0.15, 0.15);
 const HOVERED_BUTTON: Color = Color::srgb(0.25, 0.25, 0.25);
-const PRESSED_BUTTON: Color = Color::srgb(0.35, 0.75, 0.35);
 
 fn setup_menu(mut commands: Commands) {
     let button_entity = commands
@@ -254,6 +285,8 @@ fn setup_menu(mut commands: Commands) {
             },
             children![(
                 Button,
+                ActivateOnPress,
+                Hovered::default(),
                 Node {
                     width: px(150),
                     height: px(65),

--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -240,8 +240,7 @@ fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
                 position_type: PositionType::Absolute,
                 left: px(10),
                 bottom: px(10),
-                width: px(150),
-                height: px(65),
+                padding: px(5),
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
             }
@@ -253,11 +252,16 @@ fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
                     commands.entity(event.entity).insert(BackgroundColor(PRESSED_BUTTON));
             })
             on(|event: On<Remove, Pressed>,
+                is_hovered: Query<&Hovered>,
                 mut commands: Commands| {
-                    commands.entity(event.entity).insert(BackgroundColor(HOVERED_BUTTON));
+                    if is_hovered.get(event.entity).is_ok_and(|hovered| hovered.get()) {
+                        commands.entity(event.entity).insert(BackgroundColor(HOVERED_BUTTON));
+                    } else {
+                        commands.entity(event.entity).insert(BackgroundColor(NORMAL_BUTTON));
+                    }
             })
             Children [
-                Text::new("Restart")
+                Text::new("Restart Game")
                 TextFont {
                         font_size: FontSize::Px(33.0),
                 }

--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -18,6 +18,7 @@ use bevy::{
     ecs::schedule::ScheduleLabel,
     picking::hover::Hovered,
     prelude::*,
+    ui::Pressed,
     ui_widgets::{Activate, ActivateOnPress, Button},
 };
 
@@ -247,6 +248,14 @@ fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
             Button
             Hovered::default()
             BackgroundColor(NORMAL_BUTTON)
+            on(|event: On<Add, Pressed>,
+                mut commands: Commands| {
+                    commands.entity(event.entity).insert(BackgroundColor(PRESSED_BUTTON));
+            })
+            on(|event: On<Remove, Pressed>,
+                mut commands: Commands| {
+                    commands.entity(event.entity).insert(BackgroundColor(HOVERED_BUTTON));
+            })
             Children [
                 Text::new("Restart")
                 TextFont {
@@ -271,6 +280,7 @@ struct MenuData {
 
 const NORMAL_BUTTON: Color = Color::srgb(0.15, 0.15, 0.15);
 const HOVERED_BUTTON: Color = Color::srgb(0.25, 0.25, 0.25);
+const PRESSED_BUTTON: Color = Color::srgb(0.35, 0.75, 0.35);
 
 fn setup_menu(mut commands: Commands) {
     let button_entity = commands


### PR DESCRIPTION
# Objective

- Part of #24112 

## Solution

- Very straightforward port to use `ui_widgets::Button`. It was easier / less invasive to do it this way than to import a Feathers Button, plus avoids the inconvenient feature flag and it’s in the same strain of states examples that is supposed to feel game like.
- Replaced the “R” keypress in game with another button. Added some help text in game since it isn’t obvious what to do.

## Testing

-  `cargo run --example custom_transitions --features=“bevy_dev_tools”` 

## Showcase

In Game
<img width="1271" height="748" alt="Screenshot 2026-07-25 at 8 27 53 AM" src="https://github.com/user-attachments/assets/71431d63-a618-422a-8231-9a5fa65a5eec" />
