### PR TITLE
Set toolkit name and version in the accessibility tree

### DIFF
--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -81,7 +81,9 @@ impl AccessKitState {
     fn build_initial_tree(&mut self) -> TreeUpdate {
         let root = self.build_root();
         let accesskit_window_id = NodeId(self.entity.to_bits());
-        let tree = Tree::new(accesskit_window_id);
+        let mut tree = Tree::new(accesskit_window_id);
+        tree.toolkit_name = Some("Bevy".into());
+        tree.toolkit_version = Some(env!("CARGO_PKG_VERSION").into());
         self.requested.set(true);
 
         TreeUpdate {


### PR DESCRIPTION
# Objective

Some platform accessibility stacks (Windows and Linux) allow applications to communicate to assistive technologies which UI toolkit is used. This can be useful for assistive technology developers to investigate issues, to know where to report bugs or even to automatically patch malformed accessibility trees produced by certain applications or UI toolkits. Since accesskit 0.24.1, we set the toolkit name as "AccessKit" by default to at least redirect people to AccessKit, but it is better if downstream projects set the correct value themselves.

## Solution

Populate `toolkit_name` and `toolkit_version` when building an AccessKit `Tree` struct. I used `env!("CARGO_PKG_VERSION")` to get Bevy's current version which works because all crates currently share the same, this would of course report the wrong value if this ever changed.

## Testing

On Windows I ran the button UI example and used the NVDA screen reader's NVDA+F1 command to get information on the focused widget. I observed that the UIAutomation ProviderDescription property correctly contained "Bevy 0.20.0-dev".