### PR TITLE
Support Val::Em and Val::Rem, store values in ComputedNode, use in resolving values from Node, etc.

### DIFF
--- a/_release-content/migration-guides/default_font_size_is_rem.md
+++ b/_release-content/migration-guides/default_font_size_is_rem.md
@@ -1,0 +1,17 @@
+---
+title: "Default Font Size Is 1rem"
+pull_requests: [25231]
+---
+
+`TextFont::default()` now uses `FontSize::Rem(1.)` instead of `FontSize::Px(20.)`, so that the
+`RemSize` resource actually sets the default font size. With the default `RemSize` of 20 logical
+pixels this renders identically, but text left at the default size now scales when `RemSize`
+changes. To keep a fixed size, set it explicitly:
+
+```rust
+// 0.20
+TextFont {
+    font_size: FontSize::Px(20.),
+    ..default()
+}
+```

--- a/_release-content/migration-guides/default_font_size_is_rem.md
+++ b/_release-content/migration-guides/default_font_size_is_rem.md
@@ -1,5 +1,5 @@
 ---
-title: "Default Font Size Is 1rem"
+title: "`TextFont::default()` font size is now `FontSize::Rem(1.)`"
 pull_requests: [25231]
 ---
 

--- a/_release-content/migration-guides/val_em_and_rem.md
+++ b/_release-content/migration-guides/val_em_and_rem.md
@@ -38,7 +38,7 @@ node out, so when resolving a `Val` against an existing node you can take them f
 for example).
 
 `Node` now requires `EmSize` (from `bevy_text`, re-exported in `bevy_ui::prelude`), the per-node
-font size that `Val::Em` resolves against. If the node has a `TextFont`, `EmSize` is derived when `TextFont`,
+font size that `Val::Em` resolves against. If the node has a `TextFont`, `EmSize` is recomputed when `TextFont`,
 `RemSize`, or render-target info changes; values you set persist until then. If the node does not
 have a `TextFont` component then the value is yours to set and is left alone; it defaults to
 `DEFAULT_REM_SIZE_PX`, which matches the default `RemSize` but does not track changes to it. Propagating

--- a/_release-content/migration-guides/val_em_and_rem.md
+++ b/_release-content/migration-guides/val_em_and_rem.md
@@ -4,8 +4,8 @@ pull_requests: [25231]
 ---
 
 `Val` has two new variants, `Val::Em` and `Val::Rem`, which size a length relative to a font size.
-`Val::Em` resolves against the font size of the node it is set on, `Val::Rem` against the 
-`RemSize` resource. The `em` and `rem` helper functions construct them, alongside the existing `px`, 
+`Val::Em` resolves against the font size of the node it is set on, `Val::Rem` against the
+`RemSize` resource. The `em` and `rem` helper functions construct them, alongside the existing `px`,
 `percent`, `vw` and `vh`.
 
 Resolving a `Val` now needs both of those font sizes, so the following methods take two additional
@@ -33,7 +33,7 @@ let physical = val.resolve(
 ```
 
 `ComputedNode` has new `em_size` and `rem_size` fields holding the values that were used to lay the
-node out, so when resolving a `Val` against an existing node you can take them from there (`box_shadow` 
+node out, so when resolving a `Val` against an existing node you can take them from there (`box_shadow`
 for example).
 
 `Node` now requires `EmSize` (from `bevy_text`, re-exported in `bevy_ui::prelude`), the per-node
@@ -42,7 +42,7 @@ before layout each frame and any value you set is overwritten. If it does not, t
 set and is left alone; it defaults to `DEFAULT_REM_SIZE_PX`, which matches the default `RemSize` but
 does not track changes to it. Propagating `EmSize` is the responsibility of an app, not `bevy_ui`.
 
-Use `GridTrack::em`, `GridTrack::rem`, `RepeatedGridTrack::em` and `RepeatedGridTrack::rem` to construct 
+Use `GridTrack::em`, `GridTrack::rem`, `RepeatedGridTrack::em` and `RepeatedGridTrack::rem` to construct
 grid tracks sized in these units.
 
 `FontSize::eval` now takes a `RemSize` rather than an `f32`:
@@ -55,7 +55,7 @@ let size = font_size.eval(logical_viewport_size, rem_size_px);
 let size = font_size.eval(logical_viewport_size, RemSize(rem_size_px));
 ```
 
-### Note: Default `TextFont` `font_size`
+**Note: Default `TextFont` `font_size` changed**
 
 `TextFont::default()` now uses `FontSize::Rem(1.)` instead of `FontSize::Px(20.)`, so that the
 `RemSize` resource actually sets the default font size. With the default `RemSize` of 20 logical

--- a/_release-content/migration-guides/val_em_and_rem.md
+++ b/_release-content/migration-guides/val_em_and_rem.md
@@ -57,18 +57,3 @@ let size = font_size.eval(logical_viewport_size, rem_size_px);
 // 0.20
 let size = font_size.eval(logical_viewport_size, RemSize(rem_size_px));
 ```
-
-**Note: Default `TextFont` `font_size` changed**
-
-`TextFont::default()` now uses `FontSize::Rem(1.)` instead of `FontSize::Px(20.)`, so that the
-`RemSize` resource actually sets the default font size. With the default `RemSize` of 20 logical
-pixels this renders identically, but text left at the default size now scales when `RemSize`
-changes. To keep a fixed size, set it explicitly:
-
-```rust
-// 0.20
-TextFont {
-    font_size: FontSize::Px(20.),
-    ..default()
-}
-```

--- a/_release-content/migration-guides/val_em_and_rem.md
+++ b/_release-content/migration-guides/val_em_and_rem.md
@@ -1,0 +1,71 @@
+---
+title: "Val::Em and Val::Rem"
+pull_requests: [25231]
+---
+
+`Val` has two new variants, `Val::Em` and `Val::Rem`, which size a length relative to a font size.
+`Val::Em` resolves against the font size of the node it is set on, `Val::Rem` against the 
+`RemSize` resource. The `em` and `rem` helper functions construct them, alongside the existing `px`, 
+`percent`, `vw` and `vh`.
+
+Resolving a `Val` now needs both of those font sizes, so the following methods take two additional
+arguments, `em_size: EmSize` and `rem_size: RemSize`:
+
+- `Val::resolve`
+- `Val2::resolve`
+- `UiPosition::resolve`
+- `CornerRadius::resolve`
+- `RadialGradientShape::resolve`
+- `UiTransform::compute_affine`
+
+```rust
+// 0.19
+let physical = val.resolve(scale_factor, physical_base_value, physical_target_size)?;
+
+// 0.20
+let physical = val.resolve(
+    scale_factor,
+    physical_base_value,
+    physical_target_size,
+    em_size,
+    rem_size,
+)?;
+```
+
+`ComputedNode` has new `em_size` and `rem_size` fields holding the values that were used to lay the
+node out, so when resolving a `Val` against an existing node you can take them from there (`box_shadow` 
+for example).
+
+`Node` now requires `EmSize` (from `bevy_text`, re-exported in `bevy_ui::prelude`), the per-node
+font size that `Val::Em` resolves against. If the node has a `TextFont`, `EmSize` is derived from it
+before layout each frame and any value you set is overwritten. If it does not, the value is yours to
+set and is left alone; it defaults to `DEFAULT_REM_SIZE_PX`, which matches the default `RemSize` but
+does not track changes to it. Propagating `EmSize` is the responsibility of an app, not `bevy_ui`.
+
+Use `GridTrack::em`, `GridTrack::rem`, `RepeatedGridTrack::em` and `RepeatedGridTrack::rem` to construct 
+grid tracks sized in these units.
+
+`FontSize::eval` now takes a `RemSize` rather than an `f32`:
+
+```rust
+// 0.19
+let size = font_size.eval(logical_viewport_size, rem_size_px);
+
+// 0.20
+let size = font_size.eval(logical_viewport_size, RemSize(rem_size_px));
+```
+
+### Note: Default `TextFont` `font_size`
+
+`TextFont::default()` now uses `FontSize::Rem(1.)` instead of `FontSize::Px(20.)`, so that the
+`RemSize` resource actually sets the default font size. With the default `RemSize` of 20 logical
+pixels this renders identically, but text left at the default size now scales when `RemSize`
+changes. To keep a fixed size, set it explicitly:
+
+```rust
+// 0.20
+TextFont {
+    font_size: FontSize::Px(20.),
+    ..default()
+}
+```

--- a/_release-content/migration-guides/val_em_and_rem.md
+++ b/_release-content/migration-guides/val_em_and_rem.md
@@ -17,6 +17,7 @@ arguments, `em_size: EmSize` and `rem_size: RemSize`:
 - `CornerRadius::resolve`
 - `RadialGradientShape::resolve`
 - `UiTransform::compute_affine`
+- `BorderRadius::resolve`
 
 ```rust
 // 0.19
@@ -37,13 +38,15 @@ node out, so when resolving a `Val` against an existing node you can take them f
 for example).
 
 `Node` now requires `EmSize` (from `bevy_text`, re-exported in `bevy_ui::prelude`), the per-node
-font size that `Val::Em` resolves against. If the node has a `TextFont`, `EmSize` is derived from it
-before layout each frame and any value you set is overwritten. If it does not, the value is yours to
-set and is left alone; it defaults to `DEFAULT_REM_SIZE_PX`, which matches the default `RemSize` but
-does not track changes to it. Propagating `EmSize` is the responsibility of an app, not `bevy_ui`.
+font size that `Val::Em` resolves against. If the node has a `TextFont`, `EmSize` is derived when `TextFont`,
+`RemSize`, or render-target info changes; values you set persist until then. If the node does not
+have a `TextFont` component then the value is yours to set and is left alone; it defaults to
+`DEFAULT_REM_SIZE_PX`, which matches the default `RemSize` but does not track changes to it. Propagating
+`EmSize` is the responsibility of an app, not `bevy_ui`.
 
 Use `GridTrack::em`, `GridTrack::rem`, `RepeatedGridTrack::em` and `RepeatedGridTrack::rem` to construct
-grid tracks sized in these units.
+grid tracks sized in these units using new `MinTrackSizingFunction::Em`, `MinTrackSizingFunction::Rem`,
+`MaxTrackSizingFunction::Em` and `MaxTrackSizingFunction::Rem` variants.
 
 `FontSize::eval` now takes a `RemSize` rather than an `f32`:
 

--- a/_release-content/release-notes/val_em_and_rem.md
+++ b/_release-content/release-notes/val_em_and_rem.md
@@ -1,0 +1,24 @@
+---
+title: "Val::Em and Val::Rem"
+authors: ["@gagnus"]
+pull_requests: [25231]
+---
+
+Bevy UI now supports `em` and `rem` as sizing units. `em` is the current font size (represented by an `EmSize` component), `rem` is a
+global "root" font size (represented by the existing `RemSize` resource).
+
+For now, `EmSize` is derived from `TextFont` when one is on the same entity; propagating it down the hierarchy is left to your app.
+
+This is especially useful if you might want to vary your text size after authoring your UIs, for example as an accessibility feature or
+just to improve your UI on different devices.
+
+```rust
+bsn! {
+    Node { width: em(10) }
+    Text("Hello")
+    TextFont { font_size: FontSize::Rem(1.5) }
+}
+```
+
+The default font-size is now `rem(1)` rather than `px(20)`. This is a no-op if you're not changing `RemSize` but it means your
+text will scale by default when you do.

--- a/_release-content/release-notes/val_em_and_rem.md
+++ b/_release-content/release-notes/val_em_and_rem.md
@@ -7,7 +7,7 @@ pull_requests: [25231]
 Bevy UI now supports `em` and `rem` as sizing units. `em` is the current font size (represented by an `EmSize` component), `rem` is a
 global "root" font size (represented by the existing `RemSize` resource).
 
-For now, `EmSize` is derived from `TextFont` when one is on the same entity; propagating it down the hierarchy is left to your app.
+`EmSize` is derived from `TextFont` when one is on the same entity; propagating it down the hierarchy is left to your app.
 
 This is especially useful if you might want to vary your text size after authoring your UIs, for example as an accessibility feature or
 just to improve your UI on different devices.

