### PR TITLE
Remove redundant `.chain()` call from `build_text_interop`

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -239,7 +239,6 @@ fn build_text_interop(app: &mut App) {
         PostUpdate,
         (
             widget::measure_text_system
-                .chain()
                 .after(detect_text_needs_rerender)
                 .after(bevy_text::load_font_assets_into_font_collection)
                 .in_set(UiSystems::Content)


### PR DESCRIPTION
# Objective
In `build_text_interop`, `chain` is called on `measure_text_system` by itself. 

## Solution

Remove the `.chain()` line.
