### PR TITLE
Resolve System Ambiguities between `Feathers` and the other crates

### DIFF
--- a/crates/bevy_feathers/src/controls/color_plane.rs
+++ b/crates/bevy_feathers/src/controls/color_plane.rs
@@ -9,6 +9,7 @@ use bevy_ecs::{
     observer::On,
     query::{Changed, Has, Or, With},
     reflect::ReflectComponent,
+    schedule::IntoScheduleConfigs,
     system::{Commands, Query, Res, ResMut},
     template::FromTemplate,
 };
@@ -24,7 +25,7 @@ use bevy_shader::{ShaderDefVal, ShaderRef};
 use bevy_ui::{
     percent, px, AlignSelf, BorderColor, BorderRadius, ComputedNode, ComputedUiRenderTargetInfo,
     Display, InteractionDisabled, Node, Outline, PositionType, UiGlobalTransform, UiRect, UiScale,
-    UiTransform, Val2,
+    UiSystems, UiTransform, Val2,
 };
 use bevy_ui_render::{prelude::UiMaterial, ui_material::MaterialNode, UiMaterialPlugin};
 use bevy_ui_widgets::ValueChange;
@@ -464,7 +465,8 @@ pub struct ColorPlanePlugin;
 impl Plugin for ColorPlanePlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_plugins(UiMaterialPlugin::<ColorPlaneMaterial>::default());
-        app.add_systems(PostUpdate, update_plane_color);
+        // `update_plane_color` modifies a node's `left` and `top`
+        app.add_systems(PostUpdate, update_plane_color.before(UiSystems::Layout));
         app.add_observer(on_pointer_press)
             .add_observer(on_drag_start)
             .add_observer(on_drag)

--- a/crates/bevy_feathers/src/controls/color_slider.rs
+++ b/crates/bevy_feathers/src/controls/color_slider.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     component::Component,
     entity::Entity,
     hierarchy::Children,
