### PR TITLE
Migrate `split_screen` to use `FeathersButton`s (Phase 2 Item 3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1565,6 +1565,7 @@ wasm = true
 name = "split_screen"
 path = "examples/3d/split_screen.rs"
 doc-scrape-examples = true
+required-features = ["bevy_feathers"]
 
 [package.metadata.example.split_screen]
 name = "Split Screen"

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -104,9 +104,7 @@ fn setup(
                 children![(
                     Text::new(*camera_name),
                     Node {
-                        position_type: PositionType::Absolute,
-                        top: px(12),
-                        left: px(12),
+                        margin: px(12).all(),
                         ..default()
                     },
                 ),],

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -3,14 +3,24 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    camera::Viewport, light::CascadeShadowConfigBuilder, prelude::*, window::WindowResized,
+    camera::Viewport,
+    feathers::{
+        controls::FeathersButton, dark_theme::create_dark_theme, display::caption, theme::UiTheme,
+        FeathersPlugins,
+    },
+    light::CascadeShadowConfigBuilder,
+    prelude::*,
+    ui_widgets::Activate,
+    window::WindowResized,
 };
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins((DefaultPlugins, FeathersPlugins))
+        .insert_resource(UiTheme(create_dark_theme()))
         .add_systems(Startup, setup)
-        .add_systems(Update, (set_camera_viewports, button_system))
+        .add_systems(Update, set_camera_viewports)
+        .add_observer(on_activate_rotate_camera)
         .run();
 }
 
@@ -82,15 +92,16 @@ fn setup(
             .id();
 
         // Set up UI
-        commands.spawn((
-            UiTargetCamera(camera),
-            Node {
-                width: percent(100),
-                height: percent(100),
-                ..default()
-            },
-            children![
-                (
+        let buttons_entity = commands.spawn_scene(buttons_panel()).id();
+        commands
+            .spawn((
+                UiTargetCamera(camera),
+                Node {
+                    width: percent(100),
+                    height: percent(100),
+                    ..default()
+                },
+                children![(
                     Text::new(*camera_name),
                     Node {
                         position_type: PositionType::Absolute,
@@ -98,14 +109,13 @@ fn setup(
                         left: px(12),
                         ..default()
                     },
-                ),
-                buttons_panel(),
-            ],
-        ));
+                ),],
+            ))
+            .add_child(buttons_entity);
     }
 
-    fn buttons_panel() -> impl Bundle {
-        (
+    fn buttons_panel() -> impl Scene {
+        bsn! {
             Node {
                 position_type: PositionType::Absolute,
                 width: percent(100),
@@ -115,31 +125,24 @@ fn setup(
                 justify_content: JustifyContent::SpaceBetween,
                 align_items: AlignItems::Center,
                 padding: UiRect::all(px(20)),
-                ..default()
-            },
-            children![
+            }
+            Children [
                 rotate_button("<", Direction::Left),
                 rotate_button(">", Direction::Right),
-            ],
-        )
+            ]
+        }
     }
 
-    fn rotate_button(caption: &str, direction: Direction) -> impl Bundle {
-        (
-            RotateCamera(direction),
-            Button,
+    fn rotate_button(text_caption: &'static str, direction: Direction) -> impl Scene {
+        bsn! {
+            RotateCamera(direction)
+            @FeathersButton {
+                @caption: bsn! { caption(text_caption) },
+            }
             Node {
                 width: px(40),
-                height: px(40),
-                border: UiRect::all(px(2)),
-                justify_content: JustifyContent::Center,
-                align_items: AlignItems::Center,
-                ..default()
-            },
-            BorderColor::all(Color::WHITE),
-            BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
-            children![Text::new(caption)],
-        )
+            }
+        }
     }
 }
 
@@ -148,10 +151,12 @@ struct CameraPosition {
     pos: UVec2,
 }
 
-#[derive(Component)]
+#[derive(Component, Clone, Default, PartialEq)]
 struct RotateCamera(Direction);
 
+#[derive(Clone, Default, PartialEq)]
 enum Direction {
+    #[default]
     Left,
     Right,
 }
@@ -178,27 +183,25 @@ fn set_camera_viewports(
     }
 }
 
-fn button_system(
-    interaction_query: Query<
-        (&Interaction, &ComputedUiTargetCamera, &RotateCamera),
-        (Changed<Interaction>, With<Button>),
-    >,
+fn on_activate_rotate_camera(
+    event: On<Activate>,
+    button_query: Query<(&ComputedUiTargetCamera, &RotateCamera), With<FeathersButton>>,
     mut camera_query: Query<&mut Transform, With<Camera>>,
 ) {
-    for (interaction, computed_target, RotateCamera(direction)) in &interaction_query {
-        if let Interaction::Pressed = *interaction {
-            // Since TargetCamera propagates to the children, we can use it to find
-            // which side of the screen the button is on.
-            if let Some(mut camera_transform) = computed_target
-                .get()
-                .and_then(|camera| camera_query.get_mut(camera).ok())
-            {
-                let angle = match direction {
-                    Direction::Left => -0.1,
-                    Direction::Right => 0.1,
-                };
-                camera_transform.rotate_around(Vec3::ZERO, Quat::from_axis_angle(Vec3::Y, angle));
-            }
-        }
+    let Ok((computed_target, RotateCamera(direction))) = button_query.get(event.entity) else {
+        return;
+    };
+
+    // Since TargetCamera propagates to the children, we can use it to find
+    // which side of the screen the button is on.
+    if let Some(mut camera_transform) = computed_target
+        .get()
+        .and_then(|camera| camera_query.get_mut(camera).ok())
+    {
+        let angle = match direction {
+            Direction::Left => -0.1,
+            Direction::Right => 0.1,
+        };
+        camera_transform.rotate_around(Vec3::ZERO, Quat::from_axis_angle(Vec3::Y, angle));
     }
 }


### PR DESCRIPTION
# Objective

- Part of #24112

## Solution

- A straightforward port of the regular ui `Button`s to `FeathersButton`s

## Testing

- cargo run --example split_screen --features="bevy_feathers"
---

## Showcase

<img width="1281" height="750" alt="Screenshot 2026-07-27 at 9 02 00 AM" src="https://github.com/user-attachments/assets/f43f284d-0f07-49d7-981b-07a877ec1dea" />
