### PR TITLE
Change `Capsule3d` default resolution from 5 to 4.

### DIFF
--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -14,6 +14,7 @@ use bevy_math::{
 use crate::{circles::SphereBuilder, gizmos::GizmoBuffer, prelude::GizmoConfigGroup};
 
 const DEFAULT_RESOLUTION: u32 = 5;
+const DEFAULT_CAPSULE_RESOLUTION: u32 = 4;
 // length used to simulate infinite lines
 const INFINITE_LEN: f32 = 10_000.0;
 

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -497,7 +497,7 @@ where
             half_length: primitive.half_length,
             isometry: isometry.into(),
             color: color.into(),
-            resolution: DEFAULT_RESOLUTION,
+            resolution: DEFAULT_CAPSULE_RESOLUTION,
         }
     }
 }

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -157,6 +157,16 @@ fn draw_example_collection(
         .map(|t| (t, TEAL.mix(&HOT_PINK, t / 5.0)));
     gizmos.curve_gradient_3d(curve, times_and_colors);
 
+    gizmos.primitive_3d(
+        &Capsule3d::new(0.35, 0.5),
+        Isometry3d::new(
+            Vec3::new(-1.75, 0.75, 0.75),
+            Quat::from_rotation_y(ops::cos(time.elapsed_secs() / 2.0) * 10.0)
+                * Quat::from_rotation_z(PI / 3.0),
+        ),
+        YELLOW_GREEN,
+    );
+
     my_gizmos.sphere(Vec3::new(1., 0.5, 0.), 0.5, RED);
 
     my_gizmos


### PR DESCRIPTION
# Objective

- Change the `Capsule3d` gizmo primitive to have 4 segments instead of 5, as discussed in #25158 . 

## Solution

- Adds a new const, `DEFAULT_CAPSULE_RESOLUTION` set to 4 instead of 5.
  - This is to prevent changes to the other 3d primtives that use this same value.
- The default resolution of the `Capsule3d` gizmo now uses `DEFAULT_CAPSULE_RESOLUTION`.
- Adds the `Capsule3d` to the `3d_gizmos` example.

## Testing
`cargo run --features=free_camera --example=3d_gizmos`

## Showcase
<details>
  <summary>Visual Differences</summary>

**Orange (left):** 4 segments.
**Blue (right):** 5 segments.

<img width="435" height="439" alt="image" src="https://github.com/user-attachments/assets/cf8da253-2600-410a-97aa-8c88472d98aa" />

<img width="388" height="297" alt="image" src="https://github.com/user-attachments/assets/ba969773-fad6-47f1-b07d-5f371b5e4b5a" />


</details>