-    query::{Changed, Or, With},
+    query::{Changed, Or, With, Without},
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     system::Query,
@@ -23,7 +23,7 @@ use bevy_scene::prelude::*;
 use bevy_ui::{
     percent, px, AlignItems, BackgroundColor, BackgroundGradient, BorderColor, BorderRadius,
     ColorStop, Display, FlexDirection, Gradient, InterpolationColorSpace, LinearGradient, Node,
-    Outline, PositionType, UiRect, UiTransform, Val2, ZIndex,
+    Outline, PositionType, UiRect, UiSystems, UiTransform, Val2, ZIndex,
 };
 use bevy_ui_render::ui_material::MaterialNode;
 use bevy_ui_widgets::{
@@ -32,6 +32,7 @@ use bevy_ui_widgets::{
 
 use crate::{
     alpha_pattern::{AlphaPattern, AlphaPatternMaterial},
+    controls::{FeathersSlider, FeathersTextInput, ToggleSwitchSlide},
     cursor::EntityCursor,
     focus::FocusIndicator,
     palette,
@@ -199,7 +200,7 @@ struct ColorSliderTrack;
 /// Marker for the thumb
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Default, Clone)]
-struct ColorSliderThumb;
+pub(crate) struct ColorSliderThumb;
 
 impl FeathersColorSlider {
     fn scene(props: FeathersColorSliderProps) -> impl Scene {
@@ -426,7 +427,7 @@ fn update_slider_pos(
         ),
     >,
     q_children: Query<&Children>,
-    mut q_slider_thumb: Query<&mut Node, With<ColorSliderThumb>>,
+    mut q_slider_thumb: Query<&mut Node, (With<ColorSliderThumb>, Without<ToggleSwitchSlide>)>,
 ) {
     for (slider_ent, value, range) in q_sliders.iter_mut() {
         for child in q_children.iter_descendants(slider_ent) {
@@ -442,7 +443,11 @@ fn update_track_color(
     q_children: Query<&Children>,
     q_track: Query<(), With<ColorSliderTrack>>,
     mut q_background: Query<&mut BackgroundColor>,
-    mut q_gradient: Query<&mut BackgroundGradient>,
+    // Without<FeathersTextInput> and Without<FeathersSlider> to avoid ambiguity with FeathersSlider systems
+    mut q_gradient: Query<
+        &mut BackgroundGradient,
+        (Without<FeathersTextInput>, Without<FeathersSlider>),
+    >,
 ) {
     for (slider_ent, slider, SliderBaseColor(base_color)) in q_sliders.iter_mut() {
         let (start, middle, end) = slider.channel.gradient_ends(*base_color);
@@ -499,7 +504,12 @@ impl Plugin for ColorSliderPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_systems(
             PreUpdate,
-            (update_slider_pos, update_track_color).in_set(PickingSystems::Last),
+            // after UiSystems::Focus can be removed after Interaction is removed.
+            (
+                update_slider_pos.after(UiSystems::Focus),
+                update_track_color,
+            )
+                .in_set(PickingSystems::Last),
         );
     }
 }

--- a/crates/bevy_feathers/src/controls/color_slider.rs
+++ b/crates/bevy_feathers/src/controls/color_slider.rs
@@ -504,7 +504,7 @@ impl Plugin for ColorSliderPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_systems(
             PreUpdate,
-            // after UiSystems::Focus can be removed after Interaction is removed.
+            // .after(UiSystems::Focus) can be removed after Interaction is removed.
             (
                 update_slider_pos.after(UiSystems::Focus),
                 update_track_color,

--- a/crates/bevy_feathers/src/controls/disclosure_toggle.rs
+++ b/crates/bevy_feathers/src/controls/disclosure_toggle.rs
@@ -156,7 +156,9 @@ impl Plugin for DisclosureTogglePlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             PreUpdate,
-            (update_toggle_styles, update_toggle_styles_remove).in_set(PickingSystems::Last),
+            (update_toggle_styles, update_toggle_styles_remove)
+                .chain()
+                .in_set(PickingSystems::Last),
         );
     }
 }

--- a/crates/bevy_feathers/src/controls/listview.rs
+++ b/crates/bevy_feathers/src/controls/listview.rs
@@ -12,7 +12,9 @@ use bevy_ecs::{
     schedule::IntoScheduleConfigs as _,
     system::{Commands, Query, Res},
 };
-use bevy_input_focus::{tab_navigation::TabIndex, InputFocus, InputFocusVisible};
+use bevy_input_focus::{
+    tab_navigation::TabIndex, InputFocus, InputFocusSystems, InputFocusVisible,
+};
 use bevy_picking::{hover::Hovered, PickingSystems};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::{bsn, bsn_list, Scene, SceneComponent, SceneList};
@@ -21,7 +23,9 @@ use bevy_ui::{
     px, AlignItems, BorderRadius, Display, FlexDirection, InteractionDisabled, JustifyContent,
     Node, Overflow, PositionType, Selected, UiRect,
 };
-use bevy_ui_widgets::{ActiveDescendant, ControlOrientation, ListBox, ListItem, ScrollArea};
+use bevy_ui_widgets::{
+    ActiveDescendant, ControlOrientation, ListBox, ListItem, MenuFocusSystem, ScrollArea,
+};
 
 use crate::{
     constants::{fonts, size},
@@ -332,6 +336,11 @@ impl Plugin for ListViewPlugin {
             PreUpdate,
             (update_listrow_styles, update_listrow_styles_remove).in_set(PickingSystems::Last),
         );
-        app.add_systems(PostUpdate, on_change_focus);
+        app.add_systems(
+            PostUpdate,
+            on_change_focus
+                .after(MenuFocusSystem)
+                .before(InputFocusSystems::FocusChangeEvents),
+        );
     }
 }

--- a/crates/bevy_feathers/src/controls/menu.rs
+++ b/crates/bevy_feathers/src/controls/menu.rs
@@ -44,7 +44,7 @@ use crate::{
 };
 use bevy_input_focus::{
     tab_navigation::{NavAction, TabIndex},
-    FocusCause, InputFocus, InputFocusVisible,
+    FocusCause, InputFocus, InputFocusSystems, InputFocusVisible,
 };
 
 /// Top-level menu container. This wraps the menu button and provides an anchor for the popover.
@@ -616,7 +616,9 @@ impl Plugin for MenuPlugin {
                 update_menuitem_styles_remove,
                 update_menuitem_styles_focus_changed,
             )
-                .in_set(PickingSystems::Last),
+                .in_set(PickingSystems::Last)
+                // After Dispatch systems so that these systems use the most updated `InputFocus`.
+                .after(InputFocusSystems::Dispatch),
         );
     }
 }

