### PR TITLE
remove outdated android cpal direct dependency

### DIFF
--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -24,9 +24,6 @@ rodio = { version = "0.22", default-features = false, features = [
 ] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 
-[target.'cfg(target_os = "android")'.dependencies]
-cpal = { version = "0.17", optional = true }
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # TODO: Assuming all wasm builds are for the browser. Require `no_std` support to break assumption.
 rodio = { version = "0.22", default-features = false, features = [


### PR DESCRIPTION
# Objective

This direct cpal dependency was made redundant when rodio was updated to 0.22: rodio 0.22 updated cpal to 0.17 which migrated away from oboe, and we only had this direct cpal dep to enable an oboe feature

https://github.com/bevyengine/bevy/pull/20323/changes#diff-a47ef304b100bcfbb191c5d2b5428b0c6d4a0a988792529e723146f75512643aL57

## Solution

Removed the direct android cpal dep. cpal is still present in the rodio dep

## Testing

- tested on virtual and physical android devices
