### PR TITLE
Improve ECS derive macro hygiene

### DIFF
--- a/crates/bevy_ecs/macros/src/query_data.rs
+++ b/crates/bevy_ecs/macros/src/query_data.rs
@@ -53,11 +53,11 @@ fn contiguous_item_struct(
     user_where_clauses_with_world_and_state: Option<&WhereClause>,
 ) -> proc_macro2::TokenStream {
     let item_attrs = quote! {
-        #[doc = concat!(
+        #[doc = ::core::concat!(
             "Automatically generated [`ContiguousQueryData`](",
-            stringify!(#path),
+            ::core::stringify!(#path),
             "::fetch::ContiguousQueryData) item type for [`",
-            stringify!(#struct_name),
+            ::core::stringify!(#struct_name),
             "`], returned when iterating over contiguous query results",
         )]
         #[automatically_derived]
@@ -363,18 +363,18 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
             user_where_clauses_with_world,
         );
         let read_only_structs = quote! {
-            #[doc = concat!(
+            #[doc = ::core::concat!(
                 "Automatically generated [`WorldQuery`](",
-                stringify!(#path),
+                ::core::stringify!(#path),
                 "::query::WorldQuery) type for a read-only variant of [`",
-                stringify!(#struct_name),
+                ::core::stringify!(#struct_name),
                 "`]."
             )]
             #[automatically_derived]
             #visibility struct #read_only_struct_name #user_impl_generics #user_where_clauses {
                 #(
                     #[doc = "Automatically generated read-only field for accessing `"]
-                    #[doc = stringify!(#field_types)]
+                    #[doc = ::core::stringify!(#field_types)]
                     #[doc = "`."]
                     #field_visibilities #field_members: #read_only_field_types,
                 )*
@@ -632,11 +632,11 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
 
         const _: () = {
             #[doc(hidden)]
-            #[doc = concat!(
+            #[doc = ::core::concat!(
                 "Automatically generated internal [`WorldQuery`](",
-                stringify!(#path),
+                ::core::stringify!(#path),
                 "::query::WorldQuery) state type for [`",
-                stringify!(#struct_name),
+                ::core::stringify!(#struct_name),
                 "`], used for caching."
             )]
             #[automatically_derived]

--- a/crates/bevy_ecs/macros/src/query_filter.rs
+++ b/crates/bevy_ecs/macros/src/query_filter.rs
@@ -96,11 +96,11 @@ pub fn derive_query_filter_impl(input: TokenStream) -> TokenStream {
     TokenStream::from(quote! {
         const _: () = {
             #[doc(hidden)]
-            #[doc = concat!(
+            #[doc = ::core::concat!(
                 "Automatically generated internal [`WorldQuery`](",
-                stringify!(#path),
+                ::core::stringify!(#path),
                 "::query::WorldQuery) state type for [`",
-                stringify!(#struct_name),
+                ::core::stringify!(#struct_name),
                 "`], used for caching."
             )]
             #[automatically_derived]

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -20,11 +20,11 @@ pub(crate) fn item_struct(
     user_where_clauses_with_world_and_state: Option<&WhereClause>,
 ) -> proc_macro2::TokenStream {
     let item_attrs = quote! {
-        #[doc = concat!(
+        #[doc = ::core::concat!(
             "Automatically generated [`WorldQuery`](",
-            stringify!(#path),
+            ::core::stringify!(#path),
             "::query::WorldQuery) item type for [`",
-            stringify!(#struct_name),
+            ::core::stringify!(#struct_name),
             "`], returned when iterating over query results."
         )]
         #[automatically_derived]
@@ -70,11 +70,11 @@ pub(crate) fn world_query_impl(
 ) -> proc_macro2::TokenStream {
     quote! {
         #[doc(hidden)]
-        #[doc = concat!(
+        #[doc = ::core::concat!(
             "Automatically generated internal [`WorldQuery`](",
-            stringify!(#path),
+            ::core::stringify!(#path),
             "::query::WorldQuery) fetch type for [`",
-            stringify!(#struct_name),
+            ::core::stringify!(#struct_name),
             "`], used to define the world data accessed by this query."
         )]
         #[automatically_derived]


### PR DESCRIPTION
# Objective

- Improve the hygiene of the ECS derive macros.

## Solution

- Qualify the `concat!` and `stringify!` macros in generated documentation.

## Testing

- `cargo run -p ci --compile`