### PR TITLE
fix(bevy_core_pipeline): remove early return in 2d main opaque pass

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/main_opaque_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_opaque_pass_2d_node.rs
@@ -36,10 +36,6 @@ pub fn main_opaque_pass_2d(
         return;
     };
 
-    if opaque_phase.is_empty() && alpha_mask_phase.is_empty() {
-        return;
-    }
-
     #[cfg(feature = "trace")]
     let _span = info_span!("main_opaque_pass_2d").entered();
 


### PR DESCRIPTION
# Objective

Fixes `clear_color` example that was broken due to #24850 by requiring 2d opaque passes to not early return, as referenced by [this](https://github.com/bevyengine/bevy/pull/24850#issuecomment-5098419221) comment.

## Solution

Removed the early return in `main_opaque_pass_2d()` such that it follows the same general shape as `main_opaque_pass_3d()`.
Again, this comes from @beicause's comment:
> > just a heads up, this PR breaks the `clear_color` example. Just confirmed on both macos and linux personally
>
> Both `opaque_pass_2d` and `transparent_pass_2d` skip render pass when there are no items. But at least one of them should always run to clear the texture.
>
> Although the reason to always run `transparent_pass_2d` could be that transparent objects are more common than opaque objects in 2D, I think it's better to make `opaque_pass_2d` always run to be consistent with `opaque_pass_3d`.


## Testing

Tested the aforementioned `clear_color` example which now works again as expected, along with the `2d_shapes` and `transparency_2d` examples.
