### PR TITLE
`MenuButton` should use `ui_widgets::Button` instead of `ui::widgets::Button` (Extra Item 4)

### DIFF
--- a/crates/bevy_ui_widgets/src/menu.rs
+++ b/crates/bevy_ui_widgets/src/menu.rs
@@ -54,9 +54,9 @@ use bevy_input_focus::{
 use bevy_log::warn;
 use bevy_picking::events::{Cancel, Click, DragEnd, Pointer, Press, Release};
 use bevy_reflect::Reflect;
-use bevy_ui::{widget::Button, InteractionDisabled, Pressed, UiSystems};
+use bevy_ui::{InteractionDisabled, Pressed, UiSystems};
 
-use crate::{text_input::text_input_autoscroll_system, Activate, ActivateOnPress};
+use crate::{text_input::text_input_autoscroll_system, Activate, ActivateOnPress, Button};
 
 /// Action type for [`MenuEvent`].
 #[derive(Clone, Copy, Debug, Reflect)]


### PR DESCRIPTION
# Objective

- Part of #24112 

## Solution

- I’m pretty sure this is a bug, but basically when drafting a PR to officially deprecate `Button`, I noticed the usage of ui::Button in this widget module. Since `MenuButton` also requires `ActivateOnPress`, I’m pretty sure this should be referring to `ui_widgets::Button`.

The only usage of `Button` in this file, from line 407
```rust
/// Headless menu button widget. This is meant to be combined with the `Button` component, and
/// adds a few more key codes - arrow keys to open the popup.
#[derive(Component, Default, Debug, Clone)]
#[require(
    AccessibilityNode(accesskit::Node::new(Role::Button)),
    Button,
    ActivateOnPress
)]
#[derive(Reflect)]
#[reflect(Component)]
pub struct MenuButton;
```

## Testing

- `cargo run --example standard_widgets` has a `MenuButton`, it works correctly