### PR TITLE
Add headless tooltips and a Feathers  implementation

### DIFF
--- a/crates/bevy_feathers/Cargo.toml
+++ b/crates/bevy_feathers/Cargo.toml
@@ -30,6 +30,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.20.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.20.0-dev" }
 bevy_scene = { path = "../bevy_scene", version = "0.20.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.20.0-dev" }
+bevy_time = { path = "../bevy_time", version = "0.20.0-dev" }
 bevy_ui = { path = "../bevy_ui", version = "0.20.0-dev", features = [
   "bevy_picking",
 ] }

--- a/crates/bevy_feathers/src/controls/mod.rs
+++ b/crates/bevy_feathers/src/controls/mod.rs
@@ -17,6 +17,7 @@ mod select;
 mod slider;
 mod text_input;
 mod toggle_switch;
+mod tooltip;
 mod virtual_keyboard;
 
 pub use button::*;
@@ -35,6 +36,7 @@ pub use select::*;
 pub use slider::*;
 pub use text_input::*;
 pub use toggle_switch::*;
+pub use tooltip::*;
 pub use virtual_keyboard::*;
 
 use crate::alpha_pattern::AlphaPatternPlugin;
@@ -67,6 +69,7 @@ impl Plugin for ControlsPlugin {
                 ColorSliderPlugin,
                 ColorSwatchPlugin,
             ),
+            FeathersTooltipPlugin,
         ));
     }
 }

