### PR TITLE
Add `bevy_feathers` feature to wasm ci testing

### DIFF
--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -57,6 +57,7 @@ fn main() {
         file.write_fmt(format_args!("(events: [({frames}, AppExit)])"))
             .unwrap();
         features.push("bevy_ci_testing");
+        features.push("bevy_feathers");
     }
 
     match cli.api {


### PR DESCRIPTION
# Objective

- `bevy-example-runner` runs are currently failing in wasm because `split_screen` now requires the `bevy_features` feature with my changes. This should fix it.

## Solution

- Just require the `bevy_feathers` feature for ci wasm builds. I _could_ only enable it if the example is just for `split_screen`, since it’s the only example that requires it in what the bevy-example-runner tests, but with the growing usage of `bevy_feathers` for examples, correcting it once for the future seems like the way to go.

## Testing

- Trivial enough to not need testing I think...