### PR TITLE
`MaterialNode` change detection fixes

### DIFF
--- a/crates/bevy_ui_render/src/ui_material_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_material_pipeline.rs
@@ -347,6 +347,18 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
             )>,
         >,
     >,
+    unfiltered_uinode_query: Extract<
+        Query<(
+            Entity,
+            &ComputedNode,
+            &ComputedStackIndex,
+            &UiGlobalTransform,
+            &MaterialNode<M>,
+            &InheritedVisibility,
+            Option<&CalculatedClip>,
+            &ComputedUiTargetCamera,
+        )>,
+    >,
     camera_map: Extract<UiCameraMap>,
     (
         mut removed_computed_node_query,
@@ -384,7 +396,8 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
     ) in uinode_query.iter().chain(
         nodes_to_reextract
             .into_iter()
-            .filter_map(|main_entity| uinode_query.get(main_entity.entity()).ok()),
+            .chain(removed_calculated_clip_query.read().map(MainEntity::from))
+            .filter_map(|main_entity| unfiltered_uinode_query.get(main_entity.entity()).ok()),
     ) {
         let main_entity = MainEntity::from(entity);
 
@@ -456,7 +469,6 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
         .chain(removed_ui_global_transform_query.read())
         .chain(removed_material_node_query.read())
         .chain(removed_inherited_visibility_query.read())
-        .chain(removed_calculated_clip_query.read())
         .chain(removed_computed_ui_target_camera_query.read())
     {
         let main_entity = MainEntity::from(main_entity);

--- a/crates/bevy_ui_render/src/ui_material_pipeline.rs
+++ b/crates/bevy_ui_render/src/ui_material_pipeline.rs
@@ -396,8 +396,9 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
     ) in uinode_query.iter().chain(
         nodes_to_reextract
             .into_iter()
-            .chain(removed_calculated_clip_query.read().map(MainEntity::from))
-            .filter_map(|main_entity| unfiltered_uinode_query.get(main_entity.entity()).ok()),
+            .map(|main_entity| main_entity.entity())
+            .chain(removed_calculated_clip_query.read())
+            .filter_map(|entity| unfiltered_uinode_query.get(entity).ok()),
     ) {
         let main_entity = MainEntity::from(entity);
 


### PR DESCRIPTION
# Objective

If a material hasn't finished loading, it is queued for reextraction by adding it to the `nodes_to_reextract_next_frame` set.

But `ui_node_query` in `extract_ui_material_nodes` only selects entities that pass at least one of its `Changed` filters. Since an asset finishing loading doesn't effect the component state, the material isn't guaranteed to be reextracted next frame.

Also, if `CalculatedClip` is removed from a `MaterialNode` entity, the `ExtractedUiMaterialNode` isn't updated but instead is deleted along with its corresponding render entity.

## Solution

Chain the removed `CalculatedClip` entities to the reextraction iterator and filter them both by an alternative unfiltered MaterialNode query. Also removed  `removed_calculated_clip_query` from the MaterialNodes cleanup iterator.