### PR TITLE
`custom_ui_material.wgsl` fix

### DIFF
--- a/assets/shaders/custom_ui_material.wgsl
+++ b/assets/shaders/custom_ui_material.wgsl
@@ -25,7 +25,7 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     );
 
     // select radius for the nearest corner
-    let rs = select(in.border_radius.xy, in.border_radius.wz, 0.0 < p.y);
+    let rs = select(in.border_radius_x.xy, in.border_radius_x.wz, 0.0 < p.y);
     let radius = select(rs.x, rs.y, 0.0 < p.x);
 
     // distance along each axis from the corner
@@ -36,7 +36,7 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     // the border and we return the border color
     if d.x < b.x || d.y < b.y {
         // select radius for the nearest corner
-        let rs = select(in.border_radius.xy, in.border_radius.wz, 0.0 < p.y);
+        let rs = select(in.border_radius_x.xy, in.border_radius_x.wz, 0.0 < p.y);
         let radius = select(rs.x, rs.y, 0.0 < p.x);
 
         // determine if the point is inside the curved corner and return the corresponding color


### PR DESCRIPTION
# Objective

 The `custom_ui_material.wgsl` shader wasn't updated following the elliptical border radius changes and it still expects the old `UIVertexOutput`, which only had a single border radius value.

## Solution

Fixed by changing `in.border_radius` to `in_border_radius_x`.

---

The shader should be extended to support elliptical corners in a follow up. I think it's best to merge this easy to review two line fix first though.

## Testing

```
cargo run --example ui_material
```