### PR TITLE
Add MeshAllocator meshes_displaced_by_slab_growth and make update_sparse_buffers pub

### DIFF
--- a/crates/bevy_render/src/mesh/allocator.rs
+++ b/crates/bevy_render/src/mesh/allocator.rs
@@ -254,8 +254,8 @@ pub fn allocate_and_free_meshes(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
 ) {
-    // Clear list of meshes that have moved buffers.
-    mesh_allocator.clear_moved_keys();
+    // Clear the list of meshes displaced by last frame's slab growth.
+    mesh_allocator.clear_displaced_keys();
 
     // Process removed or modified meshes.
     mesh_allocator.free_meshes(&extracted_meshes);
@@ -282,20 +282,21 @@ impl MeshAllocator {
         )
     }
 
-    /// Meshes whose vertex or index data has moved to a different buffer this frame, so that
-    /// anything caching those buffers can rebuild just the affected entries.
+    /// Meshes that had the buffer under their vertex or index data replaced this frame by a slab
+    /// they were already resident in growing, so that anything caching those buffers can rebuild
+    /// just the affected entries.
     ///
-    /// A mesh can show up here without having changed in any way of its own: growing a slab
-    /// replaces the buffer for every mesh resident in it. Similarly, modifying a mesh does not
-    /// necessarily mean it will move to a different buffer. See [`SlabAllocator::moved_keys`] for
-    /// what does and does not get reported.
+    /// **It is not the full set of meshes whose buffers changed this frame, and is not meant to be.**
+    /// Callers must handle [`ExtractedAssets`] themselves if they want the full set of changed buffers.
     ///
     /// A mesh is yielded twice if both its vertex and its index slab grew, since those are separate
     /// allocations, so deduplicate if repeating the work per mesh would be expensive.
     ///
     /// Morph target and metadata allocations are filtered out.
