### PR TITLE
Migrate `benches/bevy_scene/spawn.rs` to use `ui_widgets::Button` (Extra Item 5)

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -28,6 +28,7 @@ bevy_scene = { path = "../crates/bevy_scene" }
 bevy_tasks = { path = "../crates/bevy_tasks" }
 bevy_transform = { path = "../crates/bevy_transform" }
 bevy_ui = { path = "../crates/bevy_ui" }
+bevy_ui_widgets = { path = "../crates/bevy_ui_widgets" }
 bevy_platform = { path = "../crates/bevy_platform", default-features = false, features = [
   "std",
   "bytemuck",

--- a/benches/benches/bevy_scene/spawn.rs
+++ b/benches/benches/bevy_scene/spawn.rs
@@ -15,6 +15,7 @@ use bevy_asset::{
 use bevy_ecs::prelude::*;
 use bevy_scene::{prelude::*, ScenePatch};
 use bevy_ui::prelude::*;
+use bevy_ui_widgets::Button;
 
 criterion_group!(benches, spawn);
 


### PR DESCRIPTION
# Objective

- Part of #24112 

## Solution

- The `bevy_scene` bench was still using the old to-be-deprecated button. Just changed the import (had to add `ui_widgets` as a dependency).

## Testing

- I ran `cargo bench -p benches --bench scene` between both this branch and main and “no change in performance was detected” between the two for the ui scenes.