### PR TITLE
Remove camera `Changed` filter in `extract_ui_camera_view` as it's insufficient

### DIFF
--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -1133,55 +1133,19 @@ pub fn extract_ui_camera_view(
             (
                 Entity,
                 RenderEntity,
-                Ref<Camera>,
-                Option<Ref<UiAntiAlias>>,
-                Option<Ref<BoxShadowSamples>>,
+                &Camera,
+                Option<&UiAntiAlias>,
+                Option<&BoxShadowSamples>,
             ),
             Or<(With<Camera2d>, With<Camera3d>)>,
-        >,
-    >,
-    changed_query: Extract<
-        Query<
-            Entity,
-            Or<(
-                Changed<Camera>,
-                Changed<UiAntiAlias>,
-                Changed<BoxShadowSamples>,
-                Changed<Camera2d>,
-                Changed<Camera3d>,
-            )>,
         >,
     >,
     main_pass_formats: Res<CameraMainPassTextureFormats>,
     mut live_entities: Local<HashSet<RetainedViewEntity>>,
     mut cached_ui_view_data: Local<MainEntityHashMap<CachedUiViewData>>,
-    (
-        mut removed_cameras_query,
-        mut removed_ui_anti_alias_query,
-        mut removed_box_shadow_samples_query,
-        mut removed_cameras_2d_query,
-        mut removed_cameras_3d_query,
-    ): (
-        Extract<RemovedComponents<Camera>>,
-        Extract<RemovedComponents<UiAntiAlias>>,
-        Extract<RemovedComponents<BoxShadowSamples>>,
-        Extract<RemovedComponents<Camera2d>>,
-        Extract<RemovedComponents<Camera3d>>,
-    ),
-    mut changed_cameras: Local<MainEntityHashSet>,
+    mut removed_cameras_query: Extract<RemovedComponents<Camera>>,
     mut cameras_updated_this_frame: Local<MainEntityHashSet>,
 ) {
-    changed_cameras.clear();
-    for main_entity in changed_query
-        .iter()
-        .chain(removed_ui_anti_alias_query.read())
-        .chain(removed_box_shadow_samples_query.read())
-        .chain(removed_cameras_2d_query.read())
-        .chain(removed_cameras_3d_query.read())
-    {
-        changed_cameras.insert(main_entity.into());
-    }
-
     cameras_updated_this_frame.clear();
     for (main_entity, render_entity, camera, ui_anti_alias, shadow_samples) in &query {
         let main_entity = MainEntity::from(main_entity);
@@ -1199,11 +1163,6 @@ pub fn extract_ui_camera_view(
         {
             cameras_updated_this_frame.insert(main_entity);
             transparent_render_phases.prepare_for_new_frame(retained_view_entity);
-
-            // If the camera hasn't changed, we're done.
-            if !changed_cameras.contains(&main_entity) {
-                continue;
-            }
 
             // use a projection matrix with the origin in the top left instead of the bottom left that comes with OrthographicProjection
             let projection_matrix = proj::orthographic(


### PR DESCRIPTION
# Objective

Fixes #25179

## Solution

Remove these `Changed` filters, since `ExtractedView` is reinserted every frame we cannot detect whether `target_format` has actually changed.

## Testing

`cargo r --example transmission`