--- a/crates/bevy_feathers/src/controls/tooltip.rs
+++ b/crates/bevy_feathers/src/controls/tooltip.rs
@@ -1,0 +1,558 @@
+//! Feathers rendering for the headless tooltip widget.
+
+use bevy_a11y::AccessibilityNode;
+use bevy_app::{Plugin, PostUpdate};
+use bevy_color::{Alpha, Srgba};
+use bevy_ecs::{entity::EntityHashMap, hierarchy::ChildOf, prelude::*};
+use bevy_log::warn;
+use bevy_math::Rot2;
+use bevy_picking::Pickable;
+use bevy_scene::prelude::*;
+use bevy_text::{FontSourceTemplate, FontWeight, TextFont};
+use bevy_ui::{
+    px, widget::Text, BoxShadow, ComputedNode, GlobalZIndex, Node, Overflow, OverrideClip,
+    PositionType, UiRect, UiSystems, UiTransform,
+};
+use bevy_ui_widgets::{
+    popover::{Popover, PopoverPlacement, PopoverPlugin, PopoverSide, ResolvedPopoverPlacement},
+    HideTooltip, ShowTooltip, Tooltip, TooltipContent, TooltipDetail, TooltipPlugin, TooltipPopup,
+};
+
+use crate::{
+    constants::{fonts, size},
+    theme::{ThemeBackgroundColor, ThemeBorderColor, ThemeTextColor},
+    tokens,
+};
+
+const TOOLTIP_ARROW_SIZE: f32 = 10.0;
+const TOOLTIP_ARROW_EDGE_MARGIN: f32 = 4.0;
+
+#[derive(Component, Default, Clone)]
+struct FeathersTooltipRoot {
+    arrow: bool,
+}
+
+#[derive(Component, Default, Clone)]
+struct FeathersTooltipArrowClip;
+
+#[derive(Component, Default, Clone)]
+struct FeathersTooltipArrow;
+
+#[derive(Resource, Default)]
+struct TooltipRoots(EntityHashMap<Entity>);
+
+fn placement_candidates(preferred: PopoverPlacement) -> [PopoverPlacement; 4] {
+    let sides = match preferred.side {
+        PopoverSide::Top => [
+            PopoverSide::Top,
+            PopoverSide::Bottom,
+            PopoverSide::Right,
+            PopoverSide::Left,
+        ],
+        PopoverSide::Bottom => [
+            PopoverSide::Bottom,
+            PopoverSide::Top,
+            PopoverSide::Right,
+            PopoverSide::Left,
+        ],
+        PopoverSide::Left => [
+            PopoverSide::Left,
+            PopoverSide::Right,
+            PopoverSide::Top,
+            PopoverSide::Bottom,
+        ],
+        PopoverSide::Right => [
+            PopoverSide::Right,
+            PopoverSide::Left,
+            PopoverSide::Top,
+            PopoverSide::Bottom,
+        ],
+    };
+    sides.map(|side| PopoverPlacement { side, ..preferred })
+}
+
+fn tooltip_scene(text: String, placement: PopoverPlacement, arrow: bool) -> impl Scene {
+    bsn! {
+        Node {
+            position_type: PositionType::Absolute,
+            padding: UiRect::axes(px(6), px(4)),
+            border: px(1),
+            border_radius: px(4),
+        }
+        FeathersTooltipRoot {
+            arrow: { arrow },
+        }
+        Pickable::IGNORE
+        GlobalZIndex(101)
+        OverrideClip
+        ThemeBackgroundColor(tokens::TOOLTIP_BG)
+        ThemeBorderColor(tokens::TOOLTIP_BORDER)
+        BoxShadow::new(
+            Srgba::BLACK.with_alpha(0.9).into(),
+            px(0),
+            px(0),
+            px(1),
+            px(4),
+        )
+        Popover {
+            positions: { placement_candidates(placement).to_vec() },
+            window_margin: 4.0,
+        }
+        Children [
+            (
+                Text(text)
+                TextFont {
+                    font: FontSourceTemplate::Handle(fonts::REGULAR),
+                    font_size: size::COMPACT_FONT,
+                    weight: FontWeight::NORMAL,
+                }
+                ThemeTextColor(tokens::TOOLTIP_TEXT)
+            ),
+            (
+                Node {
+                    position_type: PositionType::Absolute,
+                    width: px(0),
+                    height: px(0),
+                    overflow: Overflow::clip(),
+                }
+                FeathersTooltipArrowClip
+                Pickable::IGNORE
+                Children [
+                    (
+                        Node {
+                            position_type: PositionType::Absolute,
+                            width: px(TOOLTIP_ARROW_SIZE),
+                            height: px(TOOLTIP_ARROW_SIZE),
+                            border: px(1),
+                            border_radius: px(1),
+                        }
+                        FeathersTooltipArrow
+                        Pickable::IGNORE
+                        UiTransform::from_rotation(Rot2::FRAC_PI_4)
+                        ThemeBackgroundColor(tokens::TOOLTIP_BG)
+                        ThemeBorderColor(tokens::TOOLTIP_BORDER)
+                    )
+                ]
+            )
+        ]
+    }
+}
+
+fn arrow_cross_axis_center(root_extent: f32) -> f32 {
+    let minimum = TOOLTIP_ARROW_SIZE * 0.5 + TOOLTIP_ARROW_EDGE_MARGIN;
+    let maximum = (root_extent - minimum).max(minimum);
+    (root_extent * 0.5).clamp(minimum, maximum)
+}
+
+fn position_tooltip_arrow(
+    roots: Query<(
+        &ComputedNode,
+        &ResolvedPopoverPlacement,
+        &FeathersTooltipRoot,
+    )>,
+    mut clips: Query<
+        (&ChildOf, &Children, &mut Node),
+        (
+            With<FeathersTooltipArrowClip>,
+            Without<FeathersTooltipArrow>,
+        ),
+    >,
+    mut arrows: Query<
+        &mut Node,
+        (
+            With<FeathersTooltipArrow>,
+            Without<FeathersTooltipArrowClip>,
+        ),
+    >,
+) {
+    for (parent, children, mut clip_node) in &mut clips {
+        let Ok((root_node, resolved, root)) = roots.get(parent.parent()) else {
+            continue;
+        };
+        let Some(placement) = resolved.0.filter(|_| root.arrow) else {
+            if clip_node.width != px(0) || clip_node.height != px(0) {
+                clip_node.width = px(0);
+                clip_node.height = px(0);
+            }
+            continue;
+        };
+        let Some(arrow_entity) = children.iter().find(|entity| arrows.contains(*entity)) else {
+            continue;
+        };
+
+        let scale = root_node.inverse_scale_factor;
+        let root_size = root_node.size() * scale;
+        let half = TOOLTIP_ARROW_SIZE * 0.5;
+        let center_x = arrow_cross_axis_center(root_size.x);
+        let center_y = arrow_cross_axis_center(root_size.y);
+        let border = root_node.border();
+        let border_min = border.min_inset * scale;
+        let border_max = border.max_inset * scale;
+
+        let (clip_left, clip_top, clip_width, clip_height, arrow_left, arrow_top) =
+            match placement.side {
+                PopoverSide::Top => (
+                    center_x - half,
+                    root_size.y - border_max.y,
+                    TOOLTIP_ARROW_SIZE,
+                    TOOLTIP_ARROW_SIZE + border_max.y,
+                    0.0,
+                    -half + border_max.y,
+                ),
+                PopoverSide::Bottom => (
+                    center_x - half,
+                    -TOOLTIP_ARROW_SIZE,
+                    TOOLTIP_ARROW_SIZE,
+                    TOOLTIP_ARROW_SIZE + border_min.y,
+                    0.0,
+                    half,
+                ),
+                PopoverSide::Left => (
+                    root_size.x - border_max.x,
+                    center_y - half,
+                    TOOLTIP_ARROW_SIZE + border_max.x,
+                    TOOLTIP_ARROW_SIZE,
+                    -half + border_max.x,
+                    0.0,
+                ),
+                PopoverSide::Right => (
+                    -TOOLTIP_ARROW_SIZE,
+                    center_y - half,
+                    TOOLTIP_ARROW_SIZE + border_min.x,
+                    TOOLTIP_ARROW_SIZE,
+                    half,
+                    0.0,
+                ),
+            };
+
+        if clip_node.left != px(clip_left)
+            || clip_node.top != px(clip_top)
+            || clip_node.width != px(clip_width)
+            || clip_node.height != px(clip_height)
+        {
+            clip_node.left = px(clip_left);
+            clip_node.top = px(clip_top);
+            clip_node.width = px(clip_width);
+            clip_node.height = px(clip_height);
+        }
+
+        if let Ok(mut arrow_node) = arrows.get_mut(arrow_entity)
+            && (arrow_node.left != px(arrow_left) || arrow_node.top != px(arrow_top))
+        {
+            arrow_node.left = px(arrow_left);
+            arrow_node.top = px(arrow_top);
+        }
+    }
+}
+
+fn tooltip_text(
+    target: Entity,
+    tooltip: &Tooltip,
+    detail: TooltipDetail,
+    accessibility: Option<&AccessibilityNode>,
+    name: Option<&Name>,
+) -> String {
+    match &tooltip.content {
+        TooltipContent::Text(text) => text.clone(),
+        TooltipContent::Detailed { summary, details } => match detail {
+            TooltipDetail::Summary => summary.clone(),
+            TooltipDetail::Details => format!("{summary}\n{details}"),
+        },
+        TooltipContent::Auto => accessibility
+            .and_then(|node| node.label())
+            .map(str::to_owned)
+            .or_else(|| name.map(|name| name.as_str().to_owned()))
+            .unwrap_or_else(|| {
+                warn!(
+                    ?target,
+                    "TooltipContent::Auto requires an accessibility label or Name"
+                );
+                format!("Tooltip missing for {target}")
+            }),
+    }
+}
+
+fn on_show_tooltip(
+    trigger: On<ShowTooltip>,
+    targets: Query<(&Tooltip, Option<&AccessibilityNode>, Option<&Name>)>,
+    mut roots: ResMut<TooltipRoots>,
+    mut commands: Commands,
+) {
+    let target = trigger.target;
+    let Ok((tooltip, accessibility, name)) = targets.get(target) else {
+        return;
+    };
+    let text = tooltip_text(target, tooltip, trigger.detail, accessibility, name);
+
+    if let Some(entity) = roots.0.remove(&target)
+        && let Ok(mut entity) = commands.get_entity(entity)
+    {
+        entity.despawn();
+    }
+
+    let entity = commands
+        .spawn_scene(tooltip_scene(text, tooltip.placement, tooltip.arrow))
+        .id();
+    commands
+        .entity(entity)
+        .insert((ChildOf(target), TooltipPopup { target }));
+    roots.0.insert(target, entity);
+}
+
+fn on_hide_tooltip(
+    trigger: On<HideTooltip>,
+    mut roots: ResMut<TooltipRoots>,
+    mut commands: Commands,
+) {
+    if let Some(entity) = roots.0.remove(&trigger.target)
+        && let Ok(mut entity) = commands.get_entity(entity)
+    {
+        entity.despawn();
+    }
+}
+
+/// Feathers styling and rendering for [`Tooltip`].
+pub struct FeathersTooltipPlugin;
+
+impl Plugin for FeathersTooltipPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        if !app.is_plugin_added::<TooltipPlugin>() {
+            app.add_plugins(TooltipPlugin);
+        }
+        if !app.is_plugin_added::<PopoverPlugin>() {
+            app.add_plugins(PopoverPlugin);
+        }
+        app.init_resource::<TooltipRoots>()
+            .add_observer(on_show_tooltip)
+            .add_observer(on_hide_tooltip)
+            .add_systems(PostUpdate, position_tooltip_arrow.after(UiSystems::Layout));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_app::{App, TaskPoolPlugin};
+    use bevy_asset::{AssetApp, AssetPlugin};
+    use bevy_scene::ScenePlugin;
+    use bevy_text::Font;
+
+    #[test]
+    fn simple_tooltip_uses_static_text() {
+        let target = Entity::from_raw_u32(1).unwrap();
+        assert_eq!(
+            tooltip_text(
+                target,
+                &Tooltip {
+                    content: TooltipContent::Text("Save".into()),
+                    ..Tooltip::default()
+                },
+                TooltipDetail::Summary,
+                None,
+                None,
+            ),
+            "Save"
+        );
+    }
+
+    #[test]
+    fn auto_prefers_accessibility_label() {
+        let target = Entity::from_raw_u32(1).unwrap();
+        let mut node = accesskit::Node::new(accesskit::Role::Button);
+        node.set_label("Accessible");
+        let accessibility = AccessibilityNode(node);
+        let name = Name::new("Fallback");
+
+        assert_eq!(
+            tooltip_text(
+                target,
+                &Tooltip::default(),
+                TooltipDetail::Summary,
+                Some(&accessibility),
+                Some(&name),
+            ),
+            "Accessible"
+        );
+    }
+
+    #[test]
+    fn auto_falls_back_to_name() {
+        let target = Entity::from_raw_u32(1).unwrap();
+        let name = Name::new("Save changes");
+        assert_eq!(
+            tooltip_text(
+                target,
+                &Tooltip::default(),
+                TooltipDetail::Summary,
+                None,
+                Some(&name),
+            ),
+            "Save changes"
+        );
+    }
+
+    #[test]
+    fn detailed_tooltip_extends_the_summary() {
+        let target = Entity::from_raw_u32(1).unwrap();
+        let tooltip = Tooltip {
+            content: TooltipContent::Detailed {
+                summary: "Summary".into(),
+                details: "Details".into(),
+            },
+            ..Tooltip::default()
+        };
+
+        assert_eq!(
+            tooltip_text(target, &tooltip, TooltipDetail::Summary, None, None),
+            "Summary"
+        );
+        assert_eq!(
+            tooltip_text(target, &tooltip, TooltipDetail::Details, None, None),
+            "Summary\nDetails"
+        );
+    }
+
+    fn test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins((
+            TaskPoolPlugin::default(),
+            AssetPlugin::default(),
+            ScenePlugin,
+        ));
+        app.init_asset::<Font>();
+        app.init_resource::<TooltipRoots>();
+        app.add_observer(on_show_tooltip);
+        app.add_observer(on_hide_tooltip);
+        app
+    }
+
+    #[test]
+    fn preferred_placement_is_first_candidate() {
+        let preferred = PopoverPlacement {
+            side: PopoverSide::Right,
+            align: bevy_ui_widgets::popover::PopoverAlign::End,
+            gap: 12.0,
+        };
+
+        let candidates = placement_candidates(preferred);
+
+        assert_eq!(candidates[0], preferred);
+        assert_eq!(candidates[1].side, PopoverSide::Left);
+        assert_eq!(candidates[2].side, PopoverSide::Top);
+        assert_eq!(candidates[3].side, PopoverSide::Bottom);
+    }
+
+    #[test]
+    fn multiple_targets_keep_independent_roots() {
+        let mut app = test_app();
+
+        let first = app
+            .world_mut()
+            .spawn(Tooltip {
+                content: TooltipContent::Text("First".into()),
+                ..Tooltip::default()
+            })
+            .id();
+        let second = app
+            .world_mut()
+            .spawn(Tooltip {
+                content: TooltipContent::Text("Second".into()),
+                placement: PopoverPlacement {
+                    side: PopoverSide::Right,
+                    align: bevy_ui_widgets::popover::PopoverAlign::End,
+                    gap: 12.0,
+                },
+                arrow: false,
+                ..Tooltip::default()
+            })
+            .id();
+
+        app.world_mut().trigger(ShowTooltip::summary(first));
+        app.world_mut().trigger(ShowTooltip::summary(second));
+        app.world_mut().flush();
+
+        let roots = app.world().resource::<TooltipRoots>();
+        let first_root = roots.0[&first];
+        let second_root = roots.0[&second];
+        assert_ne!(first_root, second_root);
+        assert!(app.world().get_entity(first_root).is_ok());
+        assert!(app.world().get_entity(second_root).is_ok());
+        assert_eq!(
+            app.world().get::<TooltipPopup>(second_root),
+            Some(&TooltipPopup { target: second })
+        );
+        assert!(app
+            .world()
+            .get::<bevy_ui::RelativeCursorPosition>(second_root)
+            .is_some());
+        assert_eq!(
+            app.world().get::<Pickable>(second_root),
+            Some(&Pickable::IGNORE)
+        );
+        assert_eq!(
+            app.world().get::<ChildOf>(second_root).map(ChildOf::parent),
+            Some(second)
+        );
+        assert!(
+            !app.world()
+                .get::<FeathersTooltipRoot>(second_root)
+                .unwrap()
+                .arrow
+        );
+        assert_eq!(
+            app.world().get::<Popover>(second_root).unwrap().positions,
+            placement_candidates(app.world().get::<Tooltip>(second).unwrap().placement)
+        );
+
+        let arrow_clips = app
+            .world()
+            .iter_entities()
+            .filter(EntityRef::contains::<FeathersTooltipArrowClip>)
+            .map(|entity| entity.id())
+            .collect::<Vec<_>>();
+        let arrows = app
+            .world()
+            .iter_entities()
+            .filter(EntityRef::contains::<FeathersTooltipArrow>)
+            .map(|entity| entity.id())
+            .collect::<Vec<_>>();
+
+        assert_eq!(arrow_clips.len(), 2);
+        assert_eq!(arrows.len(), 2);
+        assert_eq!(
+            app.world().get::<ResolvedPopoverPlacement>(second_root),
+            Some(&ResolvedPopoverPlacement(None))
+        );
+
+        app.world_mut().trigger(HideTooltip { target: first });
+        app.world_mut().flush();
+
+        assert!(app.world().get_entity(first_root).is_err());
+        assert!(app.world().get_entity(second_root).is_ok());
+        assert!(!app
+            .world()
+            .resource::<TooltipRoots>()
+            .0
+            .contains_key(&first));
+        assert_eq!(
+            app.world().resource::<TooltipRoots>().0.get(&second),
+            Some(&second_root)
+        );
+    }
+
+    #[test]
+    fn showing_the_same_target_replaces_only_its_root() {
+        let mut app = test_app();
+        let target = app.world_mut().spawn(Tooltip::default()).id();
+
+        app.world_mut().trigger(ShowTooltip::summary(target));
+        let first_root = app.world().resource::<TooltipRoots>().0[&target];
+        app.world_mut().trigger(ShowTooltip::summary(target));
+        let second_root = app.world().resource::<TooltipRoots>().0[&target];
+        app.world_mut().flush();
+
+        assert_ne!(first_root, second_root);
+        assert!(app.world().get_entity(first_root).is_err());
+        assert!(app.world().get_entity(second_root).is_ok());
+    }
+}

