### PR TITLE
`LabelResolutionPlugin` registers label for `ui_widgets::Button` instead of `ui::widgets::Button` (Extra Item 6)

### DIFF
--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -43,6 +43,7 @@ bevy_shader = { path = "../bevy_shader", version = "0.20.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", version = "0.20.0-dev" }
 bevy_ui = { path = "../bevy_ui", version = "0.20.0-dev" }
 bevy_ui_render = { path = "../bevy_ui_render", version = "0.20.0-dev" }
+bevy_ui_widgets = { path = "../bevy_ui_widgets", version = "0.20.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.20.0-dev", optional = true }
 bevy_window = { path = "../bevy_window", version = "0.20.0-dev" }
 bevy_state = { path = "../bevy_state", version = "0.20.0-dev" }

--- a/crates/bevy_dev_tools/src/inspection/label_resolution.rs
+++ b/crates/bevy_dev_tools/src/inspection/label_resolution.rs
@@ -21,9 +21,10 @@ use bevy_platform::collections::HashMap;
 use bevy_sprite::{Sprite, Text2d};
 use bevy_text::TextSpan;
 use bevy_ui::{
-    widget::{Button, ImageNode, Text, ViewportNode},
+    widget::{ImageNode, Text, ViewportNode},
     Node,
 };
+use bevy_ui_widgets::Button;
 use bevy_window::{Monitor, Window};
 use core::{
     any::TypeId,


### PR DESCRIPTION
# Objective

- Part of #24112 

## Solution

- `ui_widgets::Button` will replace `ui::widgets::Button` as Bevy’s “first-party” type for buttons, so use it instead in the `LabelResolutionPlugin`
- Had to add `ui_widgets` as a dependency to the dev tools crate for this. (If we prefer to just remove the entry to avoid the dependency add, LMK)

## Testing

- This doesn’t seem to be used anywhere so… I guess I’ll depend on ci for this one