### PR TITLE
Don't panic when a wasm asset response body fails to read

### DIFF
--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -99,7 +99,12 @@ impl HttpWasmAssetReader {
             .map_err(js_value_to_err("convert fetch to Response"))?;
         match resp.status() {
             200 => {
-                let data = JsFuture::from(resp.array_buffer().unwrap()).await.unwrap();
+                let buffer = resp
+                    .array_buffer()
+                    .map_err(js_value_to_err("get Response ArrayBuffer"))?;
+                let data = JsFuture::from(buffer)
+                    .await
+                    .map_err(js_value_to_err("read Response body"))?;
                 let bytes = Uint8Array::new(&data).to_vec();
                 let reader = VecReader::new(bytes);
                 Ok(reader)


### PR DESCRIPTION
# Objective

Fix a crash that monitoring picked up from some of our users. These crashes can happen if the requests succeeds, but reading the body fails.

## Solution

Handle errors instead of calling `unwrap`.