--- a/crates/bevy_feathers/src/dark_theme.rs
+++ b/crates/bevy_feathers/src/dark_theme.rs
@@ -343,6 +343,10 @@ pub fn create_dark_theme() -> ThemeProps {
             (tokens::DIALOG_HEADER_BG, semantic::SURFACE_WINDOW),
             (tokens::DIALOG_TEXT, semantic::TEXT_DEFAULT),
             (tokens::DIALOG_HEADER_TEXT, semantic::TEXT_DEFAULT),
+            // Tooltip
+            (tokens::TOOLTIP_BG, semantic::SURFACE_WINDOW),
+            (tokens::TOOLTIP_TEXT, semantic::TEXT_ON_ACCENT),
+            (tokens::TOOLTIP_BORDER, semantic::BORDER_DEFAULT),
         ]),
     }
 }

--- a/crates/bevy_feathers/src/tokens.rs
+++ b/crates/bevy_feathers/src/tokens.rs
@@ -415,6 +415,15 @@ pub const DIALOG_TEXT: ThemeToken = ThemeToken::new_static("feathers.dialog.text
 /// Dialog header text
 pub const DIALOG_HEADER_TEXT: ThemeToken = ThemeToken::new_static("feathers.dialog.header.text");
 
+// Tooltip
+
+/// Tooltip background
+pub const TOOLTIP_BG: ThemeToken = ThemeToken::new_static("feathers.tooltip.bg");
+/// Tooltip text
+pub const TOOLTIP_TEXT: ThemeToken = ThemeToken::new_static("feathers.tooltip.text");
+/// Tooltip border
+pub const TOOLTIP_BORDER: ThemeToken = ThemeToken::new_static("feathers.tooltip.border");
+
 /// Semantic tokens.
 ///
 /// Terms:

--- a/crates/bevy_ui_widgets/Cargo.toml
+++ b/crates/bevy_ui_widgets/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["bevy"]
 bevy_app = { path = "../bevy_app", version = "0.20.0-dev" }
 bevy_a11y = { path = "../bevy_a11y", version = "0.20.0-dev" }
 bevy_camera = { path = "../bevy_camera", version = "0.20.0-dev" }
+bevy_color = { path = "../bevy_color", version = "0.20.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.20.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.20.0-dev" }
 bevy_input_focus = { path = "../bevy_input_focus", version = "0.20.0-dev", features = [

--- a/crates/bevy_ui_widgets/src/lib.rs
+++ b/crates/bevy_ui_widgets/src/lib.rs
@@ -60,6 +60,7 @@ mod scrollarea;
 mod scrollbar;
 mod slider;
 mod text_input;
+pub mod tooltip;
 
 use bevy_input_focus::pointer_focus::PointerFocusPlugin;
 pub use button::*;
@@ -74,6 +75,7 @@ pub use scrollarea::*;
 pub use scrollbar::*;
 pub use slider::*;
 pub use text_input::*;
+pub use tooltip::*;
 
 use bevy_app::{PluginGroup, PluginGroupBuilder};
 use bevy_ecs::{entity::Entity, event::EntityEvent, reflect::ReflectEvent};
@@ -101,6 +103,7 @@ impl PluginGroup for UiWidgetsPlugins {
             .add(ScrollAreaPlugin)
             .add(ScrollbarPlugin)
             .add(SliderPlugin)
+            .add(TooltipPlugin)
             .add(PointerFocusPlugin)
     }
 }

--- a/crates/bevy_ui_widgets/src/popover.rs
+++ b/crates/bevy_ui_widgets/src/popover.rs
@@ -2,6 +2,7 @@
 
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_ecs::{
+    change_detection::DetectChangesMut,
     component::Component,
     entity::Entity,
     hierarchy::{ChildOf, Children},
@@ -83,6 +84,7 @@ pub struct PopoverPlacement {
 /// an parent element.
 #[derive(Component, PartialEq, Default, Reflect)]
 #[reflect(Component)]
+#[require(ResolvedPopoverPlacement)]
 pub struct Popover {
     /// List of potential positions for the popover element relative to the parent.
     pub positions: Vec<PopoverPlacement>,
@@ -90,6 +92,15 @@ pub struct Popover {
     /// Indicates how close to the window edge the popup is allowed to go.
     pub window_margin: f32,
 }
+
+/// The placement selected for a [`Popover`] during the most recent UI layout.
+///
+/// This is `None` until the popover and its parent have valid layout information,
+/// or when the popover has no candidate [`Popover::positions`]. Styling layers
+/// can read this component to orient placement-dependent visuals such as arrows.
+#[derive(Component, Debug, Default, Clone, Copy, PartialEq, Reflect)]
+#[reflect(Component)]
+pub struct ResolvedPopoverPlacement(pub Option<PopoverPlacement>);
 
 impl Clone for Popover {
     fn clone(&self) -> Self {
@@ -109,6 +120,7 @@ pub(crate) fn position_popover(
         &ComputedNode,
         &ComputedUiRenderTargetInfo,
         &Popover,
+        &mut ResolvedPopoverPlacement,
         &ChildOf,
     )>,
     mut qs_transform: ParamSet<(
@@ -125,6 +137,7 @@ pub(crate) fn position_popover(
         computed_node,
         computed_target,
         popover,
+        mut resolved_placement,
         parent,
     ) in q_popover.iter_mut()
     {
@@ -138,6 +151,7 @@ pub(crate) fn position_popover(
         // Compute the parent rectangle.
         let q_parent = qs_transform.p0();
         let Ok((parent_node, parent_transform)) = q_parent.get(parent.parent()) else {
+            resolved_placement.set_if_neq(ResolvedPopoverPlacement(None));
             continue;
         };
 
@@ -153,6 +167,7 @@ pub(crate) fn position_popover(
 
         let mut best_occluded = f32::MAX;
         let mut best_rect = Rect::default();
+        let mut best_placement = None;
 
         // Loop through all the potential positions and find a good one.
         for position in &popover.positions {
@@ -235,20 +250,23 @@ pub(crate) fn position_popover(
             if occlusion < best_occluded {
                 best_occluded = occlusion;
                 best_rect = rect;
+                best_placement = Some(*position);
             }
         }
 
         // Update node properties, but only if they are different from before (to avoid setting
         // change detection bit).
-        if best_occluded < f32::MAX {
+        if let Some(best_placement) = best_placement {
             let best_center = 0.5 * (best_rect.min + best_rect.max);
             let current_center =
                 ui_global_transform.translation * computed_node.inverse_scale_factor;
             let physical_translation =
                 (best_center - current_center) * computed_target.scale_factor();
             if parent_matrix.determinant() == 0.0 {
+                resolved_placement.set_if_neq(ResolvedPopoverPlacement(None));
                 continue;
             }
+            resolved_placement.set_if_neq(ResolvedPopoverPlacement(Some(best_placement)));
             let resolved_translation = transform.translation.resolve(
                 computed_target.scale_factor(),
                 computed_node.size(),
@@ -281,6 +299,8 @@ pub(crate) fn position_popover(
                     }
                 }
             }
+        } else {
+            resolved_placement.set_if_neq(ResolvedPopoverPlacement(None));
         }
     }
 }

--- a/crates/bevy_ui_widgets/src/tooltip.rs
+++ b/crates/bevy_ui_widgets/src/tooltip.rs
@@ -1,0 +1,857 @@
+//! Headless tooltip metadata and hover/click activation.
+//!
+//! [`Tooltip`] describes content and behavior associated with an entity.
+//! [`TooltipPlugin`] emits target-specific [`ShowTooltip`] / [`HideTooltip`]
+//! events. Rendering is provided by a styling layer such as `bevy_feathers`.
+
+use core::time::Duration;
+
+use bevy_app::{App, Plugin, PreUpdate};
+use bevy_ecs::{entity::EntityHashSet, hierarchy::ChildOf, prelude::*, VariantDefaults};
+use bevy_picking::{
+    events::{Pointer, Press},
+    hover::HoverMap,
+    PickingSystems,
+};
+use bevy_reflect::prelude::*;
+use bevy_time::{Time, Timer, TimerMode};
+use bevy_ui::{RelativeCursorPosition, UiSystems};
+
+use crate::popover::{PopoverAlign, PopoverPlacement, PopoverSide};
+
+/// Content displayed by a [`Tooltip`].
+#[derive(Clone, Default, Debug, PartialEq, Reflect, VariantDefaults)]
+#[reflect(Default, PartialEq)]
+pub enum TooltipContent {
+    /// Derive the text from the entity's accessibility label, falling back to
+    /// its [`Name`].
+    #[default]
+    Auto,
+    /// Display a static string.
+    Text(String),
+    /// Initially display `summary`, then extend it with `details` after the
+    /// pointer remains over the target or tooltip popup for longer.
+    Detailed {
+        /// Text shown at the summary detail level.
+        summary: String,
+        /// Additional text shown at the detailed detail level.
+        details: String,
+    },
+}
+
+/// Amount of tooltip content requested by [`ShowTooltip`].
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Reflect, VariantDefaults)]
+#[reflect(Default, PartialEq)]
+pub enum TooltipDetail {
+    /// Show the short tooltip content.
+    #[default]
+    Summary,
+    /// Show all available tooltip content.
+    Details,
+}
+
+/// Interaction that shows a [`Tooltip`].
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, Reflect, VariantDefaults)]
+#[reflect(Default, PartialEq)]
+pub enum TooltipTrigger {
+    /// Show while the pointer is over the target, subject to the configured
+    /// show and hide delays.
+    #[default]
+    Hover,
+    /// Toggle immediately when the target is clicked. Clicking elsewhere
+    /// dismisses automatically opened click tooltips.
+    Click,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PendingAction {
+    Show,
+    Hide,
+}
+
+#[derive(Component, Default)]
+struct TooltipRuntime {
+    visible: bool,
+    hovered: bool,
+    initialized: bool,
+    last_open: Option<bool>,
+    last_trigger: TooltipTrigger,
+    pending: Option<(PendingAction, Timer)>,
+    detail: TooltipDetail,
+    detail_timer: Option<Timer>,
+}
+
+/// Associates a rendered tooltip popup with its source [`Tooltip`] entity.
+///
+/// Styling layers should attach this to the popup root. The required
+/// [`RelativeCursorPosition`] lets the headless controller keep hover tooltips
+/// open while the pointer is over a non-pickable popup.
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq, Reflect)]
+#[reflect(Component, PartialEq)]
+#[require(RelativeCursorPosition)]
+pub struct TooltipPopup {
+    /// Entity containing the source [`Tooltip`].
+    pub target: Entity,
+}
+
+/// Headless tooltip metadata associated with an entity.
+#[derive(Component, Clone, Debug, PartialEq, Reflect)]
+#[reflect(Component, Default, PartialEq)]
+#[require(TooltipRuntime)]
+pub struct Tooltip {
+    /// Content displayed by the tooltip.
+    pub content: TooltipContent,
+    /// Preferred placement. The styling layer may try fallback placements when
+    /// this placement would be clipped.
+    pub placement: PopoverPlacement,
+    /// Interaction that shows the tooltip when [`Self::open`] is `None`.
+    pub trigger: TooltipTrigger,
+    /// Controlled visibility. `None` enables automatic trigger behavior,
+    /// `Some(true)` keeps the tooltip open, and `Some(false)` keeps it closed.
+    pub open: Option<bool>,
+    /// Per-tooltip hover show delay. `None` uses [`TooltipHoverDelay`].
+    pub show_delay: Option<Duration>,
+    /// Per-tooltip hover hide delay. `None` uses [`TooltipHideDelay`].
+    pub hide_delay: Option<Duration>,
+    /// Whether the styling layer should render an arrow.
+    pub arrow: bool,
+}
+
+impl Default for Tooltip {
+    fn default() -> Self {
+        Self {
+            content: TooltipContent::Auto,
+            placement: PopoverPlacement {
+                side: PopoverSide::Top,
+                align: PopoverAlign::Center,
+                gap: 8.0,
+            },
+            trigger: TooltipTrigger::Hover,
+            open: None,
+            show_delay: None,
+            hide_delay: None,
+            arrow: true,
+        }
+    }
+}
+
+/// Default delay before an automatically hovered tooltip is shown.
+#[derive(Resource, Clone, Copy, Debug)]
+pub struct TooltipHoverDelay(pub Duration);
+
+impl Default for TooltipHoverDelay {
+    fn default() -> Self {
+        Self(Duration::from_millis(500))
+    }
+}
+
+/// Default delay before an automatically hovered tooltip is hidden.
+#[derive(Resource, Clone, Copy, Debug)]
+pub struct TooltipHideDelay(pub Duration);
+
+impl Default for TooltipHideDelay {
+    fn default() -> Self {
+        Self(Duration::from_millis(100))
+    }
+}
+
+/// Hover duration before a [`TooltipContent::Detailed`] tooltip expands.
+#[derive(Resource, Clone, Copy, Debug)]
+pub struct TooltipDetailDelay(pub Duration);
+
+impl Default for TooltipDetailDelay {
+    fn default() -> Self {
+        Self(Duration::from_millis(1500))
+    }
+}
+
+/// Request that the tooltip for `target` be shown.
+#[derive(Event, Clone, Copy, Debug, Reflect)]
+#[reflect(Event)]
+pub struct ShowTooltip {
+    /// Entity whose [`Tooltip`] should be displayed.
+    pub target: Entity,
+    /// Amount of content to display.
+    pub detail: TooltipDetail,
+}
+
+impl ShowTooltip {
+    /// Creates a request for the summary content.
+    pub const fn summary(target: Entity) -> Self {
+        Self {
+            target,
+            detail: TooltipDetail::Summary,
+        }
+    }
+
+    /// Creates a request for all available content.
+    pub const fn details(target: Entity) -> Self {
+        Self {
+            target,
+            detail: TooltipDetail::Details,
+        }
+    }
+}
+
+/// Request that the tooltip for `target` be hidden.
+#[derive(Event, Clone, Copy, Debug, Reflect)]
+#[reflect(Event)]
+pub struct HideTooltip {
+    /// Entity whose [`Tooltip`] should be hidden.
+    pub target: Entity,
+}
+
+fn tooltip_ancestor(
+    entity: Entity,
+    tooltips: &Query<&Tooltip>,
+    parents: &Query<&ChildOf>,
+) -> Option<Entity> {
+    core::iter::once(entity)
+        .chain(parents.iter_ancestors(entity))
+        .find(|entity| tooltips.contains(*entity))
+}
+
+fn hovered_tooltips(
+    hover_map: &HoverMap,
+    tooltips: &Query<&Tooltip>,
+    parents: &Query<&ChildOf>,
+    popups: &Query<(&TooltipPopup, &RelativeCursorPosition)>,
+) -> EntityHashSet {
+    let mut hovered: EntityHashSet = hover_map
+        .values()
+        .flat_map(|hovered| hovered.keys())
+        .filter_map(|entity| tooltip_ancestor(*entity, tooltips, parents))
+        .collect();
+    hovered.extend(
+        popups
+            .iter()
+            .filter(|(_, cursor)| cursor.cursor_over())
+            .map(|(popup, _)| popup.target)
+            .filter(|target| tooltips.contains(*target)),
+    );
+    hovered
+}
+
+fn trigger_action(target: Entity, action: PendingAction, commands: &mut Commands) {
+    match action {
+        PendingAction::Show => commands.trigger(ShowTooltip::summary(target)),
+        PendingAction::Hide => commands.trigger(HideTooltip { target }),
+    };
+}
+
+fn schedule_action(
+    target: Entity,
+    runtime: &mut TooltipRuntime,
+    action: PendingAction,
+    delay: Duration,
+    commands: &mut Commands,
+) {
+    runtime.pending = None;
+    if delay.is_zero() {
+        trigger_action(target, action, commands);
+    } else {
+        runtime.pending = Some((action, Timer::new(delay, TimerMode::Once)));
+    }
+}
+
+fn update_tooltip_hover(
+    time: Res<Time>,
+    default_show_delay: Res<TooltipHoverDelay>,
+    default_hide_delay: Res<TooltipHideDelay>,
+    detail_delay: Res<TooltipDetailDelay>,
+    hover_map: Res<HoverMap>,
+    tooltips: Query<&Tooltip>,
+    parents: Query<&ChildOf>,
+    popups: Query<(&TooltipPopup, &RelativeCursorPosition)>,
+    mut states: Query<(Entity, Ref<Tooltip>, &mut TooltipRuntime)>,
+    mut commands: Commands,
+) {
+    let hovered = hovered_tooltips(&hover_map, &tooltips, &parents, &popups);
+
+    for (target, tooltip, mut runtime) in &mut states {
+        let is_hovered = hovered.contains(&target);
+        let config_changed = tooltip.is_changed();
+        let was_initialized = runtime.initialized;
+        let behavior_changed = !was_initialized
+            || runtime.last_open != tooltip.open
+            || runtime.last_trigger != tooltip.trigger;
+
+        if behavior_changed {
+            runtime.pending = None;
+        }
+
+        let hover_changed = is_hovered != runtime.hovered;
+        let is_detailed = matches!(&tooltip.content, TooltipContent::Detailed { .. });
+        if !is_detailed {
+            runtime.detail = TooltipDetail::Summary;
+            runtime.detail_timer = None;
+        } else if is_hovered
+            && runtime.detail == TooltipDetail::Summary
+            && runtime.detail_timer.is_none()
+        {
+            runtime.detail_timer = Some(Timer::new(detail_delay.0, TimerMode::Once));
+        } else if hover_changed && !is_hovered && !runtime.visible {
+            runtime.detail_timer = None;
+        }
+
+        match tooltip.open {
+            Some(true) => {
+                if !runtime.visible {
+                    trigger_action(target, PendingAction::Show, &mut commands);
+                }
+            }
+            Some(false) => {
+                if runtime.visible {
+                    trigger_action(target, PendingAction::Hide, &mut commands);
+                }
+            }
+            None if tooltip.trigger == TooltipTrigger::Hover => {
+                if hover_changed {
+                    runtime.pending = None;
+                }
+                if (behavior_changed || hover_changed) && is_hovered && !runtime.visible {
+                    schedule_action(
+                        target,
+                        &mut runtime,
+                        PendingAction::Show,
+                        tooltip.show_delay.unwrap_or(default_show_delay.0),
+                        &mut commands,
+                    );
+                } else if (behavior_changed || hover_changed) && !is_hovered && runtime.visible {
+                    schedule_action(
+                        target,
+                        &mut runtime,
+                        PendingAction::Hide,
+                        tooltip.hide_delay.unwrap_or(default_hide_delay.0),
+                        &mut commands,
+                    );
+                }
+            }
+            None => {}
+        }
+
+        runtime.initialized = true;
+        runtime.hovered = is_hovered;
+        runtime.last_open = tooltip.open;
+        runtime.last_trigger = tooltip.trigger;
+
+        let should_remain_visible = match tooltip.open {
+            Some(open) => open,
+            None if tooltip.trigger == TooltipTrigger::Hover => is_hovered,
+            None => true,
+        };
+        if was_initialized && config_changed && runtime.visible && should_remain_visible {
+            commands.trigger(ShowTooltip {
+                target,
+                detail: runtime.detail,
+            });
+        }
+
+        if let Some((action, timer)) = runtime.pending.as_mut() {
+            timer.tick(time.delta());
+            if timer.just_finished() {
+                let action = *action;
+                runtime.pending = None;
+                trigger_action(target, action, &mut commands);
+            }
+        }
+
+        let is_visible = runtime.visible;
+        if is_hovered
+            && runtime.detail == TooltipDetail::Summary
+            && let Some(timer) = runtime.detail_timer.as_mut()
+        {
+            timer.tick(time.delta());
+            if is_visible && timer.is_finished() {
+                runtime.detail_timer = None;
+                commands.trigger(ShowTooltip::details(target));
+            }
+        }
+    }
+}
+
+fn on_pointer_press(
+    trigger: On<Pointer<Press>>,
+    tooltips: Query<&Tooltip>,
+    parents: Query<&ChildOf>,
+    states: Query<(Entity, &Tooltip, &TooltipRuntime)>,
+    mut commands: Commands,
+) {
+    if trigger.event_target() != trigger.original_event_target() {
+        return;
+    }
+
+    let clicked = tooltip_ancestor(trigger.original_event_target(), &tooltips, &parents);
+    if let Some(target) = clicked
+        && let Ok((_, tooltip, runtime)) = states.get(target)
+        && tooltip.open.is_none()
+        && tooltip.trigger == TooltipTrigger::Click
+    {
+        trigger_action(
+            target,
+            if runtime.visible {
+                PendingAction::Hide
+            } else {
+                PendingAction::Show
+            },
+            &mut commands,
+        );
+        return;
+    }
+
+    for (target, tooltip, runtime) in &states {
+        if runtime.visible && tooltip.open.is_none() && tooltip.trigger == TooltipTrigger::Click {
+            trigger_action(target, PendingAction::Hide, &mut commands);
+        }
+    }
+}
+
+fn on_show_tooltip(
+    trigger: On<ShowTooltip>,
+    detail_delay: Res<TooltipDetailDelay>,
+    tooltips: Query<&Tooltip>,
+    mut states: Query<&mut TooltipRuntime>,
+) {
+    if let Ok(mut runtime) = states.get_mut(trigger.target) {
+        runtime.visible = true;
+        runtime.pending = None;
+        runtime.detail = trigger.detail;
+        if trigger.detail == TooltipDetail::Details {
+            runtime.detail_timer = None;
+        } else if runtime.hovered
+            && runtime.detail_timer.is_none()
+            && tooltips
+                .get(trigger.target)
+                .is_ok_and(|tooltip| matches!(&tooltip.content, TooltipContent::Detailed { .. }))
+        {
+            runtime.detail_timer = Some(Timer::new(detail_delay.0, TimerMode::Once));
+        }
+    }
+}
+
+fn on_hide_tooltip(trigger: On<HideTooltip>, mut states: Query<&mut TooltipRuntime>) {
+    if let Ok(mut runtime) = states.get_mut(trigger.target) {
+        runtime.visible = false;
+        runtime.pending = None;
+        runtime.detail = TooltipDetail::Summary;
+        runtime.detail_timer = None;
+    }
+}
+
+/// Plugin providing tooltip hover/click activation and show/hide events.
+pub struct TooltipPlugin;
+
+impl Plugin for TooltipPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<TooltipHoverDelay>()
+            .init_resource::<TooltipHideDelay>()
+            .init_resource::<TooltipDetailDelay>()
+            .add_observer(on_pointer_press)
+            .add_observer(on_show_tooltip)
+            .add_observer(on_hide_tooltip)
+            .add_systems(
+                PreUpdate,
+                update_tooltip_hover
+                    .after(PickingSystems::Hover)
+                    .after(UiSystems::Focus),
+            )
+            .world_mut()
+            .register_component_hooks::<Tooltip>()
+            .on_remove(|mut world, context| {
+                if world
+                    .get::<TooltipRuntime>(context.entity)
+                    .is_some_and(|runtime| runtime.visible)
+                {
+                    world.trigger(HideTooltip {
+                        target: context.entity,
+                    });
+                }
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_camera::NormalizedRenderTarget;
+    use bevy_math::Vec2;
+    use bevy_picking::{
+        backend::HitData,
+        pointer::{Location, PointerButton, PointerId},
+    };
+
+    #[derive(Resource, Default)]
+    struct EventLog {
+        shown: Vec<Entity>,
+        details: Vec<TooltipDetail>,
+        hidden: Vec<Entity>,
+    }
+
+    fn capture_show(trigger: On<ShowTooltip>, mut log: ResMut<EventLog>) {
+        log.shown.push(trigger.target);
+        log.details.push(trigger.detail);
+    }
+
+    fn capture_hide(trigger: On<HideTooltip>, mut log: ResMut<EventLog>) {
+        log.hidden.push(trigger.target);
+    }
+
+    fn test_app() -> App {
+        let mut app = App::new();
+        app.init_resource::<Time>();
+        app.init_resource::<HoverMap>();
+        app.add_plugins(TooltipPlugin);
+        app.init_resource::<EventLog>();
+        app.add_observer(capture_show);
+        app.add_observer(capture_hide);
+        app
+    }
+
+    fn hover(app: &mut App, entity: Entity) {
+        let hit = HitData::new(Entity::PLACEHOLDER, 0.0, None, None);
+        app.world_mut()
+            .resource_mut::<HoverMap>()
+            .entry(PointerId::Mouse)
+            .or_default()
+            .insert(entity, hit);
+    }
+
+    fn press(app: &mut App, entity: Entity) {
+        app.world_mut().trigger(Pointer::new(
+            PointerId::Mouse,
+            Location {
+                target: NormalizedRenderTarget::None {
+                    width: 0,
+                    height: 0,
+                },
+                position: Vec2::ZERO,
+            },
+            Press {
+                button: PointerButton::Primary,
+                hit: HitData::new(Entity::PLACEHOLDER, 0.0, None, None),
+                count: 1,
+            },
+            entity,
+        ));
+        app.world_mut().flush();
+    }
+
+    #[test]
+    fn tooltip_defaults() {
+        let tooltip = Tooltip::default();
+        assert_eq!(tooltip.content, TooltipContent::Auto);
+        assert_eq!(tooltip.trigger, TooltipTrigger::Hover);
+        assert_eq!(tooltip.open, None);
+        assert_eq!(tooltip.show_delay, None);
+        assert_eq!(tooltip.hide_delay, None);
+        assert!(tooltip.arrow);
+    }
+
+    #[test]
+    fn hover_uses_per_tooltip_show_and_hide_delays() {
+        let mut app = test_app();
+        let target = app
+            .world_mut()
+            .spawn(Tooltip {
+                show_delay: Some(Duration::from_millis(10)),
+                hide_delay: Some(Duration::from_millis(20)),
+                ..Tooltip::default()
+            })
+            .id();
+        hover(&mut app, target);
+
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(9));
+        app.update();
+        assert!(app.world().resource::<EventLog>().shown.is_empty());
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(1));
+        app.update();
+        assert_eq!(app.world().resource::<EventLog>().shown, vec![target]);
+
+        app.world_mut().resource_mut::<HoverMap>().clear();
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(19));
+        app.update();
+        assert!(app.world().resource::<EventLog>().hidden.is_empty());
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(1));
+        app.update();
+        assert_eq!(app.world().resource::<EventLog>().hidden, vec![target]);
+    }
+
+    #[test]
+    fn hover_changes_cancel_the_opposite_pending_action() {
+        let mut app = test_app();
+        let target = app
+            .world_mut()
+            .spawn(Tooltip {
+                show_delay: Some(Duration::from_millis(10)),
+                hide_delay: Some(Duration::from_millis(10)),
+                ..Tooltip::default()
+            })
+            .id();
+
+        hover(&mut app, target);
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(5));
+        app.update();
+        app.world_mut().resource_mut::<HoverMap>().clear();
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(20));
+        app.update();
+        assert!(app.world().resource::<EventLog>().shown.is_empty());
+
+        app.world_mut()
+            .get_mut::<Tooltip>(target)
+            .unwrap()
+            .show_delay = Some(Duration::ZERO);
+        hover(&mut app, target);
+        app.update();
+        assert_eq!(app.world().resource::<EventLog>().shown, vec![target]);
+
+        app.world_mut().resource_mut::<HoverMap>().clear();
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(5));
+        app.update();
+        hover(&mut app, target);
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(20));
+        app.update();
+        assert!(app.world().resource::<EventLog>().hidden.is_empty());
+    }
+
+    #[test]
+    fn hover_uses_nearest_tooltip_ancestor() {
+        let mut app = test_app();
+        app.world_mut().resource_mut::<TooltipHoverDelay>().0 = Duration::ZERO;
+        let target = app.world_mut().spawn(Tooltip::default()).id();
+        let child = app.world_mut().spawn(ChildOf(target)).id();
+        hover(&mut app, child);
+
+        app.update();
+        assert_eq!(app.world().resource::<EventLog>().shown, vec![target]);
+    }
+
+    #[test]
+    fn popup_hover_keeps_the_source_tooltip_open() {
+        let mut app = test_app();
+        app.world_mut().resource_mut::<TooltipHoverDelay>().0 = Duration::ZERO;
+        let target = app.world_mut().spawn(Tooltip::default()).id();
+        hover(&mut app, target);
+        app.update();
+
+        let popup = app.world_mut().spawn(TooltipPopup { target }).id();
+        app.world_mut().resource_mut::<HoverMap>().clear();
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(50));
+        app.update();
+        assert!(app.world().resource::<EventLog>().hidden.is_empty());
+
+        app.world_mut()
+            .get_mut::<RelativeCursorPosition>(popup)
+            .unwrap()
+            .cursor_over = true;
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(100));
+        app.update();
+        assert!(app.world().resource::<EventLog>().hidden.is_empty());
+
+        app.world_mut()
+            .get_mut::<RelativeCursorPosition>(popup)
+            .unwrap()
+            .cursor_over = false;
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(99));
+        app.update();
+        assert!(app.world().resource::<EventLog>().hidden.is_empty());
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(1));
+        app.update();
+        assert_eq!(app.world().resource::<EventLog>().hidden, vec![target]);
+    }
+
+    #[test]
+    fn detailed_tooltip_expands_after_the_second_hover_delay() {
+        let mut app = test_app();
+        app.world_mut().resource_mut::<TooltipHoverDelay>().0 = Duration::ZERO;
+        app.world_mut().resource_mut::<TooltipDetailDelay>().0 = Duration::from_millis(20);
+        let target = app
+            .world_mut()
+            .spawn(Tooltip {
+                content: TooltipContent::Detailed {
+                    summary: "Short".into(),
+                    details: "More detail".into(),
+                },
+                ..Tooltip::default()
+            })
+            .id();
+        hover(&mut app, target);
+        app.update();
+        assert_eq!(
+            app.world().resource::<EventLog>().details,
+            vec![TooltipDetail::Summary]
+        );
+
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(19));
+        app.update();
+        assert_eq!(app.world().resource::<EventLog>().details.len(), 1);
+        app.world_mut()
+            .resource_mut::<Time>()
+            .advance_by(Duration::from_millis(1));
+        app.update();
+        assert_eq!(
+            app.world().resource::<EventLog>().details,
+            vec![TooltipDetail::Summary, TooltipDetail::Details]
+        );
+    }
+
+    #[test]
+    fn click_tooltip_toggles_immediately_from_a_child() {
+        let mut app = test_app();
+        let target = app
+            .world_mut()
+            .spawn(Tooltip {
+                trigger: TooltipTrigger::Click,
+                ..Tooltip::default()
+            })
+            .id();
+        let child = app.world_mut().spawn(ChildOf(target)).id();
+
+        press(&mut app, child);
+        assert_eq!(app.world().resource::<EventLog>().shown, vec![target]);
+        press(&mut app, child);
+        assert_eq!(app.world().resource::<EventLog>().hidden, vec![target]);
+    }
+
+    #[test]
+    fn multiple_click_tooltips_can_remain_visible() {
+        let mut app = test_app();
+        let tooltip = || Tooltip {
+            trigger: TooltipTrigger::Click,
+            ..Tooltip::default()
+        };
+        let first = app.world_mut().spawn(tooltip()).id();
+        let second = app.world_mut().spawn(tooltip()).id();
+
+        press(&mut app, first);
+        press(&mut app, second);
+
+        assert_eq!(
+            app.world().resource::<EventLog>().shown,
+            vec![first, second]
+        );
+        assert!(app.world().resource::<EventLog>().hidden.is_empty());
+    }
+
+    #[test]
+    fn clicking_outside_dismisses_automatic_click_tooltips() {
+        let mut app = test_app();
+        let target = app
+            .world_mut()
+            .spawn(Tooltip {
+                trigger: TooltipTrigger::Click,
+                ..Tooltip::default()
+            })
+            .id();
+        let outside = app.world_mut().spawn_empty().id();
+
+        press(&mut app, target);
+        press(&mut app, outside);
+
+        assert_eq!(app.world().resource::<EventLog>().hidden, vec![target]);
+    }
+
+    #[test]
+    fn multiple_controlled_tooltips_can_stay_open() {
+        let mut app = test_app();
+        let tooltip = || Tooltip {
+            open: Some(true),
+            ..Tooltip::default()
+        };
+        let first = app.world_mut().spawn(tooltip()).id();
+        let second = app.world_mut().spawn(tooltip()).id();
+
+        app.update();
+
+        assert_eq!(
+            app.world().resource::<EventLog>().shown,
+            vec![first, second]
+        );
+        app.world_mut().resource_mut::<HoverMap>().clear();
+        app.update();
+        assert!(app.world().resource::<EventLog>().hidden.is_empty());
+    }
+
+    #[test]
+    fn controlled_closed_tooltip_ignores_automatic_trigger() {
+        let mut app = test_app();
+        app.world_mut().resource_mut::<TooltipHoverDelay>().0 = Duration::ZERO;
+        let target = app
+            .world_mut()
+            .spawn(Tooltip {
+                open: Some(false),
+                ..Tooltip::default()
+            })
+            .id();
+        hover(&mut app, target);
+        app.update();
+
+        assert!(app.world().resource::<EventLog>().shown.is_empty());
+    }
+
+    #[test]
+    fn controlled_tooltip_refreshes_and_can_be_closed() {
+        let mut app = test_app();
+        let target = app
+            .world_mut()
+            .spawn(Tooltip {
+                open: Some(true),
+                ..Tooltip::default()
+            })
+            .id();
+        app.update();
+
+        app.world_mut().get_mut::<Tooltip>(target).unwrap().content =
+            TooltipContent::Text("Updated".into());
+        app.update();
+        assert_eq!(
+            app.world().resource::<EventLog>().shown,
+            vec![target, target]
+        );
+
+        app.world_mut().get_mut::<Tooltip>(target).unwrap().open = Some(false);
+        app.update();
+        assert_eq!(app.world().resource::<EventLog>().hidden, vec![target]);
+    }
+
+    #[test]
+    fn removing_visible_tooltip_hides_only_that_target() {
+        let mut app = test_app();
+        let first = app.world_mut().spawn(Tooltip::default()).id();
+        let second = app.world_mut().spawn(Tooltip::default()).id();
+        let never_shown = app.world_mut().spawn(Tooltip::default()).id();
+        app.world_mut().trigger(ShowTooltip::summary(first));
+        app.world_mut().trigger(ShowTooltip::summary(second));
+
+        app.world_mut().entity_mut(never_shown).remove::<Tooltip>();
+        assert!(app.world().resource::<EventLog>().hidden.is_empty());
+        app.world_mut().entity_mut(first).remove::<Tooltip>();
+
+        assert_eq!(app.world().resource::<EventLog>().hidden, vec![first]);
+    }
+}

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -23,8 +23,10 @@ use bevy::{
     ui_widgets::{
         checkbox_self_update, listbox_update_selection,
         popover::{Popover, PopoverAlign, PopoverPlacement, PopoverSide},
-        radio_self_update, slider_self_update, Activate, ActivateOnPress, RadioGroup, RequestClose,
-        SliderPrecision, SliderStep, SliderValue, ValueChange,
+        radio_self_update, slider_self_update,
+        tooltip::{Tooltip, TooltipContent, TooltipTrigger},
+        Activate, ActivateOnPress, RadioGroup, RequestClose, SliderPrecision, SliderStep,
+        SliderValue, ValueChange,
     },
     window::SystemCursorIcon,
 };