-    pub fn meshes_with_changed_buffers_this_frame(&self) -> impl Iterator<Item = AssetId<Mesh>> {
-        self.moved_keys()
+    ///
+    /// See [`SlabAllocator::keys_displaced_by_slab_growth`], which this wraps.
+    pub fn meshes_displaced_by_slab_growth(&self) -> impl Iterator<Item = AssetId<Mesh>> {
+        self.keys_displaced_by_slab_growth()
             .iter()
             .filter(|key| matches!(key.class, ElementClass::Vertex | ElementClass::Index))
             .map(|key| key.mesh_id)

--- a/crates/bevy_render/src/mesh/allocator.rs
+++ b/crates/bevy_render/src/mesh/allocator.rs
@@ -254,6 +254,9 @@ pub fn allocate_and_free_meshes(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
 ) {
+    // Clear list of meshes that have moved buffers.
+    mesh_allocator.clear_moved_key_list();
+
     // Process removed or modified meshes.
     mesh_allocator.free_meshes(&extracted_meshes);
 
@@ -277,6 +280,25 @@ impl MeshAllocator {
             &MeshAllocationKey::new(*mesh_id, ElementClass::Metadata),
             *self.mesh_id_to_metadata_slab(mesh_id)?,
         )
+    }
+
+    /// Meshes whose vertex or index data has moved to a different buffer this frame, so that
+    /// anything caching those buffers can rebuild just the affected entries.
+    ///
+    /// A mesh can show up here without having changed in any way of its own: growing a slab
+    /// replaces the buffer for every mesh resident in it. Similarly, modifying a mesh does not
+    /// necessarily mean it will move to a different buffer. See [`SlabAllocator::moved_keys`] for
+    /// what does and does not get reported.
+    ///
+    /// A mesh is yielded twice if both its vertex and its index slab grew, since those are separate
+    /// allocations, so deduplicate if repeating the work per mesh would be expensive.
+    ///
+    /// Morph target and metadata allocations are filtered out.
+    pub fn meshes_with_changed_buffers_this_frame(&self) -> impl Iterator<Item = AssetId<Mesh>> {
+        self.moved_keys()
+            .iter()
+            .filter(|key| matches!(key.class, ElementClass::Vertex | ElementClass::Index))
+            .map(|key| key.mesh_id)
     }
 
     /// Returns the buffer and range within that buffer of the vertex data for

--- a/crates/bevy_render/src/mesh/allocator.rs
+++ b/crates/bevy_render/src/mesh/allocator.rs
@@ -255,7 +255,7 @@ pub fn allocate_and_free_meshes(
     render_queue: Res<RenderQueue>,
 ) {
     // Clear list of meshes that have moved buffers.
-    mesh_allocator.clear_moved_key_list();
+    mesh_allocator.clear_moved_keys();
 
     // Process removed or modified meshes.
     mesh_allocator.free_meshes(&extracted_meshes);

--- a/crates/bevy_render/src/render_resource/sparse_buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/sparse_buffer_vec.rs
@@ -183,7 +183,9 @@ struct GpuSparseBufferUpdateMetadata {
 ///
 /// This runs as early in the pipeline as possible so that sparse buffers can be
 /// used for any subsequent pass.
-fn update_sparse_buffers(
+///
+/// Runs in [`RenderGraphSystems::Begin`].
+pub fn update_sparse_buffers(
     sparse_buffer_update_jobs: Res<SparseBufferUpdateJobs>,
     sparse_buffer_update_bind_groups: Res<SparseBufferUpdateBindGroups>,
     pipeline_cache: Res<PipelineCache>,

--- a/crates/bevy_render/src/slab_allocator.rs
+++ b/crates/bevy_render/src/slab_allocator.rs
@@ -76,7 +76,7 @@ where
     pub extra_buffer_usages: BufferUsages,
 
     /// Keys whose data has moved to a different [`Buffer`] since
-    /// [`Self::clear_moved_key_list`] was last called.
+    /// [`Self::clear_moved_keys`] was last called.
     ///
     /// See [`Self::moved_keys`].
     moved_keys: Vec<I::Key>,
@@ -607,7 +607,7 @@ where
     /// allocation triggered the growth. Those keys are what this reports, which is why it can't be
     /// derived from whatever the caller already knows changed.
     ///
-    /// This accumulates until [`Self::clear_moved_key_list`], so it is only correct
+    /// This accumulates until [`Self::clear_moved_keys`], so it is only correct
     /// for a consumer that runs after the allocator has been updated for the frame and before the
     /// list is cleared.
     pub fn moved_keys(&self) -> &[I::Key] {
@@ -615,7 +615,7 @@ where
     }
 
     /// Drops the accumulated [`Self::moved_keys`], starting a new round of invalidations.
-    pub fn clear_moved_key_list(&mut self) {
+    pub fn clear_moved_keys(&mut self) {
         self.moved_keys.clear();
     }
 

--- a/crates/bevy_render/src/slab_allocator.rs
+++ b/crates/bevy_render/src/slab_allocator.rs
@@ -74,6 +74,12 @@ where
 
     /// Additional buffer usages to add to any vertex or index buffers created.
     pub extra_buffer_usages: BufferUsages,
+
+    /// Keys whose data has moved to a different [`Buffer`] since
+    /// [`Self::clear_moved_key_list`] was last called.
+    ///
+    /// See [`Self::moved_keys`].
+    moved_keys: Vec<I::Key>,
 }
 
 /// Describes the type of the data that a [`SlabAllocator`] will store.
@@ -578,6 +584,7 @@ where
             key_to_slab: HashMap::default(),
             slab_layouts: HashMap::default(),
             extra_buffer_usages: BufferUsages::empty(),
+            moved_keys: Vec::new(),
         }
     }
 }
@@ -589,6 +596,27 @@ where
     /// Creates a new empty slab allocator.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// The keys whose allocations now live in a different [`Buffer`] than they did before, so that
+    /// consumers caching buffers can rebuild just the affected entries.
+    ///
+    /// Offsets within a slab are stable for as long as an allocation is live, so the only way the
+    /// [`Buffer`] behind a live allocation can change out from under you is that slab growing — and
+    /// growing a slab replaces the buffer for *every* key resident in it, not just the one whose
+    /// allocation triggered the growth. Those keys are what this reports, which is why it can't be
+    /// derived from whatever the caller already knows changed.
+    ///
+    /// This accumulates until [`Self::clear_moved_key_list`], so it is only correct
+    /// for a consumer that runs after the allocator has been updated for the frame and before the
+    /// list is cleared.
+    pub fn moved_keys(&self) -> &[I::Key] {
+        &self.moved_keys
+    }
+
+    /// Drops the accumulated [`Self::moved_keys`], starting a new round of invalidations.
+    pub fn clear_moved_key_list(&mut self) {
+        self.moved_keys.clear();
     }
 
     /// Creates an [`AllocationStage`], enabling batched allocation of objects
@@ -815,6 +843,11 @@ where
         };
 
         let old_buffer = slab.buffer.take();
+
+        if old_buffer.is_some() {
+            self.moved_keys
+                .extend(slab.resident_allocations.keys().cloned());
+        }
 
         let buffer_usages = BufferUsages::COPY_SRC
             | BufferUsages::COPY_DST

--- a/crates/bevy_render/src/slab_allocator.rs
+++ b/crates/bevy_render/src/slab_allocator.rs
@@ -75,11 +75,9 @@ where
     /// Additional buffer usages to add to any vertex or index buffers created.
     pub extra_buffer_usages: BufferUsages,
 
-    /// Keys whose data has moved to a different [`Buffer`] since
-    /// [`Self::clear_moved_keys`] was last called.
-    ///
-    /// See [`Self::moved_keys`].
-    moved_keys: Vec<I::Key>,
+    /// Keys that were resident in a slab whose [`Buffer`] was replaced by growth since
+    /// [`Self::clear_displaced_keys`] was last called.
+    displaced_keys: Vec<I::Key>,
 }
 
 /// Describes the type of the data that a [`SlabAllocator`] will store.
@@ -584,7 +582,7 @@ where
             key_to_slab: HashMap::default(),
             slab_layouts: HashMap::default(),
             extra_buffer_usages: BufferUsages::empty(),
-            moved_keys: Vec::new(),
+            displaced_keys: Vec::new(),
         }
     }
 }
