### PR TITLE
Fix missing `bevy_transform` traces

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -21,6 +21,7 @@ trace = [
   "bevy_render?/trace",
   "bevy_winit?/trace",
   "bevy_post_process?/trace",
+  "bevy_transform/trace",
 ]
 trace_chrome = ["bevy_log/tracing-chrome"]
 trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -11,17 +11,17 @@ categories = ["game-engines", "graphics", "gui", "rendering"]
 
 [features]
 trace = [
+  "bevy_anti_alias?/trace",
   "bevy_app/trace",
   "bevy_asset?/trace",
   "bevy_core_pipeline?/trace",
-  "bevy_anti_alias?/trace",
   "bevy_ecs/trace",
   "bevy_log/trace",
   "bevy_pbr?/trace",
-  "bevy_render?/trace",
-  "bevy_winit?/trace",
   "bevy_post_process?/trace",
+  "bevy_render?/trace",
   "bevy_transform/trace",
+  "bevy_winit?/trace",
 ]
 trace_chrome = ["bevy_log/tracing-chrome"]
 trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy"]


### PR DESCRIPTION
# Objective

Fix `bevy_transform` `propagation_worker` tasks not appearing in Tracy.

<img width="854" height="534" alt="image" src="https://github.com/user-attachments/assets/71dde9e3-ab7c-4db3-9392-d057695c00fd" />

## Solution

`bevy_internal` wasn't passing the `trace` feature onto `bevy_transform`.

```diff
 trace = [
   "bevy_anti_alias?/trace",
   "bevy_app/trace",
   "bevy_asset?/trace",
   "bevy_core_pipeline?/trace",
   "bevy_ecs/trace",
   "bevy_log/trace",
   "bevy_pbr?/trace",
   "bevy_post_process?/trace",
   "bevy_render?/trace",
+  "bevy_transform/trace",
   "bevy_winit?/trace",
 ]
```

I also took the liberty of sorting the feature list - this makes it easer to grep for `feature = "trace"` and confirm if all the right crates are included. But that makes the diff harder to read so happy to revert if preferred.

## Testing

```sh
cargo run --example many_foxes --profile bench --features "bevy/trace_tracy, trace, debug"
```