@@ -476,6 +478,62 @@ fn demo_column_1() -> impl Scene {
                         @FeathersToggleSwitch
                         DemoDialogToggle
                         on(toggle_demo_dialog)
+                    ),
+                ]
+            ),
+            (
+                Node {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::Start,
+                    column_gap: px(8),
+                }
+                Children [
+                    label("Tooltip:"),
+                    (
+                        @FeathersButton {
+                            @caption: bsn! { caption("Submit") }
+                        }
+                        Name::new("Submit all changes")
+                        Tooltip {
+                            content: TooltipContent::Auto,
+                            trigger: TooltipTrigger::Hover,
+                        }
+                    ),
+                    (
+                        @FeathersButton {
+                            @caption: bsn! { caption("Delete") }
+                        }
+                        Tooltip {
+                            content: { TooltipContent::Text(
+                                "Permanently delete the selected item".into()
+                            ) },
+                            trigger: TooltipTrigger::Click,
+                        }
+                    ),
+                    (
+                        @FeathersButton {
+                            @caption: bsn! { caption("Pinned") }
+                        }
+                        Tooltip {
+                            content: { TooltipContent::Text("Always visible".into()) },
+                            open: { Some(true) },
+                            arrow: false,
+                        }
+                    ),
+                    (
+                        @FeathersButton {
+                            @caption: bsn! { caption("Detailed") }
+                        }
+                        Tooltip {
+                            content: {
+                                TooltipContent::Detailed {
+                                    summary: "Short description".into(),
+                                    details: "Additional information shown after a longer hover".into(),
+                                }
+                            },
+                        }
                     ),
                 ]
             ),


