### PR TITLE
Fix `RenderDebugOverlay` migration guide

### DIFF
--- a/_release-content/migration-guides/RenderDebugOverlay_optional_keybindings.md
+++ b/_release-content/migration-guides/RenderDebugOverlay_optional_keybindings.md
@@ -10,6 +10,7 @@ App::new()
         .add_plugins(DefaultPlugins)
         .insert_resource(RenderDebugOverlayKeybindings {
             enable_keybindings: true,
+            ..Default::default()
         })
 ```
 


### PR DESCRIPTION
The `RenderDebugOverlay` migration guide was missing a `Default::default()`.

```diff
 .insert_resource(RenderDebugOverlayKeybindings {
     enable_keybindings: true,
+    ..Default::default()
 })
```