### PR TITLE
Migrate `bsn` example to use `ui_widgets::Button` (Extra Item 7)

### DIFF
--- a/examples/scene/bsn.rs
+++ b/examples/scene/bsn.rs
@@ -1,5 +1,5 @@
 //! This example demonstrates how to use BSN to compose scenes.
-use bevy::{prelude::*, text::FontSourceTemplate};
+use bevy::{prelude::*, text::FontSourceTemplate, ui_widgets::Button};
 
 fn main() {
     App::new()


### PR DESCRIPTION
# Objective

- Part of #24112 

## Solution

- A most trivial import swap to use a `ui_widgets::Button`.

## Testing

- `cargo run --example bsn` works just fine!