@@ -598,25 +596,20 @@ where
         Self::default()
     }
 
-    /// The keys whose allocations now live in a different [`Buffer`] than they did before, so that
-    /// consumers caching buffers can rebuild just the affected entries.
+    /// The keys that were already resident in a slab and had the [`Buffer`] behind them replaced by
+    /// that slab growing, so that consumers caching buffers can rebuild just the affected entries.
     ///
-    /// Offsets within a slab are stable for as long as an allocation is live, so the only way the
-    /// [`Buffer`] behind a live allocation can change out from under you is that slab growing — and
-    /// growing a slab replaces the buffer for *every* key resident in it, not just the one whose
-    /// allocation triggered the growth. Those keys are what this reports, which is why it can't be
-    /// derived from whatever the caller already knows changed.
-    ///
-    /// This accumulates until [`Self::clear_moved_keys`], so it is only correct
+    /// This accumulates until [`Self::clear_displaced_keys`], so it is only correct
     /// for a consumer that runs after the allocator has been updated for the frame and before the
     /// list is cleared.
-    pub fn moved_keys(&self) -> &[I::Key] {
-        &self.moved_keys
+    pub fn keys_displaced_by_slab_growth(&self) -> &[I::Key] {
+        &self.displaced_keys
     }
 
-    /// Drops the accumulated [`Self::moved_keys`], starting a new round of invalidations.
-    pub fn clear_moved_keys(&mut self) {
-        self.moved_keys.clear();
+    /// Drops the accumulated [`Self::keys_displaced_by_slab_growth`], starting a new round of
+    /// invalidations.
+    pub fn clear_displaced_keys(&mut self) {
+        self.displaced_keys.clear();
     }
 
     /// Creates an [`AllocationStage`], enabling batched allocation of objects
@@ -845,7 +838,7 @@ where
         let old_buffer = slab.buffer.take();
 
         if old_buffer.is_some() {
-            self.moved_keys
+            self.displaced_keys
                 .extend(slab.resident_allocations.keys().cloned());
         }
 


### PR DESCRIPTION
# Objective

- Allow solari (in a future PR) to cache some stuff, and only invalidate it when a mesh is moved to a different buffer, due to MeshAllocator having to grow and therefore re-allocate a slab.
- Make update_sparse_buffers public so that users can order other systems relative to it.

## Solution

- Add `MeshAllocator::meshes_displaced_by_slab_growth()` which uses SlabAllocator's new keys_displaced_by_slab_growth list under the hood.