--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -300,7 +300,7 @@ fn toggle_display(
         let font_size = overlay_config
             .text_config
             .font_size
-            .eval(text_node.1.logical_size(), rem_size.0);
+            .eval(text_node.1.logical_size(), *rem_size);
         graph_node.width = Val::Px(font_size * FRAME_TIME_GRAPH_WIDTH_SCALE);
         graph_node.height = Val::Px(font_size * FRAME_TIME_GRAPH_HEIGHT_SCALE);
 

--- a/crates/bevy_sprite/src/text2d.rs
+++ b/crates/bevy_sprite/src/text2d.rs
@@ -277,7 +277,7 @@ pub fn update_text2d_layout(
                 &mut font_system,
                 &mut layout_cx,
                 logical_viewport_size,
-                rem_size.0,
+                *rem_size,
             ) {
                 Err(
                     TextError::NoSuchFont

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -14,7 +14,6 @@ use parley::style::{OverflowWrap, TextWrapMode, WordBreak};
 use parley::{Alignment, AlignmentOptions, Layout, PositionedLayoutItem, StyleProperty};
 use swash::FontRef;
 
-use crate::TextBrush;
 use crate::{
     add_glyph_to_atlas,
     error::TextError,
@@ -24,6 +23,7 @@ use crate::{
     Justify, LetterSpacing, LineBreak, LineHeight, PositionedGlyph, TextBounds, TextEntity,
     TextFont, TextLayout,
 };
+use crate::{RemSize, TextBrush};
 
 struct TextSectionView<'a> {
     index: usize,
@@ -71,7 +71,7 @@ impl TextPipeline {
         font_cx: &mut FontCx,
         layout_cx: &mut LayoutCx,
         logical_viewport_size: Vec2,
-        base_rem_size: f32,
+        base_rem_size: RemSize,
     ) -> Result<(), TextError> {
         computed.entities.clear();
         computed.needs_rerender = false;
@@ -201,7 +201,7 @@ impl TextPipeline {
                     range.clone(),
                 );
                 builder.push(
-                    StyleProperty::LetterSpacing(section.letter_spacing.eval(base_rem_size)),
+                    StyleProperty::LetterSpacing(section.letter_spacing.eval(base_rem_size.0)),
                     range.clone(),
                 );
                 builder.push(
@@ -262,7 +262,7 @@ impl TextPipeline {
         font_system: &mut FontCx,
         layout_cx: &mut LayoutCx,
         logical_viewport_size: Vec2,
-        base_rem_size: f32,
+        base_rem_size: RemSize,
     ) -> Result<TextMeasureInfo, TextError> {
         const MIN_WIDTH_CONTENT_BOUNDS: TextBounds = TextBounds::new_horizontal(0.0);
 

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -201,7 +201,7 @@ impl TextPipeline {
                     range.clone(),
                 );
                 builder.push(
-                    StyleProperty::LetterSpacing(section.letter_spacing.eval(base_rem_size.0)),
+                    StyleProperty::LetterSpacing(section.letter_spacing.eval(base_rem_size)),
                     range.clone(),
                 );
                 builder.push(

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -802,7 +802,7 @@ impl FontSize {
         // Viewport size in logical pixels
         logical_viewport_size: Vec2,
         // Base Rem size in logical pixels
-        rem_size: f32,
+        rem_size: RemSize,
     ) -> f32 {
         match self {
             FontSize::Px(s) => s,
@@ -810,7 +810,7 @@ impl FontSize {
             FontSize::Vh(s) => logical_viewport_size.y * s / 100.,
             FontSize::VMin(s) => logical_viewport_size.min_element() * s / 100.,
             FontSize::VMax(s) => logical_viewport_size.max_element() * s / 100.,
-            FontSize::Rem(s) => rem_size * s,
+            FontSize::Rem(s) => rem_size.0 * s,
         }
     }
 }
@@ -864,13 +864,16 @@ impl From<f32> for FontSize {
     }
 }
 
+/// Default RemSize in pixels
+pub const DEFAULT_REM_SIZE_PX: f32 = 20.0;
+
 /// Base value used to resolve `Rem` units for font sizes.
-#[derive(Resource, Copy, Clone, Debug, PartialEq, Deref, DerefMut)]
+#[derive(Resource, Copy, Clone, Debug, PartialEq, Deref, DerefMut, Reflect)]
 pub struct RemSize(pub f32);
 
 impl Default for RemSize {
     fn default() -> Self {
-        Self(20.)
+        Self(DEFAULT_REM_SIZE_PX)
     }
 }
 

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -885,9 +885,10 @@ impl Default for RemSize {
 /// `Em` units are relative to the font size of the node they sit on, and this is that
 /// font size made concrete. Required by `Node`, so every UI node has one.
 ///
-/// If the node has a `TextFont`, this is derived from it before layout each frame and
-/// any value you set is overwritten. If it does not, the value is yours to set and is
-/// left alone. It defaults to [`DEFAULT_REM_SIZE_PX`], which matches the default
+/// If the node has a `TextFont`, the `EmSize` is derived from it whenever the `TextFont`,
+/// `RemSize` or render-target info changes; until then any value you place on it persists.
+/// If it does not have a `TextFont`, the value is yours to set, for example by an app-level
+/// propagation system. `EmSize` defaults to [`DEFAULT_REM_SIZE_PX`], which matches the default
 /// [`RemSize`] but does not track changes to it. Use `Val::Rem` instead for values that
 /// should follow the root font size.
 ///

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -864,7 +864,7 @@ impl From<f32> for FontSize {
     }
 }
 
-/// Default RemSize in pixels
+/// Default `RemSize` in pixels
 pub const DEFAULT_REM_SIZE_PX: f32 = 20.0;
 
 /// Base value used to resolve `Rem` units for font sizes.

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -877,6 +877,36 @@ impl Default for RemSize {
     }
 }
 
+/// Used for resolving `Val::Em` during layout if no `TextFont` is found.
+/// Note there is no propagation of this so resolution will fall back to
+/// `RemSize` unless the user has a font propagation strategy.
+#[derive(Debug, PartialEq, Clone, Copy, Reflect, Component)]
+#[reflect(Default, PartialEq, Debug, Clone, Component)]
+pub struct EmSize(pub f32);
+
+impl Default for EmSize {
+    fn default() -> Self {
+        EmSize(DEFAULT_REM_SIZE_PX)
+    }
+}
+
+impl From<RemSize> for EmSize {
+    fn from(value: RemSize) -> Self {
+        EmSize(value.0)
+    }
+}
+
+impl EmSize {
+    /// Convert from a `FontSize` to an `EmSize` using eval.
+    pub fn from_font_size(
+        font_size: FontSize,
+        logical_viewport_size: Vec2,
+        rem_size: RemSize,
+    ) -> Self {
+        EmSize(font_size.eval(logical_viewport_size, rem_size))
+    }
+}
+
 /// How thick or bold the strokes of a font appear.
 ///
 /// Valid font weights range from 1 to 1000, inclusive.

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -864,10 +864,13 @@ impl From<f32> for FontSize {
     }
 }
 
-/// Default `RemSize` in pixels
+/// Default [`RemSize`] and [`EmSize`], in logical pixels
 pub const DEFAULT_REM_SIZE_PX: f32 = 20.0;
 
-/// Base value used to resolve `Rem` units for font sizes.
+/// The root font size, in logical pixels.
+///
+/// `Rem` units always resolve against this one global resource, including
+/// `FontSize::Rem`, `LetterSpacing::Rem` and `Val::Rem`.
 #[derive(Resource, Copy, Clone, Debug, PartialEq, Deref, DerefMut, Reflect)]
 pub struct RemSize(pub f32);
 
@@ -877,9 +880,18 @@ impl Default for RemSize {
     }
 }
 
-/// Used for resolving `Val::Em` during layout if no `TextFont` is found.
-/// Note there is no propagation of this so resolution will fall back to
-/// `RemSize` unless the user has a font propagation strategy.
+/// The font size, in logical pixels, used to resolve `Val::Em` values in a UI node.
+///
+/// `Em` units are relative to the font size of the node they sit on, and this is that
+/// font size made concrete. Required by `Node`, so every UI node has one.
+///
+/// If the node has a `TextFont`, this is derived from it before layout each frame and
+/// any value you set is overwritten. If it does not, the value is yours to set and is
+/// left alone. It defaults to [`DEFAULT_REM_SIZE_PX`], which matches the default
+/// [`RemSize`] but does not track changes to it. Use `Val::Rem` instead for values that
+/// should follow the root font size.
+///
+/// Removing a `TextFont` leaves the last derived value in place.
 #[derive(Debug, PartialEq, Clone, Copy, Reflect, Component)]
 #[reflect(Default, PartialEq, Debug, Clone, Component)]
 pub struct EmSize(pub f32);
@@ -890,14 +902,8 @@ impl Default for EmSize {
     }
 }
 
-impl From<RemSize> for EmSize {
-    fn from(value: RemSize) -> Self {
-        EmSize(value.0)
-    }
-}
-
 impl EmSize {
-    /// Convert from a `FontSize` to an `EmSize` using eval.
+    /// Resolves a [`FontSize`] to a concrete [`EmSize`] in logical pixels.
     pub fn from_font_size(
         font_size: FontSize,
         logical_viewport_size: Vec2,
@@ -1370,15 +1376,18 @@ impl Default for LineHeight {
 pub enum LetterSpacing {
     /// Set letter spacing to a specific number of logical pixels
     Px(f32),
-    /// Set letter spacing to a multiple of the font size
+    /// Set letter spacing to a multiple of the root font size ([`RemSize`])
     Rem(f32),
 }
 
 impl LetterSpacing {
-    pub(crate) fn eval(self, rem_size: f32) -> f32 {
+    /// Evaluate a [`LetterSpacing`] into logical pixels either
+    /// because it specifies them directly or using the global
+    /// [`RemSize`] resource.
+    pub(crate) fn eval(self, rem_size: RemSize) -> f32 {
         match self {
             LetterSpacing::Px(px) => px,
-            LetterSpacing::Rem(rem) => rem * rem_size,
+            LetterSpacing::Rem(rem) => rem * rem_size.0,
         }
     }
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -759,7 +759,7 @@ impl Default for TextFont {
     fn default() -> Self {
         Self {
             font: Default::default(),
-            font_size: FontSize::from(20.),
+            font_size: FontSize::Rem(1.),
             style: FontStyle::Normal,
             weight: FontWeight::NORMAL,
             width: FontWidth::NORMAL,

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -1436,11 +1436,41 @@ mod tests {
     fn val_evaluate() {
         let size = 250.;
         let viewport_size = vec2(1000., 500.);
-        let result = Val::Percent(80.)
-            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
-            .unwrap();
+        let em_size = EmSize(10.);
+        let rem_size = RemSize(20.);
 
-        assert_eq!(result, size * 0.8);
+        assert_eq!(
+            Val::Percent(80.)
+                .resolve(1., size, viewport_size, em_size, rem_size)
+                .unwrap(),
+            size * 0.8
+        );
+        // Check em and rem
+        assert_eq!(
+            Val::Em(2.)
+                .resolve(1., size, viewport_size, em_size, rem_size)
+                .unwrap(),
+            em_size.0 * 2.
+        );
+        assert_eq!(
+            Val::Rem(5.)
+                .resolve(1., size, viewport_size, em_size, rem_size)
+                .unwrap(),
+            rem_size.0 * 5.
+        );
+        // Check scale_factor is considered
+        assert_eq!(
+            Val::Em(2.)
+                .resolve(2., size, viewport_size, em_size, rem_size)
+                .unwrap(),
+            em_size.0 * 2. * 2.
+        );
+        assert_eq!(
+            Val::Rem(5.)
+                .resolve(2., size, viewport_size, em_size, rem_size)
+                .unwrap(),
+            rem_size.0 * 5. * 2.
+        );
     }
 
     #[test]

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -55,9 +55,15 @@ pub enum Val {
     VMin(f32),
     /// Set this value in percent of the viewport's larger dimension.
     VMax(f32),
-    /// Use an `EmSize` component or the global `RemSize` resource to turn into pixels
+    /// Set this value as a multiple of the node's own font size.
+    ///
+    /// `1em` is the node's font size, so `Val::Em(2.0)` is twice that.
+    /// Resolved from the node's [`EmSize`] component.
     Em(f32),
-    /// Use the `RemSize` resource (if available) to turn into pixels
+    /// Set this value as a multiple of the root font size.
+    ///
+    /// Unlike [`Val::Em`] this ignores the node's own font size, so it means the same
+    /// length anywhere in the hierarchy. Resolved from the [`RemSize`] resource.
     Rem(f32),
 }
 
@@ -144,6 +150,8 @@ impl PartialEq for Val {
                 | (Self::Rem(_), Self::Rem(_))
         );
 
+        // as long as the units are the same comparing `inner`
+        // is valid.
         let left = self.inner();
         let right = other.inner();
 
@@ -160,8 +168,11 @@ impl Val {
     pub const DEFAULT: Self = Self::Auto;
     pub const ZERO: Self = Self::Px(0.0);
 
-    /// Returns the raw inner from a `Val` if it has one
-    pub fn inner(self) -> Option<f32> {
+    /// Returns the number this `Val` wraps, whatever its unit, or `None` for [`Val::Auto`].
+    ///
+    /// The number is meaningless without the variant it came from — `Val::Px(4.0)` and
+    /// `Val::Rem(4.0)` both return `4.0`. Use [`Val::resolve`] for a length in pixels.
+    pub(crate) fn inner(self) -> Option<f32> {
         match self {
             Self::Auto => None,
             Self::Px(v)
@@ -466,7 +477,7 @@ pub enum ValArithmeticError {
 
 impl Val {
     /// Resolves this [`Val`] to a value in physical pixels from the given `scale_factor`, `physical_base_value`,
-    /// and `physical_target_size` context values.
+    /// `physical_target_size`, `em_size`, and `rem_size` context values.
     ///
     /// Returns a [`ValArithmeticError::NonEvaluable`] if the [`Val`] is impossible to resolve into a concrete value.
     pub const fn resolve(
@@ -496,6 +507,11 @@ impl Val {
 }
 
 impl From<Val> for FontSize {
+    /// Converts a [`Val`] into a [`FontSize`].
+    ///
+    /// [`Val::Em`] becomes [`FontSize::Rem`]: em is relative to the font size of the node
+    /// itself, which is the very thing being defined here, so it resolves against the root
+    /// size instead to avoid the circularity.
     fn from(val: Val) -> Self {
         match val {
             Val::Auto => FontSize::Rem(1.),
@@ -506,10 +522,7 @@ impl From<Val> for FontSize {
             Val::VMin(vmin) => FontSize::VMin(vmin),
             Val::VMax(vmax) => FontSize::VMax(vmax),
             Val::Rem(rem) => FontSize::Rem(rem),
-            // `em` is relative to the font size of the node itself, which is
-            // what's being defined here, so fall back to the rem base,
-            // consistent with how `Val::Em` resolves on nodes without a `TextFont`.
-            Val::Em(em) => FontSize::Rem(em),
+            Val::Em(em) => FontSize::Rem(em), // see comment above
         }
     }
 }
@@ -1229,9 +1242,12 @@ impl From<(Val, Val)> for UiPosition {
 /// ```
 /// # use bevy_math::{Vec2, Vec2Swizzles};
 /// # use bevy_ui::{CornerRadius, Val};
+/// # use bevy_text::{EmSize, RemSize};
 /// let radius = Val::Px(10.0);
 /// let size = Vec2::new(100.0, 50.0);
 /// let viewport_size = Vec2::new(1920.0, 1080.0);
+/// let em_size = EmSize(20.0);
+/// let rem_size = RemSize(20.0);
 ///
 /// let c1 = CornerRadius {
 ///     x: radius,
@@ -1241,10 +1257,10 @@ impl From<(Val, Val)> for UiPosition {
 ///     x: Val::ZERO,
 ///     y: radius,
 /// };
-/// let r = c1.resolve(1.0, size, viewport_size);
+/// let r = c1.resolve(1.0, size, viewport_size, em_size, rem_size);
 /// assert_eq!(
 ///     r,
-///     c2.resolve(1.0, size, viewport_size).yx(),
+///     c2.resolve(1.0, size, viewport_size, em_size, rem_size).yx(),
 /// );
 /// assert_eq!(
 ///     r,
@@ -1291,9 +1307,12 @@ impl CornerRadius {
     /// ```
     /// # use bevy_math::Vec2;
     /// # use bevy_ui::{CornerRadius, Val};
+    /// # use bevy_text::{EmSize, RemSize};
     /// let radius = Val::Px(30.0);
     /// let size = Vec2::new(100.0, 50.0);
     /// let viewport_size = Vec2::new(1920.0, 1080.0);
+    /// let em_size = EmSize(20.0);
+    /// let rem_size = RemSize(20.0);
     ///
     /// let c1 = CornerRadius::circular(radius);
     /// let c2 = CornerRadius {
@@ -1301,10 +1320,10 @@ impl CornerRadius {
     ///     y: radius,
     /// };
     ///
-    /// let r = c1.resolve(1.0, size, viewport_size);
+    /// let r = c1.resolve(1.0, size, viewport_size, em_size, rem_size);
     /// assert_eq!(
     ///     r,
-    ///     c2.resolve(1.0, size, viewport_size),
+    ///     c2.resolve(1.0, size, viewport_size, em_size, rem_size),
     /// );
     /// assert_eq!(
     ///     r,

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -588,12 +588,12 @@ pub fn px<T: ValNum>(value: T) -> Val {
     Val::Px(value.val_num_f32())
 }
 
-/// Returns a [`Val::Em`]
+/// Returns a [`Val::Em`] representing a value proportional to the node's own font size, represented by an [`EmSize`] component.
 pub fn em<T: ValNum>(value: T) -> Val {
     Val::Em(value.val_num_f32())
 }
 
-/// Returns a [`Val::Rem`]
+/// Returns a [`Val::Rem`] representing a value proportional to the root font size.
 pub fn rem<T: ValNum>(value: T) -> Val {
     Val::Rem(value.val_num_f32())
 }

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -1,14 +1,12 @@
 use bevy_math::{MismatchedUnitsError, StableInterpolate as _, TryStableInterpolate, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_text::{FontSize, RemSize};
+use bevy_text::{EmSize, FontSize, RemSize};
 use bevy_utils::default;
 use core::ops::{Div, DivAssign, Mul, MulAssign, Neg};
 use thiserror::Error;
 
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
-
-use crate::EmSize;
 
 /// Represents the possible value types for layout properties.
 ///

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -1,12 +1,14 @@
 use bevy_math::{MismatchedUnitsError, StableInterpolate as _, TryStableInterpolate, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_text::FontSize;
+use bevy_text::{FontSize, RemSize};
 use bevy_utils::default;
 use core::ops::{Div, DivAssign, Mul, MulAssign, Neg};
 use thiserror::Error;
 
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
+
+use crate::EmSize;
 
 /// Represents the possible value types for layout properties.
 ///
@@ -55,6 +57,10 @@ pub enum Val {
     VMin(f32),
     /// Set this value in percent of the viewport's larger dimension.
     VMax(f32),
+    /// Use an `EmSize` component or the global `RemSize` resource to turn into pixels
+    Em(f32),
+    /// Use the `RemSize` resource (if available) to turn into pixels
+    Rem(f32),
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -115,6 +121,10 @@ impl core::str::FromStr for Val {
             Ok(Val::VMin(value))
         } else if unit.eq_ignore_ascii_case("vmax") {
             Ok(Val::VMax(value))
+        } else if unit.eq_ignore_ascii_case("rem") {
+            Ok(Val::Rem(value))
+        } else if unit.eq_ignore_ascii_case("em") {
+            Ok(Val::Em(value))
         } else {
             Err(ValParseError::InvalidUnit)
         }
@@ -132,32 +142,17 @@ impl PartialEq for Val {
                 | (Self::Vh(_), Self::Vh(_))
                 | (Self::VMin(_), Self::VMin(_))
                 | (Self::VMax(_), Self::VMax(_))
+                | (Self::Em(_), Self::Em(_))
+                | (Self::Rem(_), Self::Rem(_))
         );
 
-        let left = match self {
-            Self::Auto => None,
-            Self::Px(v)
-            | Self::Percent(v)
-            | Self::Vw(v)
-            | Self::Vh(v)
-            | Self::VMin(v)
-            | Self::VMax(v) => Some(v),
-        };
-
-        let right = match other {
-            Self::Auto => None,
-            Self::Px(v)
-            | Self::Percent(v)
-            | Self::Vw(v)
-            | Self::Vh(v)
-            | Self::VMin(v)
-            | Self::VMax(v) => Some(v),
-        };
+        let left = self.inner();
+        let right = other.inner();
 
         match (same_unit, left, right) {
             (true, a, b) => a == b,
             // All zero-value variants are considered equal.
-            (false, Some(&a), Some(&b)) => a == 0. && b == 0.,
+            (false, Some(a), Some(b)) => a == 0. && b == 0.,
             _ => false,
         }
     }
@@ -166,6 +161,21 @@ impl PartialEq for Val {
 impl Val {
     pub const DEFAULT: Self = Self::Auto;
     pub const ZERO: Self = Self::Px(0.0);
+
+    /// Returns the raw inner from a `Val` if it has one
+    pub fn inner(self) -> Option<f32> {
+        match self {
+            Self::Auto => None,
+            Self::Px(v)
+            | Self::Percent(v)
+            | Self::Vw(v)
+            | Self::Vh(v)
+            | Self::VMin(v)
+            | Self::VMax(v)
+            | Self::Em(v)
+            | Self::Rem(v) => Some(v),
+        }
+    }
 
     /// Returns a [`UiRect`] with its `left` equal to this value,
     /// and all other fields set to `Val::ZERO`.
@@ -323,6 +333,8 @@ impl Val {
             (Val::Vh(u), Val::Vh(v)) => Ok(Val::Vh(u + v)),
             (Val::VMin(u), Val::VMin(v)) => Ok(Val::VMin(u + v)),
             (Val::VMax(u), Val::VMax(v)) => Ok(Val::VMax(u + v)),
+            (Val::Em(u), Val::Em(v)) => Ok(Val::Em(u + v)),
+            (Val::Rem(u), Val::Rem(v)) => Ok(Val::Rem(u + v)),
             _ => Err(ValArithmeticError::IncompatibleUnits),
         }
     }
@@ -347,6 +359,8 @@ impl Val {
             (Val::Vh(u), Val::Vh(v)) => Ok(Val::Vh(u - v)),
             (Val::VMin(u), Val::VMin(v)) => Ok(Val::VMin(u - v)),
             (Val::VMax(u), Val::VMax(v)) => Ok(Val::VMax(u - v)),
+            (Val::Em(u), Val::Em(v)) => Ok(Val::Em(u - v)),
+            (Val::Rem(u), Val::Rem(v)) => Ok(Val::Rem(u - v)),
             _ => Err(ValArithmeticError::IncompatibleUnits),
         }
     }
@@ -370,6 +384,8 @@ impl Mul<f32> for Val {
             Val::Vh(value) => Val::Vh(value * rhs),
             Val::VMin(value) => Val::VMin(value * rhs),
             Val::VMax(value) => Val::VMax(value * rhs),
+            Val::Em(value) => Val::Em(value * rhs),
+            Val::Rem(value) => Val::Rem(value * rhs),
         }
     }
 }
@@ -383,7 +399,9 @@ impl MulAssign<f32> for Val {
             | Val::Vw(value)
             | Val::Vh(value)
             | Val::VMin(value)
-            | Val::VMax(value) => *value *= rhs,
+            | Val::VMax(value)
+            | Val::Em(value)
+            | Val::Rem(value) => *value *= rhs,
         }
     }
 }
@@ -400,6 +418,8 @@ impl Div<f32> for Val {
             Val::Vh(value) => Val::Vh(value / rhs),
             Val::VMin(value) => Val::VMin(value / rhs),
             Val::VMax(value) => Val::VMax(value / rhs),
+            Val::Em(value) => Val::Em(value / rhs),
+            Val::Rem(value) => Val::Rem(value / rhs),
         }
     }
 }
@@ -413,7 +433,9 @@ impl DivAssign<f32> for Val {
             | Val::Vw(value)
             | Val::Vh(value)
             | Val::VMin(value)
-            | Val::VMax(value) => *value /= rhs,
+            | Val::VMax(value)
+            | Val::Em(value)
+            | Val::Rem(value) => *value /= rhs,
         }
     }
 }
@@ -423,13 +445,15 @@ impl Neg for Val {
 
     fn neg(self) -> Self::Output {
         match self {
+            Val::Auto => Val::Auto,
             Val::Px(value) => Val::Px(-value),
             Val::Percent(value) => Val::Percent(-value),
             Val::Vw(value) => Val::Vw(-value),
             Val::Vh(value) => Val::Vh(-value),
             Val::VMin(value) => Val::VMin(-value),
             Val::VMax(value) => Val::VMax(-value),
-            _ => self,
+            Val::Em(value) => Val::Em(-value),
+            Val::Rem(value) => Val::Rem(-value),
         }
     }
 }
@@ -452,6 +476,8 @@ impl Val {
         scale_factor: f32,
         physical_base_value: f32,
         physical_target_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
     ) -> Result<f32, ValArithmeticError> {
         match self {
             Val::Percent(value) => Ok(physical_base_value * value / 100.0),
@@ -464,14 +490,16 @@ impl Val {
             Val::VMax(value) => {
                 Ok(physical_target_size.x.max(physical_target_size.y) * value / 100.0)
             }
+            Val::Em(value) => Ok(value * em_size.0 * scale_factor),
+            Val::Rem(value) => Ok(value * rem_size.0 * scale_factor),
             Val::Auto => Err(ValArithmeticError::NonEvaluable),
         }
     }
 }
 
 impl From<Val> for FontSize {
-    fn from(value: Val) -> Self {
-        match value {
+    fn from(val: Val) -> Self {
+        match val {
             Val::Auto => FontSize::Rem(1.),
             Val::Px(px) => FontSize::Px(px),
             Val::Percent(percent) => FontSize::Rem(percent / 100.),
@@ -479,6 +507,11 @@ impl From<Val> for FontSize {
             Val::Vh(vh) => FontSize::Vh(vh),
             Val::VMin(vmin) => FontSize::VMin(vmin),
             Val::VMax(vmax) => FontSize::VMax(vmax),
+            Val::Rem(rem) => FontSize::Rem(rem),
+            // `em` is relative to the font size of the node itself, which is
+            // what's being defined here, so fall back to the rem base,
+            // consistent with how `Val::Em` resolves on nodes without a `TextFont`.
+            Val::Em(em) => FontSize::Rem(em),
         }
     }
 }
@@ -540,6 +573,16 @@ pub const fn auto() -> Val {
 /// Returns a [`Val::Px`] representing a value in logical pixels.
 pub fn px<T: ValNum>(value: T) -> Val {
     Val::Px(value.val_num_f32())
+}
+
+/// Returns a [`Val::Em`]
+pub fn em<T: ValNum>(value: T) -> Val {
+    Val::Em(value.val_num_f32())
+}
+
+/// Returns a [`Val::Rem`]
+pub fn rem<T: ValNum>(value: T) -> Val {
+    Val::Rem(value.val_num_f32())
 }
 
 /// Returns a [`Val::Percent`] representing a percentage of the parent node's length
@@ -1136,16 +1179,30 @@ impl UiPosition {
         scale_factor: f32,
         physical_size: Vec2,
         physical_target_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
     ) -> Vec2 {
         let d = self.anchor.map(|p| if 0. < p { -1. } else { 1. });
 
         physical_size * self.anchor
             + d * Vec2::new(
                 self.x
-                    .resolve(scale_factor, physical_size.x, physical_target_size)
+                    .resolve(
+                        scale_factor,
+                        physical_size.x,
+                        physical_target_size,
+                        em_size,
+                        rem_size,
+                    )
                     .unwrap_or(0.),
                 self.y
-                    .resolve(scale_factor, physical_size.y, physical_target_size)
+                    .resolve(
+                        scale_factor,
+                        physical_size.y,
+                        physical_target_size,
+                        em_size,
+                        rem_size,
+                    )
                     .unwrap_or(0.),
             )
     }
@@ -1345,7 +1402,9 @@ mod tests {
     fn val_evaluate() {
         let size = 250.;
         let viewport_size = vec2(1000., 500.);
-        let result = Val::Percent(80.).resolve(1., size, viewport_size).unwrap();
+        let result = Val::Percent(80.)
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+            .unwrap();
 
         assert_eq!(result, size * 0.8);
     }
@@ -1354,14 +1413,29 @@ mod tests {
     fn val_resolve_px() {
         let size = 250.;
         let viewport_size = vec2(1000., 500.);
-        let result = Val::Px(10.).resolve(1., size, viewport_size).unwrap();
 
+        let result = Val::Px(10.)
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+            .unwrap();
         assert_eq!(result, 10.);
 
-        let result = Val::Px(10.).resolve(3., size, viewport_size).unwrap();
+        let result = Val::Px(10.)
+            .resolve(3., size, viewport_size, EmSize(20.0), RemSize(20.0))
+            .unwrap();
         assert_eq!(result, 30.);
-        let result = Val::Px(10.).resolve(0.25, size, viewport_size).unwrap();
+        let result = Val::Px(10.)
+            .resolve(0.25, size, viewport_size, EmSize(20.0), RemSize(20.0))
+            .unwrap();
         assert_eq!(result, 2.5);
+
+        let result = Val::Em(1.)
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+            .unwrap();
+        assert_eq!(result, 20.0);
+        let result = Val::Rem(1.)
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+            .unwrap();
+        assert_eq!(result, 20.0);
     }
 
     #[test]
@@ -1407,36 +1481,54 @@ mod tests {
         for value in (-10..10).map(|value| value as f32) {
             // for a square viewport there should be no difference between `Vw` and `Vh` and between `Vmin` and `Vmax`.
             assert_eq!(
-                Val::Vw(value).resolve(1., size, viewport_size),
-                Val::Vh(value).resolve(1., size, viewport_size)
+                Val::Vw(value).resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
+                Val::Vh(value).resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
             );
             assert_eq!(
-                Val::VMin(value).resolve(1., size, viewport_size),
-                Val::VMax(value).resolve(1., size, viewport_size)
+                Val::VMin(value).resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
+                Val::VMax(value).resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
             );
             assert_eq!(
-                Val::VMin(value).resolve(1., size, viewport_size),
-                Val::Vw(value).resolve(1., size, viewport_size)
+                Val::VMin(value).resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
+                Val::Vw(value).resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
             );
         }
 
         let viewport_size = vec2(1000., 500.);
         assert_eq!(
-            Val::Vw(100.).resolve(1., size, viewport_size).unwrap(),
+            Val::Vw(100.)
+                .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+                .unwrap(),
             1000.
         );
         assert_eq!(
-            Val::Vh(100.).resolve(1., size, viewport_size).unwrap(),
+            Val::Vh(100.)
+                .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+                .unwrap(),
             500.
         );
-        assert_eq!(Val::Vw(60.).resolve(1., size, viewport_size).unwrap(), 600.);
-        assert_eq!(Val::Vh(40.).resolve(1., size, viewport_size).unwrap(), 200.);
         assert_eq!(
-            Val::VMin(50.).resolve(1., size, viewport_size).unwrap(),
+            Val::Vw(60.)
+                .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+                .unwrap(),
+            600.
+        );
+        assert_eq!(
+            Val::Vh(40.)
+                .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+                .unwrap(),
+            200.
+        );
+        assert_eq!(
+            Val::VMin(50.)
+                .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+                .unwrap(),
             250.
         );
         assert_eq!(
-            Val::VMax(75.).resolve(1., size, viewport_size).unwrap(),
+            Val::VMax(75.)
+                .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0))
+                .unwrap(),
             750.
         );
     }
@@ -1445,7 +1537,7 @@ mod tests {
     fn val_auto_is_non_evaluable() {
         let size = 250.;
         let viewport_size = vec2(1000., 500.);
-        let resolve_auto = Val::Auto.resolve(1., size, viewport_size);
+        let resolve_auto = Val::Auto.resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0));
 
         assert_eq!(resolve_auto, Err(ValArithmeticError::NonEvaluable));
     }
@@ -1548,6 +1640,9 @@ mod tests {
         assert_eq!("3.5vmax".parse::<Val>(), Ok(Val::VMax(3.5)));
         assert_eq!("-3vmax".parse::<Val>(), Ok(Val::VMax(-3.)));
         assert_eq!("3.5 VMAX".parse::<Val>(), Ok(Val::VMax(3.5)));
+
+        assert_eq!("3em".parse::<Val>(), Ok(Val::Em(3.)));
+        assert_eq!("3rem".parse::<Val>(), Ok(Val::Rem(3.)));
 
         assert_eq!("".parse::<Val>(), Err(ValParseError::UnitMissing));
         assert_eq!(

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -1326,7 +1326,14 @@ impl CornerRadius {
     }
 
     /// Resolves this corner radius into horizontal and vertical radii in physical pixels.
-    pub fn resolve(self, scale_factor: f32, size: Vec2, viewport_size: Vec2) -> Vec2 {
+    pub fn resolve(
+        self,
+        scale_factor: f32,
+        size: Vec2,
+        viewport_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
+    ) -> Vec2 {
         match self {
             Self {
                 x: Val::Auto,
@@ -1341,13 +1348,21 @@ impl CornerRadius {
                 y: radius,
             } => Vec2::splat(
                 radius
-                    .resolve(scale_factor, size.min_element(), viewport_size)
+                    .resolve(
+                        scale_factor,
+                        size.min_element(),
+                        viewport_size,
+                        em_size,
+                        rem_size,
+                    )
                     .unwrap_or(0.)
                     .clamp(0., 0.5 * size.min_element()),
             ),
             Self { x, y } => Vec2::new(
-                x.resolve(scale_factor, size.x, viewport_size).unwrap_or(0.),
-                y.resolve(scale_factor, size.y, viewport_size).unwrap_or(0.),
+                x.resolve(scale_factor, size.x, viewport_size, em_size, rem_size)
+                    .unwrap_or(0.),
+                y.resolve(scale_factor, size.y, viewport_size, em_size, rem_size)
+                    .unwrap_or(0.),
             )
             .clamp(Vec2::ZERO, 0.5 * size),
         }
@@ -1448,7 +1463,7 @@ mod tests {
                 x: Val::Px(100.),
                 y: Val::Auto,
             }
-            .resolve(1., size, viewport_size),
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
             vec2(25., 25.)
         );
         assert_eq!(
@@ -1456,7 +1471,7 @@ mod tests {
                 x: Val::Px(40.),
                 y: Val::Px(40.),
             }
-            .resolve(1., size, viewport_size),
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
             vec2(40., 25.)
         );
         assert_eq!(
@@ -1464,11 +1479,11 @@ mod tests {
                 x: Val::ZERO,
                 y: Val::Px(20.),
             }
-            .resolve(1., size, viewport_size),
+            .resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
             vec2(0., 20.)
         );
         assert_eq!(
-            CornerRadius::default().resolve(1., size, viewport_size),
+            CornerRadius::default().resolve(1., size, viewport_size, EmSize(20.0), RemSize(20.0)),
             vec2(0., 0.)
         );
     }

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -172,7 +172,7 @@ impl Val {
     ///
     /// The number is meaningless without the variant it came from — `Val::Px(4.0)` and
     /// `Val::Rem(4.0)` both return `4.0`. Use [`Val::resolve`] for a length in pixels.
-    pub(crate) fn inner(self) -> Option<f32> {
+    const fn inner(self) -> Option<f32> {
         match self {
             Self::Auto => None,
             Self::Px(v)

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -534,6 +534,8 @@ impl TryStableInterpolate for Val {
             (Val::Vh(a), Val::Vh(b)) => Ok(Val::Vh(a.interpolate_stable(b, t))),
             (Val::VMin(a), Val::VMin(b)) => Ok(Val::VMin(a.interpolate_stable(b, t))),
             (Val::VMax(a), Val::VMax(b)) => Ok(Val::VMax(a.interpolate_stable(b, t))),
+            (Val::Em(a), Val::Em(b)) => Ok(Val::Em(a.interpolate_stable(b, t))),
+            (Val::Rem(a), Val::Rem(b)) => Ok(Val::Rem(a.interpolate_stable(b, t))),
             (Val::Auto, Val::Auto) => Ok(Val::Auto),
             _ => Err(MismatchedUnitsError),
         }

--- a/crates/bevy_ui/src/gradients.rs
+++ b/crates/bevy_ui/src/gradients.rs
@@ -1,8 +1,9 @@
-use crate::{UiPosition, Val, ValNum};
+use crate::{EmSize, UiPosition, Val, ValNum};
 use bevy_color::{Color, Srgba};
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
+use bevy_text::RemSize;
 use bevy_utils::default;
 use core::{f32, f32::consts::TAU};
 
@@ -611,6 +612,8 @@ impl RadialGradientShape {
         scale_factor: f32,
         physical_size: Vec2,
         physical_target_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
     ) -> Vec2 {
         let half_size = 0.5 * physical_size;
         match self {
@@ -626,14 +629,32 @@ impl RadialGradientShape {
             ),
             RadialGradientShape::Circle(radius) => Vec2::splat(
                 radius
-                    .resolve(scale_factor, physical_size.x, physical_target_size)
+                    .resolve(
+                        scale_factor,
+                        physical_size.x,
+                        physical_target_size,
+                        em_size,
+                        rem_size,
+                    )
                     .unwrap_or(0.),
             ),
             RadialGradientShape::Ellipse(x, y) => Vec2::new(
-                x.resolve(scale_factor, physical_size.x, physical_target_size)
-                    .unwrap_or(0.),
-                y.resolve(scale_factor, physical_size.y, physical_target_size)
-                    .unwrap_or(0.),
+                x.resolve(
+                    scale_factor,
+                    physical_size.x,
+                    physical_target_size,
+                    em_size,
+                    rem_size,
+                )
+                .unwrap_or(0.),
+                y.resolve(
+                    scale_factor,
+                    physical_size.y,
+                    physical_target_size,
+                    em_size,
+                    rem_size,
+                )
+                .unwrap_or(0.),
             ),
         }
     }

--- a/crates/bevy_ui/src/gradients.rs
+++ b/crates/bevy_ui/src/gradients.rs
@@ -1,9 +1,9 @@
-use crate::{EmSize, UiPosition, Val, ValNum};
+use crate::{UiPosition, Val, ValNum};
 use bevy_color::{Color, Srgba};
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
-use bevy_text::RemSize;
+use bevy_text::{EmSize, RemSize};
 use bevy_utils::default;
 use core::{f32, f32::consts::TAU};
 

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -26,11 +26,9 @@ impl Val {
             }
             Val::Vw(value) => style_helpers::length(context.physical_size.x * value / 100.),
             Val::Vh(value) => style_helpers::length(context.physical_size.y * value / 100.),
-            Val::Em(value) => {
-                style_helpers::length(context.scale_factor * value * context.em_size.0)
-            }
+            Val::Em(value) => style_helpers::length(context.scale_factor * value * context.em_size),
             Val::Rem(value) => {
-                style_helpers::length(context.scale_factor * value * context.rem_size.0)
+                style_helpers::length(context.scale_factor * value * context.rem_size)
             }
         }
     }
@@ -48,11 +46,9 @@ impl Val {
             }
             Val::Vw(value) => style_helpers::length(context.physical_size.x * value / 100.),
             Val::Vh(value) => style_helpers::length(context.physical_size.y * value / 100.),
-            Val::Em(value) => {
-                style_helpers::length(context.scale_factor * value * context.em_size.0)
-            }
+            Val::Em(value) => style_helpers::length(context.scale_factor * value * context.em_size),
             Val::Rem(value) => {
-                style_helpers::length(context.scale_factor * value * context.rem_size.0)
+                style_helpers::length(context.scale_factor * value * context.rem_size)
             }
         }
     }

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -355,6 +355,10 @@ impl MinTrackSizingFunction {
             MinTrackSizingFunction::Percent(val) => {
                 Val::Percent(val).into_length_percentage(context).into()
             }
+            MinTrackSizingFunction::Em(val) => Val::Em(val).into_length_percentage(context).into(),
+            MinTrackSizingFunction::Rem(val) => {
+                Val::Rem(val).into_length_percentage(context).into()
+            }
             MinTrackSizingFunction::Auto => taffy::style::MinTrackSizingFunction::auto(),
             MinTrackSizingFunction::MinContent => {
                 taffy::style::MinTrackSizingFunction::min_content()
@@ -380,6 +384,10 @@ impl MaxTrackSizingFunction {
             MaxTrackSizingFunction::Px(val) => Val::Px(val).into_length_percentage(context).into(),
             MaxTrackSizingFunction::Percent(val) => {
                 Val::Percent(val).into_length_percentage(context).into()
+            }
+            MaxTrackSizingFunction::Em(val) => Val::Em(val).into_length_percentage(context).into(),
+            MaxTrackSizingFunction::Rem(val) => {
+                Val::Rem(val).into_length_percentage(context).into()
             }
             MaxTrackSizingFunction::Auto => taffy::style::MaxTrackSizingFunction::auto(),
             MaxTrackSizingFunction::MinContent => {

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -464,9 +464,9 @@ impl RepeatedGridTrack {
 #[cfg(test)]
 mod tests {
     use bevy_math::Vec2;
-    use bevy_text::{RemSize, DEFAULT_REM_SIZE_PX};
+    use bevy_text::{EmSize, RemSize, DEFAULT_REM_SIZE_PX};
 
-    use crate::{BorderRadius, EmSize};
+    use crate::BorderRadius;
 
     use super::*;
 

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -26,6 +26,12 @@ impl Val {
             }
             Val::Vw(value) => style_helpers::length(context.physical_size.x * value / 100.),
             Val::Vh(value) => style_helpers::length(context.physical_size.y * value / 100.),
+            Val::Em(value) => {
+                style_helpers::length(context.scale_factor * value * context.em_size.0)
+            }
+            Val::Rem(value) => {
+                style_helpers::length(context.scale_factor * value * context.rem_size.0)
+            }
         }
     }
 
@@ -42,6 +48,12 @@ impl Val {
             }
             Val::Vw(value) => style_helpers::length(context.physical_size.x * value / 100.),
             Val::Vh(value) => style_helpers::length(context.physical_size.y * value / 100.),
+            Val::Em(value) => {
+                style_helpers::length(context.scale_factor * value * context.em_size.0)
+            }
+            Val::Rem(value) => {
+                style_helpers::length(context.scale_factor * value * context.rem_size.0)
+            }
         }
     }
 
@@ -452,8 +464,9 @@ impl RepeatedGridTrack {
 #[cfg(test)]
 mod tests {
     use bevy_math::Vec2;
+    use bevy_text::{RemSize, DEFAULT_REM_SIZE_PX};
 
-    use crate::BorderRadius;
+    use crate::{BorderRadius, EmSize};
 
     use super::*;
 
@@ -533,7 +546,12 @@ mod tests {
             grid_column: GridPlacement::start(4),
             grid_row: GridPlacement::span(3),
         };
-        let viewport_values = LayoutContext::new(1.0, Vec2::new(800., 600.));
+        let viewport_values = LayoutContext::new(
+            1.0,
+            Vec2::new(800., 600.),
+            EmSize(DEFAULT_REM_SIZE_PX),
+            RemSize(DEFAULT_REM_SIZE_PX),
+        );
         let taffy_style = from_node(&node, &viewport_values);
         assert_eq!(taffy_style.display, taffy::style::Display::Flex);
         assert_eq!(taffy_style.box_sizing, taffy::style::BoxSizing::ContentBox);
@@ -673,7 +691,12 @@ mod tests {
     #[test]
     fn test_into_length_percentage() {
         use taffy::style::LengthPercentage;
-        let context = LayoutContext::new(2.0, Vec2::new(800., 600.));
+        let context = LayoutContext::new(
+            2.0,
+            Vec2::new(800., 600.),
+            EmSize(DEFAULT_REM_SIZE_PX),
+            RemSize(DEFAULT_REM_SIZE_PX),
+        );
         let cases = [
             (Val::Auto, LengthPercentage::length(0.)),
             (Val::Percent(1.), LengthPercentage::percent(0.01)),

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -695,12 +695,7 @@ mod tests {
     #[test]
     fn test_into_length_percentage() {
         use taffy::style::LengthPercentage;
-        let context = LayoutContext::new(
-            2.0,
-            Vec2::new(800., 600.),
-            EmSize(DEFAULT_REM_SIZE_PX),
-            RemSize(DEFAULT_REM_SIZE_PX),
-        );
+        let context = LayoutContext::new(2.0, Vec2::new(800., 600.), EmSize(10.), RemSize(20.));
         let cases = [
             (Val::Auto, LengthPercentage::length(0.)),
             (Val::Percent(1.), LengthPercentage::percent(0.01)),
@@ -709,6 +704,8 @@ mod tests {
             (Val::Vh(1.), LengthPercentage::length(6.)),
             (Val::VMin(2.), LengthPercentage::length(12.)),
             (Val::VMax(2.), LengthPercentage::length(16.)),
+            (Val::Em(2.), LengthPercentage::length(40.)),
+            (Val::Rem(3.), LengthPercentage::length(120.)),
         ];
         for (val, length) in cases {
             assert!({

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -11,7 +11,7 @@ use bevy_ecs::{
     entity::{Entity, EntityHashSet},
     hierarchy::{ChildOf, Children},
     lifecycle::RemovedComponents,
-    query::{Added, Has, Or, With},
+    query::{Added, Has, With},
     system::{Query, Res, ResMut},
     world::Ref,
 };
@@ -73,24 +73,28 @@ impl Default for LayoutContext {
     }
 }
 
-/// Resolve a node's em size: its own `TextFont` if present, else its
-/// `EmSize` component, else the global rem size.
-fn node_em_size(
-    node_em_sizes_query: &Query<
-        (Option<Ref<TextFont>>, Option<Ref<EmSize>>),
-        (With<Node>, Or<(With<TextFont>, With<EmSize>)>),
+/// For any entity with a [`TextFont`], set [`EmSize`] to the font size resolved
+/// into pixels. Nodes without `TextFont` keep their `EmSize` intact, if `TextFont`
+/// is removed the `EmSize` remains unchanged.
+pub fn sync_font_size_to_em_size(
+    mut em_size_query: Query<
+        (&mut EmSize, Ref<TextFont>, Ref<ComputedUiRenderTargetInfo>),
+        With<Node>,
     >,
-    entity: Entity,
-    logical_size: Vec2,
-    rem_size: RemSize,
-) -> EmSize {
-    match node_em_sizes_query.get(entity) {
-        Ok((Some(text_font), _)) => {
-            EmSize::from_font_size(text_font.font_size, logical_size, rem_size)
+    rem_size: Res<RemSize>,
+) {
+    // `Val::Rem` resolves from rem size so need to recalc when this changes
+    let rem_size_changed = rem_size.is_changed();
+
+    for (mut em_size, text_font, computed_ui_render_target_info) in em_size_query.iter_mut() {
+        if text_font.is_changed() || computed_ui_render_target_info.is_changed() || rem_size_changed
+        {
+            em_size.set_if_neq(EmSize::from_font_size(
+                text_font.font_size,
+                computed_ui_render_target_info.logical_size(),
+                *rem_size,
+            ));
         }
-        // the `Or` filter guarantees `EmSize` is present when `TextFont` is not
-        Ok((None, em_size)) => *em_size.unwrap(),
-        Err(_) => rem_size.into(),
     }
 }
 
@@ -103,6 +107,7 @@ pub fn ui_layout_system(
     mut node_query: Query<(
         Entity,
         Ref<Node>,
+        Ref<EmSize>,
         &mut ContentSize,
         Ref<ComputedUiRenderTargetInfo>,
     )>,
@@ -113,32 +118,20 @@ pub fn ui_layout_system(
         &UiTransform,
         &mut UiGlobalTransform,
         &Node,
+        &EmSize,
         Option<&LayoutConfig>,
         Option<&Outline>,
         Option<&ScrollPosition>,
         Option<&IgnoreScroll>,
-        &ComputedUiRenderTargetInfo,
         Has<FixedNode>,
     )>,
     mut buffer_query: Query<&mut ComputedTextBlock>,
     mut font_system: ResMut<FontCx>,
-    (
-        mut removed_children,
-        mut removed_nodes,
-        mut removed_fixed_nodes,
-        mut removed_text_fonts,
-        mut removed_em_sizes,
-    ): (
+    (mut removed_children, mut removed_nodes, mut removed_fixed_nodes): (
         RemovedComponents<Children>,
         RemovedComponents<Node>,
         RemovedComponents<FixedNode>,
-        RemovedComponents<TextFont>,
-        RemovedComponents<EmSize>,
     ),
-    node_em_sizes_query: Query<
-        (Option<Ref<TextFont>>, Option<Ref<EmSize>>),
-        (With<Node>, Or<(With<TextFont>, With<EmSize>)>),
-    >,
     rem_size: Res<RemSize>,
     #[cfg(feature = "ghost_nodes")]
     (mut removed_ghost_nodes, added_ghost_node_query, ghost_node_query): (
@@ -147,39 +140,22 @@ pub fn ui_layout_system(
         Query<(), With<GhostNode>>,
     ),
 ) {
+    // `Val::Rem` resolves from rem size so need to recalc when this changes
     let rem_size_changed = rem_size.is_changed();
 
-    let em_removed: EntityHashSet = removed_text_fonts
-        .read()
-        .chain(removed_em_sizes.read())
-        .collect();
-
     // Sync Node and ContentSize to Taffy for all nodes
-    node_query
-        .iter_mut()
-        .for_each(|(entity, node, mut content_size, computed_target)| {
+    node_query.iter_mut().for_each(
+        |(entity, node, em_size, mut content_size, computed_target)| {
             if computed_target.is_changed()
                 || node.is_changed()
                 || content_size.is_changed()
                 || rem_size_changed
-                || em_removed.contains(&entity)
-                // either TextFont or EmSize exist and are changed
-                || node_em_sizes_query
-                    .get(entity)
-                    .is_ok_and(|(text_font, em_size)| {
-                        text_font.is_some_and(|f| f.is_changed())
-                            || em_size.is_some_and(|e| e.is_changed())
-                    })
+                || em_size.is_changed()
             {
                 let layout_context = LayoutContext::new(
                     computed_target.scale_factor,
                     computed_target.physical_size.as_vec2(),
-                    node_em_size(
-                        &node_em_sizes_query,
-                        entity,
-                        computed_target.logical_size(),
-                        *rem_size,
-                    ),
+                    *em_size,
                     *rem_size,
                 );
                 if content_size.is_changed() && content_size.measure.is_none() {
@@ -188,7 +164,8 @@ pub fn ui_layout_system(
                 let measure = content_size.bypass_change_detection().measure.take();
                 ui_surface.upsert_node(&layout_context, entity, &node, measure);
             }
-        });
+        },
+    );
 
     // update and remove children
     #[cfg(not(feature = "ghost_nodes"))]
@@ -285,7 +262,7 @@ pub fn ui_layout_system(
             ui_root_entity,
         );
 
-        let Ok((_, _, _, computed_target)) = node_query.get(ui_root_entity) else {
+        let Ok((_, _, _, _, computed_target)) = node_query.get(ui_root_entity) else {
             warn!("UI root {ui_root_entity} not found");
             continue;
         };
@@ -309,7 +286,6 @@ pub fn ui_layout_system(
             computed_target.scale_factor.recip(),
             Vec2::ZERO,
             Vec2::ZERO,
-            &node_em_sizes_query,
             *rem_size,
         );
     }
@@ -327,21 +303,17 @@ pub fn ui_layout_system(
             &UiTransform,
             &mut UiGlobalTransform,
             &Node,
+            &EmSize,
             Option<&LayoutConfig>,
             Option<&Outline>,
             Option<&ScrollPosition>,
             Option<&IgnoreScroll>,
-            &ComputedUiRenderTargetInfo,
             Has<FixedNode>,
         )>,
         ui_children: &UiChildren,
         inverse_target_scale_factor: f32,
         parent_size: Vec2,
         parent_scroll_position: Vec2,
-        node_em_sizes_query: &Query<
-            (Option<Ref<TextFont>>, Option<Ref<EmSize>>),
-            (With<Node>, Or<(With<TextFont>, With<EmSize>)>),
-        >,
         rem_size: RemSize,
     ) {
         if let Ok((
@@ -349,11 +321,11 @@ pub fn ui_layout_system(
             transform,
             mut global_transform,
             style,
+            em_size,
             maybe_layout_config,
             maybe_outline,
             maybe_scroll_position,
             maybe_scroll_sticky,
-            computed_target,
             is_fixed_node,
         )) = node_update_query.get_mut(entity)
         {
@@ -412,14 +384,8 @@ pub fn ui_layout_system(
                 node.padding = new_padding;
             }
 
-            let em_size = node_em_size(
-                node_em_sizes_query,
-                entity,
-                computed_target.logical_size(),
-                rem_size,
-            );
-            if node.em_size != em_size {
-                node.em_size = em_size;
+            if node.em_size != *em_size {
+                node.em_size = *em_size;
             }
             if node.rem_size != rem_size {
                 node.rem_size = rem_size;
@@ -430,7 +396,7 @@ pub fn ui_layout_system(
                 inverse_target_scale_factor.recip(),
                 layout_size,
                 target_size,
-                em_size,
+                *em_size,
                 rem_size,
             );
             local_transform.translation += local_center;
@@ -446,7 +412,7 @@ pub fn ui_layout_system(
                 inverse_target_scale_factor.recip(),
                 node.size,
                 target_size,
-                em_size,
+                *em_size,
                 rem_size,
             );
             if node.border_radius != new_border_radius {
@@ -462,7 +428,7 @@ pub fn ui_layout_system(
                             inverse_target_scale_factor.recip(),
                             node.size().x,
                             target_size,
-                            em_size,
+                            *em_size,
                             rem_size,
                         )
                         .unwrap_or(0.)
@@ -481,7 +447,7 @@ pub fn ui_layout_system(
                         inverse_target_scale_factor.recip(),
                         node.size().x,
                         target_size,
-                        em_size,
+                        *em_size,
                         rem_size,
                     )
                     .unwrap_or(0.)
@@ -539,7 +505,6 @@ pub fn ui_layout_system(
                     inverse_target_scale_factor,
                     layout_size,
                     physical_scroll_position,
-                    node_em_sizes_query,
                     rem_size,
                 );
             }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -3,16 +3,16 @@ use crate::experimental::GhostNode;
 use crate::{
     experimental::{UiChildren, UiRootNodes},
     ui_transform::{UiGlobalTransform, UiTransform},
-    ComputedNode, ComputedUiRenderTargetInfo, ContentSize, Display, FixedNode, IgnoreScroll,
-    LayoutConfig, Node, Outline, OverflowAxis, ScrollPosition,
+    ComputedNode, ComputedUiRenderTargetInfo, ContentSize, Display, EmSize, FixedNode,
+    IgnoreScroll, LayoutConfig, Node, Outline, OverflowAxis, ScrollPosition,
 };
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
     entity::{Entity, EntityHashSet},
     hierarchy::{ChildOf, Children},
     lifecycle::RemovedComponents,
-    query::{Added, Has, With},
-    system::{Query, ResMut},
+    query::{Added, Has, Or, With},
+    system::{Query, Res, ResMut},
     world::Ref,
 };
 
@@ -20,9 +20,8 @@ use bevy_math::{Affine2, Vec2};
 use bevy_sprite::BorderRect;
 use ui_surface::UiSurface;
 
-use bevy_text::ComputedTextBlock;
-
-use bevy_text::FontCx;
+use bevy_text::{ComputedTextBlock, RemSize, TextFont};
+use bevy_text::{FontCx, DEFAULT_REM_SIZE_PX};
 
 use bevy_log::warn;
 
@@ -33,19 +32,30 @@ pub mod ui_surface;
 pub struct LayoutContext {
     pub scale_factor: f32,
     pub physical_size: Vec2,
+    pub em_size: EmSize,
+    pub rem_size: RemSize,
 }
 
 impl LayoutContext {
     pub const DEFAULT: Self = Self {
         scale_factor: 1.0,
         physical_size: Vec2::ZERO,
+        em_size: EmSize(DEFAULT_REM_SIZE_PX),
+        rem_size: RemSize(DEFAULT_REM_SIZE_PX),
     };
     /// Create a new [`LayoutContext`] from the window's physical size and scale factor
     #[inline]
-    const fn new(scale_factor: f32, physical_size: Vec2) -> Self {
+    const fn new(
+        scale_factor: f32,
+        physical_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
+    ) -> Self {
         Self {
             scale_factor,
             physical_size,
+            em_size,
+            rem_size,
         }
     }
 }
@@ -53,14 +63,35 @@ impl LayoutContext {
 #[cfg(test)]
 impl LayoutContext {
     pub const TEST_CONTEXT: Self = Self {
-        scale_factor: 1.0,
         physical_size: Vec2::new(1000.0, 1000.0),
+        ..Self::DEFAULT
     };
 }
 
 impl Default for LayoutContext {
     fn default() -> Self {
         Self::DEFAULT
+    }
+}
+
+/// Resolve a node's em size: its own `TextFont` if present, else its
+/// `EmSize` component, else the global rem size.
+fn node_em_size(
+    node_em_sizes_query: &Query<
+        (Option<Ref<TextFont>>, Option<Ref<EmSize>>),
+        (With<Node>, Or<(With<TextFont>, With<EmSize>)>),
+    >,
+    entity: Entity,
+    logical_size: Vec2,
+    rem_size: RemSize,
+) -> EmSize {
+    match node_em_sizes_query.get(entity) {
+        Ok((Some(text_font), _)) => {
+            EmSize::from_font_size(text_font.font_size, logical_size, rem_size)
+        }
+        // the `Or` filter guarantees `EmSize` is present when `TextFont` is not
+        Ok((None, em_size)) => *em_size.unwrap(),
+        Err(_) => rem_size.into(),
     }
 }
 
@@ -87,25 +118,70 @@ pub fn ui_layout_system(
         Option<&Outline>,
         Option<&ScrollPosition>,
         Option<&IgnoreScroll>,
+        &ComputedUiRenderTargetInfo,
         Has<FixedNode>,
     )>,
     mut buffer_query: Query<&mut ComputedTextBlock>,
     mut font_system: ResMut<FontCx>,
-    mut removed_children: RemovedComponents<Children>,
-    mut removed_nodes: RemovedComponents<Node>,
-    mut removed_fixed_nodes: RemovedComponents<FixedNode>,
-    #[cfg(feature = "ghost_nodes")] mut removed_ghost_nodes: RemovedComponents<GhostNode>,
-    #[cfg(feature = "ghost_nodes")] added_ghost_node_query: Query<Entity, Added<GhostNode>>,
-    #[cfg(feature = "ghost_nodes")] ghost_node_query: Query<(), With<GhostNode>>,
+    (
+        mut removed_children,
+        mut removed_nodes,
+        mut removed_fixed_nodes,
+        mut removed_text_fonts,
+        mut removed_em_sizes,
+    ): (
+        RemovedComponents<Children>,
+        RemovedComponents<Node>,
+        RemovedComponents<FixedNode>,
+        RemovedComponents<TextFont>,
+        RemovedComponents<EmSize>,
+    ),
+    node_em_sizes_query: Query<
+        (Option<Ref<TextFont>>, Option<Ref<EmSize>>),
+        (With<Node>, Or<(With<TextFont>, With<EmSize>)>),
+    >,
+    rem_size: Res<RemSize>,
+    #[cfg(feature = "ghost_nodes")]
+    (mut removed_ghost_nodes, added_ghost_node_query, ghost_node_query): (
+        RemovedComponents<GhostNode>,
+        Query<Entity, Added<GhostNode>>,
+        Query<(), With<GhostNode>>,
+    ),
 ) {
+    let rem_size_changed = rem_size.is_changed();
+    
+    let em_removed: EntityHashSet = removed_text_fonts
+        .read()
+        .chain(removed_em_sizes.read())
+        .collect();
+
     // Sync Node and ContentSize to Taffy for all nodes
     node_query
         .iter_mut()
         .for_each(|(entity, node, mut content_size, computed_target)| {
-            if computed_target.is_changed() || node.is_changed() || content_size.is_changed() {
+            if computed_target.is_changed()
+                || node.is_changed()
+                || content_size.is_changed()
+                || rem_size_changed
+                || em_removed.contains(&entity)
+                // either TextFont or EmSize exist and are changed
+                || node_em_sizes_query
+                    .get(entity)
+                    .is_ok_and(|(text_font, em_size)| {
+                        text_font.is_some_and(|f| f.is_changed())
+                            || em_size.is_some_and(|e| e.is_changed())
+                    })
+            {
                 let layout_context = LayoutContext::new(
                     computed_target.scale_factor,
                     computed_target.physical_size.as_vec2(),
+                    node_em_size(
+                        &node_em_sizes_query,
+                        entity,
+                        computed_target.logical_size(),
+                        *rem_size,
+                    ),
+                    *rem_size,
                 );
                 if content_size.is_changed() && content_size.measure.is_none() {
                     ui_surface.try_remove_node_context(entity);
@@ -234,6 +310,8 @@ pub fn ui_layout_system(
             computed_target.scale_factor.recip(),
             Vec2::ZERO,
             Vec2::ZERO,
+            &node_em_sizes_query,
+            *rem_size,
         );
     }
 
@@ -254,12 +332,18 @@ pub fn ui_layout_system(
             Option<&Outline>,
             Option<&ScrollPosition>,
             Option<&IgnoreScroll>,
+            &ComputedUiRenderTargetInfo,
             Has<FixedNode>,
         )>,
         ui_children: &UiChildren,
         inverse_target_scale_factor: f32,
         parent_size: Vec2,
         parent_scroll_position: Vec2,
+        node_em_sizes_query: &Query<
+            (Option<Ref<TextFont>>, Option<Ref<EmSize>>),
+            (With<Node>, Or<(With<TextFont>, With<EmSize>)>),
+        >,
+        rem_size: RemSize,
     ) {
         if let Ok((
             mut node,
@@ -270,6 +354,7 @@ pub fn ui_layout_system(
             maybe_outline,
             maybe_scroll_position,
             maybe_scroll_sticky,
+            computed_target,
             is_fixed_node,
         )) = node_update_query.get_mut(entity)
         {
@@ -328,11 +413,26 @@ pub fn ui_layout_system(
                 node.padding = new_padding;
             }
 
+            let em_size = node_em_size(
+                node_em_sizes_query,
+                entity,
+                computed_target.logical_size(),
+                rem_size,
+            );
+            if node.em_size != em_size {
+                node.em_size = em_size;
+            }
+            if node.rem_size != rem_size {
+                node.rem_size = rem_size;
+            }
+
             // Compute the node's new global transform
             let mut local_transform = transform.compute_affine(
                 inverse_target_scale_factor.recip(),
                 layout_size,
                 target_size,
+                em_size,
+                rem_size,
             );
             local_transform.translation += local_center;
             inherited_transform *= local_transform;
@@ -347,6 +447,8 @@ pub fn ui_layout_system(
                 inverse_target_scale_factor.recip(),
                 node.size,
                 target_size,
+                em_size,
+                rem_size,
             );
             if node.border_radius != new_border_radius {
                 node.border_radius = new_border_radius;
@@ -361,6 +463,8 @@ pub fn ui_layout_system(
                             inverse_target_scale_factor.recip(),
                             node.size().x,
                             target_size,
+                            em_size,
+                            rem_size,
                         )
                         .unwrap_or(0.)
                         .max(0.)
@@ -378,6 +482,8 @@ pub fn ui_layout_system(
                         inverse_target_scale_factor.recip(),
                         node.size().x,
                         target_size,
+                        em_size,
+                        rem_size,
                     )
                     .unwrap_or(0.)
                     // Clamp outline offsets to at least the length of the node's shorter side
@@ -434,6 +540,8 @@ pub fn ui_layout_system(
                     inverse_target_scale_factor,
                     layout_size,
                     physical_scroll_position,
+                    node_em_sizes_query,
+                    rem_size,
                 );
             }
         }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -3,8 +3,8 @@ use crate::experimental::GhostNode;
 use crate::{
     experimental::{UiChildren, UiRootNodes},
     ui_transform::{UiGlobalTransform, UiTransform},
-    ComputedNode, ComputedUiRenderTargetInfo, ContentSize, Display, EmSize, FixedNode,
-    IgnoreScroll, LayoutConfig, Node, Outline, OverflowAxis, ScrollPosition,
+    ComputedNode, ComputedUiRenderTargetInfo, ContentSize, Display, FixedNode, IgnoreScroll,
+    LayoutConfig, Node, Outline, OverflowAxis, ScrollPosition,
 };
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
@@ -20,8 +20,7 @@ use bevy_math::{Affine2, Vec2};
 use bevy_sprite::BorderRect;
 use ui_surface::UiSurface;
 
-use bevy_text::{ComputedTextBlock, RemSize, TextFont};
-use bevy_text::{FontCx, DEFAULT_REM_SIZE_PX};
+use bevy_text::{ComputedTextBlock, EmSize, FontCx, RemSize, TextFont, DEFAULT_REM_SIZE_PX};
 
 use bevy_log::warn;
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -149,7 +149,7 @@ pub fn ui_layout_system(
     ),
 ) {
     let rem_size_changed = rem_size.is_changed();
-    
+
     let em_removed: EntityHashSet = removed_text_fonts
         .read()
         .chain(removed_em_sizes.read())

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -581,6 +581,7 @@ mod tests {
         app.init_resource::<UiSurface>();
         app.init_resource::<bevy_text::TextPipeline>();
         app.init_resource::<bevy_text::FontCx>();
+        app.init_resource::<bevy_text::RemSize>();
         app.init_resource::<bevy_text::ScaleCx>();
         app.init_resource::<bevy_transform::StaticTransformOptimizations>();
 
@@ -1377,9 +1378,8 @@ mod tests {
         world.init_resource::<UiSurface>();
 
         world.init_resource::<bevy_text::TextPipeline>();
-
         world.init_resource::<bevy_text::FontCx>();
-
+        world.init_resource::<bevy_text::RemSize>();
         world.init_resource::<bevy_text::ScaleCx>();
 
         let ui_root = world

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -31,16 +31,16 @@ pub mod ui_surface;
 pub struct LayoutContext {
     pub scale_factor: f32,
     pub physical_size: Vec2,
-    pub em_size: EmSize,
-    pub rem_size: RemSize,
+    pub em_size: f32,
+    pub rem_size: f32,
 }
 
 impl LayoutContext {
     pub const DEFAULT: Self = Self {
         scale_factor: 1.0,
         physical_size: Vec2::ZERO,
-        em_size: EmSize(DEFAULT_REM_SIZE_PX),
-        rem_size: RemSize(DEFAULT_REM_SIZE_PX),
+        em_size: DEFAULT_REM_SIZE_PX,
+        rem_size: DEFAULT_REM_SIZE_PX,
     };
     /// Create a new [`LayoutContext`] from the window's physical size and scale factor
     #[inline]
@@ -53,8 +53,8 @@ impl LayoutContext {
         Self {
             scale_factor,
             physical_size,
-            em_size,
-            rem_size,
+            em_size: em_size.0,
+            rem_size: rem_size.0,
         }
     }
 }
@@ -74,8 +74,9 @@ impl Default for LayoutContext {
 }
 
 /// For any entity with a [`TextFont`], set [`EmSize`] to the font size resolved
-/// into pixels. Nodes without `TextFont` keep their `EmSize` intact, if `TextFont`
-/// is removed the `EmSize` remains unchanged.
+/// into pixels when the `TextFont`, render target or `RemSize` changes. Nodes
+/// without `TextFont` keep their `EmSize` intact. If `TextFont` is removed the
+/// `EmSize` remains unchanged.
 pub fn sync_font_size_to_em_size(
     mut em_size_query: Query<
         (&mut EmSize, Ref<TextFont>, Ref<ComputedUiRenderTargetInfo>),

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -581,7 +581,7 @@ mod tests {
         app.init_resource::<UiSurface>();
         app.init_resource::<bevy_text::TextPipeline>();
         app.init_resource::<bevy_text::FontCx>();
-        app.init_resource::<bevy_text::RemSize>();
+        app.init_resource::<RemSize>();
         app.init_resource::<bevy_text::ScaleCx>();
         app.init_resource::<bevy_transform::StaticTransformOptimizations>();
 
@@ -1379,7 +1379,7 @@ mod tests {
 
         world.init_resource::<bevy_text::TextPipeline>();
         world.init_resource::<bevy_text::FontCx>();
-        world.init_resource::<bevy_text::RemSize>();
+        world.init_resource::<RemSize>();
         world.init_resource::<bevy_text::ScaleCx>();
 
         let ui_root = world

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -292,6 +292,9 @@ fn build_text_interop(app: &mut App) {
                 .ambiguous_with(widget::text_system)
                 .ambiguous_with(bevy_sprite::update_text2d_layout)
                 .ambiguous_with(bevy_sprite::calculate_bounds_text2d),
+            sync_font_size_to_em_size
+                .in_set(UiSystems::Content)
+                .after(bevy_text::load_font_assets_into_font_collection),
         ),
     );
 

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -79,7 +79,7 @@ pub mod prelude {
         },
         // `bevy_sprite` re-exports for texture slicing
         bevy_sprite::{BorderRect, SliceScaleMode, SpriteImageMode, TextureSlicer},
-        bevy_text::TextBackgroundColor,
+        bevy_text::{RemSize, TextBackgroundColor},
     };
 }
 

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -79,7 +79,7 @@ pub mod prelude {
         },
         // `bevy_sprite` re-exports for texture slicing
         bevy_sprite::{BorderRect, SliceScaleMode, SpriteImageMode, TextureSlicer},
-        bevy_text::{RemSize, TextBackgroundColor},
+        bevy_text::{EmSize, RemSize, TextBackgroundColor},
     };
 }
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -44,44 +44,23 @@ pub struct ComputedNode {
     pub scroll_position: Vec2,
     /// The width of this node's outline in physical pixels.
     /// If this value is negative or zero then no outline will be rendered.
-    ///
-    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
-    /// when updating this field.
     pub outline_width: f32,
     /// The amount of space between the outline and the edge of the node.
-    ///
-    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
-    /// when updating this field.
     pub outline_offset: f32,
     /// The unrounded size of the node as width and height in physical pixels.
     pub unrounded_size: Vec2,
     /// Resolved border values in physical pixels.
-    ///
-    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
-    /// when updating this field.
     pub border: BorderRect,
     /// Resolved border radius values in physical pixels.
-    ///
-    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
-    /// when updating this field.
     pub border_radius: ResolvedBorderRadius,
     /// Resolved padding values in physical pixels.
-    ///
-    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
-    /// when updating this field.
     pub padding: BorderRect,
     /// Inverse scale factor for this Node.
     /// Multiply physical coordinates by the inverse scale factor to give logical coordinates.
     pub inverse_scale_factor: f32,
     /// Stored em spacing for this Node.
-    ///
-    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
-    /// when updating this field.
     pub em_size: EmSize,
     /// Stored rem spacing for this Node. Technically could be shared but easier to store here
-    ///
-    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
-    /// when updating this field.
     pub rem_size: RemSize,
 }
 

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{prelude::*, system::SystemParam};
 use bevy_math::{BVec2, Rect, UVec2, Vec2, Vec4, Vec4Swizzles};
 use bevy_reflect::prelude::*;
 use bevy_sprite::BorderRect;
-use bevy_text::{RemSize, DEFAULT_REM_SIZE_PX};
+use bevy_text::{EmSize, RemSize, DEFAULT_REM_SIZE_PX};
 use bevy_utils::once;
 use bevy_window::{PrimaryWindow, WindowRef};
 use core::{f32, num::NonZero};

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -58,9 +58,15 @@ pub struct ComputedNode {
     /// Inverse scale factor for this Node.
     /// Multiply physical coordinates by the inverse scale factor to give logical coordinates.
     pub inverse_scale_factor: f32,
-    /// Stored em spacing for this Node.
+    /// The font size used to resolve this node's `Val::Em` lengths, in logical pixels.
+    ///
+    /// Copied from the node's [`EmSize`] component during layout.
     pub em_size: EmSize,
-    /// Stored rem spacing for this Node. Technically could be shared but easier to store here
+    /// The root font size used to resolve this node's `Val::Rem` lengths, in logical pixels.
+    ///
+    /// Copied from the [`RemSize`] resource during layout.
+    // Stored per node rather than read from the resource because `ComputedNode` is extracted
+    // to the render world and `RemSize` is not.
     pub rem_size: RemSize,
 }
 
@@ -466,7 +472,8 @@ impl From<BVec2> for IgnoreScroll {
     FocusPolicy,
     ScrollPosition,
     Visibility,
-    ZIndex
+    ZIndex,
+    EmSize
 )]
 #[reflect(Component, Default, PartialEq, Debug, Clone)]
 #[cfg_attr(

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1542,6 +1542,10 @@ pub enum MinTrackSizingFunction {
     Px(f32),
     /// Track minimum size should be a percentage value
     Percent(f32),
+    /// Track minimum size should be a multiple of the grid container's font size.
+    Em(f32),
+    /// Track minimum size should be a multiple of the root font size.
+    Rem(f32),
     /// Track minimum size should be content sized under a min-content constraint
     MinContent,
     /// Track minimum size should be content sized under a max-content constraint
@@ -1571,6 +1575,10 @@ pub enum MaxTrackSizingFunction {
     Px(f32),
     /// Track maximum size should be a percentage value
     Percent(f32),
+    /// Track maximum size should be a multiple of the grid container's font size.
+    Em(f32),
+    /// Track maximum size should be a multiple of the root font size.
+    Rem(f32),
     /// Track maximum size should be content sized under a min-content constraint
     MinContent,
     /// Track maximum size should be content sized under a max-content constraint
@@ -1631,6 +1639,24 @@ impl GridTrack {
         Self {
             min_sizing_function: MinTrackSizingFunction::Percent(value),
             max_sizing_function: MaxTrackSizingFunction::Percent(value),
+        }
+        .into()
+    }
+
+    /// Create a grid track with size as a multiple of the grid container's font size.
+    pub fn em<T: From<Self>>(value: f32) -> T {
+        Self {
+            min_sizing_function: MinTrackSizingFunction::Em(value),
+            max_sizing_function: MaxTrackSizingFunction::Em(value),
+        }
+        .into()
+    }
+
+    /// Create a grid track with size as a multiple of the root font size.
+    pub fn rem<T: From<Self>>(value: f32) -> T {
+        Self {
+            min_sizing_function: MinTrackSizingFunction::Rem(value),
+            max_sizing_function: MaxTrackSizingFunction::Rem(value),
         }
         .into()
     }
@@ -1840,6 +1866,24 @@ impl RepeatedGridTrack {
         Self {
             repetition: repetition.into(),
             tracks: SmallVec::from_buf([GridTrack::percent(value)]),
+        }
+        .into()
+    }
+
+    /// Create a repeating set of grid tracks with size as a multiple of the grid containers's font size.
+    pub fn em<T: From<Self>>(repetition: impl Into<GridTrackRepetition>, value: f32) -> T {
+        Self {
+            repetition: repetition.into(),
+            tracks: SmallVec::from_buf([GridTrack::em(value)]),
+        }
+        .into()
+    }
+
+    /// Create a repeating set of grid tracks with size as a multiple of the root font size.
+    pub fn rem<T: From<Self>>(repetition: impl Into<GridTrackRepetition>, value: f32) -> T {
+        Self {
+            repetition: repetition.into(),
+            tracks: SmallVec::from_buf([GridTrack::rem(value)]),
         }
         .into()
     }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -9,6 +9,7 @@ use bevy_ecs::{prelude::*, system::SystemParam};
 use bevy_math::{BVec2, Rect, UVec2, Vec2, Vec4, Vec4Swizzles};
 use bevy_reflect::prelude::*;
 use bevy_sprite::BorderRect;
+use bevy_text::{RemSize, DEFAULT_REM_SIZE_PX};
 use bevy_utils::once;
 use bevy_window::{PrimaryWindow, WindowRef};
 use core::{f32, num::NonZero};
@@ -72,6 +73,16 @@ pub struct ComputedNode {
     /// Inverse scale factor for this Node.
     /// Multiply physical coordinates by the inverse scale factor to give logical coordinates.
     pub inverse_scale_factor: f32,
+    /// Stored em spacing for this Node.
+    ///
+    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
+    /// when updating this field.
+    pub em_size: EmSize,
+    /// Stored rem spacing for this Node. Technically could be shared but easier to store here
+    ///
+    /// [`ui_layout_system`](`super::layout::ui_layout_system`) bypasses change detection
+    /// when updating this field.
+    pub rem_size: RemSize,
 }
 
 impl ComputedNode {
@@ -389,6 +400,8 @@ impl ComputedNode {
         border: BorderRect::ZERO,
         padding: BorderRect::ZERO,
         inverse_scale_factor: 1.,
+        em_size: EmSize(DEFAULT_REM_SIZE_PX),
+        rem_size: RemSize(DEFAULT_REM_SIZE_PX),
     };
 }
 
@@ -2772,6 +2785,8 @@ impl BorderRadius {
         scale_factor: f32,
         node_size: Vec2,
         viewport_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
     ) -> ResolvedBorderRadius {
         ResolvedBorderRadius {
             top_left: self

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -2768,18 +2768,34 @@ impl BorderRadius {
         rem_size: RemSize,
     ) -> ResolvedBorderRadius {
         ResolvedBorderRadius {
-            top_left: self
-                .top_left
-                .resolve(scale_factor, node_size, viewport_size),
-            top_right: self
-                .top_right
-                .resolve(scale_factor, node_size, viewport_size),
-            bottom_left: self
-                .bottom_left
-                .resolve(scale_factor, node_size, viewport_size),
-            bottom_right: self
-                .bottom_right
-                .resolve(scale_factor, node_size, viewport_size),
+            top_left: self.top_left.resolve(
+                scale_factor,
+                node_size,
+                viewport_size,
+                em_size,
+                rem_size,
+            ),
+            top_right: self.top_right.resolve(
+                scale_factor,
+                node_size,
+                viewport_size,
+                em_size,
+                rem_size,
+            ),
+            bottom_left: self.bottom_left.resolve(
+                scale_factor,
+                node_size,
+                viewport_size,
+                em_size,
+                rem_size,
+            ),
+            bottom_right: self.bottom_right.resolve(
+                scale_factor,
+                node_size,
+                viewport_size,
+                em_size,
+                rem_size,
+            ),
         }
     }
 }

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -9,40 +9,8 @@ use bevy_math::Mat2;
 use bevy_math::Rot2;
 use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
-use bevy_text::FontSize;
-use bevy_text::RemSize;
-use bevy_text::DEFAULT_REM_SIZE_PX;
+use bevy_text::{EmSize, RemSize};
 use core::ops::Mul;
-
-/// Used for resolving `Val::Em` during layout if no `TextFont` is found.
-/// Note there is no propagation of this so resolution will fall back to
-/// `RemSize` unless the user has a font propagation strategy.
-#[derive(Debug, PartialEq, Clone, Copy, Reflect, Component)]
-#[reflect(Default, PartialEq, Debug, Clone, Component)]
-pub struct EmSize(pub f32);
-
-impl Default for EmSize {
-    fn default() -> Self {
-        EmSize(DEFAULT_REM_SIZE_PX)
-    }
-}
-
-impl From<RemSize> for EmSize {
-    fn from(value: RemSize) -> Self {
-        EmSize(value.0)
-    }
-}
-
-impl EmSize {
-    /// Convert from a `FontSize` to an `EmSize` using eval.
-    pub fn from_font_size(
-        font_size: FontSize,
-        logical_viewport_size: Vec2,
-        rem_size: RemSize,
-    ) -> Self {
-        EmSize(font_size.eval(logical_viewport_size, rem_size))
-    }
-}
 
 /// A pair of [`Val`]s used to represent a 2-dimensional size or offset.
 #[derive(Debug, PartialEq, Clone, Copy, Reflect)]

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -16,7 +16,7 @@ use core::ops::Mul;
 
 /// Used for resolving Val::Em during layout if no `TextFont` is found.
 /// Note there is no propagation of this so resolution will fall back to
-/// `RemSize` unless the user has a font propagation startegy.
+/// `RemSize` unless the user has a font propagation strategy.
 #[derive(Debug, PartialEq, Clone, Copy, Reflect, Component)]
 #[reflect(Default, PartialEq, Debug, Clone, Component)]
 pub struct EmSize(pub f32);

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -14,7 +14,7 @@ use bevy_text::RemSize;
 use bevy_text::DEFAULT_REM_SIZE_PX;
 use core::ops::Mul;
 
-/// Used for resolving Val::Em during layout if no `TextFont` is found.
+/// Used for resolving `Val::Em` during layout if no `TextFont` is found.
 /// Note there is no propagation of this so resolution will fall back to
 /// `RemSize` unless the user has a font propagation strategy.
 #[derive(Debug, PartialEq, Clone, Copy, Reflect, Component)]

--- a/crates/bevy_ui/src/ui_transform.rs
+++ b/crates/bevy_ui/src/ui_transform.rs
@@ -9,7 +9,40 @@ use bevy_math::Mat2;
 use bevy_math::Rot2;
 use bevy_math::Vec2;
 use bevy_reflect::prelude::*;
+use bevy_text::FontSize;
+use bevy_text::RemSize;
+use bevy_text::DEFAULT_REM_SIZE_PX;
 use core::ops::Mul;
+
+/// Used for resolving Val::Em during layout if no `TextFont` is found.
+/// Note there is no propagation of this so resolution will fall back to
+/// `RemSize` unless the user has a font propagation startegy.
+#[derive(Debug, PartialEq, Clone, Copy, Reflect, Component)]
+#[reflect(Default, PartialEq, Debug, Clone, Component)]
+pub struct EmSize(pub f32);
+
+impl Default for EmSize {
+    fn default() -> Self {
+        EmSize(DEFAULT_REM_SIZE_PX)
+    }
+}
+
+impl From<RemSize> for EmSize {
+    fn from(value: RemSize) -> Self {
+        EmSize(value.0)
+    }
+}
+
+impl EmSize {
+    /// Convert from a `FontSize` to an `EmSize` using eval.
+    pub fn from_font_size(
+        font_size: FontSize,
+        logical_viewport_size: Vec2,
+        rem_size: RemSize,
+    ) -> Self {
+        EmSize(font_size.eval(logical_viewport_size, rem_size))
+    }
+}
 
 /// A pair of [`Val`]s used to represent a 2-dimensional size or offset.
 #[derive(Debug, PartialEq, Clone, Copy, Reflect)]
@@ -60,13 +93,20 @@ impl Val2 {
     /// and `viewport_size`.
     ///
     /// Component values of [`Val::Auto`] are resolved to 0.
-    pub fn resolve(&self, scale_factor: f32, base_size: Vec2, viewport_size: Vec2) -> Vec2 {
+    pub fn resolve(
+        &self,
+        scale_factor: f32,
+        base_size: Vec2,
+        viewport_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
+    ) -> Vec2 {
         Vec2::new(
             self.x
-                .resolve(scale_factor, base_size.x, viewport_size)
+                .resolve(scale_factor, base_size.x, viewport_size, em_size, rem_size)
                 .unwrap_or(0.),
             self.y
-                .resolve(scale_factor, base_size.y, viewport_size)
+                .resolve(scale_factor, base_size.y, viewport_size, em_size, rem_size)
                 .unwrap_or(0.),
         )
     }
@@ -183,11 +223,18 @@ impl UiTransform {
 
     /// Resolves the translation from the given `scale_factor`, `base_value`, and `target_size`
     /// and returns a 2d affine transform from the resolved translation, and the `UiTransform`'s rotation, and scale.
-    pub fn compute_affine(&self, scale_factor: f32, base_size: Vec2, target_size: Vec2) -> Affine2 {
+    pub fn compute_affine(
+        &self,
+        scale_factor: f32,
+        base_size: Vec2,
+        target_size: Vec2,
+        em_size: EmSize,
+        rem_size: RemSize,
+    ) -> Affine2 {
         Affine2::from_mat2_translation(
             Mat2::from(self.rotation) * Mat2::from_diagonal(self.scale),
             self.translation
-                .resolve(scale_factor, base_size, target_size),
+                .resolve(scale_factor, base_size, target_size, em_size, rem_size),
         )
     }
 }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -322,7 +322,7 @@ pub fn measure_text_system(
             &mut font_system,
             &mut layout_cx,
             computed_target.logical_size(),
-            rem_size.0,
+            *rem_size,
         ) {
             Ok(measure) => {
                 if block.linebreak == LineBreak::NoWrap {

--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -92,7 +92,7 @@ pub fn update_editable_text_content_size(
             continue;
         }
 
-        let font_size = text_font.font_size.eval(target.logical_size(), rem_size.0);
+        let font_size = text_font.font_size.eval(target.logical_size(), *rem_size);
 
         let width = editable_text.visible_width.and_then(|visible_width| {
             let font_context = &mut font_cx.context;
@@ -202,7 +202,7 @@ pub fn update_editable_text_styles(
                 .editor
                 .edit_styles()
                 .insert(StyleProperty::FontSize(
-                    text_font.font_size.eval(target.logical_size(), rem_size.0),
+                    text_font.font_size.eval(target.logical_size(), *rem_size),
                 ));
         }
 
@@ -505,7 +505,7 @@ pub fn update_editable_text_layout(
             info.cursor = driver
                 .editor
                 .cursor_geometry(
-                    cursor_width * text_font.font_size.eval(target.logical_size(), rem_size.0),
+                    cursor_width * text_font.font_size.eval(target.logical_size(), *rem_size),
                 )
                 .map(bounding_box_to_rect)
                 .map(|rect| (*cursor_timer < cursor_blink_period / 2, rect));

--- a/crates/bevy_ui_render/src/box_shadow.rs
+++ b/crates/bevy_ui_render/src/box_shadow.rs
@@ -319,6 +319,8 @@ pub fn extract_shadows(
                 Val::Vh(percent) => percent / 100. * ui_physical_viewport_size.y,
                 Val::VMin(percent) => percent / 100. * ui_physical_viewport_size.min_element(),
                 Val::VMax(percent) => percent / 100. * ui_physical_viewport_size.max_element(),
+                Val::Em(em) => em * uinode.em_size.0 * scale_factor,
+                Val::Rem(rem) => rem * uinode.rem_size.0 * scale_factor,
             };
 
             let spread_x = resolve_val(drop_shadow.spread_radius, uinode.size().x, scale_factor);

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -31,9 +31,10 @@ use bevy_render::{
 use bevy_render::{GpuResourceAppExt, RenderStartup};
 use bevy_shader::Shader;
 use bevy_sprite::BorderRect;
+use bevy_text::RemSize;
 use bevy_ui::{
     BackgroundGradient, BorderGradient, ColorStop, ComputedStackIndex, ComputedUiRenderTargetInfo,
-    ConicGradient, Gradient, InterpolationColorSpace, LinearGradient, RadialGradient,
+    ConicGradient, EmSize, Gradient, InterpolationColorSpace, LinearGradient, RadialGradient,
     ResolvedBorderRadius, Val,
 };
 use bevy_utils::default;
@@ -293,13 +294,15 @@ fn compute_color_stops(
     length: f32,
     target_size: Vec2,
     scratch: &mut Vec<(LinearRgba, f32, f32)>,
+    em_size: EmSize,
+    rem_size: RemSize,
 ) -> Vec<(LinearRgba, f32, f32)> {
     let mut extracted_color_stops = vec![];
 
     // resolve the physical distances of explicit stops and sort them
     scratch.extend(stops.iter().filter_map(|stop| {
         stop.point
-            .resolve(scale_factor, length, target_size)
+            .resolve(scale_factor, length, target_size, em_size, rem_size)
             .ok()
             .map(|physical_point| (stop.color.to_linear(), physical_point, stop.hint))
     }));
@@ -453,6 +456,8 @@ pub fn extract_gradients(
                         length,
                         target.physical_size().as_vec2(),
                         &mut sorted_stops,
+                        uinode.em_size,
+                        uinode.rem_size,
                     );
                     extracted_gradients
                         .items
@@ -493,6 +498,8 @@ pub fn extract_gradients(
                             length,
                             target.physical_size().as_vec2(),
                             &mut sorted_stops,
+                            uinode.em_size,
+                            uinode.rem_size,
                         );
 
                         extracted_gradients
@@ -529,6 +536,8 @@ pub fn extract_gradients(
                             target.scale_factor(),
                             uinode.size,
                             target.physical_size().as_vec2(),
+                            uinode.em_size,
+                            uinode.rem_size,
                         );
 
                         let size = shape.resolve(
@@ -536,6 +545,8 @@ pub fn extract_gradients(
                             target.scale_factor(),
                             uinode.size,
                             target.physical_size().as_vec2(),
+                            uinode.em_size,
+                            uinode.rem_size,
                         );
 
                         let length = size.x;
@@ -546,6 +557,8 @@ pub fn extract_gradients(
                             length,
                             target.physical_size().as_vec2(),
                             &mut sorted_stops,
+                            uinode.em_size,
+                            uinode.rem_size,
                         );
 
                         extracted_gradients
@@ -582,6 +595,8 @@ pub fn extract_gradients(
                             target.scale_factor(),
                             uinode.size,
                             target.physical_size().as_vec2(),
+                            uinode.em_size,
+                            uinode.rem_size,
                         );
 
                         // sort the explicit stops

--- a/crates/bevy_ui_render/src/gradient.rs
+++ b/crates/bevy_ui_render/src/gradient.rs
@@ -31,10 +31,10 @@ use bevy_render::{
 use bevy_render::{GpuResourceAppExt, RenderStartup};
 use bevy_shader::Shader;
 use bevy_sprite::BorderRect;
-use bevy_text::RemSize;
+use bevy_text::{EmSize, RemSize};
 use bevy_ui::{
     BackgroundGradient, BorderGradient, ColorStop, ComputedStackIndex, ComputedUiRenderTargetInfo,
-    ConicGradient, EmSize, Gradient, InterpolationColorSpace, LinearGradient, RadialGradient,
+    ConicGradient, Gradient, InterpolationColorSpace, LinearGradient, RadialGradient,
     ResolvedBorderRadius, Val,
 };
 use bevy_utils::default;

--- a/crates/bevy_ui_widgets/src/popover.rs
+++ b/crates/bevy_ui_widgets/src/popover.rs
@@ -253,6 +253,8 @@ pub(crate) fn position_popover(
                 computed_target.scale_factor(),
                 computed_node.size(),
                 computed_target.physical_size().as_vec2(),
+                computed_node.em_size,
+                computed_node.rem_size,
             );
             let logical_translation = (resolved_translation
                 + parent_matrix.inverse() * physical_translation)

--- a/crates/bevy_ui_widgets/src/scrollbar.rs
+++ b/crates/bevy_ui_widgets/src/scrollbar.rs
@@ -401,6 +401,8 @@ pub(crate) fn update_scrollbar_thumb(
                 target_info.scale_factor(),
                 thumb_physical_size,
                 target_info.physical_size().as_vec2(),
+                thumb_node.em_size,
+                thumb_node.rem_size,
             );
             if thumb_node.border_radius != border_radius {
                 thumb_node.border_radius = border_radius;
@@ -411,6 +413,8 @@ pub(crate) fn update_scrollbar_thumb(
                     target_info.scale_factor(),
                     thumb_physical_size.x,
                     target_info.physical_size().as_vec2(),
+                    thumb_node.em_size,
+                    thumb_node.rem_size,
                 )
                 .unwrap_or(0.)
             };
@@ -447,6 +451,8 @@ pub(crate) fn update_scrollbar_thumb(
                     target_info.scale_factor(),
                     thumb_physical_size,
                     target_info.physical_size().as_vec2(),
+                    thumb_node.em_size,
+                    thumb_node.rem_size,
                 )
                 * Affine2::from_translation(thumb_center * target_info.scale_factor());
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -61,6 +61,10 @@ fn main() {
     .add_systems(OnEnter(Scene::BoxedContent), boxed_content::setup)
     .add_systems(OnEnter(Scene::EditableText), editable_text::setup)
     .add_systems(OnEnter(Scene::NodeMaterial), node_material::setup)
+    .add_systems(
+        OnEnter(Scene::FontRelativeUnits),
+        font_relative_units::setup,
+    )
     .add_systems(Update, switch_scene);
 
     match args.scene {
@@ -107,6 +111,7 @@ enum Scene {
     BoxedContent,
     EditableText,
     NodeMaterial,
+    FontRelativeUnits,
 }
 
 impl Scene {
@@ -134,6 +139,7 @@ impl Scene {
         Scene::BoxedContent,
         Scene::EditableText,
         Scene::NodeMaterial,
+        Scene::FontRelativeUnits,
     ];
 }
 
@@ -3685,5 +3691,135 @@ mod node_material {
                 ),
             ],
         ));
+    }
+}
+
+mod font_relative_units {
+    use bevy::{color::palettes::css::*, prelude::*};
+
+    pub fn setup(mut commands: Commands) {
+        commands.spawn((Camera2d, DespawnOnExit(super::Scene::FontRelativeUnits)));
+
+        commands.spawn((
+            Node {
+                width: percent(100),
+                height: percent(100),
+                flex_direction: FlexDirection::Row,
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                column_gap: rem(1),
+                ..default()
+            },
+            BackgroundColor(Color::srgb(0.12, 0.12, 0.16)),
+            DespawnOnExit(super::Scene::FontRelativeUnits),
+            children![
+                text_font_column("10px Text", 10.),
+                text_font_column("20px Text", 20.),
+                text_font_column("30px Text", 30.),
+            ],
+        ));
+    }
+
+    fn text_font_column(title: &'static str, font_size: f32) -> impl Bundle {
+        (
+            Node {
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::Center,
+                row_gap: rem(1),
+                ..default()
+            },
+            children![
+                (
+                    Text::new(title),
+                    TextFont::from_font_size(font_size),
+                    TextColor(LAVENDER.into()),
+                ),
+                // `em` padding: scales with this node's own font size.
+                (
+                    Node {
+                        padding: UiRect::all(em(1)),
+                        flex_basis: Val::Auto,
+                        border_radius: em(1).into(),
+                        ..default()
+                    },
+                    EmSize(font_size),
+                    BackgroundColor(DARK_SLATE_BLUE.into()),
+                    children![(
+                        Text::new("1em padding"),
+                        TextFont::from_font_size(font_size),
+                        BackgroundColor(PEACHPUFF.into()),
+                        TextColor(DARK_SLATE_GRAY.into())
+                    )],
+                ),
+                // Always 20rem across
+                (
+                    Node {
+                        flex_direction: FlexDirection::Row,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    EmSize(font_size),
+                    children![(
+                        Node {
+                            width: rem(20),
+                            ..default()
+                        },
+                        Text::new("< 20rem >"),
+                        TextLayout {
+                            justify: Justify::Center,
+                            ..default()
+                        },
+                        TextFont::from_font_size(font_size),
+                        BackgroundColor(PALE_TURQUOISE.into()),
+                        TextColor(DARK_SLATE_GRAY.into())
+                    )],
+                ),
+                // Grid tracks: left is 5em sized, right is 10rem, padding is 0.5rem
+                (
+                    Node {
+                        display: Display::Grid,
+                        grid_template_columns: vec![GridTrack::em(5.), GridTrack::rem(10.)],
+                        padding: rem(0.5).into(),
+                        border_radius: rem(0.5).into(),
+                        column_gap: rem(0.5),
+                        ..default()
+                    },
+                    EmSize(font_size),
+                    BackgroundColor(DARK_SLATE_BLUE.into()),
+                    children![
+                        (
+                            Node {
+                                display: Display::Grid,
+                                grid_column: GridPlacement::span(2),
+                                ..default()
+                            },
+                            Text::new("0.5rem padding"),
+                            TextFont::from_font_size(font_size),
+                            TextColor(LAVENDER.into()),
+                        ),
+                        (
+                            Text::new("< 5em >"),
+                            TextLayout {
+                                justify: Justify::Center,
+                                ..default()
+                            },
+                            TextFont::from_font_size(font_size),
+                            BackgroundColor(PEACHPUFF.into()),
+                            TextColor(DARK_SLATE_GRAY.into())
+                        ),
+                        (
+                            Text::new("< 10rem >"),
+                            TextLayout {
+                                justify: Justify::Center,
+                                ..default()
+                            },
+                            TextFont::from_font_size(font_size),
+                            BackgroundColor(PALE_TURQUOISE.into()),
+                            TextColor(DARK_SLATE_GRAY.into())
+                        ),
+                    ]
+                ),
+            ],
+        )
     }
 }

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -3712,11 +3712,7 @@ mod font_relative_units {
             },
             BackgroundColor(Color::srgb(0.12, 0.12, 0.16)),
             DespawnOnExit(super::Scene::FontRelativeUnits),
-            children![
-                text_font_row(10.),
-                text_font_row(20.),
-                text_font_row(30.),
-            ],
+            children![text_font_row(12.), text_font_row(24.), text_font_row(36.),],
         ));
     }
 
@@ -3741,7 +3737,7 @@ mod font_relative_units {
                 // `em` padding: scales with this node's own font size.
                 (
                     Node {
-                        width: rem(15),
+                        width: rem(20),
                         justify_content: JustifyContent::Center,
                         ..default()
                     },
@@ -3757,14 +3753,14 @@ mod font_relative_units {
                         BackgroundColor(DARK_SLATE_BLUE.into()),
                         BorderColor::all(LAVENDER),
                         children![(
-                            Text::new("1em padding"),
+                            Text::new("em sizing"),
                             TextFont::from_font_size(font_size),
                             BackgroundColor(PEACHPUFF.into()),
                             TextColor(DARK_SLATE_GRAY.into())
                         )],
                     )],
                 ),
-                // Always 15rem across
+                // Always 10rem across
                 (
                     Node {
                         flex_direction: FlexDirection::Row,
@@ -3774,10 +3770,10 @@ mod font_relative_units {
                     EmSize(font_size),
                     children![(
                         Node {
-                            width: rem(15),
+                            width: rem(10),
                             ..default()
                         },
-                        Text::new("< 15rem >"),
+                        Text::new("< rem >"),
                         TextLayout {
                             justify: Justify::Center,
                             ..default()
@@ -3790,7 +3786,7 @@ mod font_relative_units {
                 // Grid tracks: left is 5em sized, right is 10rem, padding is 0.5rem
                 (
                     Node {
-                        width: rem(20),
+                        width: rem(24),
                         justify_content: JustifyContent::End,
                         ..default()
                     },
@@ -3813,12 +3809,12 @@ mod font_relative_units {
                                     grid_column: GridPlacement::span(2),
                                     ..default()
                                 },
-                                Text::new("10px padding"),
-                                TextFont::from_font_size(font_size),
+                                Text::new("px sizing"),
+                                TextFont::from_font_size(px(16)),
                                 TextColor(LAVENDER.into()),
                             ),
                             (
-                                Text::new("< 5em >"),
+                                Text::new("< em >"),
                                 TextLayout {
                                     justify: Justify::Center,
                                     ..default()
@@ -3828,7 +3824,7 @@ mod font_relative_units {
                                 TextColor(DARK_SLATE_GRAY.into())
                             ),
                             (
-                                Text::new("< 10rem >"),
+                                Text::new("< rem >"),
                                 TextLayout {
                                     justify: Justify::Center,
                                     ..default()

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -3704,54 +3704,67 @@ mod font_relative_units {
             Node {
                 width: percent(100),
                 height: percent(100),
-                flex_direction: FlexDirection::Row,
+                flex_direction: FlexDirection::Column,
                 justify_content: JustifyContent::Center,
                 align_items: AlignItems::Center,
-                column_gap: rem(1),
+                row_gap: rem(1),
                 ..default()
             },
             BackgroundColor(Color::srgb(0.12, 0.12, 0.16)),
             DespawnOnExit(super::Scene::FontRelativeUnits),
             children![
-                text_font_column("10px Text", 10.),
-                text_font_column("20px Text", 20.),
-                text_font_column("30px Text", 30.),
+                text_font_row(10.),
+                text_font_row(20.),
+                text_font_row(30.),
             ],
         ));
     }
 
-    fn text_font_column(title: &'static str, font_size: f32) -> impl Bundle {
+    fn text_font_row(font_size: f32) -> impl Bundle {
         (
             Node {
-                flex_direction: FlexDirection::Column,
+                flex_direction: FlexDirection::Row,
                 align_items: AlignItems::Center,
-                row_gap: rem(1),
+                column_gap: rem(1),
                 ..default()
             },
             children![
                 (
-                    Text::new(title),
+                    Node {
+                        width: rem(4),
+                        ..default()
+                    },
+                    Text::new(format!("{font_size}px")),
                     TextFont::from_font_size(font_size),
                     TextColor(LAVENDER.into()),
                 ),
                 // `em` padding: scales with this node's own font size.
                 (
                     Node {
-                        padding: UiRect::all(em(1)),
-                        flex_basis: Val::Auto,
-                        border_radius: em(1).into(),
+                        width: rem(15),
+                        justify_content: JustifyContent::Center,
                         ..default()
                     },
-                    EmSize(font_size),
-                    BackgroundColor(DARK_SLATE_BLUE.into()),
                     children![(
-                        Text::new("1em padding"),
-                        TextFont::from_font_size(font_size),
-                        BackgroundColor(PEACHPUFF.into()),
-                        TextColor(DARK_SLATE_GRAY.into())
+                        Node {
+                            padding: UiRect::all(em(1)),
+                            flex_basis: Val::Auto,
+                            border_radius: em(1).into(),
+                            border: em(0.5).into(),
+                            ..default()
+                        },
+                        EmSize(font_size),
+                        BackgroundColor(DARK_SLATE_BLUE.into()),
+                        BorderColor::all(LAVENDER),
+                        children![(
+                            Text::new("1em padding"),
+                            TextFont::from_font_size(font_size),
+                            BackgroundColor(PEACHPUFF.into()),
+                            TextColor(DARK_SLATE_GRAY.into())
+                        )],
                     )],
                 ),
-                // Always 20rem across
+                // Always 15rem across
                 (
                     Node {
                         flex_direction: FlexDirection::Row,
@@ -3761,10 +3774,10 @@ mod font_relative_units {
                     EmSize(font_size),
                     children![(
                         Node {
-                            width: rem(20),
+                            width: rem(15),
                             ..default()
                         },
-                        Text::new("< 20rem >"),
+                        Text::new("< 15rem >"),
                         TextLayout {
                             justify: Justify::Center,
                             ..default()
@@ -3777,47 +3790,55 @@ mod font_relative_units {
                 // Grid tracks: left is 5em sized, right is 10rem, padding is 0.5rem
                 (
                     Node {
-                        display: Display::Grid,
-                        grid_template_columns: vec![GridTrack::em(5.), GridTrack::rem(10.)],
-                        padding: rem(0.5).into(),
-                        border_radius: rem(0.5).into(),
-                        column_gap: rem(0.5),
+                        width: rem(20),
+                        justify_content: JustifyContent::End,
                         ..default()
                     },
-                    EmSize(font_size),
-                    BackgroundColor(DARK_SLATE_BLUE.into()),
-                    children![
-                        (
-                            Node {
-                                display: Display::Grid,
-                                grid_column: GridPlacement::span(2),
-                                ..default()
-                            },
-                            Text::new("0.5rem padding"),
-                            TextFont::from_font_size(font_size),
-                            TextColor(LAVENDER.into()),
-                        ),
-                        (
-                            Text::new("< 5em >"),
-                            TextLayout {
-                                justify: Justify::Center,
-                                ..default()
-                            },
-                            TextFont::from_font_size(font_size),
-                            BackgroundColor(PEACHPUFF.into()),
-                            TextColor(DARK_SLATE_GRAY.into())
-                        ),
-                        (
-                            Text::new("< 10rem >"),
-                            TextLayout {
-                                justify: Justify::Center,
-                                ..default()
-                            },
-                            TextFont::from_font_size(font_size),
-                            BackgroundColor(PALE_TURQUOISE.into()),
-                            TextColor(DARK_SLATE_GRAY.into())
-                        ),
-                    ]
+                    children![(
+                        Node {
+                            display: Display::Grid,
+                            grid_template_columns: vec![GridTrack::em(5.), GridTrack::rem(10.)],
+                            padding: px(10).into(),
+                            border_radius: px(10).into(),
+                            border: px(1).into(),
+                            ..default()
+                        },
+                        EmSize(font_size),
+                        BackgroundColor(DARK_SLATE_BLUE.into()),
+                        BorderColor::all(LAVENDER),
+                        children![
+                            (
+                                Node {
+                                    display: Display::Grid,
+                                    grid_column: GridPlacement::span(2),
+                                    ..default()
+                                },
+                                Text::new("10px padding"),
+                                TextFont::from_font_size(font_size),
+                                TextColor(LAVENDER.into()),
+                            ),
+                            (
+                                Text::new("< 5em >"),
+                                TextLayout {
+                                    justify: Justify::Center,
+                                    ..default()
+                                },
+                                TextFont::from_font_size(font_size),
+                                BackgroundColor(PEACHPUFF.into()),
+                                TextColor(DARK_SLATE_GRAY.into())
+                            ),
+                            (
+                                Text::new("< 10rem >"),
+                                TextLayout {
+                                    justify: Justify::Center,
+                                    ..default()
+                                },
+                                TextFont::from_font_size(font_size),
+                                BackgroundColor(PALE_TURQUOISE.into()),
+                                TextColor(DARK_SLATE_GRAY.into())
+                            ),
+                        ]
+                    )]
                 ),
             ],
         )


### PR DESCRIPTION

# Objective

- Many accessibility features and standard layout techniques involve sizing proportional to the font size. We already have the concept of a global `RemSize`. I have introduced a per-node `EmSize` component and fixed it up so it resolves Val::Rem and Val::Em values into pixel sizes for layout.

## Testing

- Tested in a manual copy of button example with changing EmSize on nodes, changing global RemSize

## Notes

- Like a lot of font support in `bevy_ui` the EmSize component is not propagated by the engine, this is instead left up to users such as `bevy_feathers` to implement alongside their own style propagation. Currently for EmSize to work the component (or a TextFont component) has to be added directly to the entity which is doing the proportional styling.

## Code Example

```
bsn! {
  EmSize(20.)
  Node {
     width: em(2),
  }
}
```

width will compute to 40px.

```
bsn! {
  Node {
     width: rem(1),
  }
}
```

width will compute to whatever the global RemSize resource was set to.

### Code Notes

There were a few places passing RemSize around as an f32 (ie the inner pixel value), I have changed these to pass the RemSize directly so that there can be no confusion where functions take a RemSize and an EmSize, it is not possible now to pass them in wrong order.
