### PR TITLE
Add adaptive arrow positioning to Popover

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5521,6 +5521,18 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "feathers_popover"
+path = "examples/ui/widgets/feathers_popover.rs"
+doc-scrape-examples = true
+required-features = ["bevy_feathers"]
+
+[package.metadata.example.feathers_popover]
+name = "Feathers Popover"
+description = "Demonstrates popover arrow placement and scrolling"
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "feathers_number_input"
 path = "examples/ui/widgets/feathers_number_input.rs"
 doc-scrape-examples = true

--- a/crates/bevy_feathers/src/assets/shaders/popover_arrow.wgsl
+++ b/crates/bevy_feathers/src/assets/shaders/popover_arrow.wgsl
@@ -1,0 +1,20 @@
+#import bevy_ui::ui_vertex_output::UiVertexOutput
+
+@group(1) @binding(0) var<uniform> fill_color: vec4<f32>;
+@group(1) @binding(1) var<uniform> border_color: vec4<f32>;
+@group(1) @binding(2) var<uniform> border_width: vec4<f32>;
+
+@fragment
+fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
+    let size = in.size;
+    let p = in.uv * size;
+    let slope = 0.5 * size.x / size.y;
+    let edge_distance =
+        (slope * p.y - abs(p.x - 0.5 * size.x)) / sqrt(slope * slope + 1.0);
+    let triangle_distance = min(edge_distance, p.y);
+    let coverage = smoothstep(-0.75, 0.75, triangle_distance);
+    let fill_mix = smoothstep(border_width.x - 0.5, border_width.x + 0.5, edge_distance);
+    let color = mix(border_color, fill_color, fill_mix);
+
+    return vec4<f32>(color.rgb, color.a * coverage);
+}

--- a/crates/bevy_feathers/src/controls/mod.rs
+++ b/crates/bevy_feathers/src/controls/mod.rs
@@ -11,6 +11,7 @@ mod disclosure_toggle;
 mod listview;
 mod menu;
 mod number_input;
+mod popover;
 mod radio;
 mod scrollbar;
 mod select;
@@ -29,6 +30,7 @@ pub use disclosure_toggle::*;
 pub use listview::*;
 pub use menu::*;
 pub use number_input::*;
+pub use popover::*;
 pub use radio::*;
 pub use scrollbar::*;
 pub use select::*;
@@ -67,6 +69,7 @@ impl Plugin for ControlsPlugin {
                 ColorSliderPlugin,
                 ColorSwatchPlugin,
             ),
+            FeathersPopoverPlugin,
         ));
     }
 }

