### PR TITLE
Trigger `ArchetypeCreated` directly instead of queuing it

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -23,7 +23,7 @@ use crate::{
     bundle::BundleId,
     component::{ComponentId, Components, RequiredComponentConstructor, StorageType},
     entity::{Entity, EntityLocation},
-    event::Event,
+    event::{Event, EventKey},
     observer::Observers,
     query::DebugCheckedUnwrap,
     storage::{ImmutableSparseSet, SparseArray, SparseSet, TableId, TableRow},
@@ -37,8 +37,14 @@ use core::{
 use nonmax::NonMaxU32;
 
 #[derive(Event)]
-#[expect(dead_code, reason = "Prepare for the upcoming Query as Entities")]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "Prepare for the upcoming Query as Entities")
+)]
 pub(crate) struct ArchetypeCreated(pub ArchetypeId);
+
+pub(crate) const ARCHETYPE_CREATED: EventKey =
+    EventKey(ComponentId::new(crate::component::ARCHETYPE_CREATED));
 
 /// An opaque location within a [`Archetype`].
 ///

--- a/crates/bevy_ecs/src/bundle/insert.rs
+++ b/crates/bevy_ecs/src/bundle/insert.rs
@@ -5,13 +5,13 @@ use core::ptr::NonNull;
 use crate::{
     archetype::{
         Archetype, ArchetypeAfterBundleInsert, ArchetypeCreated, ArchetypeId, Archetypes,
-        ComponentStatus,
+        ComponentStatus, ARCHETYPE_CREATED,
     },
     bundle::{ArchetypeMoveType, Bundle, BundleId, BundleInfo, DynamicBundle, InsertMode},
     change_detection::{MaybeLocation, Tick},
     component::{Components, StorageType},
     entity::{Entities, Entity, EntityLocation},
-    event::EntityComponentsTrigger,
+    event::{EntityComponentsTrigger, GlobalTrigger},
     lifecycle::{Add, Discard, Insert, ADD, DISCARD, INSERT},
     observer::Observers,
     query::DebugCheckedUnwrap as _,
@@ -116,7 +116,16 @@ impl<'w> BundleInserter<'w> {
             // SAFETY:
             // - we have exclusive ownership of the world and hold no references to command queue or component data
             // - as this goes through `DeferredWorld`, our pointers will not be invalidated
-            unsafe { inserter.world.into_deferred() }.trigger(ArchetypeCreated(new_archetype_id));
+            let mut world = unsafe { inserter.world.into_deferred() };
+            // SAFETY: the ARCHETYPE_CREATED event_key corresponds to the ArchetypeCreated event's type
+            unsafe {
+                world.trigger_raw(
+                    ARCHETYPE_CREATED,
+                    &mut ArchetypeCreated(new_archetype_id),
+                    &mut GlobalTrigger,
+                    MaybeLocation::caller(),
+                );
+            }
         }
         inserter
     }

--- a/crates/bevy_ecs/src/bundle/remove.rs
+++ b/crates/bevy_ecs/src/bundle/remove.rs
@@ -3,12 +3,12 @@ use bevy_ptr::ConstNonNull;
 use core::ptr::NonNull;
 
 use crate::{
-    archetype::{Archetype, ArchetypeCreated, ArchetypeId, Archetypes},
+    archetype::{Archetype, ArchetypeCreated, ArchetypeId, Archetypes, ARCHETYPE_CREATED},
     bundle::{Bundle, BundleId, BundleInfo},
     change_detection::MaybeLocation,
     component::{ComponentId, Components, StorageType},
     entity::{Entity, EntityLocation},
-    event::EntityComponentsTrigger,
+    event::{EntityComponentsTrigger, GlobalTrigger},
     lifecycle::{Discard, Remove, DISCARD, REMOVE},
     observer::Observers,
     relationship::RelationshipHookMode,
@@ -101,7 +101,19 @@ impl<'w> BundleRemover<'w> {
             // SAFETY:
             // - we have exclusive ownership of the world and hold no references to command queue or component data
             // - as this goes through `DeferredWorld`, our pointers will not be invalidated
-            unsafe { remover.world.into_deferred() }.trigger(ArchetypeCreated(new_archetype_id));
+            // SAFETY:
+            // - we have exclusive ownership of the world and hold no references to command queue or component data
+            // - as this goes through `DeferredWorld`, our pointers will not be invalidated
+            let mut world = unsafe { remover.world.into_deferred() };
+            // SAFETY: the ARCHETYPE_CREATED event_key corresponds to the ArchetypeCreated event's type
+            unsafe {
+                world.trigger_raw(
+                    ARCHETYPE_CREATED,
+                    &mut ArchetypeCreated(new_archetype_id),
+                    &mut GlobalTrigger,
+                    MaybeLocation::caller(),
+                );
+            }
         }
         Some(remover)
     }

