### PR TITLE
Change `QueryManyIter` to return `Result` instead of only matched items

### DIFF
--- a/_release-content/migration-guides/query_many_iter_results.md
+++ b/_release-content/migration-guides/query_many_iter_results.md
@@ -1,5 +1,5 @@
 ---
-title: `QueryManyIter` and all other `*iter_many*` iterators now iterate over `Result` instead of `QueryData::Item`.
+title: Query iterators from "many" entities now iterate over `Result` instead of `QueryData::Item`.
 pull_requests: [25200]
 ---
 
@@ -22,9 +22,9 @@ Likewise, the following parallel iterator methods now have `Result<QueryData::It
 instead of `QueryData::Item<'w, 's>` as the closure argument.
 
 - `QueryParManyIter::for_each`
-- `QueryParManyIter::for_each_init`, 
+- `QueryParManyIter::for_each_init`,
 - `QueryParManyUniqueIter::for_each`
-- `QueryParManyUniqueIter::for_each_init`, 
+- `QueryParManyUniqueIter::for_each_init`,
 
 These parallel iterators are created by the following methods.
 

--- a/_release-content/migration-guides/query_many_iter_results.md
+++ b/_release-content/migration-guides/query_many_iter_results.md
@@ -1,0 +1,121 @@
+---
+title: `QueryManyIter` and all other `*iter_many*` iterators now iterate over `Result` instead of `QueryData::Item`.
+pull_requests: [25200]
+---
+
+The following iterators now return `Result<QueryData::Item<'w, 's>, QueryEntityError>`
+instead of `QueryData::Item<'w, 's>` as the `Iterator::Item`.
+
+- `QueryManyIter`
+- `QueryManyUniqueIter`
+- `QuerySortedManyIter`
+
+These iterators are created by the following methods.
+
+- `Query::iter_many`
+- `Query::iter_many_mut`
+- `Query::iter_many_unique`
+- `Query::iter_many_unique_mut`
+- `QueryManyIter::sort*`
+
+Likewise, the following parallel iterator methods now have `Result<QueryData::Item<'w, 's>, QueryEntityError>`
+instead of `QueryData::Item<'w, 's>` as the closure argument.
+
+- `QueryParManyIter::for_each`
+- `QueryParManyIter::for_each_init`, 
+- `QueryParManyUniqueIter::for_each`
+- `QueryParManyUniqueIter::for_each_init`, 
+
+These parallel iterators are created by the following methods.
+
+- `Query::par_iter_many`
+- `Query::par_iter_many_unique`
+- `Query::par_iter_many_unique_mut`
+
+These changes were made to allow for full flexibility in handling not matched or not spawned entities.
+This allows easier debugging by making these errors visible through a panic or logging
+instead of only giving the option to silently ignore these errors.
+
+For `QueryManyIter` and `QueryManyUniqueIter` users can migrate using
+
+- `QueryManyIter::matched`
+- `QueryManyUniqueIter::matched`
+
+which provide the same behavior as before.
+
+```rust
+// 0.19
+fn my_system(entity_list: Res<MyEntityList>, my_component_query: Query<&MyComponent>) {
+    for my_component in my_component_query.iter_many(entity_list.iter()) {
+        // ...
+    }
+}
+
+// 0.20
+fn my_system(entity_list: Res<MyEntityList>, my_component_query: Query<&MyComponent>) {
+    for my_component in my_component_query.iter_many(entity_list.iter()).matched() {
+        // ...
+    }
+}
+
+// 0.19
+fn my_mutation_system(entity_list: Res<MyEntityList>, mut my_component_query: Query<&mut MyComponent>) {
+    let mut iter = my_component_query.iter_many_mut(entity_list.iter());
+    while let Some(my_component) in iter.fetch_next() {
+        // ...
+    }
+}
+
+// 0.20
+fn my_mutation_system(entity_list: Res<MyEntityList>, mut my_component_query: Query<&mut MyComponent>) {
+    let mut iter = my_component_query.iter_many_mut(entity_list.iter()).matched();
+    while let Some(my_component) in iter.fetch_next() {
+        // ...
+    }
+}
+```
+
+For `QuerySortedManyIter` you can only use `.flat_map(Result::ok)`.
+
+```rust
+// 0.19
+fn my_system(entity_list: Res<MyEntityList>, my_component_query: Query<&MyComponent>) {
+    for my_component in my_component_query.iter_many(entity_list.iter())
+        .sort::<&MyComponent>()
+    {
+        // ...
+    }
+}
+
+// 0.20
+fn my_system(entity_list: Res<MyEntityList>, my_component_query: Query<&MyComponent>) {
+    for my_component in my_component_query.iter_many(entity_list.iter())
+        .sort::<&MyComponent>()
+        .flat_map(Result::ok)
+    {
+        // ...
+    }
+}
+```
+
+For `QueryParManyIter` and `QueryParManyUniqueIter` you need to return early when there is an error
+to get the same `matched` behavior as before.
+
+```rust
+// 0.19
+fn my_system(entity_list: Res<MyEntityList>, my_component_query: Query<&MyComponent>) {
+    my_component_query.par_iter_many(entity_list.iter()).for_each(|my_component| {
+        // ...
+    });
+}
+
+// 0.20
+fn my_system(entity_list: Res<MyEntityList>, my_component_query: Query<&MyComponent>) {
+    my_component_query.par_iter_many(entity_list.iter()).for_each(|my_component| {
+        let Ok(my_component) = my_component else {
+            return;
+        };
+        // ...
+    });
+}
+```

--- a/crates/bevy_dev_tools/src/diagnostics_overlay.rs
+++ b/crates/bevy_dev_tools/src/diagnostics_overlay.rs
@@ -471,7 +471,9 @@ fn collapse_on_click_to_header(
         let Ok(children) = diagnostics_overlays.get_mut(child_of.get()) else {
             unreachable!("DiagnosticsOverlay has been tempered with. Do not despawn its children.");
         };
-        let mut lists_iter = diagnostics_overlay_contents.iter_many_mut(children.collection());
+        let mut lists_iter = diagnostics_overlay_contents
+            .iter_many_mut(children.collection())
+            .matched();
 
         let Some(mut node) = lists_iter.fetch_next() else {
             panic!(

--- a/crates/bevy_ecs/src/entity/entity_set.rs
+++ b/crates/bevy_ecs/src/entity/entity_set.rs
@@ -831,8 +831,10 @@ mod tests {
             .cloned();
 
         // With `iter_many_mut` collecting is not possible, because you need to drop each `Mut`/`&mut` before the next is retrieved.
-        let _results: Vec<Mut<Thing>> =
-            query.iter_many_unique_mut(&mut world, entity_set).collect();
+        let _results: Vec<Mut<Thing>> = query
+            .iter_many_unique_mut(&mut world, entity_set)
+            .unwrapped()
+            .collect();
     }
 
     #[test]

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -2151,7 +2151,6 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
         let query_lens = unsafe { query_lens_state.query_unchecked_manual(world) }
             .iter_many_inner(self.entity_iter);
         let mut keyed_query: Vec<_> = query_lens
-            // .map(|(key, entity)| (key, NeutralOrd(entity)))
             .map(|result| match result {
                 Ok((key, entity)) => Ok((key, NeutralOrd(entity))),
                 Err(e) => Err(NeutralOrd(e)),
@@ -2638,8 +2637,6 @@ impl<
     pub fn fetch_next(&mut self) -> Option<Result<D::Item<'_, 's>, QueryEntityError>> {
         let entity_result = self.entity_iter.next()?;
         // SAFETY:
-        // We have collected the entity_iter once to drop all internal lens query item
-        // references.
         // We are limiting the returned reference to self,
         // making sure this method cannot be called multiple times without getting rid
         // of any previously returned unique references first, thus preventing aliasing.
@@ -2662,8 +2659,6 @@ impl<
     pub fn fetch_next_back(&mut self) -> Option<Result<D::Item<'_, 's>, QueryEntityError>> {
         let entity_result = self.entity_iter.next_back()?;
         // SAFETY:
-        // We have collected the entity_iter once to drop all internal lens query item
-        // references.
         // We are limiting the returned reference to self,
         // making sure this method cannot be called multiple times without getting rid
         // of any previously returned unique references first, thus preventing aliasing.

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -3,10 +3,10 @@ use crate::{
     archetype::{Archetype, ArchetypeEntity, Archetypes},
     bundle::Bundle,
     change_detection::Tick,
-    entity::{ContainsEntity, Entities, Entity, EntityEquivalent, EntitySet, EntitySetIterator},
+    entity::{Entities, Entity, EntityEquivalent, EntitySet, EntitySetIterator},
     query::{
         ArchetypeFilter, ArchetypeQueryData, ContiguousQueryData, DebugCheckedUnwrap,
-        IterQueryData, QueryState, SingleEntityQueryData, StorageId,
+        IterQueryData, QueryEntityError, QueryState, SingleEntityQueryData, StorageId,
     },
     storage::{Table, TableRow, Tables},
     world::{
@@ -1457,7 +1457,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item = Entity>> Debug
 /// An [`Iterator`] over the query items generated from an iterator of [`Entity`]s.
 ///
 /// Items are returned in the order of the provided iterator.
-/// Entities that don't match the query are skipped.
+/// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
 ///
 /// This struct is created by the [`Query::iter_many`](crate::system::Query::iter_many) and [`Query::iter_many_mut`](crate::system::Query::iter_many_mut) methods.
 pub struct QueryManyIter<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
@@ -1507,77 +1507,81 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
     /// - If `D` does not impl `ReadOnlyQueryData`, then there must not be any other `Item`s alive for the current entity
     /// - If `D` does not impl `IterQueryData`, then there must not be any other `Item`s alive for *any* entity
     #[inline(always)]
-    unsafe fn fetch_next_aliased_unchecked(
-        entity_iter: impl Iterator<Item: EntityEquivalent>,
+    unsafe fn fetch_next_aliased_unchecked_internal(
+        entity_borrow: impl EntityEquivalent,
         entities: &'w Entities,
         tables: &'w Tables,
         archetypes: &'w Archetypes,
         fetch: &mut D::Fetch<'w>,
         filter: &mut F::Fetch<'w>,
         query_state: &'s QueryState<D, F>,
-    ) -> Option<D::Item<'w, 's>> {
-        for entity_borrow in entity_iter {
-            let entity = entity_borrow.entity();
-            let Ok(location) = entities.get_spawned(entity) else {
-                continue;
-            };
+    ) -> Result<D::Item<'w, 's>, QueryEntityError> {
+        let entity = entity_borrow.entity();
+        let location = entities.get_spawned(entity)?;
 
-            if !query_state
-                .matched_archetypes
-                .contains(location.archetype_id.index())
-            {
-                continue;
-            }
-
-            let archetype = archetypes.get(location.archetype_id).debug_checked_unwrap();
-            let table = tables.get(location.table_id).debug_checked_unwrap();
-
-            // SAFETY: `archetype` is from the world that `fetch/filter` were created for,
-            // `fetch_state`/`filter_state` are the states that `fetch/filter` were initialized with
-            unsafe {
-                D::set_archetype(fetch, &query_state.fetch_state, archetype, table);
-            }
-            // SAFETY: `table` is from the world that `fetch/filter` were created for,
-            // `fetch_state`/`filter_state` are the states that `fetch/filter` were initialized with
-            unsafe {
-                F::set_archetype(filter, &query_state.filter_state, archetype, table);
-            }
-
-            // SAFETY: set_archetype was called prior.
-            // `location.archetype_row` is an archetype index row in range of the current archetype, because if it was not, the match above would have `continue`d
-            if unsafe {
-                F::filter_fetch(
-                    &query_state.filter_state,
-                    filter,
-                    entity,
-                    location.table_row,
-                )
-            } {
-                // SAFETY:
-                // - set_archetype was called prior, `location.archetype_row` is an archetype index in range of the current archetype
-                // - Caller ensures there are no conflicting items alive
-                let item = unsafe {
-                    D::fetch(&query_state.fetch_state, fetch, entity, location.table_row)
-                };
-                if let Some(item) = item {
-                    return Some(item);
-                }
-            }
+        if !query_state
+            .matched_archetypes
+            .contains(location.archetype_id.index())
+        {
+            return Err(QueryEntityError::QueryDoesNotMatch(
+                entity,
+                location.archetype_id,
+            ));
         }
-        None
+
+        let archetype = archetypes.get(location.archetype_id).debug_checked_unwrap();
+        let table = tables.get(location.table_id).debug_checked_unwrap();
+
+        // SAFETY: `archetype` is from the world that `fetch/filter` were created for,
+        // `fetch_state`/`filter_state` are the states that `fetch/filter` were initialized with
+        unsafe {
+            D::set_archetype(fetch, &query_state.fetch_state, archetype, table);
+        }
+        // SAFETY: `table` is from the world that `fetch/filter` were created for,
+        // `fetch_state`/`filter_state` are the states that `fetch/filter` were initialized with
+        unsafe {
+            F::set_archetype(filter, &query_state.filter_state, archetype, table);
+        }
+
+        // SAFETY: set_archetype was called prior.
+        // `location.archetype_row` is an archetype index row in range of the current archetype, because if it was not, the match above would have `continue`d
+        if unsafe {
+            F::filter_fetch(
+                &query_state.filter_state,
+                filter,
+                entity,
+                location.table_row,
+            )
+        } && let Some(item) =
+            // SAFETY:
+            // - set_archetype was called prior, `location.archetype_row` is an archetype index in range of the current archetype
+            // - Caller ensures there are no conflicting items alive
+            unsafe {
+                D::fetch(&query_state.fetch_state, fetch, entity, location.table_row)
+            }
+        {
+            Ok(item)
+        } else {
+            Err(QueryEntityError::QueryDoesNotMatch(
+                entity,
+                location.archetype_id,
+            ))
+        }
     }
 
-    /// Get the next result from the query
-    #[inline(always)]
-    pub fn fetch_next(&mut self) -> Option<D::Item<'_, 's>> {
+    /// # Safety
+    ///
+    /// - If `D` does not impl `ReadOnlyQueryData`, then there must not be any other `Item`s alive for the current entity
+    /// - If `D` does not impl `IterQueryData`, then there must not be any other `Item`s alive for *any* entity
+    unsafe fn fetch_next_aliased_unchecked(
+        &mut self,
+    ) -> Option<Result<D::Item<'w, 's>, QueryEntityError>> {
         // SAFETY:
         // All arguments stem from self.
-        // We are limiting the returned reference to self,
-        // making sure this method cannot be called multiple times without getting rid
-        // of any previously returned unique references first, thus preventing aliasing.
-        unsafe {
-            Self::fetch_next_aliased_unchecked(
-                &mut self.entity_iter,
+        // The caller has to prevent aliasing.
+        Some(unsafe {
+            Self::fetch_next_aliased_unchecked_internal(
+                self.entity_iter.next()?,
                 self.entities,
                 self.tables,
                 self.archetypes,
@@ -1585,8 +1589,32 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
                 &mut self.filter,
                 self.query_state,
             )
-            .map(D::shrink)
+        })
+    }
+
+    /// Get the next result from the query
+    #[inline(always)]
+    pub fn fetch_next(&mut self) -> Option<Result<D::Item<'_, 's>, QueryEntityError>> {
+        // SAFETY:
+        // We are limiting the returned reference to self,
+        // making sure this method cannot be called multiple times without getting rid
+        // of any previously returned unique references first, thus preventing aliasing.
+        unsafe {
+            self.fetch_next_aliased_unchecked()
+                .map(|result| result.map(D::shrink))
         }
+    }
+
+    /// Creates an iterator which calls [`Result::unwrap`] on each element.
+    #[inline(always)]
+    pub fn unwrapped(self) -> QueryManyUnwrappedIter<Self> {
+        QueryManyUnwrappedIter(self)
+    }
+
+    /// Creates an iterator which skips entities that don't match the query.
+    #[inline(always)]
+    pub fn matched(self) -> QueryManyMatchedIter<Self> {
+        QueryManyMatchedIter(self)
     }
 
     /// Sorts all query items into a new iterator, using the query lens as a key.
@@ -1654,13 +1682,13 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
     /// // We can ensure that a query always returns in the same order.
     /// fn system_1(query: Query<(Entity, &PartIndex)>) {
     /// #   let entity_list: Vec<Entity> = Vec::new();
-    ///     let parts: Vec<(Entity, &PartIndex)> = query.iter_many(entity_list).sort::<&PartIndex>().collect();
+    ///     let parts: Result<Vec<(Entity, &PartIndex)>, _> = query.iter_many(entity_list).sort::<&PartIndex>().collect();
     /// }
     ///
     /// // We can freely rearrange query components in the key.
     /// fn system_2(query: Query<(&Length, &Width, &Height), With<PartMarker>>) {
     /// #   let entity_list: Vec<Entity> = Vec::new();
-    ///     for (length, width, height) in query.iter_many(entity_list).sort::<(&Height, &Length, &Width)>() {
+    ///     for (length, width, height) in query.iter_many(entity_list).sort::<(&Height, &Length, &Width)>().flat_map(Result::ok) {
     ///         println!("height: {height:?}, width: {width:?}, length: {length:?}")
     ///     }
     /// }
@@ -1675,7 +1703,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
     ///         .sort::<Entity>();
     ///
     ///     let mut scratch_value = 0;
-    ///     while let Some(mut part_value) = parent_query_iter.fetch_next_back()
+    ///     while let Some(mut part_value) = parent_query_iter.fetch_next_back().map(Result::unwrap)
     ///     {
     ///         // some order-dependent operation, here bitwise XOR
     ///         **part_value ^= scratch_value;
@@ -1694,12 +1722,17 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
         's,
         D,
         F,
-        impl ExactSizeIterator<Item = Entity> + DoubleEndedIterator + FusedIterator + 'w,
+        impl ExactSizeIterator<Item = Result<Entity, QueryEntityError>>
+            + DoubleEndedIterator
+            + FusedIterator
+            + 'w,
     >
     where
         for<'lw, 'ls> L::Item<'lw, 'ls>: Ord,
     {
-        self.sort_impl::<L>(|keyed_query| keyed_query.sort())
+        self.sort_impl::<L>(|keyed_query| {
+            keyed_query.sort();
+        })
     }
 
     /// Sorts all query items into a new iterator, using the query lens as a key.
@@ -1742,7 +1775,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
     /// // We perform an unstable sort by a Component with few values.
     /// fn system_1(query: Query<&Flying, With<PartMarker>>) {
     /// #   let entity_list: Vec<Entity> = Vec::new();
-    ///     let part_values: Vec<&Flying> = query.iter_many(entity_list).sort_unstable::<&Flying>().collect();
+    ///     let part_values: Vec<&Flying> = query.iter_many(entity_list).sort_unstable::<&Flying>().map(Result::unwrap).collect();
     /// }
     /// #
     /// # let mut schedule = Schedule::default();
@@ -1756,7 +1789,10 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
         's,
         D,
         F,
-        impl ExactSizeIterator<Item = Entity> + DoubleEndedIterator + FusedIterator + 'w,
+        impl ExactSizeIterator<Item = Result<Entity, QueryEntityError>>
+            + DoubleEndedIterator
+            + FusedIterator
+            + 'w,
     >
     where
         for<'lw, 'ls> L::Item<'lw, 'ls>: Ord,
@@ -1811,6 +1847,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
     ///     let part_values: Vec<&PartValue> = query
     ///         .iter_many(entity_list)
     ///         .sort_by::<&PartValue>(|value_1, value_2| value_1.total_cmp(*value_2))
+    ///         .map(Result::unwrap)
     ///         .collect();
     /// }
     /// #
@@ -1826,10 +1863,18 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
         's,
         D,
         F,
-        impl ExactSizeIterator<Item = Entity> + DoubleEndedIterator + FusedIterator + 'w,
+        impl ExactSizeIterator<Item = Result<Entity, QueryEntityError>>
+            + DoubleEndedIterator
+            + FusedIterator
+            + 'w,
     > {
         self.sort_impl::<L>(move |keyed_query| {
-            keyed_query.sort_by(|(key_1, _), (key_2, _)| compare(key_1, key_2));
+            keyed_query.sort_by(|result_1, result_2| match (result_1, result_2) {
+                (Ok((key_1, _)), Ok((key_2, _))) => compare(key_1, key_2),
+                (Ok(_), Err(_)) => Ordering::Greater,
+                (Err(_), Ok(_)) => Ordering::Less,
+                (Err(_), Err(_)) => Ordering::Equal,
+            });
         })
     }
 
@@ -1861,10 +1906,18 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
         's,
         D,
         F,
-        impl ExactSizeIterator<Item = Entity> + DoubleEndedIterator + FusedIterator + 'w,
+        impl ExactSizeIterator<Item = Result<Entity, QueryEntityError>>
+            + DoubleEndedIterator
+            + FusedIterator
+            + 'w,
     > {
         self.sort_impl::<L>(move |keyed_query| {
-            keyed_query.sort_unstable_by(|(key_1, _), (key_2, _)| compare(key_1, key_2));
+            keyed_query.sort_unstable_by(|result_1, result_2| match (result_1, result_2) {
+                (Ok((key_1, _)), Ok((key_2, _))) => compare(key_1, key_2),
+                (Ok(_), Err(_)) => Ordering::Greater,
+                (Err(_), Ok(_)) => Ordering::Less,
+                (Err(_), Err(_)) => Ordering::Equal,
+            });
         })
     }
 
@@ -1926,7 +1979,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
     /// fn system_1(query: Query<(Entity, &PartValue)>) {
     /// #   let entity_list: Vec<Entity> = Vec::new();
     ///     // Sort by the sines of the part values.
-    ///     let parts: Vec<(Entity, &PartValue)> = query
+    ///     let parts: Result<Vec<(Entity, &PartValue)>, _> = query
     ///         .iter_many(entity_list)
     ///         .sort_by_key::<&PartValue, _>(|value| value.sin() as usize)
     ///         .collect();
@@ -1945,6 +1998,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
     ///             )
     ///         })
     ///         .rev()
+    ///         .flat_map(Result::ok)
     ///         .collect();
     /// }
     /// # let mut schedule = Schedule::default();
@@ -1959,12 +2013,17 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
         's,
         D,
         F,
-        impl ExactSizeIterator<Item = Entity> + DoubleEndedIterator + FusedIterator + 'w,
+        impl ExactSizeIterator<Item = Result<Entity, QueryEntityError>>
+            + DoubleEndedIterator
+            + FusedIterator
+            + 'w,
     >
     where
         K: Ord,
     {
-        self.sort_impl::<L>(move |keyed_query| keyed_query.sort_by_key(|(lens, _)| f(lens)))
+        self.sort_impl::<L>(move |keyed_query| {
+            keyed_query.sort_by_key(|result| result.as_ref().ok().map(|(key, _)| f(key)));
+        })
     }
 
     /// Sorts all query items into a new iterator with a key extraction function over the query lens.
@@ -1995,13 +2054,16 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
         's,
         D,
         F,
-        impl ExactSizeIterator<Item = Entity> + DoubleEndedIterator + FusedIterator + 'w,
+        impl ExactSizeIterator<Item = Result<Entity, QueryEntityError>>
+            + DoubleEndedIterator
+            + FusedIterator
+            + 'w,
     >
     where
         K: Ord,
     {
         self.sort_impl::<L>(move |keyed_query| {
-            keyed_query.sort_unstable_by_key(|(lens, _)| f(lens));
+            keyed_query.sort_unstable_by_key(|result| result.as_ref().ok().map(|(key, _)| f(key)));
         })
     }
 
@@ -2033,12 +2095,17 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
         's,
         D,
         F,
-        impl ExactSizeIterator<Item = Entity> + DoubleEndedIterator + FusedIterator + 'w,
+        impl ExactSizeIterator<Item = Result<Entity, QueryEntityError>>
+            + DoubleEndedIterator
+            + FusedIterator
+            + 'w,
     >
     where
         K: Ord,
     {
-        self.sort_impl::<L>(move |keyed_query| keyed_query.sort_by_cached_key(|(lens, _)| f(lens)))
+        self.sort_impl::<L>(move |keyed_query| {
+            keyed_query.sort_by_cached_key(|result| result.as_ref().ok().map(|(key, _)| f(key)));
+        })
     }
 
     /// Shared implementation for the various `sort` methods.
@@ -2060,13 +2127,18 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
     /// called on [`QueryManyIter`] before.
     fn sort_impl<L: ReadOnlyQueryData + SingleEntityQueryData + 'w>(
         self,
-        f: impl FnOnce(&mut Vec<(L::Item<'_, '_>, NeutralOrd<Entity>)>),
+        sort: impl FnOnce(
+            &mut Vec<Result<(L::Item<'_, '_>, NeutralOrd<Entity>), NeutralOrd<QueryEntityError>>>,
+        ),
     ) -> QuerySortedManyIter<
         'w,
         's,
         D,
         F,
-        impl ExactSizeIterator<Item = Entity> + DoubleEndedIterator + FusedIterator + 'w,
+        impl ExactSizeIterator<Item = Result<Entity, QueryEntityError>>
+            + DoubleEndedIterator
+            + FusedIterator
+            + 'w,
     > {
         let world = self.world;
 
@@ -2079,15 +2151,19 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
         let query_lens = unsafe { query_lens_state.query_unchecked_manual(world) }
             .iter_many_inner(self.entity_iter);
         let mut keyed_query: Vec<_> = query_lens
-            .map(|(key, entity)| (key, NeutralOrd(entity)))
+            // .map(|(key, entity)| (key, NeutralOrd(entity)))
+            .map(|result| match result {
+                Ok((key, entity)) => Ok((key, NeutralOrd(entity))),
+                Err(e) => Err(NeutralOrd(e)),
+            })
             .collect();
-        f(&mut keyed_query);
+        sort(&mut keyed_query);
         // Re-collect into a `Vec` to eagerly drop the lens items.
         // They must be dropped before `fetch_next` is called since they may alias
         // with other data items if there are duplicate entities in `entity_iter`.
         let entity_iter = keyed_query
             .into_iter()
-            .map(|(.., entity)| entity.0)
+            .map(|result| result.map(|(.., entity)| entity.0).map_err(|error| error.0))
             .collect::<Vec<_>>()
             .into_iter();
         // SAFETY:
@@ -2108,17 +2184,19 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
 impl<'w, 's, D: QueryData, F: QueryFilter, I: DoubleEndedIterator<Item: EntityEquivalent>>
     QueryManyIter<'w, 's, D, F, I>
 {
-    /// Get the next result from the back of the query
-    #[inline(always)]
-    pub fn fetch_next_back(&mut self) -> Option<D::Item<'_, 's>> {
+    /// # Safety
+    ///
+    /// - If `D` does not impl `ReadOnlyQueryData`, then there must not be any other `Item`s alive for the current entity
+    /// - If `D` does not impl `IterQueryData`, then there must not be any other `Item`s alive for *any* entity
+    unsafe fn fetch_next_back_aliased_unchecked(
+        &mut self,
+    ) -> Option<Result<D::Item<'w, 's>, QueryEntityError>> {
         // SAFETY:
         // All arguments stem from self.
-        // We are limiting the returned reference to self,
-        // making sure this method cannot be called multiple times without getting rid
-        // of any previously returned unique references first, thus preventing aliasing.
-        unsafe {
-            Self::fetch_next_aliased_unchecked(
-                self.entity_iter.by_ref().rev(),
+        // The caller has to prevent aliasing.
+        Some(unsafe {
+            Self::fetch_next_aliased_unchecked_internal(
+                self.entity_iter.next_back()?,
                 self.entities,
                 self.tables,
                 self.archetypes,
@@ -2126,7 +2204,19 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: DoubleEndedIterator<Item: EntityEq
                 &mut self.filter,
                 self.query_state,
             )
-            .map(D::shrink)
+        })
+    }
+
+    /// Get the next result from the back of the query
+    #[inline(always)]
+    pub fn fetch_next_back(&mut self) -> Option<Result<D::Item<'_, 's>, QueryEntityError>> {
+        // SAFETY:
+        // We are limiting the returned reference to self,
+        // making sure this method cannot be called multiple times without getting rid
+        // of any previously returned unique references first, thus preventing aliasing.
+        unsafe {
+            self.fetch_next_back_aliased_unchecked()
+                .map(|result| result.map(D::shrink))
         }
     }
 }
@@ -2134,29 +2224,17 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: DoubleEndedIterator<Item: EntityEq
 impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>> Iterator
     for QueryManyIter<'w, 's, D, F, I>
 {
-    type Item = D::Item<'w, 's>;
+    type Item = Result<D::Item<'w, 's>, QueryEntityError>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         // SAFETY:
-        // All arguments stem from self.
         // It is safe to alias for ReadOnlyWorldQuery.
-        unsafe {
-            Self::fetch_next_aliased_unchecked(
-                &mut self.entity_iter,
-                self.entities,
-                self.tables,
-                self.archetypes,
-                &mut self.fetch,
-                &mut self.filter,
-                self.query_state,
-            )
-        }
+        unsafe { self.fetch_next_aliased_unchecked() }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (_, max_size) = self.entity_iter.size_hint();
-        (0, max_size)
+        self.entity_iter.size_hint()
     }
 }
 
@@ -2171,19 +2249,8 @@ impl<
     #[inline(always)]
     fn next_back(&mut self) -> Option<Self::Item> {
         // SAFETY:
-        // All arguments stem from self.
         // It is safe to alias for ReadOnlyWorldQuery.
-        unsafe {
-            Self::fetch_next_aliased_unchecked(
-                self.entity_iter.by_ref().rev(),
-                self.entities,
-                self.tables,
-                self.archetypes,
-                &mut self.fetch,
-                &mut self.filter,
-                self.query_state,
-            )
-        }
+        unsafe { self.fetch_next_back_aliased_unchecked() }
     }
 }
 
@@ -2193,17 +2260,189 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, I: Iterator<Item: EntityEquiv
 {
 }
 
-// SAFETY: Fetching unique entities maintains uniqueness.
-unsafe impl<'w, 's, F: QueryFilter, I: EntitySetIterator> EntitySetIterator
-    for QueryManyIter<'w, 's, Entity, F, I>
-{
-}
-
 impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>> Debug
     for QueryManyIter<'w, 's, D, F, I>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("QueryManyIter").finish()
+    }
+}
+
+/// An [`Iterator`] over the query items generated from an iterator of [`Entity`]s.
+///
+/// Items are returned in the order of the provided iterator.
+/// In case of a nonexisting entity or mismatched component, iteration will panic.
+///
+/// This struct is created by the [`QueryManyIter::unwrapped`] and [`QueryManyUniqueIter::unwrapped`] methods.
+pub struct QueryManyUnwrappedIter<I>(I);
+
+impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
+    QueryManyUnwrappedIter<QueryManyIter<'w, 's, D, F, I>>
+{
+    /// Get the next result from the query
+    #[inline(always)]
+    pub fn fetch_next(&mut self) -> Option<D::Item<'_, 's>> {
+        self.0.fetch_next().map(Result::unwrap)
+    }
+}
+
+impl<'w, 's, D: QueryData, F: QueryFilter, I: DoubleEndedIterator<Item: EntityEquivalent>>
+    QueryManyUnwrappedIter<QueryManyIter<'w, 's, D, F, I>>
+{
+    /// Get the next result from the back of the query
+    #[inline(always)]
+    pub fn fetch_next_back(&mut self) -> Option<D::Item<'_, 's>> {
+        self.0.fetch_next_back().map(Result::unwrap)
+    }
+}
+
+impl<T, E: Debug, I: Iterator<Item = Result<T, E>>> Iterator for QueryManyUnwrappedIter<I> {
+    type Item = T;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Result::unwrap)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<T, E: Debug, I: DoubleEndedIterator<Item = Result<T, E>>> DoubleEndedIterator
+    for QueryManyUnwrappedIter<I>
+{
+    #[inline(always)]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back().map(Result::unwrap)
+    }
+}
+
+impl<T, E: Debug, I: FusedIterator<Item = Result<T, E>>> FusedIterator
+    for QueryManyUnwrappedIter<I>
+{
+}
+
+// SAFETY: Fetching unique entities maintains uniqueness.
+unsafe impl<'w, 's, F: QueryFilter, I: EntitySetIterator> EntitySetIterator
+    for QueryManyUnwrappedIter<QueryManyIter<'w, 's, Entity, F, I>>
+{
+}
+
+// SAFETY: Fetching unique entities maintains uniqueness.
+unsafe impl<'w, 's, F: QueryFilter, I: EntitySetIterator> EntitySetIterator
+    for QueryManyUnwrappedIter<QueryManyUniqueIter<'w, 's, Entity, F, I>>
+{
+}
+
+impl<I> Debug for QueryManyUnwrappedIter<I> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QueryManyUnwrappedIter").finish()
+    }
+}
+
+/// An [`Iterator`] over the query items generated from an iterator of [`Entity`]s.
+///
+/// Items are returned in the order of the provided iterator.
+/// Entities that don't match the query are skipped.
+///
+/// This struct is created by the [`QueryManyIter::matched`] and [`QueryManyUniqueIter::matched`] methods.
+pub struct QueryManyMatchedIter<I>(I);
+
+impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item: EntityEquivalent>>
+    QueryManyMatchedIter<QueryManyIter<'w, 's, D, F, I>>
+{
+    /// Get the next result from the query
+    #[inline(always)]
+    pub fn fetch_next(&mut self) -> Option<D::Item<'_, 's>> {
+        loop {
+            // SAFETY:
+            // We are limiting the returned reference to self,
+            // making sure this method cannot be called multiple times without getting rid
+            // of any previously returned unique references first, thus preventing aliasing.
+            let next_option_result = unsafe {
+                self.0
+                    .fetch_next_aliased_unchecked()
+                    .map(|result| result.map(D::shrink))
+            };
+            if let Ok(next) = next_option_result? {
+                return Some(next);
+            }
+        }
+    }
+}
+
+impl<'w, 's, D: QueryData, F: QueryFilter, I: DoubleEndedIterator<Item: EntityEquivalent>>
+    QueryManyMatchedIter<QueryManyIter<'w, 's, D, F, I>>
+{
+    /// Get the next result from the back of the query
+    #[inline(always)]
+    pub fn fetch_next_back(&mut self) -> Option<D::Item<'_, 's>> {
+        loop {
+            // SAFETY:
+            // We are limiting the returned reference to self,
+            // making sure this method cannot be called multiple times without getting rid
+            // of any previously returned unique references first, thus preventing aliasing.
+            let next_option_result = unsafe {
+                self.0
+                    .fetch_next_back_aliased_unchecked()
+                    .map(|result| result.map(D::shrink))
+            };
+            if let Ok(next) = next_option_result? {
+                return Some(next);
+            }
+        }
+    }
+}
+
+impl<T, E: Debug, I: Iterator<Item = Result<T, E>>> Iterator for QueryManyMatchedIter<I> {
+    type Item = T;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Ok(next) = self.0.next()? {
+                return Some(next);
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, max) = self.0.size_hint();
+        (0, max)
+    }
+}
+
+impl<T, E: Debug, I: DoubleEndedIterator<Item = Result<T, E>>> DoubleEndedIterator
+    for QueryManyMatchedIter<I>
+{
+    #[inline(always)]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Ok(next) = self.0.next_back()? {
+                return Some(next);
+            }
+        }
+    }
+}
+
+impl<T, E: Debug, I: FusedIterator<Item = Result<T, E>>> FusedIterator for QueryManyMatchedIter<I> {}
+
+// SAFETY: Fetching unique entities maintains uniqueness.
+unsafe impl<'w, 's, F: QueryFilter, I: EntitySetIterator> EntitySetIterator
+    for QueryManyMatchedIter<QueryManyIter<'w, 's, Entity, F, I>>
+{
+}
+
+// SAFETY: Fetching unique entities maintains uniqueness.
+unsafe impl<'w, 's, F: QueryFilter, I: EntitySetIterator> EntitySetIterator
+    for QueryManyMatchedIter<QueryManyUniqueIter<'w, 's, Entity, F, I>>
+{
+}
+
+impl<I> Debug for QueryManyMatchedIter<I> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("QueryManyMatchedIter").finish()
     }
 }
 
@@ -2245,29 +2484,31 @@ impl<'w, 's, D: IterQueryData, F: QueryFilter, I: EntitySetIterator>
             this_run,
         ))
     }
+
+    /// Creates an iterator which calls [`Result::unwrap`] on each element.
+    #[inline(always)]
+    pub fn unwrapped(self) -> QueryManyUnwrappedIter<Self> {
+        QueryManyUnwrappedIter(self)
+    }
+
+    /// Creates an iterator which skips entities that don't match the query.
+    #[inline(always)]
+    pub fn matched(self) -> QueryManyMatchedIter<Self> {
+        QueryManyMatchedIter(self)
+    }
 }
 
 impl<'w, 's, D: IterQueryData, F: QueryFilter, I: EntitySetIterator> Iterator
     for QueryManyUniqueIter<'w, 's, D, F, I>
 {
-    type Item = D::Item<'w, 's>;
+    type Item = Result<D::Item<'w, 's>, QueryEntityError>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         // SAFETY:
         // - Entities are guaranteed to be unique, thus do not alias.
         // - `D: IterQueryData`
-        unsafe {
-            QueryManyIter::<'w, 's, D, F, I>::fetch_next_aliased_unchecked(
-                &mut self.0.entity_iter,
-                self.0.entities,
-                self.0.tables,
-                self.0.archetypes,
-                &mut self.0.fetch,
-                &mut self.0.filter,
-                self.0.query_state,
-            )
-        }
+        unsafe { self.0.fetch_next_aliased_unchecked() }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -2279,12 +2520,6 @@ impl<'w, 's, D: IterQueryData, F: QueryFilter, I: EntitySetIterator> Iterator
 // This is correct as [`QueryManyIter`] always returns `None` once exhausted.
 impl<'w, 's, D: IterQueryData, F: QueryFilter, I: EntitySetIterator> FusedIterator
     for QueryManyUniqueIter<'w, 's, D, F, I>
-{
-}
-
-// SAFETY: Fetching unique entities maintains uniqueness.
-unsafe impl<'w, 's, F: QueryFilter, I: EntitySetIterator> EntitySetIterator
-    for QueryManyUniqueIter<'w, 's, Entity, F, I>
 {
 }
 
@@ -2301,7 +2536,13 @@ impl<'w, 's, D: IterQueryData, F: QueryFilter, I: EntitySetIterator> Debug
 /// This struct is created by the [`sort`](QueryManyIter), [`sort_unstable`](QueryManyIter),
 /// [`sort_by`](QueryManyIter), [`sort_unstable_by`](QueryManyIter), [`sort_by_key`](QueryManyIter),
 /// [`sort_unstable_by_key`](QueryManyIter), and [`sort_by_cached_key`](QueryManyIter) methods of [`QueryManyIter`].
-pub struct QuerySortedManyIter<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item = Entity>> {
+pub struct QuerySortedManyIter<
+    'w,
+    's,
+    D: QueryData,
+    F: QueryFilter,
+    I: Iterator<Item = Result<Entity, QueryEntityError>>,
+> {
     entity_iter: I,
     entities: &'w Entities,
     tables: &'w Tables,
@@ -2310,8 +2551,13 @@ pub struct QuerySortedManyIter<'w, 's, D: QueryData, F: QueryFilter, I: Iterator
     query_state: &'s QueryState<D, F>,
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item = Entity>>
-    QuerySortedManyIter<'w, 's, D, F, I>
+impl<
+        'w,
+        's,
+        D: QueryData,
+        F: QueryFilter,
+        I: Iterator<Item = Result<Entity, QueryEntityError>>,
+    > QuerySortedManyIter<'w, 's, D, F, I>
 {
     /// # Safety
     /// - `world` must have permission to access any of the components registered in `query_state`.
@@ -2339,11 +2585,15 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item = Entity>>
 
     /// # Safety
     ///
-    /// - `entity` must stem from `self.entity_iter`
+    /// - `entity_result` must stem from `self.entity_iter`
     /// - If `D` does not impl `ReadOnlyQueryData`, then there must not be any other `Item`s alive for the current entity
     /// - If `D` does not impl `IterQueryData`, then there must not be any other `Item`s alive for *any* entity
     #[inline(always)]
-    unsafe fn fetch_next_aliased_unchecked(&mut self, entity: Entity) -> Option<D::Item<'w, 's>> {
+    unsafe fn fetch_next_aliased_unchecked(
+        &mut self,
+        entity_result: Result<Entity, QueryEntityError>,
+    ) -> Result<D::Item<'w, 's>, QueryEntityError> {
+        let entity = entity_result?;
         let (location, archetype, table);
         // SAFETY:
         // `tables` and `archetypes` belong to the same world that the [`QueryIter`]
@@ -2380,102 +2630,116 @@ impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item = Entity>>
                 location.table_row,
             )
         }
+        .ok_or(QueryEntityError::QueryDoesNotMatch(entity, archetype.id()))
     }
 
     /// Get the next result from the query
     #[inline(always)]
-    pub fn fetch_next(&mut self) -> Option<D::Item<'_, 's>> {
-        while let Some(entity) = self.entity_iter.next() {
-            // SAFETY:
-            // We have collected the entity_iter once to drop all internal lens query item
-            // references.
-            // We are limiting the returned reference to self,
-            // making sure this method cannot be called multiple times without getting rid
-            // of any previously returned unique references first, thus preventing aliasing.
-            // `entity` is passed from `entity_iter` the first time.
-            if let Some(item) = unsafe { self.fetch_next_aliased_unchecked(entity) } {
-                return Some(D::shrink(item));
-            }
-        }
-        None
-    }
-}
-
-impl<'w, 's, D: QueryData, F: QueryFilter, I: DoubleEndedIterator<Item = Entity>>
-    QuerySortedManyIter<'w, 's, D, F, I>
-{
-    /// Get the next result from the query
-    #[inline(always)]
-    pub fn fetch_next_back(&mut self) -> Option<D::Item<'_, 's>> {
-        while let Some(entity) = self.entity_iter.next_back() {
-            // SAFETY:
-            // We have collected the entity_iter once to drop all internal lens query item
-            // references.
-            // We are limiting the returned reference to self,
-            // making sure this method cannot be called multiple times without getting rid
-            // of any previously returned unique references first, thus preventing aliasing.
-            // `entity` is passed from `entity_iter` the first time.
-            if let Some(item) = unsafe { self.fetch_next_aliased_unchecked(entity) } {
-                return Some(D::shrink(item));
-            }
-        }
-        None
-    }
-}
-
-impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, I: Iterator<Item = Entity>> Iterator
-    for QuerySortedManyIter<'w, 's, D, F, I>
-{
-    type Item = D::Item<'w, 's>;
-
-    #[inline(always)]
-    fn next(&mut self) -> Option<Self::Item> {
-        while let Some(entity) = self.entity_iter.next() {
-            // SAFETY:
-            // It is safe to alias for ReadOnlyWorldQuery.
-            // `entity` is passed from `entity_iter` the first time.
-            if let Some(item) = unsafe { self.fetch_next_aliased_unchecked(entity) } {
-                return Some(D::shrink(item));
-            }
-        }
-        None
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let (min_size, max_size) = self.entity_iter.size_hint();
-        let archetype_query = D::IS_ARCHETYPAL;
-        let min_size = if archetype_query { min_size } else { 0 };
-        (min_size, max_size)
-    }
-}
-
-impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, I: DoubleEndedIterator<Item = Entity>>
-    DoubleEndedIterator for QuerySortedManyIter<'w, 's, D, F, I>
-{
-    #[inline(always)]
-    fn next_back(&mut self) -> Option<Self::Item> {
-        while let Some(entity) = self.entity_iter.next_back() {
-            // SAFETY:
-            // It is safe to alias for ReadOnlyWorldQuery.
-            // `entity` is passed from `entity_iter` the first time.
-            if let Some(item) = unsafe { self.fetch_next_aliased_unchecked(entity) } {
-                return Some(D::shrink(item));
-            }
-        }
-        None
+    pub fn fetch_next(&mut self) -> Option<Result<D::Item<'_, 's>, QueryEntityError>> {
+        let entity_result = self.entity_iter.next()?;
+        // SAFETY:
+        // We have collected the entity_iter once to drop all internal lens query item
+        // references.
+        // We are limiting the returned reference to self,
+        // making sure this method cannot be called multiple times without getting rid
+        // of any previously returned unique references first, thus preventing aliasing.
+        // `entity_result` is passed from `entity_iter` the first time.
+        let next = unsafe { self.fetch_next_aliased_unchecked(entity_result) };
+        Some(next.map(D::shrink))
     }
 }
 
 impl<
-        D: ReadOnlyQueryData + ArchetypeQueryData,
+        'w,
+        's,
+        D: QueryData,
         F: QueryFilter,
-        I: ExactSizeIterator<Item = Entity>,
+        I: DoubleEndedIterator<Item = Result<Entity, QueryEntityError>>,
+    > QuerySortedManyIter<'w, 's, D, F, I>
+{
+    /// Get the next result from the query
+    #[inline(always)]
+    pub fn fetch_next_back(&mut self) -> Option<Result<D::Item<'_, 's>, QueryEntityError>> {
+        let entity_result = self.entity_iter.next_back()?;
+        // SAFETY:
+        // We have collected the entity_iter once to drop all internal lens query item
+        // references.
+        // We are limiting the returned reference to self,
+        // making sure this method cannot be called multiple times without getting rid
+        // of any previously returned unique references first, thus preventing aliasing.
+        // `entity_result` is passed from `entity_iter` the first time.
+        let next = unsafe { self.fetch_next_aliased_unchecked(entity_result) };
+        Some(next.map(D::shrink))
+    }
+}
+
+impl<
+        'w,
+        's,
+        D: ReadOnlyQueryData,
+        F: QueryFilter,
+        I: Iterator<Item = Result<Entity, QueryEntityError>>,
+    > Iterator for QuerySortedManyIter<'w, 's, D, F, I>
+{
+    type Item = Result<D::Item<'w, 's>, QueryEntityError>;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        let entity_result = self.entity_iter.next()?;
+        // SAFETY:
+        // We have collected the entity_iter once to drop all internal lens query item
+        // references.
+        // We are limiting the returned reference to self,
+        // making sure this method cannot be called multiple times without getting rid
+        // of any previously returned unique references first, thus preventing aliasing.
+        // `entity_result` is passed from `entity_iter` the first time.
+        let next = unsafe { self.fetch_next_aliased_unchecked(entity_result) };
+        Some(next.map(D::shrink))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.entity_iter.size_hint()
+    }
+}
+
+impl<
+        'w,
+        's,
+        D: ReadOnlyQueryData,
+        F: QueryFilter,
+        I: DoubleEndedIterator<Item = Result<Entity, QueryEntityError>>,
+    > DoubleEndedIterator for QuerySortedManyIter<'w, 's, D, F, I>
+{
+    #[inline(always)]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let entity_result = self.entity_iter.next_back()?;
+        // SAFETY:
+        // We have collected the entity_iter once to drop all internal lens query item
+        // references.
+        // We are limiting the returned reference to self,
+        // making sure this method cannot be called multiple times without getting rid
+        // of any previously returned unique references first, thus preventing aliasing.
+        // `entity_result` is passed from `entity_iter` the first time.
+        let next = unsafe { self.fetch_next_aliased_unchecked(entity_result) };
+        Some(next.map(D::shrink))
+    }
+}
+
+impl<
+        D: ReadOnlyQueryData,
+        F: QueryFilter,
+        I: ExactSizeIterator<Item = Result<Entity, QueryEntityError>>,
     > ExactSizeIterator for QuerySortedManyIter<'_, '_, D, F, I>
 {
 }
 
-impl<'w, 's, D: QueryData, F: QueryFilter, I: Iterator<Item = Entity>> Debug
-    for QuerySortedManyIter<'w, 's, D, F, I>
+impl<
+        'w,
+        's,
+        D: QueryData,
+        F: QueryFilter,
+        I: Iterator<Item = Result<Entity, QueryEntityError>>,
+    > Debug for QuerySortedManyIter<'w, 's, D, F, I>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("QuerySortedManyIter").finish()
@@ -3254,57 +3518,85 @@ mod tests {
         let sort = query
             .iter_many(&world, entity_list)
             .sort::<Entity>()
+            .map(Result::unwrap)
             .collect::<Vec<_>>();
 
         let sort_unstable = query
             .iter_many(&world, entity_list)
             .sort_unstable::<Entity>()
+            .map(Result::unwrap)
             .collect::<Vec<_>>();
 
         let sort_by = query
             .iter_many(&world, entity_list)
             .sort_by::<Entity>(Ord::cmp)
+            .map(Result::unwrap)
             .collect::<Vec<_>>();
 
         let sort_unstable_by = query
             .iter_many(&world, entity_list)
             .sort_unstable_by::<Entity>(Ord::cmp)
+            .map(Result::unwrap)
             .collect::<Vec<_>>();
 
         let sort_by_key = query
             .iter_many(&world, entity_list)
             .sort_by_key::<Entity, _>(|&e| e)
+            .map(Result::unwrap)
             .collect::<Vec<_>>();
 
         let sort_unstable_by_key = query
             .iter_many(&world, entity_list)
             .sort_unstable_by_key::<Entity, _>(|&e| e)
+            .map(Result::unwrap)
             .collect::<Vec<_>>();
 
         let sort_by_cached_key = query
             .iter_many(&world, entity_list)
             .sort_by_cached_key::<Entity, _>(|&e| e)
+            .map(Result::unwrap)
             .collect::<Vec<_>>();
 
-        let mut sort_v2 = query.iter_many(&world, entity_list).collect::<Vec<_>>();
+        let mut sort_v2 = query
+            .iter_many(&world, entity_list)
+            .unwrapped()
+            .collect::<Vec<_>>();
         sort_v2.sort();
 
-        let mut sort_unstable_v2 = query.iter_many(&world, entity_list).collect::<Vec<_>>();
+        let mut sort_unstable_v2 = query
+            .iter_many(&world, entity_list)
+            .unwrapped()
+            .collect::<Vec<_>>();
         sort_unstable_v2.sort_unstable();
 
-        let mut sort_by_v2 = query.iter_many(&world, entity_list).collect::<Vec<_>>();
+        let mut sort_by_v2 = query
+            .iter_many(&world, entity_list)
+            .unwrapped()
+            .collect::<Vec<_>>();
         sort_by_v2.sort_by(Ord::cmp);
 
-        let mut sort_unstable_by_v2 = query.iter_many(&world, entity_list).collect::<Vec<_>>();
+        let mut sort_unstable_by_v2 = query
+            .iter_many(&world, entity_list)
+            .unwrapped()
+            .collect::<Vec<_>>();
         sort_unstable_by_v2.sort_unstable_by(Ord::cmp);
 
-        let mut sort_by_key_v2 = query.iter_many(&world, entity_list).collect::<Vec<_>>();
+        let mut sort_by_key_v2 = query
+            .iter_many(&world, entity_list)
+            .unwrapped()
+            .collect::<Vec<_>>();
         sort_by_key_v2.sort_by_key(|&e| e);
 
-        let mut sort_unstable_by_key_v2 = query.iter_many(&world, entity_list).collect::<Vec<_>>();
+        let mut sort_unstable_by_key_v2 = query
+            .iter_many(&world, entity_list)
+            .unwrapped()
+            .collect::<Vec<_>>();
         sort_unstable_by_key_v2.sort_unstable_by_key(|&e| e);
 
-        let mut sort_by_cached_key_v2 = query.iter_many(&world, entity_list).collect::<Vec<_>>();
+        let mut sort_by_cached_key_v2 = query
+            .iter_many(&world, entity_list)
+            .unwrapped()
+            .collect::<Vec<_>>();
         sort_by_cached_key_v2.sort_by_cached_key(|&e| e);
 
         assert_eq!(sort, sort_v2);

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -719,7 +719,8 @@ mod tests {
         world.spawn(B(0));
         {
             fn system(has_a: Query<Entity, With<A>>, has_a_and_b: Query<(&A, &B)>) {
-                assert_eq!(has_a_and_b.iter_many(&has_a).count(), 2);
+                assert_eq!(has_a_and_b.iter_many(&has_a).matched().count(), 2);
+                assert_eq!(has_a_and_b.iter_many(&has_a).count(), 3);
             }
             let mut system = IntoSystem::into_system(system);
             system.initialize(&mut world);
@@ -727,7 +728,7 @@ mod tests {
         }
         {
             fn system(has_a: Query<Entity, With<A>>, mut b_query: Query<&mut B>) {
-                let mut iter = b_query.iter_many_mut(&has_a);
+                let mut iter = b_query.iter_many_mut(&has_a).matched();
                 while let Some(mut b) = iter.fetch_next() {
                     b.0 = 1;
                 }
@@ -764,7 +765,7 @@ mod tests {
         let _: Option<&Foo> = q.iter(&world).next();
         let _: Option<[&Foo; 2]> = q.iter_combinations::<2>(&world).next();
         let _: Option<&Foo> = q.iter_manual(&world).next();
-        let _: Option<&Foo> = q.iter_many(&world, [e]).next();
+        let _: Option<&Foo> = q.iter_many(&world, [e]).next().map(Result::unwrap);
         q.iter(&world).for_each(|_: &Foo| ());
 
         let _: Option<&Foo> = q.get(&world, e).ok();
@@ -778,7 +779,7 @@ mod tests {
         let q = q.get_mut(&mut world).unwrap();
         let _: Option<&Foo> = q.iter().next();
         let _: Option<[&Foo; 2]> = q.iter_combinations::<2>().next();
-        let _: Option<&Foo> = q.iter_many([e]).next();
+        let _: Option<&Foo> = q.iter_many([e]).next().map(Result::unwrap);
         q.iter().for_each(|_: &Foo| ());
 
         let _: Option<&Foo> = q.get(e).ok();

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -2,6 +2,7 @@ use crate::{
     batching::BatchingStrategy,
     change_detection::Tick,
     entity::{EntityEquivalent, UniqueEntityEquivalentVec},
+    query::QueryEntityError,
     world::unsafe_world_cell::UnsafeWorldCell,
 };
 
@@ -190,7 +191,12 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityEquivalent + Sync>
     ///
     /// [`ComputeTaskPool`]: bevy_tasks::ComputeTaskPool
     #[inline]
-    pub fn for_each<FN: Fn(QueryItem<'w, 's, D>) + Send + Sync + Clone>(self, func: FN) {
+    pub fn for_each<
+        FN: Fn(Result<QueryItem<'w, 's, D>, QueryEntityError>) + Send + Sync + Clone,
+    >(
+        self,
+        func: FN,
+    ) {
         self.for_each_init(|| {}, |_, item| func(item));
     }
 
@@ -231,12 +237,13 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityEquivalent + Sync>
     ///     let mut queue: Parallel<usize> = Parallel::default();
     ///     // queue.borrow_local_mut() will get or create a thread_local queue for each task/thread;
     ///     query.par_iter_many(&entities).for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {
-    ///         **local_queue += some_expensive_operation(item);
+    ///         **local_queue += some_expensive_operation(item.unwrap());
     ///     });
     ///
     ///     // collect value from every thread
     ///     let final_value: usize = queue.iter_mut().map(|v| *v).sum();
     /// }
+    /// # bevy_ecs::system::assert_is_system(system);
     /// ```
     ///
     /// # Panics
