### PR TITLE
Reextract box shadows on removal of `CalculatedClip`

### DIFF
--- a/crates/bevy_ui_render/src/box_shadow.rs
+++ b/crates/bevy_ui_render/src/box_shadow.rs
@@ -233,6 +233,19 @@ pub fn extract_shadows(
             )>,
         >,
     >,
+    unfiltered_box_shadow_query: Extract<
+        Query<(
+            Entity,
+            &ComputedNode,
+            &ComputedStackIndex,
+            &UiGlobalTransform,
+            &InheritedVisibility,
+            &BoxShadow,
+            Option<&CalculatedClip>,
+            &ComputedUiTargetCamera,
+            &ComputedUiRenderTargetInfo,
+        )>,
+    >,
     camera_map: Extract<UiCameraMap>,
     (
         mut removed_computed_node_query,
@@ -260,7 +273,11 @@ pub fn extract_shadows(
     let mut mapping = camera_map.get_mapper();
 
     for (entity, uinode, stack_index, transform, visibility, box_shadow, clip, camera, target) in
-        &box_shadow_query
+        box_shadow_query.iter().chain(
+            removed_calculated_clip_query
+                .read()
+                .filter_map(|entity| unfiltered_box_shadow_query.get(entity).ok()),
+        )
     {
         let main_entity = MainEntity::from(entity);
 
@@ -359,7 +376,6 @@ pub fn extract_shadows(
         .chain(removed_ui_global_transform_query.read())
         .chain(removed_inherited_visibility_query.read())
         .chain(removed_box_shadow_query.read())
-        .chain(removed_calculated_clip_query.read())
         .chain(removed_computed_ui_target_camera_query.read())
         .chain(removed_computed_ui_render_target_info_query.read())
     {


### PR DESCRIPTION
# Objective

`BoxShadow`s need to be reextracted if their calculated clip component is removed. Instead their corresponding render entity is despawned.

## Solution

Reextract `Boxshadow`s with removed `CalculatedClip` in `extract_shadows`.
Don't despawn the render entity on `CalculatedClip` removal.

## Testing

Modified overflow example:

```rust
//! Simple example demonstrating overflow behavior.

use bevy::{color::palettes::css::*, prelude::*};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .add_systems(Update, update_outlines)
        .run();
}

fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
    commands.spawn(Camera2d);

    let text_style = TextFont::default();

    let image = asset_server.load("branding/icon.png");

    commands
        .spawn((
            Node {
                width: percent(100),
                height: percent(100),
                align_items: AlignItems::Center,
                justify_content: JustifyContent::Center,
                ..Default::default()
            },
            BackgroundColor(ANTIQUE_WHITE.into()),
        ))
        .with_children(|parent| {
            for overflow in [
                Overflow::visible(),
                Overflow::clip_x(),
                Overflow::clip_y(),
                Overflow::clip(),
            ] {
                parent
                    .spawn(Node {
                        flex_direction: FlexDirection::Column,
                        align_items: AlignItems::Center,
                        margin: UiRect::horizontal(px(25)),
                        ..Default::default()
                    })
                    .with_children(|parent| {
                        let label = format!("{overflow:#?}");
                        parent
                            .spawn((
                                Node {
                                    padding: UiRect::all(px(10)),
                                    margin: UiRect::bottom(px(25)),
                                    ..Default::default()
                                },
                                BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
                            ))
                            .with_children(|parent| {
                                parent.spawn((Text::new(label), text_style.clone()));
                            });
                        parent
                            .spawn((
                                Node {
                                    width: px(100),
                                    height: px(100),
                                    padding: UiRect {
                                        left: px(25),
                                        top: px(25),
                                        ..Default::default()
                                    },
                                    border: UiRect::all(px(5)),
                                    overflow,
                                    ..default()
                                },
                                BorderColor::all(Color::BLACK),
                                BackgroundColor(GRAY.into()),
                            ))
                            .with_children(|parent| {
                                parent.spawn((
                                    ImageNode::new(image.clone()),
                                    Node {
                                        min_width: px(100),
                                        min_height: px(100),
                                        ..default()
                                    },
                                    Interaction::default(),
                                    Outline {
                                        width: px(2),
                                        offset: px(2),
                                        color: Color::NONE,
                                    },
                                ));
                            });
                    });
            }
        });
}

fn update_outlines(mut outlines_query: Query<(&mut Outline, Ref<Interaction>)>) {
    for (mut outline, interaction) in outlines_query.iter_mut() {
        if interaction.is_changed() {
            outline.color = match *interaction {
                Interaction::Pressed => RED.into(),
                Interaction::Hovered => WHITE.into(),
                Interaction::None => Color::NONE,
            };
        }
    }
}
```

Replace `examples\ui\scroll_and_overflow\overflow.rs`, then run:

```
cargo run --example overflow
```

The modfied example displays four red shows, three of them with clipping.

After five seconds have passed, the clear_ui_clipping system removes the clipping on the shadows by setting Overflow::visible() on every UI node.

On main you should see that the three clipped shadows disappear, leaving only the gradient on the left unclipped.
With this PR the three shadows should become completely visible with no clipping.