--- a/crates/bevy_feathers/src/controls/popover.rs
+++ b/crates/bevy_feathers/src/controls/popover.rs
@@ -1,0 +1,566 @@
+//! Feathers visuals for popover callout arrows.
+
+use bevy_app::{Plugin, PostUpdate};
+use bevy_asset::{Asset, Assets, Handle};
+use bevy_color::ColorToComponents;
+use bevy_ecs::{prelude::*, VariantDefaults};
+use bevy_math::{Affine2, Vec2, Vec4};
+use bevy_picking::Pickable;
+use bevy_reflect::{prelude::ReflectDefault, Reflect, TypePath};
+use bevy_render::render_resource::AsBindGroup;
+use bevy_scene::prelude::*;
+use bevy_shader::ShaderRef;
+use bevy_ui::{
+    px, BackgroundColor, BorderColor, ComputedNode, Node, PositionType, UiGlobalTransform,
+    UiSystems, ZIndex,
+};
+use bevy_ui_render::{
+    ui_material::{MaterialNode, UiMaterial},
+    UiMaterialPlugin,
+};
+use bevy_ui_widgets::popover::{PopoverArrow, PopoverDirection, PopoverPlugin, PopoverSide};
+
+const ARROW_WIDTH: f32 = 16.0;
+const ARROW_HEIGHT: f32 = 8.0;
+const ARROW_EDGE_MARGIN: f32 = 4.0;
+const ARROW_BORDER_ANTIALIAS_OVERLAP: f32 = 1.0;
+
+#[derive(Component, Clone, Default)]
+struct FeathersPopoverArrowVisual;
+
+#[derive(AsBindGroup, Asset, TypePath, Debug, Clone, Default, PartialEq)]
+struct PopoverArrowMaterial {
+    #[uniform(0)]
+    fill_color: Vec4,
+    #[uniform(1)]
+    border_color: Vec4,
+    #[uniform(2)]
+    border_width: Vec4,
+}
+
+impl UiMaterial for PopoverArrowMaterial {
+    fn fragment_shader() -> ShaderRef {
+        "embedded://bevy_feathers/assets/shaders/popover_arrow.wgsl".into()
+    }
+}
+
+#[derive(Component, Clone, Copy, Default, VariantDefaults)]
+#[require(BackgroundColor)]
+enum FeathersPopoverArrowBorderSegment {
+    #[default]
+    Start,
+    End,
+}
+
+/// A themed callout arrow for a [`bevy_ui_widgets::popover::Popover`].
+///
+/// Add this as a direct child of the popover. [`PopoverArrow`] positions and
+/// rotates the zero-sized root while Feathers supplies the reusable triangle
+/// geometry and theme colors.
+#[derive(SceneComponent, Default, Clone, Reflect)]
+#[reflect(Component, Default, Clone)]
+pub struct FeathersPopoverArrow;
+
+impl FeathersPopoverArrow {
+    fn scene() -> impl Scene {
+        bsn! {
+            PopoverArrow {
+                corner_margin: { ARROW_WIDTH * 0.5 + ARROW_EDGE_MARGIN },
+            }
+            Pickable::IGNORE
+            ZIndex(-1)
+            Children [
+                (
+                    Node {
+                        position_type: PositionType::Absolute,
+                        left: px(-ARROW_WIDTH * 0.5),
+                        top: px(-ARROW_HEIGHT),
+                        width: px(ARROW_WIDTH),
+                        height: px(ARROW_HEIGHT),
+                    }
+                    Pickable::IGNORE
+                    MaterialNode::<PopoverArrowMaterial>(Handle::default())
+                    FeathersPopoverArrowVisual
+                ),
+                (
+                    Node {
+                        position_type: PositionType::Absolute,
+                        width: px(0),
+                        height: px(0),
+                    }
+                    Pickable::IGNORE
+                    FeathersPopoverArrowBorderSegment::Start
+                ),
+                (
+                    Node {
+                        position_type: PositionType::Absolute,
+                        width: px(0),
+                        height: px(0),
+                    }
+                    Pickable::IGNORE
+                    FeathersPopoverArrowBorderSegment::End
+                ),
+            ]
+        }
+    }
+}
+
+fn initialize_arrow_materials(
+    mut visuals: Query<&mut MaterialNode<PopoverArrowMaterial>, Added<FeathersPopoverArrowVisual>>,
+    mut materials: ResMut<Assets<PopoverArrowMaterial>>,
+) {
+    for mut material in &mut visuals {
+        material.0 = materials.add(PopoverArrowMaterial::default());
+    }
+}
+
+fn sync_arrow_style(
+    arrows: Query<
+        (&ChildOf, &Children, &PopoverDirection, &UiGlobalTransform),
+        (
+            With<FeathersPopoverArrow>,
+            Without<FeathersPopoverArrowBorderSegment>,
+        ),
+    >,
+    mut popovers: Query<
+        (
+            &mut ComputedNode,
+            &UiGlobalTransform,
+            Option<&BackgroundColor>,
+            Option<&BorderColor>,
+        ),
+        (
+            Without<FeathersPopoverArrowBorderSegment>,
+            Without<FeathersPopoverArrowVisual>,
+        ),
+    >,
+    visuals: Query<&MaterialNode<PopoverArrowMaterial>, With<FeathersPopoverArrowVisual>>,
+    mut materials: ResMut<Assets<PopoverArrowMaterial>>,
+    mut segments: Query<
+        (
+            &FeathersPopoverArrowBorderSegment,
+            &mut ComputedNode,
+            &mut UiGlobalTransform,
+            &mut BackgroundColor,
+        ),
+        Without<FeathersPopoverArrowVisual>,
+    >,
+) {
+    for (parent, children, direction, arrow_transform) in &arrows {
+        let Ok((mut computed_popover, popover_transform, popover_background, popover_border)) =
+            popovers.get_mut(parent.parent())
+        else {
+            continue;
+        };
+        let popover_border = popover_border.copied().unwrap_or_default();
+        let border_color = match direction.0 {
+            PopoverSide::Top => popover_border.top,
+            PopoverSide::Right => popover_border.right,
+            PopoverSide::Bottom => popover_border.bottom,
+            PopoverSide::Left => popover_border.left,
+        };
+        let background = popover_background.copied().unwrap_or_default();
+
+        // Preserve the layout input while removing only the rendered edge for this frame.
+        // The two segment nodes below redraw that edge with a gap for the arrow.
+        let physical_border_width = remove_connecting_border(&mut computed_popover, direction.0);
+        let arrow_material = PopoverArrowMaterial {
+            fill_color: background.0.to_linear().to_vec4(),
+            border_color: border_color.to_linear().to_vec4(),
+            border_width: Vec4::splat(physical_border_width),
+        };
+        for child in children.iter() {
+            let Ok(material_node) = visuals.get(child) else {
+                continue;
+            };
+            let Some(mut material) = materials.get_mut(material_node) else {
+                continue;
+            };
+            if *material != arrow_material {
+                *material = arrow_material.clone();
+            }
+        }
+        let Some(popover_inverse) = popover_transform.try_inverse() else {
+            continue;
+        };
+        let arrow_local = popover_inverse.transform_point2(arrow_transform.translation);
+        let segment_ranges = border_segment_ranges(
+            &computed_popover,
+            direction.0,
+            arrow_local,
+            physical_border_width,
+        );
+
+        for child in children.iter() {
+            let Ok((segment, mut computed_segment, mut segment_transform, mut segment_background)) =
+                segments.get_mut(child)
+            else {
+                continue;
+            };
+            let range = match segment {
+                FeathersPopoverArrowBorderSegment::Start => segment_ranges.0,
+                FeathersPopoverArrowBorderSegment::End => segment_ranges.1,
+            };
+            let (size, center) =
+                segment_geometry(&computed_popover, direction.0, range, physical_border_width);
+            update_segment_geometry(
+                &mut computed_segment,
+                &mut segment_transform,
+                popover_transform,
+                size,
+                center,
+            );
+            let segment_color = BackgroundColor(border_color);
+            if *segment_background != segment_color {
+                *segment_background = segment_color;
+            }
+        }
+    }
+}
+
+fn remove_connecting_border(popover: &mut ComputedNode, side: PopoverSide) -> f32 {
+    let border_width = match side {
+        PopoverSide::Top => &mut popover.border.min_inset.y,
+        PopoverSide::Right => &mut popover.border.max_inset.x,
+        PopoverSide::Bottom => &mut popover.border.max_inset.y,
+        PopoverSide::Left => &mut popover.border.min_inset.x,
+    };
+    let width = *border_width;
+    *border_width = 0.0;
+    width.max(0.0)
+}
+
+fn border_segment_ranges(
+    popover: &ComputedNode,
+    side: PopoverSide,
+    arrow_local: Vec2,
+    border_width: f32,
+) -> ((f32, f32), (f32, f32)) {
+    let radius = popover.border_radius;
+    let size = popover.size();
+    let (side_min, side_max, arrow_axis) = match side {
+        PopoverSide::Top => (
+            -size.x * 0.5 + radius.top_left.x,
+            size.x * 0.5 - radius.top_right.x,
+            arrow_local.x,
+        ),
+        PopoverSide::Right => (
+            -size.y * 0.5 + radius.top_right.y,
+            size.y * 0.5 - radius.bottom_right.y,
+            arrow_local.y,
+        ),
+        PopoverSide::Bottom => (
+            -size.x * 0.5 + radius.bottom_left.x,
+            size.x * 0.5 - radius.bottom_right.x,
+            arrow_local.x,
+        ),
+        PopoverSide::Left => (
+            -size.y * 0.5 + radius.top_left.y,
+            size.y * 0.5 - radius.bottom_left.y,
+            arrow_local.y,
+        ),
+    };
+    let arrow_half_width = ARROW_WIDTH * 0.5 / popover.inverse_scale_factor;
+    // Extend each segment beneath the arrow by one physical pixel. The
+    // material's antialiased base corners are partially transparent, so an
+    // exact edge-to-edge join otherwise exposes a small gap at either end.
+    let overlap = border_width * 0.5 + ARROW_BORDER_ANTIALIAS_OVERLAP;
+    let gap_min = (arrow_axis - arrow_half_width + overlap).clamp(side_min, side_max);
+    let gap_max = (arrow_axis + arrow_half_width - overlap).clamp(side_min, side_max);
+    ((side_min, gap_min), (gap_max, side_max))
+}
+
+fn segment_geometry(
+    popover: &ComputedNode,
+    side: PopoverSide,
+    (min, max): (f32, f32),
+    border_width: f32,
+) -> (Vec2, Vec2) {
+    let length = (max - min).max(0.0);
+    let axis_center = (min + max) * 0.5;
+    let half_size = popover.size() * 0.5;
+    match side {
+        PopoverSide::Top => (
+            Vec2::new(length, border_width),
+            Vec2::new(axis_center, -half_size.y + border_width * 0.5),
+        ),
+        PopoverSide::Right => (
+            Vec2::new(border_width, length),
+            Vec2::new(half_size.x - border_width * 0.5, axis_center),
+        ),
+        PopoverSide::Bottom => (
+            Vec2::new(length, border_width),
+            Vec2::new(axis_center, half_size.y - border_width * 0.5),
+        ),
+        PopoverSide::Left => (
+            Vec2::new(border_width, length),
+            Vec2::new(-half_size.x + border_width * 0.5, axis_center),
+        ),
+    }
+}
+
+fn update_segment_geometry(
+    segment: &mut ComputedNode,
+    transform: &mut UiGlobalTransform,
+    popover_transform: &UiGlobalTransform,
+    size: Vec2,
+    local_center: Vec2,
+) {
+    if segment.size != size || segment.unrounded_size != size {
+        segment.size = size;
+        segment.unrounded_size = size;
+    }
+    let popover_affine = popover_transform.affine();
+    let global = Affine2::from_mat2_translation(
+        popover_affine.matrix2,
+        popover_affine.transform_point2(local_center),
+    );
+    if transform.affine() != global {
+        *transform = global.into();
+    }
+}
+
+/// Plugin providing reusable Feathers visuals for popover callout arrows.
+pub struct FeathersPopoverPlugin;
+
+impl Plugin for FeathersPopoverPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        if !app.is_plugin_added::<PopoverPlugin>() {
+            app.add_plugins(PopoverPlugin);
+        }
+        if !app.is_plugin_added::<UiMaterialPlugin<PopoverArrowMaterial>>() {
+            app.add_plugins(UiMaterialPlugin::<PopoverArrowMaterial>::default());
+        }
+        app.add_systems(
+            PostUpdate,
+            (initialize_arrow_materials, sync_arrow_style)
+                .chain()
+                .after(crate::theme::update_theme)
+                .after(UiSystems::Layout)
+                .before(UiSystems::Stack),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_app::{App, TaskPoolPlugin};
+    use bevy_asset::{AssetApp, AssetPlugin};
+    use bevy_color::Color;
+    use bevy_ecs::system::RunSystemOnce;
+    use bevy_scene::ScenePlugin;
+    use bevy_ui::UiRect;
+
+    #[test]
+    fn scene_builds_a_reusable_arrow() {
+        let mut app = App::new();
+        app.add_plugins((
+            TaskPoolPlugin::default(),
+            AssetPlugin::default(),
+            ScenePlugin,
+        ));
+
+        let root = app
+            .world_mut()
+            .spawn_scene(bsn! { @FeathersPopoverArrow })
+            .unwrap()
+            .id();
+        app.world_mut().flush();
+
+        assert!(app.world().get::<FeathersPopoverArrow>(root).is_some());
+        assert!(app.world().get::<PopoverArrow>(root).is_some());
+        let node = app.world().get::<Node>(root).unwrap();
+        assert_eq!(node.position_type, PositionType::Absolute);
+        assert_eq!(node.width, px(0));
+        assert_eq!(node.height, px(0));
+        let children = app.world().get::<Children>(root).unwrap();
+        assert_eq!(
+            children
+                .iter()
+                .filter(|entity| app
+                    .world()
+                    .get::<FeathersPopoverArrowVisual>(*entity)
+                    .is_some())
+                .count(),
+            1
+        );
+        assert_eq!(
+            children
+                .iter()
+                .filter(|entity| app
+                    .world()
+                    .get::<FeathersPopoverArrowBorderSegment>(*entity)
+                    .is_some())
+                .count(),
+            2
+        );
+        assert_eq!(app.world().get::<ZIndex>(root), Some(&ZIndex(-1)));
+    }
+
+    #[test]
+    fn arrow_inherits_the_parent_surface_style() {
+        let mut app = App::new();
+        app.add_plugins((
+            TaskPoolPlugin::default(),
+            AssetPlugin::default(),
+            ScenePlugin,
+        ));
+        app.init_asset::<PopoverArrowMaterial>();
+
+        let background = BackgroundColor(Color::srgb(0.1, 0.2, 0.3));
+        let border_color = Color::srgb(0.7, 0.8, 0.9);
+        let parent = app
+            .world_mut()
+            .spawn((
+                Node {
+                    border: UiRect {
+                        right: px(2),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                background,
+                BorderColor {
+                    right: border_color,
+                    ..Default::default()
+                },
+            ))
+            .id();
+        let arrow = app
+            .world_mut()
+            .spawn_scene(bsn! { @FeathersPopoverArrow })
+            .unwrap()
+            .id();
+        app.world_mut()
+            .entity_mut(arrow)
+            .insert((ChildOf(parent), PopoverDirection(PopoverSide::Right)));
+        app.world_mut().flush();
+        app.world_mut()
+            .get_mut::<ComputedNode>(parent)
+            .unwrap()
+            .border
+            .max_inset
+            .x = 2.0;
+
+        app.world_mut()
+            .run_system_once(initialize_arrow_materials)
+            .unwrap();
+        app.world_mut().run_system_once(sync_arrow_style).unwrap();
+
+        let visual = app
+            .world()
+            .get::<Children>(arrow)
+            .unwrap()
+            .iter()
+            .find(|entity| {
+                app.world()
+                    .get::<FeathersPopoverArrowVisual>(*entity)
+                    .is_some()
+            })
+            .unwrap();
+        let material_node = app
+            .world()
+            .get::<MaterialNode<PopoverArrowMaterial>>(visual)
+            .unwrap();
+        let materials = app.world().resource::<Assets<PopoverArrowMaterial>>();
+        assert_eq!(
+            materials.get(material_node),
+            Some(&PopoverArrowMaterial {
+                fill_color: background.0.to_linear().to_vec4(),
+                border_color: border_color.to_linear().to_vec4(),
+                border_width: Vec4::splat(2.0),
+            })
+        );
+        for child in app.world().get::<Children>(arrow).unwrap().iter() {
+            if app
+                .world()
+                .get::<FeathersPopoverArrowBorderSegment>(child)
+                .is_some()
+            {
+                assert_eq!(
+                    app.world().get::<BackgroundColor>(child),
+                    Some(&BackgroundColor(border_color))
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn connecting_border_is_split_around_the_arrow() {
+        let mut popover = ComputedNode::default();
+        popover.size = Vec2::new(200.0, 100.0);
+        popover.unrounded_size = popover.size;
+        popover.inverse_scale_factor = 1.0;
+        popover.border.max_inset.x = 2.0;
+        popover.border_radius.top_right.y = 8.0;
+        popover.border_radius.bottom_right.y = 8.0;
+
+        let border_width = remove_connecting_border(&mut popover, PopoverSide::Right);
+        assert_eq!(border_width, 2.0);
+        assert_eq!(popover.border.max_inset.x, 0.0);
+
+        let ranges = border_segment_ranges(
+            &popover,
+            PopoverSide::Right,
+            Vec2::new(100.0, 10.0),
+            border_width,
+        );
+        assert_eq!(ranges, ((-42.0, 4.0), (16.0, 42.0)));
+        assert_eq!(
+            segment_geometry(&popover, PopoverSide::Right, ranges.0, border_width),
+            (Vec2::new(2.0, 46.0), Vec2::new(99.0, -19.0))
+        );
+        assert_eq!(
+            segment_geometry(&popover, PopoverSide::Right, ranges.1, border_width),
+            (Vec2::new(2.0, 26.0), Vec2::new(99.0, 29.0))
+        );
+    }
+
+    #[test]
+    fn connecting_border_split_covers_every_side_and_scale_factor() {
+        for inverse_scale_factor in [1.0, 0.5] {
+            for side in [
+                PopoverSide::Top,
+                PopoverSide::Right,
+                PopoverSide::Bottom,
+                PopoverSide::Left,
+            ] {
+                let mut popover = computed_node(Vec2::new(200.0, 100.0));
+                popover.inverse_scale_factor = inverse_scale_factor;
+                match side {
+                    PopoverSide::Top => popover.border.min_inset.y = 2.0,
+                    PopoverSide::Right => popover.border.max_inset.x = 2.0,
+                    PopoverSide::Bottom => popover.border.max_inset.y = 2.0,
+                    PopoverSide::Left => popover.border.min_inset.x = 2.0,
+                }
+
+                let border_width = remove_connecting_border(&mut popover, side);
+                let ranges = border_segment_ranges(&popover, side, Vec2::ZERO, border_width);
+                let side_extent = match side {
+                    PopoverSide::Top | PopoverSide::Bottom => 100.0,
+                    PopoverSide::Left | PopoverSide::Right => 50.0,
+                };
+                let arrow_half_width = ARROW_WIDTH * 0.5 / inverse_scale_factor;
+                let overlap = border_width * 0.5 + ARROW_BORDER_ANTIALIAS_OVERLAP;
+
+                assert_eq!(
+                    ranges,
+                    (
+                        (-side_extent, -arrow_half_width + overlap),
+                        (arrow_half_width - overlap, side_extent),
+                    )
+                );
+            }
+        }
+    }
+
+    fn computed_node(size: Vec2) -> ComputedNode {
+        ComputedNode {
+            size,
+            unrounded_size: size,
+            inverse_scale_factor: 1.0,
+            ..Default::default()
+        }
+    }
+}

--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -74,6 +74,7 @@ impl Plugin for FeathersCorePlugin {
         // Embedded shader
         embedded_asset!(app, "assets/shaders/alpha_pattern.wgsl");
         embedded_asset!(app, "assets/shaders/color_plane.wgsl");
+        embedded_asset!(app, "assets/shaders/popover_arrow.wgsl");
 
         app.add_plugins((
             ControlsPlugin,

--- a/crates/bevy_ui_widgets/src/popover.rs
+++ b/crates/bevy_ui_widgets/src/popover.rs
@@ -1,20 +1,22 @@
 //! Framework for positioning of popups, tooltips, and other popover UI elements.
 
 use bevy_app::{App, Plugin, PostUpdate};
+use bevy_camera::visibility::Visibility;
 use bevy_ecs::{
+    change_detection::DetectChangesMut,
     component::Component,
     entity::Entity,
     hierarchy::{ChildOf, Children},
-    query::Without,
+    query::{Has, With, Without},
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     system::{ParamSet, Query},
 };
-use bevy_math::{Affine2, Rect, Vec2};
-use bevy_reflect::Reflect;
+use bevy_math::{Affine2, Mat2, Rect, Rot2, Vec2};
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{
-    ui_layout_system, ComputedNode, ComputedUiRenderTargetInfo, Node, PositionType,
-    UiGlobalTransform, UiSystems, UiTransform, Val2,
+    ui_layout_system, CalculatedClip, ComputedNode, ComputedUiRenderTargetInfo, Node, OverrideClip,
+    PositionType, UiGlobalTransform, UiSystems, UiTransform, Val, Val2,
 };
 
 use crate::update_scrollbar_thumb;
@@ -80,7 +82,7 @@ pub struct PopoverPlacement {
 }
 
 /// Component which is inserted into a popover element to make it dynamically position relative to
-/// an parent element.
+/// a parent element.
 #[derive(Component, PartialEq, Default, Reflect)]
 #[reflect(Component)]
 pub struct Popover {
@@ -89,6 +91,68 @@ pub struct Popover {
 
     /// Indicates how close to the window edge the popup is allowed to go.
     pub window_margin: f32,
+}
+
+/// Shifts a [`Popover`] along its alignment axis to keep it inside its
+/// collision boundary before trying another placement.
+///
+/// The inherited clip of the anchor is used as the collision boundary. Add
+/// [`OverrideClip`] to the popover to use the entire render target instead.
+#[derive(Component, Debug, Default, Clone, Copy, PartialEq, Reflect)]
+#[reflect(Component, Default, PartialEq)]
+pub struct PopoverShift;
+
+/// Hides a [`Popover`] after its anchor is fully clipped by an ancestor or the
+/// render target.
+///
+/// While this component is present, [`PopoverPlugin`] controls the entity's
+/// [`Visibility`].
+#[derive(Component, Debug, Default, Clone, Copy, PartialEq, Reflect)]
+#[reflect(Component, Default, PartialEq)]
+#[require(Visibility)]
+pub struct PopoverHideWhenAnchorClipped;
+
+/// A zero-sized, optional child of a [`Popover`] that is positioned at the
+/// point where a callout arrow meets the popover edge.
+///
+/// [`Popover`] positions and rotates this entity after layout, in the same pass
+/// as the popover itself. The arrow points up when its [`UiTransform`] has its
+/// identity rotation. Visuals should be added as children so they inherit the
+/// transform without affecting UI layout. Keeping the visual as a child also
+/// lets headless users and themed UI layers provide different arrow shapes.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Reflect)]
+#[reflect(Component, Default, PartialEq)]
+#[require(Node = popover_arrow_node(), PopoverDirection)]
+pub struct PopoverArrow {
+    /// Minimum distance between the arrow point and either corner of the
+    /// popover, in logical pixels.
+    pub corner_margin: f32,
+}
+
+fn popover_arrow_node() -> Node {
+    Node {
+        position_type: PositionType::Absolute,
+        width: Val::Px(0.0),
+        height: Val::Px(0.0),
+        ..Default::default()
+    }
+}
+
+impl Default for PopoverArrow {
+    fn default() -> Self {
+        Self { corner_margin: 0.0 }
+    }
+}
+
+/// The direction in which a [`PopoverArrow`] points.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Reflect)]
+#[reflect(Component, Default, PartialEq)]
+pub struct PopoverDirection(pub PopoverSide);
+
+impl Default for PopoverDirection {
+    fn default() -> Self {
+        Self(PopoverSide::Top)
+    }
 }
 
 impl Clone for Popover {
@@ -101,20 +165,38 @@ impl Clone for Popover {
 }
 
 pub(crate) fn position_popover(
-    mut q_popover: Query<(
-        Entity,
-        &mut Node,
-        &mut UiTransform,
-        &mut UiGlobalTransform,
-        &ComputedNode,
-        &ComputedUiRenderTargetInfo,
-        &Popover,
-        &ChildOf,
-    )>,
+    mut q_popover: Query<
+        (
+            Entity,
+            &mut Node,
+            &mut UiTransform,
+            &mut UiGlobalTransform,
+            &ComputedNode,
+            &ComputedUiRenderTargetInfo,
+            &Popover,
+            Has<OverrideClip>,
+            Has<PopoverShift>,
+            &ChildOf,
+        ),
+        Without<PopoverArrow>,
+    >,
     mut qs_transform: ParamSet<(
-        Query<(&ComputedNode, &UiGlobalTransform), Without<Popover>>,
-        Query<&mut UiGlobalTransform, Without<Popover>>,
+        Query<
+            (&ComputedNode, &UiGlobalTransform, Option<&CalculatedClip>),
+            (Without<Popover>, Without<PopoverArrow>),
+        >,
+        Query<&mut UiGlobalTransform, (Without<Popover>, Without<PopoverArrow>)>,
     )>,
+    mut q_arrows: Query<
+        (
+            &PopoverArrow,
+            &ComputedNode,
+            &mut UiTransform,
+            &mut UiGlobalTransform,
+            &mut PopoverDirection,
+        ),
+        (With<PopoverArrow>, Without<Popover>),
+    >,
     q_children: Query<&Children>,
 ) {
     for (
@@ -125,10 +207,11 @@ pub(crate) fn position_popover(
         computed_node,
         computed_target,
         popover,
+        overrides_clip,
+        shifts_into_view,
         parent,
     ) in q_popover.iter_mut()
     {
-        // A rectangle which represents the area of the window.
         let window_rect = Rect {
             min: Vec2::ZERO,
             max: computed_target.logical_size(),
@@ -137,8 +220,19 @@ pub(crate) fn position_popover(
 
         // Compute the parent rectangle.
         let q_parent = qs_transform.p0();
-        let Ok((parent_node, parent_transform)) = q_parent.get(parent.parent()) else {
+        let Ok((parent_node, parent_transform, parent_clip)) = q_parent.get(parent.parent()) else {
             continue;
+        };
+        let collision_rect = if shifts_into_view {
+            popover_boundary(
+                computed_target.logical_size(),
+                parent_clip,
+                parent_node.inverse_scale_factor,
+                overrides_clip,
+                popover.window_margin,
+            )
+        } else {
+            window_rect
         };
 
         // Computed node size includes the border, but since absolute positioning doesn't include
@@ -153,6 +247,7 @@ pub(crate) fn position_popover(
 
         let mut best_occluded = f32::MAX;
         let mut best_rect = Rect::default();
+        let mut best_placement = None;
 
         // Loop through all the potential positions and find a good one.
         for position in &popover.positions {
@@ -225,22 +320,27 @@ pub(crate) fn position_popover(
                 },
             }
 
+            if shifts_into_view {
+                rect = shift_popover_rect(rect, collision_rect, position.side);
+            }
+
             // Clip to window and see how much of the popover element is occluded. We can calculate
             // how much was clipped by intersecting the rectangle against the window bounds, and
             // then subtracting the area from the area of the unclipped rectangle.
-            let clipped_rect = rect.intersect(window_rect);
+            let clipped_rect = rect.intersect(collision_rect);
             let occlusion = rect.area() - clipped_rect.area();
 
             // Find the position that has the least occlusion.
             if occlusion < best_occluded {
                 best_occluded = occlusion;
                 best_rect = rect;
+                best_placement = Some(*position);
             }
         }
 
         // Update node properties, but only if they are different from before (to avoid setting
         // change detection bit).
-        if best_occluded < f32::MAX {
+        if let Some(best_placement) = best_placement {
             let best_center = 0.5 * (best_rect.min + best_rect.max);
             let current_center =
                 ui_global_transform.translation * computed_node.inverse_scale_factor;
@@ -281,6 +381,215 @@ pub(crate) fn position_popover(
                     }
                 }
             }
+
+            position_popover_arrow(
+                popover_entity,
+                best_rect,
+                parent_rect,
+                best_placement,
+                computed_target,
+                &ui_global_transform,
+                &q_children,
+                &mut q_arrows,
+                &mut qs_transform.p1(),
+            );
+        }
+    }
+}
+
+fn position_popover_arrow(
+    popover_entity: Entity,
+    popover_rect: Rect,
+    anchor_rect: Rect,
+    placement: PopoverPlacement,
+    computed_target: &ComputedUiRenderTargetInfo,
+    popover_global_transform: &UiGlobalTransform,
+    q_children: &Query<&Children>,
+    q_arrows: &mut Query<
+        (
+            &PopoverArrow,
+            &ComputedNode,
+            &mut UiTransform,
+            &mut UiGlobalTransform,
+            &mut PopoverDirection,
+        ),
+        (With<PopoverArrow>, Without<Popover>),
+    >,
+    q_transform: &mut Query<&mut UiGlobalTransform, (Without<Popover>, Without<PopoverArrow>)>,
+) {
+    let Some(children) = q_children.get(popover_entity).ok() else {
+        return;
+    };
+    let popover_matrix = popover_global_transform.affine().matrix2;
+    if popover_matrix.determinant() == 0.0 {
+        return;
+    }
+
+    for child in children.iter() {
+        let Ok((arrow, arrow_node, mut transform, mut global_transform, mut direction)) =
+            q_arrows.get_mut(*child)
+        else {
+            continue;
+        };
+        let (target, arrow_direction) =
+            arrow_target(popover_rect, anchor_rect, placement, arrow.corner_margin);
+        let rotation = arrow_rotation(arrow_direction);
+        let current_physical = global_transform.translation;
+        let target_physical = target * computed_target.scale_factor();
+        let physical_translation = target_physical - current_physical;
+        let resolved_translation = transform.translation.resolve(
+            computed_target.scale_factor(),
+            arrow_node.size(),
+            computed_target.physical_size().as_vec2(),
+        );
+        let logical_translation = (resolved_translation
+            + popover_matrix.inverse() * physical_translation)
+            / computed_target.scale_factor();
+        transform.translation = Val2::px(logical_translation.x, logical_translation.y);
+
+        let rotation_delta = rotation * transform.rotation.inverse();
+        transform.rotation = rotation;
+        direction.set_if_neq(PopoverDirection(arrow_direction));
+
+        let global_rotation =
+            popover_matrix * Mat2::from(rotation_delta) * popover_matrix.inverse();
+        let child_transform = Affine2::from_mat2_translation(
+            global_rotation,
+            target_physical - global_rotation * current_physical,
+        );
+        *global_transform = (child_transform * global_transform.affine()).into();
+
+        if let Ok(children) = q_children.get(*child) {
+            for child in children.iter() {
+                transform_ui_children_recursive(*child, child_transform, q_children, q_transform);
+            }
+        }
+    }
+}
+
+fn arrow_target(
+    popover_rect: Rect,
+    anchor_rect: Rect,
+    placement: PopoverPlacement,
+    corner_margin: f32,
+) -> (Vec2, PopoverSide) {
+    let margin = corner_margin.max(0.0);
+    match placement.side {
+        PopoverSide::Top => (
+            Vec2::new(
+                clamp_arrow_axis(
+                    aligned_anchor_axis(
+                        anchor_rect.min.x,
+                        anchor_rect.max.x,
+                        placement.align,
+                        margin,
+                    ),
+                    popover_rect.min.x,
+                    popover_rect.max.x,
+                    margin,
+                ),
+                popover_rect.max.y,
+            ),
+            PopoverSide::Bottom,
+        ),
+        PopoverSide::Bottom => (
+            Vec2::new(
+                clamp_arrow_axis(
+                    aligned_anchor_axis(
+                        anchor_rect.min.x,
+                        anchor_rect.max.x,
+                        placement.align,
+                        margin,
+                    ),
+                    popover_rect.min.x,
+                    popover_rect.max.x,
+                    margin,
+                ),
+                popover_rect.min.y,
+            ),
+            PopoverSide::Top,
+        ),
+        PopoverSide::Left => (
+            Vec2::new(
+                popover_rect.max.x,
+                clamp_arrow_axis(
+                    aligned_anchor_axis(
+                        anchor_rect.min.y,
+                        anchor_rect.max.y,
+                        placement.align,
+                        margin,
+                    ),
+                    popover_rect.min.y,
+                    popover_rect.max.y,
+                    margin,
+                ),
+            ),
+            PopoverSide::Right,
+        ),
+        PopoverSide::Right => (
+            Vec2::new(
+                popover_rect.min.x,
+                clamp_arrow_axis(
+                    aligned_anchor_axis(
+                        anchor_rect.min.y,
+                        anchor_rect.max.y,
+                        placement.align,
+                        margin,
+                    ),
+                    popover_rect.min.y,
+                    popover_rect.max.y,
+                    margin,
+                ),
+            ),
+            PopoverSide::Left,
+        ),
+    }
+}
+
+fn aligned_anchor_axis(min: f32, max: f32, align: PopoverAlign, margin: f32) -> f32 {
+    if max - min <= margin * 2.0 {
+        return (min + max) * 0.5;
+    }
+    match align {
+        PopoverAlign::Start => min + margin,
+        PopoverAlign::Center => (min + max) * 0.5,
+        PopoverAlign::End => max - margin,
+    }
+}
+
+fn clamp_arrow_axis(value: f32, min: f32, max: f32, margin: f32) -> f32 {
+    let available = max - min;
+    if available <= margin * 2.0 {
+        (min + max) * 0.5
+    } else {
+        value.clamp(min + margin, max - margin)
+    }
+}
+
+fn arrow_rotation(direction: PopoverSide) -> Rot2 {
+    match direction {
+        PopoverSide::Top => Rot2::IDENTITY,
+        PopoverSide::Right => Rot2::FRAC_PI_2,
+        PopoverSide::Bottom => Rot2::PI,
+        PopoverSide::Left => Rot2::FRAC_PI_2.inverse(),
+    }
+}
+
+fn transform_ui_children_recursive(
+    entity: Entity,
+    transform: Affine2,
+    q_children: &Query<&Children>,
+    q_transform: &mut Query<&mut UiGlobalTransform, (Without<Popover>, Without<PopoverArrow>)>,
+) {
+    let Ok(mut ui_global_transform) = q_transform.get_mut(entity) else {
+        return;
+    };
+
+    *ui_global_transform = (transform * ui_global_transform.affine()).into();
+
+    if let Ok(children) = q_children.get(entity) {
+        for child in children.iter() {
+            transform_ui_children_recursive(*child, transform, q_children, q_transform);
         }
     }
 }
@@ -289,19 +598,56 @@ fn translate_ui_children_recursive(
     entity: Entity,
     translation: Vec2,
     q_children: &Query<&Children>,
-    q_transform: &mut Query<&mut UiGlobalTransform, Without<Popover>>,
+    q_transform: &mut Query<&mut UiGlobalTransform, (Without<Popover>, Without<PopoverArrow>)>,
 ) {
     let Ok(mut ui_global_transform) = q_transform.get_mut(entity) else {
         return;
     };
 
-    *ui_global_transform =
-        (ui_global_transform.affine() * Affine2::from_translation(translation)).into();
+    *ui_global_transform = translate_global(ui_global_transform.affine(), translation).into();
 
     if let Ok(children) = q_children.get(entity) {
         for child in children.iter() {
             translate_ui_children_recursive(*child, translation, q_children, q_transform);
         }
+    }
+}
+
+fn translate_global(transform: Affine2, translation: Vec2) -> Affine2 {
+    Affine2::from_translation(translation) * transform
+}
+
+fn update_popover_anchor_visibility(
+    mut popovers: Query<
+        (&ChildOf, &ComputedUiRenderTargetInfo, &mut Visibility),
+        (With<Popover>, With<PopoverHideWhenAnchorClipped>),
+    >,
+    anchors: Query<(&ComputedNode, &UiGlobalTransform, Option<&CalculatedClip>)>,
+) {
+    for (parent, computed_target, mut visibility) in &mut popovers {
+        let reference_hidden = anchors
+            .get(parent.parent())
+            .map(|(anchor_node, anchor_transform, inherited_clip)| {
+                let anchor_size = anchor_node.size()
+                    - anchor_node.border.min_inset
+                    - anchor_node.border.max_inset;
+                let anchor_rect = scale_rect(
+                    Rect::from_center_size(anchor_transform.translation, anchor_size),
+                    anchor_node.inverse_scale_factor,
+                );
+                reference_is_fully_clipped(
+                    anchor_rect,
+                    inherited_clip,
+                    computed_target.logical_size(),
+                    anchor_node.inverse_scale_factor,
+                )
+            })
+            .unwrap_or(true);
+        visibility.set_if_neq(if reference_hidden {
+            Visibility::Hidden
+        } else {
+            Visibility::Inherited
+        });
     }
 }
 
@@ -316,7 +662,18 @@ impl Plugin for PopoverPlugin {
                 .in_set(UiSystems::Layout)
                 .after(ui_layout_system)
                 .before(update_scrollbar_thumb),
-        );
+        )
+        .add_systems(
+            PostUpdate,
+            update_popover_anchor_visibility.after(UiSystems::PostLayout),
+        )
+        .world_mut()
+        .register_component_hooks::<PopoverHideWhenAnchorClipped>()
+        .on_remove(|mut world, context| {
+            if let Some(mut visibility) = world.get_mut::<Visibility>(context.entity) {
+                *visibility = Visibility::Inherited;
+            }
+        });
     }
 }
 
@@ -326,4 +683,71 @@ fn scale_rect(rect: Rect, factor: f32) -> Rect {
         min: rect.min * factor,
         max: rect.max * factor,
     }
+}
+
+fn popover_boundary(
+    target_size: Vec2,
+    inherited_clip: Option<&CalculatedClip>,
+    inverse_scale_factor: f32,
+    overrides_clip: bool,
+    margin: f32,
+) -> Rect {
+    let target_rect = Rect::from_corners(Vec2::ZERO, target_size);
+    if overrides_clip {
+        target_rect
+    } else {
+        inherited_clip.map_or(target_rect, |clip| {
+            target_rect.intersect(scale_rect(clip.clip, inverse_scale_factor))
+        })
+    }
+    .inflate(-margin)
+}
+
+fn shift_popover_rect(mut rect: Rect, boundary: Rect, side: PopoverSide) -> Rect {
+    let delta = match side {
+        PopoverSide::Top | PopoverSide::Bottom => {
+            shift_axis(rect.min.x, rect.max.x, boundary.min.x, boundary.max.x)
+        }
+        PopoverSide::Left | PopoverSide::Right => {
+            shift_axis(rect.min.y, rect.max.y, boundary.min.y, boundary.max.y)
+        }
+    };
+    match side {
+        PopoverSide::Top | PopoverSide::Bottom => {
+            rect.min.x += delta;
+            rect.max.x += delta;
+        }
+        PopoverSide::Left | PopoverSide::Right => {
+            rect.min.y += delta;
+            rect.max.y += delta;
+        }
+    }
+    rect
+}
+
+fn shift_axis(min: f32, max: f32, boundary_min: f32, boundary_max: f32) -> f32 {
+    if max - min > boundary_max - boundary_min {
+        return 0.5 * (boundary_min + boundary_max - min - max);
+    }
+    if min < boundary_min {
+        boundary_min - min
+    } else if max > boundary_max {
+        boundary_max - max
+    } else {
+        0.0
+    }
+}
+
+fn reference_is_fully_clipped(
+    reference_rect: Rect,
+    inherited_clip: Option<&CalculatedClip>,
+    target_size: Vec2,
+    inverse_scale_factor: f32,
+) -> bool {
+    let target_rect = Rect::from_corners(Vec2::ZERO, target_size);
+    let visible_rect = reference_rect.intersect(target_rect);
+    let visible_rect = inherited_clip.map_or(visible_rect, |clip| {
+        visible_rect.intersect(scale_rect(clip.clip, inverse_scale_factor))
+    });
+    visible_rect.area() <= 0.0
 }

--- a/examples/ui/widgets/feathers_popover.rs
+++ b/examples/ui/widgets/feathers_popover.rs
@@ -1,0 +1,258 @@
+//! Demonstrates Feathers popover arrows across all placements and while scrolling.
+
+use bevy::{
+    feathers::{
+        controls::{FeathersButton, FeathersPopoverArrow, FeathersScrollbar},
+        dark_theme::create_dark_theme,
+        display::caption,
+        theme::{ThemeBackgroundColor, ThemeBorderColor, UiTheme},
+        tokens, FeathersPlugins,
+    },
+    prelude::*,
+    ui_widgets::{
+        popover::{
+            Popover, PopoverAlign, PopoverHideWhenAnchorClipped, PopoverPlacement, PopoverShift,
+            PopoverSide,
+        },
+        ControlOrientation, ScrollArea,
+    },
+};
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, FeathersPlugins))
+        .insert_resource(UiTheme(create_dark_theme()))
+        .add_systems(Startup, scene.spawn())
+        .run();
+}
+
+fn scene() -> impl SceneList {
+    bsn_list![
+        Camera2d,
+        (
+            Node {
+                width: percent(100),
+                height: percent(100),
+                padding: UiRect {
+                    left: px(16),
+                    right: px(16),
+                    top: px(52),
+                    bottom: px(16),
+                },
+                display: Display::Flex,
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::Center,
+                row_gap: px(12),
+            }
+            ThemeBackgroundColor(tokens::WINDOW_BG)
+            Children [
+                (
+                    Node {
+                        width: px(728),
+                        height: px(248),
+                        margin: UiRect::bottom(px(44)),
+                        display: Display::Grid,
+                        grid_template_columns: {
+                            RepeatedGridTrack::px::<Vec<RepeatedGridTrack>>(5, 136.0)
+                        },
+                        grid_template_rows: {
+                            RepeatedGridTrack::px::<Vec<RepeatedGridTrack>>(5, 40.0)
+                        },
+                        column_gap: px(12),
+                        row_gap: px(12),
+                    }
+                    Children [
+                        placement_anchor("TL", "Start", PopoverSide::Top, PopoverAlign::Start, 2, 1),
+                        placement_anchor("Top", "Center", PopoverSide::Top, PopoverAlign::Center, 3, 1),
+                        placement_anchor("TR", "End", PopoverSide::Top, PopoverAlign::End, 4, 1),
+                        placement_anchor("LT", "Start", PopoverSide::Left, PopoverAlign::Start, 1, 2),
+                        placement_anchor("RT", "Start", PopoverSide::Right, PopoverAlign::Start, 5, 2),
+                        placement_anchor("Left", "Center", PopoverSide::Left, PopoverAlign::Center, 1, 3),
+                        placement_anchor("Right", "Center", PopoverSide::Right, PopoverAlign::Center, 5, 3),
+                        placement_anchor("LB", "End", PopoverSide::Left, PopoverAlign::End, 1, 4),
+                        placement_anchor("RB", "End", PopoverSide::Right, PopoverAlign::End, 5, 4),
+                        placement_anchor("BL", "Start", PopoverSide::Bottom, PopoverAlign::Start, 2, 5),
+                        placement_anchor("Bottom", "Center", PopoverSide::Bottom, PopoverAlign::Center, 3, 5),
+                        placement_anchor("BR", "End", PopoverSide::Bottom, PopoverAlign::End, 4, 5),
+                    ]
+                ),
+                (
+                    Node {
+                        width: percent(100),
+                        max_width: px(728),
+                        height: px(180),
+                        position_type: PositionType::Relative,
+                    }
+                    ThemeBackgroundColor(tokens::PANE_BODY_BG)
+                    Children [
+                        (
+                            #scroll_area
+                            Node {
+                                width: percent(100),
+                                height: percent(100),
+                                padding: UiRect {
+                                    left: px(12),
+                                    right: px(24),
+                                    top: px(12),
+                                    bottom: px(24),
+                                },
+                                overflow: Overflow::scroll(),
+                            }
+                            ScrollArea
+                            ScrollPosition(Vec2::new(180.0, 180.0))
+                            Children [
+                                (
+                                    Node {
+                                        min_width: px(1200),
+                                        min_height: px(640),
+                                        position_type: PositionType::Relative,
+                                    }
+                                    Children [
+                                        (
+                                            Node {
+                                                width: px(136),
+                                                height: px(48),
+                                                position_type: PositionType::Absolute,
+                                                left: px(540),
+                                                top: px(290),
+                                            }
+                                            Children [
+                                                (
+                                                    @FeathersButton {
+                                                        @caption: bsn! { caption("Scrollable anchor") },
+                                                    }
+                                                    Node {
+                                                        width: percent(100),
+                                                        height: percent(100),
+                                                    }
+                                                ),
+                                                popover_with_positions(
+                                                    "Tracks the anchor",
+                                                    [
+                                                        PopoverSide::Left,
+                                                        PopoverSide::Right,
+                                                        PopoverSide::Top,
+                                                        PopoverSide::Bottom,
+                                                    ]
+                                                    .map(|side| PopoverPlacement {
+                                                        side,
+                                                        align: PopoverAlign::Center,
+                                                        gap: 8.0,
+                                                    })
+                                                    .to_vec(),
+                                                ),
+                                            ]
+                                        )
+                                    ]
+                                )
+                            ]
+                        ),
+                        (
+                            @FeathersScrollbar {
+                                @target: #scroll_area,
+                                @orientation: { ControlOrientation::Vertical },
+                                @auto_hide: false,
+                            }
+                            Node {
+                                position_type: PositionType::Absolute,
+                                right: px(5),
+                                top: px(8),
+                                bottom: px(18),
+                                width: px(6),
+                            }
+                        ),
+                        (
+                            @FeathersScrollbar {
+                                @target: #scroll_area,
+                                @orientation: { ControlOrientation::Horizontal },
+                                @auto_hide: false,
+                            }
+                            Node {
+                                position_type: PositionType::Absolute,
+                                left: px(8),
+                                right: px(18),
+                                bottom: px(5),
+                                height: px(6),
+                            }
+                        ),
+                    ]
+                ),
+            ]
+        )
+    ]
+}
+
+fn placement_anchor(
+    button_text: &'static str,
+    popover_text: &'static str,
+    side: PopoverSide,
+    align: PopoverAlign,
+    column: i16,
+    row: i16,
+) -> impl Scene {
+    bsn! {
+        Node {
+            width: px(136),
+            height: px(40),
+            grid_column: { GridPlacement::start(column) },
+            grid_row: { GridPlacement::start(row) },
+            justify_self: JustifySelf::Center,
+            align_self: AlignSelf::Center,
+        }
+        Children [
+            (
+                @FeathersButton {
+                    @caption: bsn! { caption(button_text) },
+                }
+                Node {
+                    width: percent(100),
+                    height: percent(100),
+                }
+            ),
+            popover_label(
+                popover_text,
+                PopoverPlacement {
+                    side,
+                    align,
+                    gap: 8.0,
+                },
+            ),
+        ]
+    }
+}
+
+fn popover_label(text: &'static str, placement: PopoverPlacement) -> impl Scene {
+    popover_with_positions(text, vec![placement])
+}
+
+fn popover_with_positions(text: &'static str, positions: Vec<PopoverPlacement>) -> impl Scene {
+    bsn! {
+        Node {
+            position_type: PositionType::Absolute,
+            padding: UiRect::axes(px(10), px(6)),
+            border: px(1),
+            border_radius: px(4),
+        }
+        Pickable::IGNORE
+        GlobalZIndex(10)
+        ThemeBackgroundColor(tokens::MENU_BG)
+        ThemeBorderColor(tokens::MENU_BORDER)
+        BoxShadow::new(
+            Srgba::new(0.0, 0.0, 0.0, 0.55).into(),
+            px(0),
+            px(1),
+            px(1),
+            px(5),
+        )
+        Popover {
+            positions,
+            window_margin: 4.0,
+        }
+        PopoverShift
+        PopoverHideWhenAnchorClipped
+        Children [
+            caption(text),
+            @FeathersPopoverArrow,
+        ]
+    }
+}


### PR DESCRIPTION
# Objective

Add reusable callout-arrow positioning to `Popover` as a foundation for tooltip and other floating UI work.
Related:  #20601 #25168

## Solution

- Add an optional, headless `PopoverArrow` child component and expose its resolved orientation through `PopoverDirection`.
- Position and rotate the arrow in the same post-layout system that positions the popover.
- Keep the arrow aimed toward the anchor while clamping it away from popover corners when cross-axis shifting is required.
- Add opt-in `PopoverShift` behavior to keep a popover within its collision boundary before falling back to another placement.
- Add opt-in `PopoverHideWhenAnchorClipped` behavior so a popover follows a partially clipped anchor and becomes hidden once that anchor is fully clipped.
- Use the anchor's inherited clip as the collision boundary, or the full render target when the popover has `OverrideClip`.
- Add a reusable `FeathersPopoverArrow` visual that inherits the popover surface and border colors and maintains a continuous border at the join.
- Add a standalone Feathers example covering all 12 side/alignment combinations and a container that scrolls horizontally and vertically.

The positioning components remain independent from rendering: `bevy_ui_widgets` calculates the arrow origin and direction, while Feathers supplies one possible themed visual.

## Testing

cargo test -p bevy_ui_widgets -p bevy_feathers
cargo clippy -p bevy_ui_widgets -p bevy_feathers --all-targets -- -D warnings
cargo clippy --example feathers_popover --features bevy_feathers -- -D warnings
cargo fmt -p bevy -p bevy_ui_widgets -p bevy_feathers -- --check

---

## Showcase


`PopoverArrow` is an optional direct child of a `Popover`. A rendering layer can attach any visual representation beneath it:

```rust
bsn! {
    Node {
        position_type: PositionType::Absolute,
        ..default()
    }
    Popover {
        positions: vec![
            PopoverPlacement {
                side: PopoverSide::Top,
                align: PopoverAlign::Center,
                gap: 8.0,
            },
            PopoverPlacement {
                side: PopoverSide::Bottom,
                align: PopoverAlign::Center,
                gap: 8.0,
            },
        ],
        window_margin: 4.0,
    }
    PopoverShift
    PopoverHideWhenAnchorClipped
    Children [
        caption("Popover content"),
        @FeathersPopoverArrow,
    ]
}
```
<img width="1802" height="1044" alt="image" src="https://github.com/user-attachments/assets/e371f7d3-bfb3-48a3-8b7a-d808f30382fc" />
