### PR TITLE
Add Metal GPU pass timings

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/main_opaque_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_opaque_pass_3d_node.rs
@@ -9,7 +9,7 @@ use bevy_log::error;
 use bevy_log::info_span;
 use bevy_render::{
     camera::ExtractedCamera,
-    diagnostic::RecordDiagnostics,
+    diagnostic::{PassKind, RecordDiagnostics},
     render_phase::ViewBinnedRenderPhases,
     render_resource::{PipelineCache, RenderPassDescriptor, StoreOp},
     renderer::{RenderContext, ViewQuery},
@@ -63,16 +63,17 @@ pub fn main_opaque_pass_3d(
 
     let color_attachments = [Some(target.get_color_attachment())];
     let depth_stencil_attachment = Some(depth.get_attachment(StoreOp::Store));
+    let pass_span = diagnostics.pass_span_descriptor(PassKind::Render, "main_opaque_pass_3d");
 
     let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
         label: Some("main_opaque_pass_3d"),
         color_attachments: &color_attachments,
         depth_stencil_attachment,
-        timestamp_writes: None,
+        timestamp_writes: pass_span.render_timestamp_writes(),
         occlusion_query_set: None,
         multiview_mask: None,
     });
-    let pass_span = diagnostics.pass_span(&mut render_pass, "main_opaque_pass_3d");
+    let pass_span = pass_span.begin(&mut render_pass);
 
     if let Some(viewport) =
         Viewport::from_viewport_and_override(camera.viewport.as_ref(), resolution_override)

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -40,6 +40,7 @@ use bevy_mesh::{Mesh3d, MeshVertexBufferLayoutRef};
 use bevy_platform::collections::{HashMap, HashSet};
 use bevy_platform::hash::FixedHasher;
 use bevy_render::camera::{DirtySpecializations, PendingQueues};
