### PR TITLE
Migrate `sub_states` to use `ui_widgets::Button` (Phase 2 Item 5)

### DIFF
--- a/examples/state/sub_states.rs
+++ b/examples/state/sub_states.rs
@@ -7,7 +7,12 @@
 //! In this case, we're transitioning from a `Menu` state to an `InGame` state, at which point we create
 //! a substate called `IsPaused` to track whether the game is paused or not.
 
-use bevy::{dev_tools::states::*, prelude::*};
+use bevy::{
+    dev_tools::states::*,
+    picking::hover::Hovered,
+    prelude::*,
+    ui_widgets::{Activate, ActivateOnPress, Button},
+};
 
 use ui::*;
 
@@ -40,7 +45,8 @@ fn main() {
         // Most of these remain the same
         .add_systems(Startup, setup)
         .add_systems(OnEnter(AppState::Menu), setup_menu)
-        .add_systems(Update, menu.run_if(in_state(AppState::Menu)))
+        .add_observer(on_activate_start_game.run_if(in_state(AppState::Menu)))
+        .add_systems(Update, hover_style)
         .add_systems(OnExit(AppState::Menu), cleanup_menu)
         .add_systems(OnEnter(AppState::InGame), setup_game)
         .add_systems(OnEnter(IsPaused::Paused), setup_paused_screen)
@@ -60,25 +66,18 @@ fn main() {
         .run();
 }
 
-fn menu(
-    mut next_state: ResMut<NextState<AppState>>,
-    mut interaction_query: Query<
-        (&Interaction, &mut BackgroundColor),
-        (Changed<Interaction>, With<Button>),
-    >,
+fn on_activate_start_game(_: On<Activate>, mut next_state: ResMut<NextState<AppState>>) {
+    next_state.set(AppState::InGame);
+}
+
+fn hover_style(
+    mut button_query: Query<(&Hovered, &mut BackgroundColor), (Changed<Hovered>, With<Button>)>,
 ) {
-    for (interaction, mut color) in &mut interaction_query {
-        match *interaction {
-            Interaction::Pressed => {
-                *color = PRESSED_BUTTON.into();
-                next_state.set(AppState::InGame);
-            }
-            Interaction::Hovered => {
-                *color = HOVERED_BUTTON.into();
-            }
-            Interaction::None => {
-                *color = NORMAL_BUTTON.into();
-            }
+    for (hovered, mut color) in &mut button_query {
+        if hovered.get() {
+            *color = HOVERED_BUTTON.into();
+        } else {
+            *color = NORMAL_BUTTON.into();
         }
     }
 }
@@ -148,7 +147,6 @@ mod ui {
 
     pub const NORMAL_BUTTON: Color = Color::srgb(0.15, 0.15, 0.15);
     pub const HOVERED_BUTTON: Color = Color::srgb(0.25, 0.25, 0.25);
-    pub const PRESSED_BUTTON: Color = Color::srgb(0.35, 0.75, 0.35);
 
     pub fn setup(mut commands: Commands) {
         commands.spawn(Camera2d);
@@ -167,6 +165,8 @@ mod ui {
                 },
                 children![(
                     Button,
+                    ActivateOnPress,
+                    Hovered::default(),
                     Node {
                         width: px(150),
                         height: px(65),
@@ -193,6 +193,23 @@ mod ui {
 
     pub fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
         commands.spawn(Sprite::from_image(asset_server.load("branding/icon.png")));
+
+        commands.spawn_scene(bsn! {
+            Node {
+                width: percent(100),
+                height: percent(100),
+            }
+            Children [
+                Node {
+                    position_type: PositionType::Absolute,
+                    left: px(10),
+                    top: px(10),
+                }
+                Children [
+                    Text::new("Move with arrow keys.\nPress SPACEBAR to pause.")
+                ],
+            ]
+        });
     }
 
     pub fn setup_paused_screen(mut commands: Commands) {

--- a/examples/state/sub_states.rs
+++ b/examples/state/sub_states.rs
@@ -196,19 +196,9 @@ mod ui {
 
         commands.spawn_scene(bsn! {
             Node {
-                width: percent(100),
-                height: percent(100),
+                margin: px(10),
             }
-            Children [
-                Node {
-                    position_type: PositionType::Absolute,
-                    left: px(10),
-                    top: px(10),
-                }
-                Children [
-                    Text::new("Move with arrow keys.\nPress SPACEBAR to pause.")
-                ],
-            ]
+            Text::new("Move with arrow keys.\nPress SPACEBAR to pause.")
         });
     }
 


### PR DESCRIPTION
# Objective

- Part of #24112

## Solution

- Basically the same as #25160, but I don’t make pause a button because, in a keyboard focused game, you would want to pause asap instead of having to use switch to using a pointer to click a button to pause.

## Testing

- `cargo run --example sub_states --features=“bevy_dev_tools"`

---

## Showcase

in game

<img width="1276" height="747" alt="Screenshot 2026-07-26 at 4 07 36 PM" src="https://github.com/user-attachments/assets/2ec6b8fb-95bc-41a6-a82f-3ed1c22ae384" />