--- a/crates/bevy_ecs/src/bundle/spawner.rs
+++ b/crates/bevy_ecs/src/bundle/spawner.rs
@@ -3,11 +3,11 @@ use core::ptr::NonNull;
 use bevy_ptr::{ConstNonNull, MovingPtr};
 
 use crate::{
-    archetype::{Archetype, ArchetypeCreated, ArchetypeId, SpawnBundleStatus},
+    archetype::{Archetype, ArchetypeCreated, ArchetypeId, SpawnBundleStatus, ARCHETYPE_CREATED},
     bundle::{Bundle, BundleId, BundleInfo, DynamicBundle, InsertMode},
     change_detection::{MaybeLocation, Tick},
     entity::{Entity, EntityAllocator, EntityLocation},
-    event::EntityComponentsTrigger,
+    event::{EntityComponentsTrigger, GlobalTrigger},
     lifecycle::{Add, Insert, ADD, INSERT},
     relationship::RelationshipHookMode,
     storage::Table,
@@ -69,7 +69,19 @@ impl<'w> BundleSpawner<'w> {
             // SAFETY:
             // - we have exclusive ownership of the world and hold no references to command queue or component data
             // - as this goes through `DeferredWorld`, our pointers will not be invalidated
-            unsafe { spawner.world.into_deferred() }.trigger(ArchetypeCreated(new_archetype_id));
+            // SAFETY:
+            // - we have exclusive ownership of the world and hold no references to command queue or component data
+            // - as this goes through `DeferredWorld`, our pointers will not be invalidated
+            let mut world = unsafe { spawner.world.into_deferred() };
+            // SAFETY: the ARCHETYPE_CREATED event_key corresponds to the ArchetypeCreated event's type
+            unsafe {
+                world.trigger_raw(
+                    ARCHETYPE_CREATED,
+                    &mut ArchetypeCreated(new_archetype_id),
+                    &mut GlobalTrigger,
+                    MaybeLocation::caller(),
+                );
+            }
         }
         spawner
     }

--- a/crates/bevy_ecs/src/bundle/tests.rs
+++ b/crates/bevy_ecs/src/bundle/tests.rs
@@ -1,6 +1,10 @@
 use crate::{
-    archetype::ArchetypeCreated, lifecycle::HookContext, prelude::*, world::DeferredWorld,
+    archetype::{Archetype, ArchetypeCreated, ArchetypeId},
+    lifecycle::HookContext,
+    prelude::*,
+    world::DeferredWorld,
 };
+use alloc::{vec, vec::Vec};
 
 #[derive(Component)]
 struct A;
@@ -253,6 +257,32 @@ fn new_archetype_created() {
     e.insert(A);
 
     assert_eq!(world.resource::<Count>().0, 3);
+}
+
+#[test]
+fn new_archetype_created_triggered_first() {
+    let mut world = World::new();
+    #[derive(Resource, Default)]
+    struct Log(Vec<(Option<ArchetypeId>, &'static str)>);
+    world.init_resource::<Log>();
+    world.add_observer(|t: On<ArchetypeCreated>, mut log: ResMut<Log>| {
+        log.0.push((Some(t.event().0), "Archetype created"));
+    });
+    world.add_observer(|t: On<Insert, A>, mut log: ResMut<Log>| {
+        log.0.push((
+            t.trigger().new_archetype.map(Archetype::id),
+            "Bundle inserted",
+        ));
+    });
+
+    let archetype = world.spawn(A).archetype().id();
+    assert_eq!(
+        world.resource::<Log>().0,
+        vec![
+            (Some(archetype), "Archetype created"),
+            (Some(archetype), "Bundle inserted")
+        ]
+    );
 }
 
 #[derive(Bundle)]

--- a/crates/bevy_ecs/src/component/constants.rs
+++ b/crates/bevy_ecs/src/component/constants.rs
@@ -12,3 +12,5 @@ pub const REMOVE: usize = 3;
 pub const DESPAWN: usize = 4;
 /// `usize` of the [`IsResource`](crate::resource::IsResource) component used to mark entities with resources.
 pub const IS_RESOURCE: usize = 5;
+/// `usize` for [`ArchetypeCreated`](crate::archetype::ArchetypeCreated) component used as an observer event key.
+pub(crate) const ARCHETYPE_CREATED: usize = 6;

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -30,7 +30,7 @@ pub use identifier::WorldId;
 pub use spawn_batch::*;
 
 use crate::{
-    archetype::{ArchetypeId, Archetypes},
+    archetype::{ArchetypeCreated, ArchetypeId, Archetypes, ARCHETYPE_CREATED},
     bundle::{
         Bundle, BundleId, BundleInfo, BundleInserter, BundleSpawner, Bundles, DynamicBundle,
         InsertMode, NoBundleEffect,
@@ -170,6 +170,9 @@ impl World {
 
         let is_resource = self.register_component::<IsResource>();
         assert_eq!(IS_RESOURCE, is_resource);
+
+        let archetype_created = self.register_event_key::<ArchetypeCreated>();
+        assert_eq!(ARCHETYPE_CREATED, archetype_created);
 
         // This sets up `Disabled` as a disabling component, via the FromWorld impl
         self.init_resource::<DefaultQueryFilters>();


### PR DESCRIPTION
# Objective

Ensure the `ArchetypeCreated` event is triggered before any lifecycle events that involve that archetype, and improve the performance of triggering it.  

It currently uses `DeferredWorld::trigger`, which queues a `Command` to trigger the event.  This means it is not triggered until commands are flushed, which happens *after* any lifecycle events that use the new archetype.  Using the command buffer also adds some additional overhead to copy the command data and call a function pointer.  

## Solution

Use `DeferredWorld::trigger_raw` instead of `DeferredWorld::trigger`.  

This requires an `EventKey`, and `register_event_key` requires `&mut World`, so preregister the key like we do with lifecycle events.  
