### PR TITLE
Fix incorrect samples range in the `box_shadow` example

### DIFF
--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -282,7 +282,7 @@ fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
                     Some(AppNumberInputI32::Samples),
                     app_settings.samples as i32,
                     NumberInputPrecision(0),
-                    1..15
+                    0..15
                 ),
                 // Reset button
                 @FeathersButton {


### PR DESCRIPTION
# Objective

The label for the box_shadow examples samples input says 0..15 but the input takes a range of 1..15.

## Solution

Changed the input to take a range from 0..15.

## Testing

```
cargo run --example box_shadow
```