@@ -247,7 +254,7 @@ impl<'w, 's, D: ReadOnlyQueryData, F: QueryFilter, E: EntityEquivalent + Sync>
     #[inline]
     pub fn for_each_init<FN, INIT, T>(self, init: INIT, func: FN)
     where
-        FN: Fn(&mut T, QueryItem<'w, 's, D>) + Send + Sync + Clone,
+        FN: Fn(&mut T, Result<QueryItem<'w, 's, D>, QueryEntityError>) + Send + Sync + Clone,
         INIT: Fn() -> T + Sync + Send + Clone,
     {
         let func = |mut init, item| {
@@ -350,7 +357,12 @@ impl<'w, 's, D: IterQueryData, F: QueryFilter, E: EntityEquivalent + Sync>
     ///
     /// [`ComputeTaskPool`]: bevy_tasks::ComputeTaskPool
     #[inline]
-    pub fn for_each<FN: Fn(QueryItem<'w, 's, D>) + Send + Sync + Clone>(self, func: FN) {
+    pub fn for_each<
+        FN: Fn(Result<QueryItem<'w, 's, D>, QueryEntityError>) + Send + Sync + Clone,
+    >(
+        self,
+        func: FN,
+    ) {
         self.for_each_init(|| {}, |_, item| func(item));
     }
 
@@ -391,12 +403,13 @@ impl<'w, 's, D: IterQueryData, F: QueryFilter, E: EntityEquivalent + Sync>
     ///     let mut queue: Parallel<usize> = Parallel::default();
     ///     // queue.borrow_local_mut() will get or create a thread_local queue for each task/thread;
     ///     query.par_iter_many_unique(&entities).for_each_init(|| queue.borrow_local_mut(),|local_queue, item| {
-    ///         **local_queue += some_expensive_operation(item);
+    ///         **local_queue += some_expensive_operation(item.unwrap());
     ///     });
     ///
     ///     // collect value from every thread
     ///     let final_value: usize = queue.iter_mut().map(|v| *v).sum();
     /// }
+    /// # bevy_ecs::system::assert_is_system(system);
     /// ```
     ///
     /// # Panics
@@ -407,7 +420,7 @@ impl<'w, 's, D: IterQueryData, F: QueryFilter, E: EntityEquivalent + Sync>
     #[inline]
     pub fn for_each_init<FN, INIT, T>(self, init: INIT, func: FN)
     where
-        FN: Fn(&mut T, QueryItem<'w, 's, D>) + Send + Sync + Clone,
+        FN: Fn(&mut T, Result<QueryItem<'w, 's, D>, QueryEntityError>) + Send + Sync + Clone,
         INIT: Fn() -> T + Sync + Send + Clone,
     {
         let func = |mut init, item| {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1255,7 +1255,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// Returns an [`Iterator`] over the read-only query items generated from an [`Entity`] list.
     ///
     /// Items are returned in the order of the list of entities.
-    /// Entities that don't match the query are skipped.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// If you need to iterate multiple times at once but get borrowing errors,
     /// consider using [`Self::update_archetypes`] followed by multiple [`Self::iter_many_manual`] calls.
@@ -1275,7 +1275,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// Returns an [`Iterator`] over the read-only query items generated from an [`Entity`] list.
     ///
     /// Items are returned in the order of the list of entities.
-    /// Entities that don't match the query are skipped.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// If `world` archetypes changed since [`Self::update_archetypes`] was last called,
     /// this will skip entities contained in new archetypes.
@@ -1298,7 +1298,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// Returns an iterator over the query items generated from an [`Entity`] list.
     ///
     /// Items are returned in the order of the list of entities.
-    /// Entities that don't match the query are skipped.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     #[inline]
     pub fn iter_many_mut<'w, 's, EntityList: IntoIterator<Item: EntityEquivalent>>(
         &'s mut self,
@@ -1311,7 +1311,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// Returns an [`Iterator`] over the unique read-only query items generated from an [`EntitySet`].
     ///
     /// Items are returned in the order of the list of entities.
-    /// Entities that don't match the query are skipped.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// # See also
     ///
@@ -1328,7 +1328,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// Returns an [`Iterator`] over the unique read-only query items generated from an [`EntitySet`].
     ///
     /// Items are returned in the order of the list of entities.
-    /// Entities that don't match the query are skipped.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// If `world` archetypes changed since [`Self::update_archetypes`] was last called,
     /// this will skip entities contained in new archetypes.
@@ -1352,7 +1352,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// Returns an iterator over the unique query items generated from an [`EntitySet`].
     ///
     /// Items are returned in the order of the list of entities.
-    /// Entities that don't match the query are skipped.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     #[inline]
     pub fn iter_many_unique_mut<'w, 's, EntityList: EntitySet>(
         &'s mut self,
@@ -1645,7 +1645,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         last_run: Tick,
         this_run: Tick,
     ) where
-        FN: Fn(T, D::Item<'w, 's>) -> T + Send + Sync + Clone,
+        FN: Fn(T, Result<D::Item<'w, 's>, QueryEntityError>) -> T + Send + Sync + Clone,
         INIT: Fn() -> T + Sync + Send + Clone,
         E: EntityEquivalent + Sync,
         D: IterQueryData,
@@ -1709,7 +1709,7 @@ impl<D: ReadOnlyQueryData, F: QueryFilter> QueryState<D, F> {
         last_run: Tick,
         this_run: Tick,
     ) where
-        FN: Fn(T, D::Item<'w, 's>) -> T + Send + Sync + Clone,
+        FN: Fn(T, Result<D::Item<'w, 's>, QueryEntityError>) -> T + Send + Sync + Clone,
         INIT: Fn() -> T + Sync + Send + Clone,
         E: EntityEquivalent + Sync,
     {

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -871,17 +871,15 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///     list: Vec<Entity>,
     /// }
     ///
-    /// fn error_system(
+    /// fn matching_system(
     ///     friends_query: Query<&Friends>,
     ///     counter_query: Query<&Counter>,
-    /// ) -> Result<(), BevyError> {
+    /// ) {
     ///     for friends in &friends_query {
-    ///         for counter_result in counter_query.iter_many(&friends.list) {
-    ///             let counter = counter_result?;
+    ///         for counter in counter_query.iter_many(&friends.list).matched() {
     ///             println!("Friend's counter: {}", counter.value);
     ///         }
     ///     }
-    ///     Ok(())
     /// }
     ///
     /// fn unwrapping_system(
@@ -895,19 +893,21 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///     }
     /// }
     ///
-    /// fn matching_system(
+    /// fn error_system(
     ///     friends_query: Query<&Friends>,
     ///     counter_query: Query<&Counter>,
-    /// ) {
+    /// ) -> Result<(), BevyError> {
     ///     for friends in &friends_query {
-    ///         for counter in counter_query.iter_many(&friends.list).matched() {
+    ///         for counter_result in counter_query.iter_many(&friends.list) {
+    ///             let counter = counter_result?;
     ///             println!("Friend's counter: {}", counter.value);
     ///         }
     ///     }
+    ///     Ok(())
     /// }
-    /// # bevy_ecs::system::assert_is_system::<(), Result<(), BevyError>, _>(error_system);
-    /// # bevy_ecs::system::assert_is_system(unwrapping_system);
     /// # bevy_ecs::system::assert_is_system(matching_system);
+    /// # bevy_ecs::system::assert_is_system(unwrapping_system);
+    /// # bevy_ecs::system::assert_is_system::<(), Result<(), BevyError>, _>(error_system);
     /// ```
     ///
     /// # See also

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -853,9 +853,10 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// Returns an [`Iterator`] over the read-only query items generated from an [`Entity`] list.
     ///
     /// Items are returned in the order of the list of entities, and may not be unique if the input
-    /// doesn't guarantee uniqueness. Entities that don't match the query are skipped.
+    /// doesn't guarantee uniqueness.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
@@ -870,17 +871,43 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///     list: Vec<Entity>,
     /// }
     ///
-    /// fn system(
+    /// fn error_system(
+    ///     friends_query: Query<&Friends>,
+    ///     counter_query: Query<&Counter>,
+    /// ) -> Result<(), BevyError> {
+    ///     for friends in &friends_query {
+    ///         for counter_result in counter_query.iter_many(&friends.list) {
+    ///             let counter = counter_result?;
+    ///             println!("Friend's counter: {}", counter.value);
+    ///         }
+    ///     }
+    ///     Ok(())
+    /// }
+    ///
+    /// fn unwrapping_system(
     ///     friends_query: Query<&Friends>,
     ///     counter_query: Query<&Counter>,
     /// ) {
     ///     for friends in &friends_query {
-    ///         for counter in counter_query.iter_many(&friends.list) {
+    ///         for counter in counter_query.iter_many(&friends.list).unwrapped() {
     ///             println!("Friend's counter: {}", counter.value);
     ///         }
     ///     }
     /// }
-    /// # bevy_ecs::system::assert_is_system(system);
+    ///
+    /// fn matching_system(
+    ///     friends_query: Query<&Friends>,
+    ///     counter_query: Query<&Counter>,
+    /// ) {
+    ///     for friends in &friends_query {
+    ///         for counter in counter_query.iter_many(&friends.list).matched() {
+    ///             println!("Friend's counter: {}", counter.value);
+    ///         }
+    ///     }
+    /// }
+    /// # bevy_ecs::system::assert_is_system::<(), Result<(), BevyError>, _>(error_system);
+    /// # bevy_ecs::system::assert_is_system(unwrapping_system);
+    /// # bevy_ecs::system::assert_is_system(matching_system);
     /// ```
     ///
     /// # See also
@@ -898,7 +925,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// Returns an iterator over the query items generated from an [`Entity`] list.
     ///
     /// Items are returned in the order of the list of entities, and may not be unique if the input
-    /// doesn't guarantee uniqueness. Entities that don't match the query are skipped.
+    /// doesn't guarantee uniqueness.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// # Examples
     ///
@@ -919,7 +947,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///     mut counter_query: Query<&mut Counter>,
     /// ) {
     ///     for friends in &friends_query {
-    ///         let mut iter = counter_query.iter_many_mut(&friends.list);
+    ///         let mut iter = counter_query.iter_many_mut(&friends.list).matched();
     ///         while let Some(mut counter) = iter.fetch_next() {
     ///             println!("Friend's counter: {}", counter.value);
     ///             counter.value += 1;
@@ -944,7 +972,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// This consumes the [`Query`] to return results with the actual "inner" world lifetime.
     ///
     /// Items are returned in the order of the list of entities, and may not be unique if the input
-    /// doesn't guarantee uniqueness. Entities that don't match the query are skipped.
+    /// doesn't guarantee uniqueness.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// # See also
     ///
@@ -969,7 +998,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
 
     /// Returns an [`Iterator`] over the unique read-only query items generated from an [`EntitySet`].
     ///
-    /// Items are returned in the order of the list of entities. Entities that don't match the query are skipped.
+    /// Items are returned in the order of the list of entities.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// # Example
     ///
@@ -1003,7 +1033,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///     counter_query: Query<&Counter>,
     /// ) {
     ///     for friends in &friends_query {
-    ///         for counter in counter_query.iter_many_unique(friends) {
+    ///         for counter in counter_query.iter_many_unique(friends).matched() {
     ///             println!("Friend's counter: {:?}", counter.value);
     ///         }
     ///     }
@@ -1025,7 +1055,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
 
     /// Returns an iterator over the unique query items generated from an [`EntitySet`].
     ///
-    /// Items are returned in the order of the list of entities. Entities that don't match the query are skipped.
+    /// Items are returned in the order of the list of entities.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// # Examples
     ///
@@ -1058,7 +1089,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///     mut counter_query: Query<&mut Counter>,
     /// ) {
     ///     for friends in &friends_query {
-    ///         for mut counter in counter_query.iter_many_unique_mut(friends) {
+    ///         for mut counter in counter_query.iter_many_unique_mut(friends).matched() {
     ///             println!("Friend's counter: {:?}", counter.value);
     ///             counter.value += 1;
     ///         }
@@ -1084,7 +1115,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// Returns an iterator over the unique query items generated from an [`EntitySet`].
     /// This consumes the [`Query`] to return results with the actual "inner" world lifetime.
     ///
-    /// Items are returned in the order of the list of entities. Entities that don't match the query are skipped.
+    /// Items are returned in the order of the list of entities.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// # Examples
     ///
@@ -1117,7 +1149,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///     mut counter_query: Query<&mut Counter>,
     /// ) {
     ///     let friends = friends_query.single().unwrap();
-    ///     for mut counter in counter_query.iter_many_unique_inner(friends) {
+    ///     for mut counter in counter_query.iter_many_unique_inner(friends).matched() {
     ///         println!("Friend's counter: {:?}", counter.value);
     ///         counter.value += 1;
     ///     }
@@ -1204,7 +1236,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// Returns an [`Iterator`] over the query items generated from an [`Entity`] list.
     ///
     /// Items are returned in the order of the list of entities, and may not be unique if the input
-    /// doesnn't guarantee uniqueness. Entities that don't match the query are skipped.
+    /// doesnn't guarantee uniqueness.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// # Safety
     ///
@@ -1225,7 +1258,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
 
     /// Returns an [`Iterator`] over the unique query items generated from an [`Entity`] list.
     ///
-    /// Items are returned in the order of the list of entities. Entities that don't match the query are skipped.
+    /// Items are returned in the order of the list of entities.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// # Safety
     ///
@@ -1348,7 +1382,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
 
     /// Returns a parallel iterator over the read-only query items generated from an [`Entity`] list.
     ///
-    /// Entities that don't match the query are skipped. Iteration order and thread assignment is not guaranteed.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
+    /// Iteration order and thread assignment is not guaranteed.
     ///
     /// If the `multithreaded` feature is disabled, iterating with this operates identically to [`Iterator::for_each`]
     /// on [`QueryManyIter`].
@@ -1378,7 +1413,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
 
     /// Returns a parallel iterator over the unique read-only query items generated from an [`EntitySet`].
     ///
-    /// Entities that don't match the query are skipped. Iteration order and thread assignment is not guaranteed.
+    /// Iteration order and thread assignment is not guaranteed.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// If the `multithreaded` feature is disabled, iterating with this operates identically to [`Iterator::for_each`]
     /// on [`QueryManyUniqueIter`].
@@ -1407,7 +1443,8 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
 
     /// Returns a parallel iterator over the unique query items generated from an [`EntitySet`].
     ///
-    /// Entities that don't match the query are skipped. Iteration order and thread assignment is not guaranteed.
+    /// Iteration order and thread assignment is not guaranteed.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is generated instead.
     ///
     /// If the `multithreaded` feature is disabled, iterating with this operates identically to [`Iterator::for_each`]
     /// on [`QueryManyUniqueIter`].

--- a/crates/bevy_light/src/lib.rs
+++ b/crates/bevy_light/src/lib.rs
@@ -501,7 +501,7 @@ pub fn check_dir_light_mesh_visibility(
     commands.queue(move |world: &mut World| {
         let mut query = world.query::<&mut ViewVisibility>();
         for entities in defer_queue.iter_mut() {
-            let mut iter = query.iter_many_mut(world, entities.iter());
+            let mut iter = query.iter_many_mut(world, entities.iter()).matched();
             while let Some(mut view_visibility) = iter.fetch_next() {
                 view_visibility.set_visible();
             }

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -70,7 +70,7 @@ pub fn sync_simple_transforms(
         });
     // Update orphaned entities.
     let mut query = query.p1();
-    let mut iter = query.iter_many_mut(orphaned.read());
+    let mut iter = query.iter_many_mut(orphaned.read()).matched();
     while let Some((transform, mut global_transform)) = iter.fetch_next() {
         if !transform.is_changed() && !global_transform.is_added() {
             *global_transform = GlobalTransform::from(*transform);
@@ -355,7 +355,7 @@ mod serial {
                 *global_transform = GlobalTransform::from(*transform);
             }
 
-            for (child, child_of) in child_query.iter_many(children) {
+            for (child, child_of) in child_query.iter_many(children).matched() {
                 assert_eq!(
                     child_of.parent(), entity,
                     "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
@@ -455,7 +455,7 @@ mod serial {
         };
 
         let Some(children) = children else { return };
-        for (child, child_of) in child_query.iter_many(children) {
+        for (child, child_of) in child_query.iter_many(children).matched() {
             assert_eq!(
             child_of.parent(), entity,
             "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
@@ -699,7 +699,8 @@ mod parallel {
             #[expect(unsafe_code, reason = "Mutating disjoint entities in parallel")]
             let children_iter = unsafe {
                 nodes.iter_many_unique_unsafe(UniqueEntitySlice::from_slice_unchecked(p_children))
-            };
+            }
+            .matched();
 
             let mut last_child = None;
             let new_children = children_iter.filter_map(

--- a/crates/bevy_ui/src/experimental/ghost_hierarchy.rs
+++ b/crates/bevy_ui/src/experimental/ghost_hierarchy.rs
@@ -47,6 +47,7 @@ impl<'w, 's> UiRootNodes<'w, 's> {
             .chain(self.root_ghost_node_query.iter().flat_map(|root_ghost| {
                 self.all_nodes_query
                     .iter_many(self.ui_children.iter_ui_children(root_ghost))
+                    .matched()
             }))
     }
 }
@@ -113,6 +114,7 @@ impl<'w, 's> UiChildren<'w, 's> {
                 .flat_map(|children| {
                     self.ghost_nodes_query
                         .iter_many(children)
+                        .matched()
                         .flat_map(|entity| {
                             core::iter::once(entity).chain(self.iter_ghost_nodes(entity))
                         })
@@ -232,7 +234,7 @@ mod tests {
         let mut system_state = SystemState::<(UiRootNodes, Query<&A>)>::new(world);
         let (ui_root_nodes, a_query) = system_state.get(world).unwrap();
 
-        let result: Vec<_> = a_query.iter_many(ui_root_nodes.iter()).collect();
+        let result: Vec<_> = a_query.iter_many(ui_root_nodes.iter()).matched().collect();
 
         assert_eq!([&A(1), &A(6), &A(8)], result.as_slice());
     }
@@ -267,6 +269,7 @@ mod tests {
 
         let result: Vec<_> = a_query
             .iter_many(ui_children.iter_ui_children(n1))
+            .matched()
             .collect();
 
         assert_eq!([&A(5), &A(4), &A(8), &A(10)], result.as_slice());

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -327,7 +327,7 @@ pub fn ui_focus_system(
     // set Pressed or Hovered on top nodes. as soon as a node with a `Block` focus policy is detected,
     // the iteration will stop on it because it "captures" the interaction.
     let mut hovered_nodes = hovered_nodes.iter();
-    let mut iter = node_query.iter_many_mut(hovered_nodes.by_ref());
+    let mut iter = node_query.iter_many_mut(hovered_nodes.by_ref()).matched();
     while let Some(node) = iter.fetch_next() {
         if let Some(mut interaction) = node.interaction {
             if mouse_clicked {
@@ -354,7 +354,7 @@ pub fn ui_focus_system(
     }
     // reset `Interaction` for the remaining lower nodes to `None`. those are the nodes that remain in
     // `moused_over_nodes` after the previous loop is exited.
-    let mut iter = node_query.iter_many_mut(hovered_nodes);
+    let mut iter = node_query.iter_many_mut(hovered_nodes).matched();
     while let Some(node) = iter.fetch_next() {
         if let Some(mut interaction) = node.interaction {
             // don't reset pressed nodes because they're handled separately

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -70,7 +70,9 @@ pub fn ui_stack_system(
     ui_stack.uinodes.clear();
     visited_root_nodes.clear();
 
-    for (id, maybe_global_zindex, maybe_zindex) in root_node_query.iter_many(ui_root_nodes.iter()) {
+    for (id, maybe_global_zindex, maybe_zindex) in
+        root_node_query.iter_many(ui_root_nodes.iter()).matched()
+    {
         root_nodes.push((
             id,
             (

--- a/crates/bevy_ui_widgets/src/radio.rs
+++ b/crates/bevy_ui_widgets/src/radio.rs
@@ -356,7 +356,7 @@ pub fn radio_self_update(
     };
 
     // Iterate the children of this radio group
-    let mut iter = q_radio.iter_many(children);
+    let mut iter = q_radio.iter_many(children).matched();
     while let Some(radio) = iter.fetch_next() {
         if radio == value_change.value {
             commands.entity(radio).insert(Checked);

--- a/examples/3d/order_independent_transparency.rs
+++ b/examples/3d/order_independent_transparency.rs
@@ -381,7 +381,7 @@ fn change_setting(
         if *group_setting != radio_group_setting {
             continue;
         }
-        for (entity, setting) in setting_q.iter_many(children) {
+        for (entity, setting) in setting_q.iter_many(children).matched() {
             if setting.0 == *new_app_setting {
                 commands.entity(entity).insert(Checked);
             } else {


### PR DESCRIPTION
# Objective

Fixes #24607

## Solution

The original solution created a modified copy of `QueryManyIter`, but that would induce some API bloat and compile times.

Instead, this PR now changes the signature of `QueryManyIter` to iterate over `Result<D::Item<'w, 's>, QueryEntityError>` instead of only matched `D::Item<'w, 's>`. To make the common cases of iterating only matched entities or unwrapping the errors easy, there are new `.matched()` and `.unwrapped()` methods. Similar changes have also been made to related unique and parallel iterators.

## Testing

- Existing unit and documentation test have been adjusted.
- You can run the tests with `cargo test -p bevy_ecs` and `cargo test -p bevy_ecs --doc`

---

## Showcase

This makes it possible to perform custom error handling when an entity does not match, which was not possible with `QueryManyIter`.
For example logging, returning errors or a panic (unwrap) when iterating many entities are all now possible.

<details>
  <summary>Click to view showcase (Example: return `BevyError`)</summary>

```rust
use bevy_ecs::prelude::*;

#[derive(Component)]
struct Counter {
    value: i32
}

// A component containing an entity list.
#[derive(Component)]
struct Friends {
    list: Vec<Entity>,
}

fn system(
    friends_query: Query<&Friends>,
    counter_query: Query<&Counter>,
) -> Result<(), BevyError> {
    for friends in &friends_query {
        for counter_result in counter_query.iter_many(&friends.list) {
            let counter = counter_result?;
            println!("Friend's counter: {}", counter.value);
        }
    }
    Ok(())
}
```

</details>
