### PR TITLE
update homebrew fomula in `config_fast_builds.toml` (llvm -> lld)

### DIFF
--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -105,9 +105,9 @@ rustflags = [
   #
   # You may need to install it:
   #
-  # Brew: `brew install llvm`
+  # Brew: `brew install lld`
   # Manually: <https://lld.llvm.org/MachO/index.html>
-  # "-Clink-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld",
+  # "-Clink-arg=-fuse-ld=/usr/local/opt/lld/bin/ld64.lld",
 
   # Nightly
   # "-Zshare-generics=y",
@@ -122,9 +122,9 @@ rustflags = [
   #
   # You may need to install it:
   #
-  # Brew: `brew install llvm`
+  # Brew: `brew install lld`
   # Manually: <https://lld.llvm.org/MachO/index.html>
-  # "-Clink-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld",
+  # "-Clink-arg=-fuse-ld=/opt/homebrew/opt/lld/bin/ld64.lld",
 
   # Nightly
   # "-Zshare-generics=y",


### PR DESCRIPTION
# Objective

On macOS the instructions and path given in `config_fast_builds.toml` for using `lld` are outdated.

`lld` is no longer part of the `llvm` formula; it has been split out into its own, so both path and instructions should refer to `lld` instead of `llvm`.

## Solution

Update path and installation instructions.

## Testing

Using `config_fast_builds.toml` previously gave linker errors (not found). Now project builds. Only tested on aarch64, but principle should apply equally to x86_64.