### PR TITLE
Make update_cursors run in a new CursorSystems::Update system set

### DIFF
--- a/crates/bevy_window/src/cursor/mod.rs
+++ b/crates/bevy_window/src/cursor/mod.rs
@@ -27,7 +27,7 @@ pub use crate::cursor::{CustomCursor, CustomCursorImage};
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet, Reflect)]
 pub enum CursorSystems {
     /// Reads changes to [`CursorIcon`] and queues the corresponding cursor to
-    /// be applied to the window by the winit event loop.
+    /// be applied to the window by the windowing backend.
     ///
     /// Order your systems before this set to set [`CursorIcon`] and have it
     /// take effect on the same frame.

--- a/crates/bevy_window/src/cursor/mod.rs
+++ b/crates/bevy_window/src/cursor/mod.rs
@@ -1,4 +1,10 @@
-//! Components to customize the window cursor.
+//! Cursor handling for windows.
+//!
+//! Note: [`CursorSystems`] lives in `bevy_window` rather than `bevy_winit` so
+//! that systems which need to order themselves around cursor updates don't have
+//! to depend on `bevy_winit` just for this set. The system set is intended to
+//! be backend-agnostic and consumable by any windowing backend (`bevy_winit`,
+//! or a future one).
 
 #[cfg(feature = "custom_cursor")]
 mod custom_cursor;
@@ -8,14 +14,25 @@ mod system_cursor;
 pub use custom_cursor::*;
 pub use system_cursor::*;
 
-use bevy_ecs::component::Component;
 #[cfg(feature = "bevy_reflect")]
 use bevy_ecs::reflect::ReflectComponent;
+use bevy_ecs::{component::Component, schedule::SystemSet};
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 #[cfg(feature = "custom_cursor")]
 pub use crate::cursor::{CustomCursor, CustomCursorImage};
+
+/// System sets for cursor-related systems.
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet, Reflect)]
+pub enum CursorSystems {
+    /// Reads changes to [`CursorIcon`] and queues the corresponding cursor to
+    /// be applied to the window by the winit event loop.
+    ///
+    /// Order your systems before this set to set [`CursorIcon`] and have it
+    /// take effect on the same frame.
+    Update,
+}
 
 /// Insert into a window entity to set the cursor for that window.
 #[derive(Component, Debug, Clone, PartialEq, Eq)]

--- a/crates/bevy_winit/src/cursor/custom_cursor.rs
+++ b/crates/bevy_winit/src/cursor/custom_cursor.rs
@@ -15,11 +15,17 @@ pub struct WinitCustomCursorCache(pub HashMap<CustomCursorCacheKey, winit::windo
 pub enum CustomCursorCacheKey {
     /// A custom cursor with an image.
     Image {
+        /// The ID of the image.
         id: AssetId<Image>,
+        /// The ID of the texture atlas layout, if any.
         texture_atlas_layout_id: Option<AssetId<TextureAtlasLayout>>,
+        /// The index into the texture atlas, if any.
         texture_atlas_index: Option<usize>,
+        /// Whether the image should be flipped along its x-axis.
         flip_x: bool,
+        /// Whether the image should be flipped along its y-axis.
         flip_y: bool,
+        /// The sub-rectangle of the image to use, if any.
         rect: Option<URect>,
     },
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]

--- a/crates/bevy_winit/src/cursor/mod.rs
+++ b/crates/bevy_winit/src/cursor/mod.rs
@@ -11,11 +11,23 @@ use bevy_asset::Assets;
 use bevy_ecs::{entity::EntityHashSet, prelude::*, system::SystemState};
 #[cfg(feature = "custom_cursor")]
 use bevy_image::{Image, TextureAtlasLayout};
+use bevy_reflect::Reflect;
 #[cfg(feature = "custom_cursor")]
 use bevy_window::CustomCursor;
 use bevy_window::{CursorIcon, SystemCursorIcon, Window};
 #[cfg(feature = "custom_cursor")]
 use winit::event_loop::ActiveEventLoop;
+
+/// System sets for cursor-related systems.
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet, Reflect)]
+pub enum CursorSystems {
+    /// Reads changes to [`CursorIcon`] and queues the corresponding cursor to
+    /// be applied to the window by the winit event loop.
+    ///
+    /// Order your systems before this set to set [`CursorIcon`] and have it
+    /// take effect on the same frame.
+    Update,
+}
 
 /// Adds support for custom cursors.
 pub(crate) struct WinitCursorPlugin;
@@ -31,7 +43,7 @@ impl Plugin for WinitCursorPlugin {
             app.init_resource::<WinitCustomCursorCache>();
         }
 
-        app.add_systems(Last, update_cursors)
+        app.add_systems(Last, update_cursors.in_set(CursorSystems::Update))
             .add_observer(on_remove_cursor_icon);
     }
 }

--- a/crates/bevy_winit/src/cursor/mod.rs
+++ b/crates/bevy_winit/src/cursor/mod.rs
@@ -13,23 +13,11 @@ use bevy_asset::Assets;
 use bevy_ecs::{entity::EntityHashSet, prelude::*, system::SystemState};
 #[cfg(feature = "custom_cursor")]
 use bevy_image::{Image, TextureAtlasLayout};
-use bevy_reflect::Reflect;
 #[cfg(feature = "custom_cursor")]
 use bevy_window::CustomCursor;
-use bevy_window::{CursorIcon, SystemCursorIcon, Window};
+use bevy_window::{CursorIcon, CursorSystems, SystemCursorIcon, Window};
 #[cfg(feature = "custom_cursor")]
 use winit::event_loop::ActiveEventLoop;
-
-/// System sets for cursor-related systems.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet, Reflect)]
-pub enum CursorSystems {
-    /// Reads changes to [`CursorIcon`] and queues the corresponding cursor to
-    /// be applied to the window by the winit event loop.
-    ///
-    /// Order your systems before this set to set [`CursorIcon`] and have it
-    /// take effect on the same frame.
-    Update,
-}
 
 /// Adds support for custom cursors.
 pub(crate) struct WinitCursorPlugin;

--- a/crates/bevy_winit/src/cursor/mod.rs
+++ b/crates/bevy_winit/src/cursor/mod.rs
@@ -1,3 +1,5 @@
+//! Cursor handling for winit windows.
+
 #[cfg(feature = "custom_cursor")]
 mod custom_cursor;
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -43,7 +43,7 @@ use crate::{
 
 pub mod accessibility;
 pub mod converters;
-mod cursor;
+pub mod cursor;
 mod state;
 mod system;
 mod winit_config;

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -43,7 +43,7 @@ use crate::{
 
 pub mod accessibility;
 pub mod converters;
-pub mod cursor;
+mod cursor;
 mod state;
 mod system;
 mod winit_config;


### PR DESCRIPTION
# Objective

- Allow apps to order their `CursorIcon` inserts strictly before they are applied/updated.

## Solution

- Add a new system set.
- Open question: Should the set exist in `bevy_window` a la `CursorIcon` so that call sites don't depend on `bevy_winit` specifics for this ordering? In that way, `bevy_winit` would import the system set from `bevy_window` and itself become a "user" of the system set. One could imagine a future `bevy_sdl` backend would use the same system set from `bevy_window`. Might be fine as I've done it though?

## Testing

- Ran the `custom_cursor_image` example.