--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -10,7 +10,7 @@ use bevy_ecs::{
     hierarchy::{ChildOf, Children},
     lifecycle::{Add, Insert, Remove},
     observer::On,
-    query::{Changed, Has, With},
+    query::{Changed, Has, With, Without},
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     system::{Commands, Query, Res},
@@ -19,7 +19,7 @@ use bevy_input::{
     keyboard::{Key, KeyCode, KeyboardInput},
     ButtonInput,
 };
-use bevy_input_focus::{FocusGained, FocusLost, FocusedInput, InputFocus};
+use bevy_input_focus::{FocusGained, FocusLost, FocusedInput, InputFocus, InputFocusSystems};
 use bevy_log::{warn, warn_once};
 use bevy_math::ops;
 use bevy_picking::{
@@ -44,7 +44,7 @@ use bevy_ui_widgets::ValueChange;
 
 use crate::{
     constants::{fonts, size},
-    controls::{FeathersTextInput, FeathersTextInputContainer},
+    controls::{FeathersSlider, FeathersTextInput, FeathersTextInputContainer},
     cursor::EntityCursor,
     rounded_corners::RoundedCorners,
     theme::{
@@ -1287,7 +1287,11 @@ fn update_slidebar_styles_theme(
         (Entity, Has<InteractionDisabled>, Option<&ThemeContext>),
         With<FeathersNumberInput>,
     >,
-    mut q_text_input: Query<(&Hovered, &mut BackgroundGradient)>,
+    // Without<FeathersSlider> to avoid ambiguity with FeathersSlider systems.
+    mut q_text_input: Query<
+        (&Hovered, &mut BackgroundGradient),
+        (With<FeathersTextInput>, Without<FeathersSlider>),
+    >,
     theme: Res<UiTheme>,
     input_focus: Res<InputFocus>,
     mut commands: Commands,
@@ -1325,7 +1329,11 @@ fn update_slidebar_styles_context(
         (Entity, Has<InteractionDisabled>, Option<&ThemeContext>),
         (With<FeathersNumberInput>, Changed<ThemeContext>),
     >,
-    mut q_text_input: Query<(&Hovered, &mut BackgroundGradient)>,
+    // Without<FeathersSlider> to avoid ambiguity with FeathersSlider systems.
+    mut q_text_input: Query<
+        (&Hovered, &mut BackgroundGradient),
+        (With<FeathersTextInput>, Without<FeathersSlider>),
+    >,
     theme: Res<UiTheme>,
     input_focus: Res<InputFocus>,
     mut commands: Commands,
@@ -1362,7 +1370,9 @@ impl Plugin for NumberInputPlugin {
             PreUpdate,
             (update_slidebar_styles_context, update_slidebar_styles_theme)
                 .chain()
-                .in_set(PickingSystems::Last),
+                .in_set(PickingSystems::Last)
+                // After Dispatch systems so that these systems use the most updated `InputFocus`.
+                .after(InputFocusSystems::Dispatch),
         );
     }
 }

--- a/crates/bevy_feathers/src/controls/scrollbar.rs
+++ b/crates/bevy_feathers/src/controls/scrollbar.rs
@@ -1,4 +1,4 @@
-use bevy_app::{Plugin, PostUpdate, PreUpdate};
+use bevy_app::{Plugin, PostUpdate, PreUpdate, TransformGizmoRenderStep};
 use bevy_camera::visibility::Visibility;
 use bevy_ecs::{
     component::Component,
@@ -171,7 +171,10 @@ impl Plugin for ScrollbarPlugin {
         );
         app.add_systems(
             PostUpdate,
-            update_scrollbar_visibility.after(UiSystems::Layout),
+            update_scrollbar_visibility
+                .after(UiSystems::Layout)
+                .before(bevy_ui::update::update_clipping_system)
+                .ambiguous_with(TransformGizmoRenderStep),
         );
     }
 }

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -456,6 +456,7 @@ impl Plugin for SliderPlugin {
                 update_slider_styles_theme,
                 update_slider_pos,
             )
+                .chain()
                 .in_set(PickingSystems::Last),
         );
     }

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -433,7 +433,7 @@ impl Plugin for ToggleSwitchPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_systems(
             PreUpdate,
-            // after UiSystems::Focus can be removed after Interaction is removed.
+            // .after(UiSystems::Focus) can be removed after Interaction is removed.
             (
                 update_switch_styles.after(UiSystems::Focus),
                 update_switch_styles_remove,

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     entity::Entity,
     hierarchy::Children,
     lifecycle::RemovedComponents,
-    query::{Added, Changed, Has, Or, With},
+    query::{Added, Changed, Has, Or, With, Without},
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     system::{Commands, Query},
@@ -20,11 +20,13 @@ use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::prelude::*;
 use bevy_ui::{
     percent, px, BorderRadius, Checked, InteractionDisabled, Node, PositionType, Pressed, UiRect,
+    UiSystems,
 };
 use bevy_ui_widgets::{ActivateOnPress, Checkbox};
 
 use crate::{
     constants::size,
+    controls::ColorSliderThumb,
     cursor::EntityCursor,
     focus::FocusIndicator,
     theme::{ThemeBackgroundColor, ThemeBorderColor},
@@ -85,7 +87,7 @@ impl FeathersToggleSwitch {
 /// Marker for the toggle switch slide
 #[derive(Component, Default, Clone, Reflect)]
 #[reflect(Component, Clone, Default)]
-struct ToggleSwitchSlide;
+pub(crate) struct ToggleSwitchSlide;
 
 /// Template function to spawn a toggle switch.
 ///
@@ -219,7 +221,7 @@ fn update_switch_styles_remove(
     q_children: Query<&Children>,
     mut q_slide: Query<
         (&mut Node, &ThemeBackgroundColor, &ThemeBorderColor),
-        With<ToggleSwitchSlide>,
+        (With<ToggleSwitchSlide>, Without<ColorSliderThumb>),
     >,
     mut removed_disabled: RemovedComponents<InteractionDisabled>,
     mut removed_checked: RemovedComponents<Checked>,
@@ -431,7 +433,13 @@ impl Plugin for ToggleSwitchPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_systems(
             PreUpdate,
-            (update_switch_styles, update_switch_styles_remove).in_set(PickingSystems::Last),
+            // after UiSystems::Focus can be removed after Interaction is removed.
+            (
+                update_switch_styles.after(UiSystems::Focus),
+                update_switch_styles_remove,
+            )
+                .chain()
+                .in_set(PickingSystems::Last),
         );
     }
 }

--- a/crates/bevy_feathers/src/focus.rs
+++ b/crates/bevy_feathers/src/focus.rs
@@ -14,6 +14,7 @@ use bevy_input_focus::{InputFocus, InputFocusVisible};
 use bevy_platform::collections::HashSet;
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_ui::{px, Outline, UiSystems};
+use bevy_ui_widgets::MenuFocusSystem;
 
 use crate::{
     theme::{SurfaceLevel, UiTheme},
@@ -97,7 +98,9 @@ impl Plugin for FocusOutlinesPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_systems(
             PostUpdate,
-            manage_focus_indicators.in_set(UiSystems::Content),
+            manage_focus_indicators
+                .after(MenuFocusSystem)
+                .in_set(UiSystems::Content),
         );
     }
 }

--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -28,8 +28,8 @@ use bevy_asset::embedded_asset;
 use bevy_ecs::{query::With, schedule::IntoScheduleConfigs};
 use bevy_input_focus::tab_navigation::TabNavigationPlugin;
 use bevy_text::{TextColor, TextFont};
-use bevy_ui::UiSystems;
-use bevy_ui_render::UiMaterialPlugin;
+use bevy_ui::{AccessibilityUiSystems, UiSystems};
+use bevy_ui_render::{ImageNodeAssetChangedSystems, UiMaterialPlugin};
 
 use crate::{
     alpha_pattern::{AlphaPatternMaterial, AlphaPatternResource},
@@ -91,6 +91,10 @@ impl Plugin for FeathersCorePlugin {
             PostUpdate,
             PropagateSet::<TextFont>::default().in_set(UiSystems::Propagate),
         );
+        app.configure_sets(
+            PostUpdate,
+            PropagateSet::<TextColor>::default().in_set(UiSystems::Propagate),
+        );
 
         app.insert_resource(DefaultCursor(EntityCursor::System(
             bevy_window::SystemCursorIcon::Default,
@@ -99,9 +103,19 @@ impl Plugin for FeathersCorePlugin {
         app.add_systems(
             PostUpdate,
             (
-                theme::update_theme,
-                display::update_themed_icons.after(PropagateSet::<TextColor>::default()),
-            ),
+                theme::update_theme.in_set(UiSystems::Prepare),
+                display::update_themed_icons
+                    .after(PropagateSet::<TextColor>::default())
+                    // These systems deal with the underlying asset of the ImageNode,
+                    // which this system does not change.
+                    .ambiguous_with(ImageNodeAssetChangedSystems)
+                    // These systems merely update the `AccessibilityNode` and do not depend
+                    // on any changes `update_themed_icons` does to an image node.
+                    .ambiguous_with(AccessibilityUiSystems)
+                    // `update_themed_icons` does not affect the size of content.
+                    .ambiguous_with(UiSystems::Content),
+            )
+                .chain(),
         )
         .add_observer(theme::on_changed_background)
         .add_observer(theme::on_changed_border)

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -75,7 +75,7 @@ pub mod prelude {
     };
 }
 
-use bevy_app::prelude::*;
+use bevy_app::{prelude::*, PropagateSet};
 use bevy_asset::AssetApp;
 use bevy_ecs::prelude::*;
 
@@ -130,7 +130,8 @@ impl Plugin for TextPlugin {
                     load_font_assets_into_font_collection,
                     detect_text_needs_rerender,
                 )
-                    .chain(),
+                    .chain()
+                    .after(PropagateSet::<TextFont>::default()),
             )
             .add_systems(Last, trim_source_cache)
             .add_systems(

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -20,7 +20,7 @@ use bevy_ecs::{
     prelude::Entity,
     query::{Changed, With, Without},
     reflect::ReflectComponent,
-    schedule::IntoScheduleConfigs,
+    schedule::{IntoScheduleConfigs, SystemSet},
     system::{Commands, Query},
     world::{DeferredWorld, Ref},
 };
@@ -183,6 +183,11 @@ fn label_changed(
     }
 }
 
+/// System set for UI Systems that update the [`AccessibilityNode`] information
+/// of UI-related entities
+#[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AccessibilityUiSystems;
+
 /// A component which permits the a11y label to be specified independently from other a11y
 /// attributes.
 ///
@@ -240,6 +245,7 @@ impl Plugin for AccessibilityPlugin {
                     .after(label_changed),
             )
                 .in_set(UiSystems::PostLayout)
+                .in_set(AccessibilityUiSystems)
                 .before(AccessibilitySystems::Update),
         );
     }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -28,6 +28,7 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_picking::PickingSystems;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 mod accessibility;
+pub use accessibility::AccessibilityUiSystems;
 // This module is not re-exported, but is instead made public.
 // This is intended to discourage accidental use of the experimental API.
 pub mod experimental;

--- a/crates/bevy_ui_render/src/image.rs
+++ b/crates/bevy_ui_render/src/image.rs
@@ -43,10 +43,8 @@ impl AsAssetId for ImageNodeTextureAtlasLayout {
     }
 }
 
-/// System set for [`mark_images_as_changed_if_their_assets_changed`]
-/// and [`update_texture_atlas_layout_components`], systems that handle
-/// the asset underlying [`ImageNode`] and [`ImageNodeTextureAtlasLayout`]
-/// changing.
+/// System set for systems that react to the asset underlying
+/// [`ImageNode`] changing.
 #[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ImageNodeAssetChangedSystems;
 

--- a/crates/bevy_ui_render/src/image.rs
+++ b/crates/bevy_ui_render/src/image.rs
@@ -8,6 +8,7 @@ use bevy_ecs::{
     entity::Entity,
     query::{Changed, Or},
     reflect::ReflectComponent,
+    schedule::SystemSet,
     system::{Commands, Query},
 };
 use bevy_image::TextureAtlasLayout;
@@ -42,6 +43,13 @@ impl AsAssetId for ImageNodeTextureAtlasLayout {
     }
 }
 
+/// System set for [`mark_images_as_changed_if_their_assets_changed`]
+/// and [`update_texture_atlas_layout_components`], systems that handle
+/// the asset underlying [`ImageNode`] and [`ImageNodeTextureAtlasLayout`]
+/// changing.
+#[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ImageNodeAssetChangedSystems;
+
 /// A system that marks [`ImageNode`]s as changed if either their
 /// [`bevy_image::Image`] or [`TextureAtlasLayout`] changed.
 pub(crate) fn mark_images_as_changed_if_their_assets_changed(
@@ -62,7 +70,7 @@ pub(crate) fn mark_images_as_changed_if_their_assets_changed(
 }
 
 /// A system that copies the [`TextureAtlasLayout`] stored within an
-/// [`ImageNode`] to the [`TextureAtlasLayout`] component.
+/// [`ImageNode`] to the [`ImageNodeTextureAtlasLayout`] component.
 pub(crate) fn update_texture_atlas_layout_components(
     mut commands: Commands,
     images_query: Query<(Entity, &ImageNode), Changed<ImageNode>>,

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod box_shadow;
 mod gradient;
 mod image;
+pub use image::ImageNodeAssetChangedSystems;
 mod pipeline;
 pub mod render_pass;
 mod text;
@@ -215,6 +216,7 @@ impl Plugin for UiRenderPlugin {
                 image::update_texture_atlas_layout_components,
             )
                 .chain()
+                .in_set(ImageNodeAssetChangedSystems)
                 .after(UiSystems::Content)
                 .after(AssetEventSystems)
                 .after(AccessibilitySystems::Update),

--- a/crates/bevy_ui_widgets/src/menu.rs
+++ b/crates/bevy_ui_widgets/src/menu.rs
@@ -150,7 +150,8 @@ pub enum MenuFocusState {
     Closed,
 }
 
-/// System set for [`menu_acquire_focus`]. It potentially modifies [`InputFocus`].
+/// System set for the system that menus use to acquire focus on one of its items upon first opening.
+/// It potentially modifies [`InputFocus`].
 ///
 /// These system runs in the [`PostUpdate`] schedule.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, SystemSet)]

--- a/crates/bevy_ui_widgets/src/menu.rs
+++ b/crates/bevy_ui_widgets/src/menu.rs
@@ -40,7 +40,7 @@ use bevy_ecs::{
     observer::On,
     query::{Has, With},
     reflect::{ReflectComponent, ReflectEvent},
-    schedule::IntoScheduleConfigs,
+    schedule::{IntoScheduleConfigs, SystemSet},
     system::{Commands, Query, Res, ResMut},
 };
 use bevy_input::{
@@ -150,6 +150,13 @@ pub enum MenuFocusState {
     Closed,
 }
 
+/// System set for [`menu_acquire_focus`]. It potentially modifies [`InputFocus`].
+///
+/// These system runs in the [`PostUpdate`] schedule.
+#[derive(Debug, PartialEq, Eq, Hash, Clone, SystemSet)]
+pub struct MenuFocusSystem;
+
+/// System that sets the focus to an item in the menu when the menu is opening.
 fn menu_acquire_focus(
     mut q_menus: Query<(Entity, &mut MenuFocusState), With<MenuPopup>>,
     mut focus: ResMut<InputFocus>,
@@ -474,7 +481,10 @@ impl Plugin for MenuPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             PostUpdate,
-            (menu_acquire_focus, menu_on_lose_focus)
+            (
+                menu_acquire_focus.in_set(MenuFocusSystem),
+                menu_on_lose_focus,
+            )
                 .chain()
                 .after(VisibilitySystems::VisibilityPropagate)
                 .before(InputFocusSystems::FocusChangeEvents)


### PR DESCRIPTION
# Objective

- Blocks #25211 
- Since adding `bevy_feathers` as a default feature is not a certain thing, I spun out this separate PR as it’s probably valuable to do outside of the feature discussion (plus, if we decide not to make it a default feature for now but change our minds in the future, this will at least make the process easier)

## Solution

- I tried my best to make decisions on how to order the systems, but if I’m completely off base somewhere, let me know. I tried to add code comments where they made sense to clarify the system ordering.

## Testing

- `cargo run --example feathers_gallery --features=“bevy_feathers”` everything seems to function as it did on main with a bunch of fiddling in the example.