### PR TITLE
Fix uninitialized-drawable pink screen on iOS

### DIFF
--- a/crates/bevy_core_pipeline/src/upscaling/node.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/node.rs
@@ -74,8 +74,9 @@ pub fn upscaling(
     };
 
     let Some(pipeline) = pipeline_cache.get_render_pipeline(upscaling_target.0) else {
-        // we need to do some work on the swapchain to avoid pink screen uninit on macos
-        #[cfg(target_os = "macos")]
+        // we need to do some work on the swapchain to avoid uninitialized-drawable
+        // artifacts (a pink/magenta screen) on Metal platforms
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         ctx.command_encoder().begin_render_pass(&pass_descriptor);
         return;
     };


### PR DESCRIPTION
# Objective

The uninitialized-drawable mitigation in `upscaling_node` is gated to macOS, but the underlying hazard is a Metal property rather than a macOS one. On iOS every cold launch shows a full-screen magenta flash for roughly half a second while the upscaling pipeline compiles.

This is the same symptom as #20318, which was closed with a macOS-only mitigation. It is also related to #20756, which tracks the underlying frame-latency cause; this PR does not attempt to address that, it only extends the existing workaround to the platform it missed.

## Solution

`out_texture_color_attachment` is called before the pipeline-readiness check, which flips the attachment's `is_first_call` flag. `ViewTarget::needs_present()` resolves to `!is_first_call`, so the frame is presented even though nothing ever wrote to it, and an unwritten `CAMetalDrawable` composites as solid `#FF00FF`.

The attachment's own doc comment states the assumption being broken here:

> we re-use is_first_call atomic to track usage, which assumes that calls to get_attachment are always consumed by a render pass that writes to the attachment

The early-return path is exactly where that assumption does not hold.

Beginning the empty render pass executes the attachment's `LoadOp::Clear`, so warmup frames present the camera's clear color instead. That is exactly what the existing macOS branch does; this widens its `cfg` to include iOS.

Scoped to Apple platforms since Metal is the only backend I can verify.

## Testing

Reproduced and fixed on an iPhone 15 Pro Max (iOS 27, Release build) in a shipping commercial game.

Reviewers on macOS will see no change, since that path was already covered. Confirming this on iOS requires a physical device; the simulator does not exercise the same Metal drawable path.

---

## Showcase

**Before** — solid `#FF00FF` between the iOS launch screen and the first rendered frame:

<img width="2578" height="1190" alt="image" src="https://github.com/user-attachments/assets/07cd4ccd-9683-4c19-a924-369d03a015e3" />

**After** — the camera's clear color, as intended. No flash.