### PR TITLE
Update lens_distortion.wgsl

### DIFF
--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
@@ -15,6 +15,7 @@ struct LensDistortionSettings {
 
 const VISUAL_THRESHOLD: f32 = 1e-4;
 const MATH_EPSILON: f32 = 1e-6;
+const TAU: f32 = radians(360);
 
 // The settings supplied by the developer.
 @group(0) @binding(5) var<uniform> lens_distortion_settings: LensDistortionSettings;
@@ -31,8 +32,8 @@ fn lens_distortion(uv: vec2<f32>) -> vec2<f32> {
     // Prevent division by zero.
     let radius = max(length(uv_centered), MATH_EPSILON);
 
-    let direction = uv_centered / radius;
-    let adjust = dot(abs(direction), multiplier);
+    let direction = normalize(uv_centered);
+    let adjust = ((dot(abs(direction), multiplier) - TAU) * 0.5) + TAU;
 
     // Maintains the correlation between k2 and k1, while ensuring the sign of k2
     // is determined solely by `edge_curvature` rather than being influenced by intensity.

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
@@ -16,6 +16,7 @@ struct LensDistortionSettings {
 const VISUAL_THRESHOLD: f32 = 1e-4;
 const MATH_EPSILON: f32 = 1e-6;
 const TAU: f32 = radians(360);
+const ONE: vec2<f32> = vec2<f32>(1.0, 1.0);
 
 // The settings supplied by the developer.
 @group(0) @binding(5) var<uniform> lens_distortion_settings: LensDistortionSettings;
@@ -27,26 +28,45 @@ fn lens_distortion(uv: vec2<f32>) -> vec2<f32> {
     }
     let multiplier = lens_distortion_settings.multiplier;
     let center = lens_distortion_settings.center;
-
     let uv_centered = uv - center;
-    // Prevent division by zero.
-    let radius = max(length(uv_centered), MATH_EPSILON);
 
-    let direction = normalize(uv_centered);
-    let adjust = ((dot(abs(direction), multiplier) - TAU) * 0.5) + TAU;
+    // This shader takes the UV as a vector centered on the screen and splits it into two parts: the direction, and the magnitude.
+    // The direction is used to add warp the corners more than the sides.
+    // The magnitude is the value that is actually distorted.
+    // The adjusted and distorted direction and magnitudes are then recombined and scaled to map the original UV coordinates to the new output coordinates.
 
-    // Maintains the correlation between k2 and k1, while ensuring the sign of k2
-    // is determined solely by `edge_curvature` rather than being influenced by intensity.
+    // This will scale the influence of the distortion, but not the image.
+    // A multiplier of {1.0, 1.0} will place the most distorted parts of the output exactly on the corners.
+    // A multiplier of {1.0, 2.0} would place the top and bottom points of highest influence 0.5 screens above and below the rendered output respectively.
+    // This can be used to always guarantee an even distortion using the ratio between the screen width and height.
+    let uv_multiplied = uv_centered * multiplier;
+    
+    let magnitude = length(uv_multiplied);
+    let m2 = magnitude * magnitude;
+    let direction = normalize(uv_multiplied);
+
+    // Correct for the uv multiplier to prevent scaling the image along with the distortion.
+    let direction_adjusted = direction / multiplier;
+
+    // Gets a value from -TAU to TAU for how aligned the direction is with the closest corner.  0 is perpendicular.
+    let influence = dot(abs(direction), ONE);
+
+    // Adjusts the output so that the perpendicular angle (where the output is zero) is always 45 degrees from the corner (aligned with the axes)
+    let adjust = ((influence - TAU) * 0.5) + (TAU * 2);
+
+    // Maintains the correlation between k2 and k1, while ensuring the sign of k2 is determined solely by `edge_curvature` rather than being influenced by intensity.
+    // Based on maths that can be found here: https://en.wikipedia.org/wiki/Distortion_(optics)#Software_correction
     let k1 = intensity * adjust;
     let k2 = k1 * intensity * lens_distortion_settings.edge_curvature;
 
-    let r2 = radius * radius;
-    let r_distorted = radius * (1.0 + (k1 + k2 * r2) * r2);
+    // Calculating the distortion based on distance from center and the two variables k1 and k2 to create a compound parabola.
+    let magnitude_distorted = magnitude * (1.0 + (k1 + k2 * m2) * m2);
 
-    let uv_distorted = direction * r_distorted + center;
+    // Re-combining the direction and magnitude after.
+    let uv_distorted = direction_adjusted * magnitude_distorted + center;
 
     // Compensates for the distortion pushing pixels outside the [0,1] UV bounds.
-    let uv_scaled = (uv_distorted - center) / lens_distortion_settings.scale + center;
+    let uv_scaled = ((uv_distorted - center) / lens_distortion_settings.scale + center);
 
     // Discard out-of-bounds pixels to prevent edge bleeding artifacts.
     let uv_safe = clamp(uv_scaled, vec2<f32>(0.0), vec2<f32>(1.0));

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.wgsl
@@ -13,8 +13,6 @@ struct LensDistortionSettings {
     unused: u32,
 }
 
-const VISUAL_THRESHOLD: f32 = 1e-4;
-const MATH_EPSILON: f32 = 1e-6;
 const TAU: f32 = radians(360);
 const ONE: vec2<f32> = vec2<f32>(1.0, 1.0);
 
@@ -23,9 +21,6 @@ const ONE: vec2<f32> = vec2<f32>(1.0, 1.0);
 
 fn lens_distortion(uv: vec2<f32>) -> vec2<f32> {
     let intensity = lens_distortion_settings.intensity;
-    if (abs(intensity) < VISUAL_THRESHOLD) {
-        return uv;
-    }
     let multiplier = lens_distortion_settings.multiplier;
     let center = lens_distortion_settings.center;
     let uv_centered = uv - center;
@@ -68,8 +63,5 @@ fn lens_distortion(uv: vec2<f32>) -> vec2<f32> {
     // Compensates for the distortion pushing pixels outside the [0,1] UV bounds.
     let uv_scaled = ((uv_distorted - center) / lens_distortion_settings.scale + center);
 
-    // Discard out-of-bounds pixels to prevent edge bleeding artifacts.
-    let uv_safe = clamp(uv_scaled, vec2<f32>(0.0), vec2<f32>(1.0));
-
-    return uv_safe;
+    return uv_scaled;
 }


### PR DESCRIPTION
## Summary of Changes
Fixed the visual creasing between quadrants by changing the perpendicular value of the dot product (zero) to be at 45 degrees from the corner rather than 90.  Also changed the `direction` calculation to use the built-in `normalize` function.

## Objective
Correct the visual creasing in the lens distortion shader.

## Solution
The distortion is warped by the dot product between the closest corner and the absolute position of the current texle position.  This means that zero influence will be perpendicular to the corner.  The angle between the corner and the axis is 45 degrees, which is only half of the way to the 90 degrees we need.
To correct this, I subtract TAU (the maximum value of the dot product in this situation), then multiply the value by 0.5.  This multiplication shifts the original point of zero up from 90 degrees away from the corner to 45 degrees to the corner.  I then add TAU back to make the maximum value line up with where it originally was.

## Testing
I placed the edge of the screen aligned with a straight element to examine the curve visually.  With this fix, the axis crease no longer appeared.

<img width="562" height="824" alt="LensDistortionShaderFix" src="https://github.com/user-attachments/assets/80b49ecf-f747-4c48-ae70-d79075ff8de0" />