+use bevy_render::diagnostic::{PassKind, RecordDiagnostics};
 use bevy_render::erased_render_asset::ErasedRenderAssets;
 use bevy_render::mesh::allocator::MeshSlabs;
 use bevy_render::occlusion_culling::{
@@ -2954,19 +2955,25 @@ fn view_shadow_pass<const IS_LATE: bool>(
     let _shadow_pass_span = info_span!("", "{}", view_light.pass_name).entered();
 
     let depth_stencil_attachment = Some(view_light.depth_attachment.get_attachment(StoreOp::Store));
+    let diagnostics = ctx.diagnostic_recorder();
+    let diagnostics = diagnostics.as_deref();
+    let pass_span =
+        diagnostics.pass_span_descriptor(PassKind::Render, view_light.pass_name.clone());
 
     let mut render_pass = ctx.begin_tracked_render_pass(RenderPassDescriptor {
         label: Some(&view_light.pass_name),
         color_attachments: &[],
         depth_stencil_attachment,
-        timestamp_writes: None,
+        timestamp_writes: pass_span.render_timestamp_writes(),
         occlusion_query_set: None,
         multiview_mask: None,
     });
+    let pass_span = pass_span.begin(&mut render_pass);
 
     if let Err(err) = shadow_phase.render(&mut render_pass, world, view_light_entity) {
         error!("Error encountered while rendering the shadow phase {err:?}");
     }
+    pass_span.end(&mut render_pass);
 }
 
 /// Creates the [`ClusterableObjectType`] data for a point or spot light.

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -18,7 +18,7 @@ use bevy_image::ToExtents;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     camera::{ExtractedCamera, TemporalJitter},
-    diagnostic::RecordDiagnostics,
+    diagnostic::{PassKind, RecordDiagnostics},
     extract_component::ExtractComponent,
     globals::{GlobalsBuffer, GlobalsUniform},
     render_resource::{
@@ -211,7 +211,8 @@ fn ssao(
 
     let diagnostics = ctx.diagnostic_recorder();
     let diagnostics = diagnostics.as_deref();
-    let time_span = diagnostics.time_span(ctx.command_encoder(), "ssao");
+    let preprocess_span =
+        diagnostics.pass_span_descriptor(PassKind::Compute, "ssao_preprocess_depth");
 
     let command_encoder = ctx.command_encoder();
     command_encoder.push_debug_group("ssao");
@@ -220,8 +221,9 @@ fn ssao(
         let mut preprocess_depth_pass =
             command_encoder.begin_compute_pass(&ComputePassDescriptor {
                 label: Some("ssao_preprocess_depth"),
-                timestamp_writes: None,
+                timestamp_writes: preprocess_span.compute_timestamp_writes(),
             });
+        let preprocess_span = preprocess_span.begin(&mut preprocess_depth_pass);
         preprocess_depth_pass.set_pipeline(preprocess_depth_pipeline);
         preprocess_depth_pass.set_bind_group(0, &bind_groups.preprocess_depth_bind_group, &[]);
         preprocess_depth_pass.set_bind_group(
@@ -234,13 +236,16 @@ fn ssao(
             camera_size.y.div_ceil(16),
             1,
         );
+        preprocess_span.end(&mut preprocess_depth_pass);
     }
 
+    let ssao_span = diagnostics.pass_span_descriptor(PassKind::Compute, "ssao");
     {
         let mut ssao_pass = command_encoder.begin_compute_pass(&ComputePassDescriptor {
             label: Some("ssao"),
-            timestamp_writes: None,
+            timestamp_writes: ssao_span.compute_timestamp_writes(),
         });
+        let ssao_span = ssao_span.begin(&mut ssao_pass);
         ssao_pass.set_pipeline(ssao_pipeline);
         ssao_pass.set_bind_group(0, &bind_groups.ssao_bind_group, &[]);
         ssao_pass.set_bind_group(
@@ -249,13 +254,16 @@ fn ssao(
             &[view_uniform_offset.offset],
         );
         ssao_pass.dispatch_workgroups(camera_size.x.div_ceil(8), camera_size.y.div_ceil(8), 1);
+        ssao_span.end(&mut ssao_pass);
     }
 
+    let denoise_span = diagnostics.pass_span_descriptor(PassKind::Compute, "ssao_spatial_denoise");
     {
         let mut spatial_denoise_pass = command_encoder.begin_compute_pass(&ComputePassDescriptor {
             label: Some("ssao_spatial_denoise"),
-            timestamp_writes: None,
+            timestamp_writes: denoise_span.compute_timestamp_writes(),
         });
+        let denoise_span = denoise_span.begin(&mut spatial_denoise_pass);
         spatial_denoise_pass.set_pipeline(spatial_denoise_pipeline);
         spatial_denoise_pass.set_bind_group(0, &bind_groups.spatial_denoise_bind_group, &[]);
         spatial_denoise_pass.set_bind_group(
@@ -268,10 +276,10 @@ fn ssao(
             camera_size.y.div_ceil(8),
             1,
         );
+        denoise_span.end(&mut spatial_denoise_pass);
     }
 
     command_encoder.pop_debug_group();
-    time_span.end(ctx.command_encoder());
 }
 
 #[derive(Resource)]

--- a/crates/bevy_render/src/diagnostic/internal.rs
+++ b/crates/bevy_render/src/diagnostic/internal.rs
@@ -18,7 +18,7 @@ use wgpu::{
 
 use crate::renderer::{RenderAdapterInfo, RenderDevice, RenderQueue, WgpuWrapper};
 
-use super::RecordDiagnostics;
+use super::{PassBoundaryTimestamps, RecordDiagnostics};
 
 // buffer offset must be divisible by 256, so this constant must be divisible by 32 (=256/8)
 const MAX_TIMESTAMP_QUERIES: u32 = 256;
@@ -30,7 +30,10 @@ const PIPELINE_STATISTICS_SIZE: u64 = 40;
 struct DiagnosticsRecorderInternal {
     timestamp_period_ns: f32,
     features: Features,
+    defer_query_resolve: bool,
     current_frame: Mutex<FrameData>,
+    unresolved_frames: Vec<FrameData>,
+    resolved_frames_pending_map: Vec<FrameData>,
     submitted_frames: Vec<FrameData>,
     finished_frames: Vec<FrameData>,
     #[cfg(feature = "tracing-tracy")]
@@ -59,12 +62,20 @@ impl DiagnosticsRecorder {
         DiagnosticsRecorder(WgpuWrapper::new(DiagnosticsRecorderInternal {
             timestamp_period_ns: queue.get_timestamp_period(),
             features,
+            // Metal exposes automatic pass-boundary timestamps, but an
+            // end-of-pass sample may not be visible to a resolve submitted in
+            // the same frame. Resolve those query sets on the next frame.
+            defer_query_resolve: adapter_info.backend == wgpu::Backend::Metal
+                && features.contains(Features::TIMESTAMP_QUERY)
+                && !features.contains(Features::TIMESTAMP_QUERY_INSIDE_PASSES),
             current_frame: Mutex::new(FrameData::new(
                 device,
                 features,
                 #[cfg(feature = "tracing-tracy")]
                 tracy_gpu_context.clone(),
             )),
+            unresolved_frames: Vec::new(),
+            resolved_frames_pending_map: Vec::new(),
             submitted_frames: Vec::new(),
             finished_frames: Vec::new(),
             #[cfg(feature = "tracing-tracy")]
@@ -101,7 +112,18 @@ impl DiagnosticsRecorder {
     ///
     /// Should be called before [`DiagnosticsRecorder::finish_frame`].
     pub fn resolve(&mut self, encoder: &mut CommandEncoder) {
-        self.current_frame_mut().resolve(encoder);
+        if !self.0.defer_query_resolve {
+            self.current_frame_mut().resolve(encoder);
+            return;
+        }
+
+        for frame in &mut self.0.unresolved_frames {
+            frame.resolve(encoder);
+        }
+        let mut unresolved_frames = core::mem::take(&mut self.0.unresolved_frames);
+        self.0
+            .resolved_frames_pending_map
+            .append(&mut unresolved_frames);
     }
 
     /// Finishes recording diagnostics for the current frame.
@@ -119,6 +141,12 @@ impl DiagnosticsRecorder {
         let tracy_gpu_context = self.0.tracy_gpu_context.clone();
 
         let internal = &mut self.0;
+        for frame in &mut internal.resolved_frames_pending_map {
+            frame.map_after_submit();
+        }
+        let mut resolved_frames = core::mem::take(&mut internal.resolved_frames_pending_map);
+        internal.submitted_frames.append(&mut resolved_frames);
+
         internal
             .current_frame
             .get_mut()
@@ -140,7 +168,13 @@ impl DiagnosticsRecorder {
             internal.current_frame.get_mut().expect("lock poisoned"),
             new_frame,
         );
-        internal.submitted_frames.push(old_frame);
+        if internal.defer_query_resolve {
+            internal.unresolved_frames.push(old_frame);
+        } else {
+            let mut old_frame = old_frame;
+            old_frame.map_after_submit();
+            internal.submitted_frames.push(old_frame);
+        }
     }
 }
 
@@ -196,6 +230,19 @@ impl RecordDiagnostics for DiagnosticsRecorder {
 
     fn end_pass_span<P: Pass>(&self, pass: &mut P) {
         self.current_frame_lock().end_pass(pass);
+    }
+
+    fn begin_pass_boundary_fallback(
+        &self,
+        kind: PassKind,
+        name: Cow<'static, str>,
+    ) -> Option<PassBoundaryTimestamps> {
+        self.current_frame_lock()
+            .begin_pass_boundary_fallback(kind, name)
+    }
+
+    fn end_pass_boundary_fallback(&self) {
+        self.current_frame_lock().end_pass_boundary_fallback();
     }
 }
 
@@ -477,6 +524,39 @@ impl FrameData {
         span.end_instant = Some(Instant::now());
     }
 
+    fn begin_pass_boundary_fallback(
+        &mut self,
+        kind: PassKind,
+        name: Cow<'static, str>,
+    ) -> Option<PassBoundaryTimestamps> {
+        if self.supports_timestamps_inside_passes
+            || self.num_timestamps.saturating_add(2) > MAX_TIMESTAMP_QUERIES
+        {
+            return None;
+        }
+
+        let query_set = self.timestamps_query_set.as_ref()?.clone();
+        let beginning_of_pass_write_index = self.num_timestamps;
+        let end_of_pass_write_index = beginning_of_pass_write_index + 1;
+        self.num_timestamps += 2;
+
+        let span = self.open_span(Some(kind), name);
+        span.begin_instant = Some(Instant::now());
+        span.begin_timestamp_index = Some(beginning_of_pass_write_index);
+        span.end_timestamp_index = Some(end_of_pass_write_index);
+
+        Some(PassBoundaryTimestamps {
+            query_set,
+            beginning_of_pass_write_index,
+            end_of_pass_write_index,
+        })
+    }
+
+    fn end_pass_boundary_fallback(&mut self) {
+        let span = self.close_span();
+        span.end_instant = Some(Instant::now());
+    }
+
     fn resolve(&mut self, encoder: &mut CommandEncoder) {
         let Some(resolve_buffer) = &self.resolve_buffer else {
             return;
@@ -517,7 +597,7 @@ impl FrameData {
     }
 
     fn finish(&mut self, callback: impl FnOnce(RenderDiagnostics) + Send + Sync + 'static) {
-        let Some(read_buffer) = &self.read_buffer else {
+        let Some(_) = &self.read_buffer else {
             // we still have cpu timings, so let's use them
 
             let mut diagnostics = Vec::new();
@@ -553,6 +633,12 @@ impl FrameData {
         };
 
         self.callback = Some(Box::new(callback));
+    }
+
+    fn map_after_submit(&mut self) {
+        let Some(read_buffer) = &self.read_buffer else {
+            return;
+        };
 
         let is_mapped = self.is_mapped.clone();
         read_buffer.slice(..).map_async(MapMode::Read, move |res| {

--- a/crates/bevy_render/src/diagnostic/mod.rs
+++ b/crates/bevy_render/src/diagnostic/mod.rs
@@ -16,7 +16,9 @@ use bevy_ecs::{
     world::{FromWorld, World},
 };
 use core::marker::PhantomData;
-use wgpu::{BufferSlice, CommandEncoder};
+use wgpu::{
+    BufferSlice, CommandEncoder, ComputePassTimestampWrites, QuerySet, RenderPassTimestampWrites,
+};
 
 use bevy_app::{App, Plugin, PreUpdate};
 
@@ -28,7 +30,8 @@ use crate::{
 use self::internal::{sync_diagnostics, Pass, RenderDiagnosticsMutex, WriteTimestamp};
 pub use self::{
     erased_render_asset_diagnostic_plugin::ErasedRenderAssetDiagnosticPlugin,
-    internal::DiagnosticsRecorder, mesh_allocator_diagnostic_plugin::MeshAllocatorDiagnosticPlugin,
+    internal::{DiagnosticsRecorder, PassKind},
+    mesh_allocator_diagnostic_plugin::MeshAllocatorDiagnosticPlugin,
     render_asset_diagnostic_plugin::RenderAssetDiagnosticPlugin,
 };
 
@@ -58,8 +61,9 @@ use crate::renderer::RenderDevice;
 ///     ```
 ///
 /// # Supported platforms
-/// Timestamp queries and pipeline statistics are currently supported only on Vulkan and DX12.
-/// On other platforms (Metal, WebGPU, WebGL2) only CPU time will be recorded.
+/// Timestamp queries and pipeline statistics are supported when the backend
+/// exposes the corresponding wgpu features. Metal supports whole-pass GPU
+/// timestamps through pass descriptor boundary writes.
 #[derive(Default)]
 pub struct RenderDiagnosticsPlugin;
 
@@ -137,6 +141,24 @@ fn finish_diagnostics_frame(
 
 /// Allows recording diagnostic spans.
 pub trait RecordDiagnostics: Send + Sync {
+    /// Prepares a pass diagnostic span before its descriptor is constructed.
+    ///
+    /// This follows the same begin/end model as [`RecordDiagnostics::pass_span`],
+    /// while also supplying automatic descriptor timestamps on backends that
+    /// cannot write timestamps inside an active pass.
+    fn pass_span_descriptor<N>(&self, kind: PassKind, name: N) -> PassDescriptorSpan<'_, Self>
+    where
+        N: Into<Cow<'static, str>>,
+    {
+        let name = name.into();
+        let timestamps = self.begin_pass_boundary_fallback(kind, name.clone());
+        PassDescriptorSpan {
+            recorder: self,
+            name,
+            timestamps,
+        }
+    }
+
     /// Begin a time span, which will record elapsed CPU and GPU time.
     ///
     /// Returns a guard, which will panic on drop unless you end the span.
@@ -195,6 +217,113 @@ pub trait RecordDiagnostics: Send + Sync {
 
     #[doc(hidden)]
     fn end_pass_span<P: Pass>(&self, pass: &mut P);
+
+    #[doc(hidden)]
+    fn begin_pass_boundary_fallback(
+        &self,
+        kind: PassKind,
+        name: Cow<'static, str>,
+    ) -> Option<PassBoundaryTimestamps>;
+
+    #[doc(hidden)]
+    fn end_pass_boundary_fallback(&self);
+}
+
+/// Query indices reserved for automatic beginning/end timestamp writes on a
+/// render or compute pass descriptor.
+#[doc(hidden)]
+pub struct PassBoundaryTimestamps {
+    query_set: QuerySet,
+    beginning_of_pass_write_index: u32,
+    end_of_pass_write_index: u32,
+}
+
+/// A pass diagnostic span prepared before constructing its pass descriptor.
+pub struct PassDescriptorSpan<'a, R: ?Sized> {
+    recorder: &'a R,
+    name: Cow<'static, str>,
+    timestamps: Option<PassBoundaryTimestamps>,
+}
+
+impl<'a, R: RecordDiagnostics + ?Sized> PassDescriptorSpan<'a, R> {
+    /// Returns timestamp writes suitable for a [`wgpu::RenderPassDescriptor`].
+    pub fn render_timestamp_writes(&self) -> Option<RenderPassTimestampWrites<'_>> {
+        self.timestamps
+            .as_ref()
+            .map(|timestamps| RenderPassTimestampWrites {
+                query_set: &timestamps.query_set,
+                beginning_of_pass_write_index: Some(timestamps.beginning_of_pass_write_index),
+                end_of_pass_write_index: Some(timestamps.end_of_pass_write_index),
+            })
+    }
+
+    /// Returns timestamp writes suitable for a [`wgpu::ComputePassDescriptor`].
+    pub fn compute_timestamp_writes(&self) -> Option<ComputePassTimestampWrites<'_>> {
+        self.timestamps
+            .as_ref()
+            .map(|timestamps| ComputePassTimestampWrites {
+                query_set: &timestamps.query_set,
+                beginning_of_pass_write_index: Some(timestamps.beginning_of_pass_write_index),
+                end_of_pass_write_index: Some(timestamps.end_of_pass_write_index),
+            })
+    }
+
+    /// Begins recording after the pass has been constructed.
+    pub fn begin<P: Pass>(self, pass: &mut P) -> DescriptorPassSpanGuard<'a, R, P> {
+        let uses_descriptor_timestamps = self.timestamps.is_some();
+        if !uses_descriptor_timestamps {
+            self.recorder.begin_pass_span(pass, self.name.clone());
+        }
+
+        let guard = DescriptorPassSpanGuard {
+            recorder: self.recorder,
+            name: self.name.clone(),
+            uses_descriptor_timestamps,
+            marker: PhantomData,
+        };
+        core::mem::forget(self);
+        guard
+    }
+}
+
+impl<R: ?Sized> Drop for PassDescriptorSpan<'_, R> {
+    fn drop(&mut self) {
+        if self.timestamps.is_some() {
+            panic!(
+                "PassDescriptorSpan::begin was never called for {}",
+                self.name
+            );
+        }
+    }
+}
+
+/// Guard returned by [`PassDescriptorSpan::begin`].
+pub struct DescriptorPassSpanGuard<'a, R: ?Sized, P> {
+    recorder: &'a R,
+    name: Cow<'static, str>,
+    uses_descriptor_timestamps: bool,
+    marker: PhantomData<P>,
+}
+
+impl<R: RecordDiagnostics + ?Sized, P: Pass> DescriptorPassSpanGuard<'_, R, P> {
+    /// Ends the pass diagnostic span.
+    pub fn end(self, pass: &mut P) {
+        if self.uses_descriptor_timestamps {
+            self.recorder.end_pass_boundary_fallback();
+        } else {
+            self.recorder.end_pass_span(pass);
+        }
+        core::mem::forget(self);
+    }
+}
+
+impl<R: ?Sized, P> Drop for DescriptorPassSpanGuard<'_, R, P> {
+    fn drop(&mut self) {
+        panic!(
+            "DescriptorPassSpanGuard::end was never called for {}",
+            self.name
+        );
+    }
 }
 
 /// Guard returned by [`RecordDiagnostics::time_span`].
@@ -284,6 +413,21 @@ impl<T: RecordDiagnostics> RecordDiagnostics for Option<Arc<T>> {
             recorder.end_pass_span(pass);
         }
     }
+
+    fn begin_pass_boundary_fallback(
+        &self,
+        kind: PassKind,
+        name: Cow<'static, str>,
+    ) -> Option<PassBoundaryTimestamps> {
+        self.as_ref()
+            .and_then(|recorder| recorder.begin_pass_boundary_fallback(kind, name))
+    }
+
+    fn end_pass_boundary_fallback(&self) {
+        if let Some(recorder) = self {
+            recorder.end_pass_boundary_fallback();
+        }
+    }
 }
 
 impl<'a, T: RecordDiagnostics> RecordDiagnostics for Option<&'a T> {
@@ -326,6 +470,20 @@ impl<'a, T: RecordDiagnostics> RecordDiagnostics for Option<&'a T> {
     fn end_pass_span<P: Pass>(&self, pass: &mut P) {
         if let Some(recorder) = self {
             recorder.end_pass_span(pass);
+        }
+    }
+
+    fn begin_pass_boundary_fallback(
+        &self,
+        kind: PassKind,
+        name: Cow<'static, str>,
+    ) -> Option<PassBoundaryTimestamps> {
+        self.and_then(|recorder| recorder.begin_pass_boundary_fallback(kind, name))
+    }
+
+    fn end_pass_boundary_fallback(&self) {
+        if let Some(recorder) = self {
+            recorder.end_pass_boundary_fallback();
         }
     }
 }


### PR DESCRIPTION
Adds pass-descriptor GPU timestamps when in-pass timestamps are unavailable. Metal query resolution is deferred by one frame because same-frame resolves can observe stale end timestamps.

Validated on Apple M4 Pro and with `cargo check -p bevy_pbr -p bevy_core_pipeline`.