### PR DESCRIPTION
# Objective

Add headless tooltips, implementing the design discussed in #20601. Complete Phase 1 and Phase 2


## Solution

Add a headless `TooltipPlugin` to `bevy_ui_widgets`. A `Tooltip` can be attached to any hoverable entity and supports:

- content derived from an accessibility label or `Name` with `TooltipContent::Auto`;
- static text with `TooltipContent::Text`;
- long-dwell content with `TooltipContent::Detailed`, which first shows a summary and later expands with additional details;
- automatic hover activation and click-to-toggle activation;
- controlled visibility through `open: Option<bool>`;
- global default delays and per-tooltip show/hide delay overrides;
- nearest-ancestor resolution for nested UI entities;
- target-specific show and hide events, cleanup when a tooltip is removed, and multiple independently visible tooltips.


## Testing
cargo run --example feathers_gallery --features bevy_feathers
cargo test -p bevy_ui_widgets -p bevy_feathers
cargo clippy -p bevy_ui_widgets -p bevy_feathers --all-targets -- -D warnings
cargo clippy --example feathers_gallery --features bevy_feathers -- -D warnings

---

## Showcase
<img width="521" height="143" alt="image" src="https://github.com/user-attachments/assets/e3944c25-d307-42af-8c3d-c7c132dc0572" />


```rust
commands.spawn((
    Node::default(),
    Tooltip {
        content: TooltipContent::Text("Submit the form".into()),
        ..default()
    },
));
```

The Feathers Gallery includes a click-opened Examples tooltip containing placement, custom-content, styling, and
  nested-tooltip cases.

</details>
