### PR TITLE
Migrate `mobile/src/lib.rs` to use `ui_widgets::Button` (Phase 2 Item 4)

### DIFF
--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -4,7 +4,11 @@ use bevy::{
     color::palettes::basic::*,
     input::{gestures::RotationGesture, touch::TouchPhase},
     log::{Level, LogPlugin},
+    picking::hover::Hovered,
+    platform::collections::HashSet,
     prelude::*,
+    ui::Pressed,
+    ui_widgets::Button,
     window::{AppLifecycle, ScreenEdge, WindowMode},
     winit::WinitSettings,
 };
@@ -145,6 +149,7 @@ fn setup_scene(
     commands
         .spawn((
             Button,
+            Hovered::default(),
             Node {
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
@@ -167,21 +172,33 @@ fn setup_scene(
 }
 
 fn button_handler(
-    mut interaction_query: Query<
-        (&Interaction, &mut BackgroundColor),
-        (Changed<Interaction>, With<Button>),
+    mut button_query: Query<
+        (
+            Entity,
+            Option<Ref<Pressed>>,
+            Ref<Hovered>,
+            &mut BackgroundColor,
+        ),
+        With<Button>,
     >,
+    mut removed_pressed: RemovedComponents<Pressed>,
 ) {
-    for (interaction, mut color) in &mut interaction_query {
-        match *interaction {
-            Interaction::Pressed => {
-                *color = BLUE.into();
-            }
-            Interaction::Hovered => {
-                *color = GRAY.into();
-            }
-            Interaction::None => {
-                *color = WHITE.into();
+    let just_unpressed: HashSet<Entity> = removed_pressed.read().collect();
+    for (entity, pressed, hovered, mut color) in &mut button_query {
+        if hovered.is_changed()
+            || pressed.as_ref().is_some_and(Ref::is_changed)
+            || just_unpressed.contains(&entity)
+        {
+            match (pressed.is_some(), hovered.get()) {
+                (true, _) => {
+                    *color = BLUE.into();
+                }
+                (_, true) => {
+                    *color = GRAY.into();
+                }
+                _ => {
+                    *color = WHITE.into();
+                }
             }
         }
     }


### PR DESCRIPTION
# Objective

- Part of #24112 

## Solution

- A very straightforward port of the button to use `ui_widgets::Button`. Didn’t use a feathers button since it seemed like a heavier dependency to put in the mobile example / it’s simpler with just a `ui_widgets::Button`

## Testing

- I followed the mobile testing directions for Android and used Android Studio to run the project `android_example` with the changes in this PR: (https://github.com/bevyengine/bevy/tree/main/examples#platform-specific-examples). It works correctly on my setup virtual device (Android 15.0). The button works as expected (although I think sometimes the button can get stuck in the pressed state for some reason but usually clicking it again makes it remember how to return back to the normal button background).
- I did NOT test on mobile iOS if that’s something someone else wants to test.

(I had rotated the scene in this screenshot)
<img width="344" height="837" alt="Screenshot 2026-07-26 at 9 53 37 PM" src="https://github.com/user-attachments/assets/cfaae5dd-da4b-48cf-8396-ba51ac06ceb3" />
