### PR TITLE
Extract gradients on removal of `CalculatedClip`.

### DIFF
--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -363,6 +363,19 @@ pub fn extract_gradients(
             )>,
         >,
     >,
+    unfilitered_gradients_query: Extract<
+        Query<(
+            Entity,
+            &ComputedNode,
+            &ComputedStackIndex,
+            &ComputedUiTargetCamera,
+            &ComputedUiRenderTargetInfo,
+            &UiGlobalTransform,
+            &InheritedVisibility,
+            Option<&CalculatedClip>,
+            AnyOf<(&BackgroundGradient, &BorderGradient)>,
+        )>,
+    >,
     (
         mut removed_computed_node_query,
         mut removed_computed_stack_index_query,
@@ -401,8 +414,11 @@ pub fn extract_gradients(
         inherited_visibility,
         clip,
         (gradient, gradient_border),
-    ) in &gradients_query
-    {
+    ) in gradients_query.iter().chain(
+        removed_calculated_clip_query
+            .read()
+            .filter_map(|entity| unfilitered_gradients_query.get(entity).ok()),
+    ) {
         let main_entity = MainEntity::from(entity);
 
         // If there were any previous gradients for this entity, despawn them.
@@ -649,7 +665,6 @@ pub fn extract_gradients(
         .chain(removed_computed_ui_render_target_info_query.read())
         .chain(removed_ui_global_transform_query.read())
         .chain(removed_inherited_visibility_query.read())
-        .chain(removed_calculated_clip_query.read())
         .chain(removed_background_gradient_query.read())
         .chain(removed_border_gradient_query.read())
     {


### PR DESCRIPTION
# Objective

Gradients need to be reextracted if their calculated clip component is removed. Instead their corresponding render entity is despawned.

## Solution

- Chain the removed CalculatedClip entities to the UI nodes changed query. 
-  Remove removed_calculated_clip_query from the cleanup iterator.

## Testing

Modified overflow example:

```rust
//! Simple example demonstrating overflow behavior.

use bevy::{color::palettes::css::*, prelude::*};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .add_systems(Update, update_outlines)
        .add_systems(Update, clear_ui_clipping)
        .run();
}

fn setup(mut commands: Commands) {
    commands.spawn(Camera2d);

    let text_style = TextFont::default();

    commands
        .spawn((
            Node {
                width: percent(100),
                height: percent(100),
                align_items: AlignItems::Center,
                justify_content: JustifyContent::Center,
                ..Default::default()
            },
            BackgroundColor(ANTIQUE_WHITE.into()),
        ))
        .with_children(|parent| {
            for overflow in [
                Overflow::visible(),
                Overflow::clip_x(),
                Overflow::clip_y(),
                Overflow::clip(),
            ] {
                parent
                    .spawn(Node {
                        flex_direction: FlexDirection::Column,
                        align_items: AlignItems::Center,
                        margin: UiRect::horizontal(px(25)),
                        ..Default::default()
                    })
                    .with_children(|parent| {
                        let label = format!("{overflow:#?}");
                        parent
                            .spawn((
                                Node {
                                    padding: UiRect::all(px(10)),
                                    margin: UiRect::bottom(px(25)),
                                    ..Default::default()
                                },
                                BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
                            ))
                            .with_children(|parent| {
                                parent.spawn((Text::new(label), text_style.clone()));
                            });
                        parent
                            .spawn((
                                Node {
                                    width: px(100),
                                    height: px(100),
                                    padding: UiRect {
                                        left: px(25),
                                        top: px(25),
                                        ..Default::default()
                                    },
                                    border: UiRect::all(px(5)),
                                    overflow,
                                    ..default()
                                },
                                BorderColor::all(Color::BLACK),
                                BackgroundColor(GRAY.into()),
                            ))
                            .with_children(|parent| {
                                parent.spawn((
                                    BackgroundGradient::from(RadialGradient {
                                        color_space: InterpolationColorSpace::Oklaba,
                                        stops: vec![
                                            RED.into(),
                                            ColorStop::new(RED, percent(100. / 7.)),
                                            ColorStop::new(ORANGE, percent(100. / 7.)),
                                            ColorStop::new(ORANGE, percent(200. / 7.)),
                                            ColorStop::new(YELLOW, percent(200. / 7.)),
                                            ColorStop::new(YELLOW, percent(300. / 7.)),
                                            ColorStop::new(GREEN, percent(300. / 7.)),
                                            ColorStop::new(GREEN, percent(400. / 7.)),
                                            ColorStop::new(BLUE, percent(400. / 7.)),
                                            ColorStop::new(BLUE, percent(500. / 7.)),
                                            ColorStop::new(INDIGO, percent(500. / 7.)),
                                            ColorStop::new(INDIGO, percent(600. / 7.)),
                                            ColorStop::new(VIOLET, percent(600. / 7.)),
                                            VIOLET.into(),
                                        ],
                                        shape: RadialGradientShape::ClosestSide,
                                        position: UiPosition::CENTER,
                                    }),
                                    Node {
                                        min_width: px(100),
                                        min_height: px(100),
                                        ..default()
                                    },
                                    Interaction::default(),
                                    Outline {
                                        width: px(2),
                                        offset: px(2),
                                        color: Color::NONE,
                                    },
                                ));
                            });
                    });
            }
        });
}

fn update_outlines(mut outlines_query: Query<(&mut Outline, Ref<Interaction>)>) {
    for (mut outline, interaction) in outlines_query.iter_mut() {
        if interaction.is_changed() {
            outline.color = match *interaction {
                Interaction::Pressed => RED.into(),
                Interaction::Hovered => WHITE.into(),
                Interaction::None => Color::NONE,
            };
        }
    }
}

fn clear_ui_clipping(time: Res<Time>, mut query: Query<&mut Node>) {
    if 5. < time.elapsed_secs() {
        for mut node in query.iter_mut() {
            node.overflow = Overflow::visible();
        }
    }
}
```

Replace `examples\ui\scroll_and_overflow\overflow.rs` then run:
```
cargo run --example overflow
```

The modfied example displays four gradients, three of them clipped:

<img width="1296" height="229" alt="image" src="https://github.com/user-attachments/assets/5f84d4cf-2563-4c15-b0c4-f3e4cca53cf1" />

After five seconds have passed, the `clear_ui_clipping` system removes the clipping on the gradients by setting `Overflow::visible()` on every UI node. 

On main you should see that the three clipped gradient nodes disappear, leaving only the gradient on the left unclipped.
With this PR the three gradients should become completely visible with no clipping.




