### PR TITLE
Add missing ok color spaces to `try_interpolate_stable` and docs

### DIFF
--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -1182,6 +1182,9 @@ impl TryStableInterpolate for Color {
             (Color::Oklaba(a), Color::Oklaba(b)) => Ok(Color::Oklaba(a.mix(b, t))),
             (Color::Oklcha(a), Color::Oklcha(b)) => Ok(Color::Oklcha(a.mix(b, t))),
             (Color::Xyza(a), Color::Xyza(b)) => Ok(Color::Xyza(a.mix(b, t))),
+            (Color::Okhsla(a), Color::Okhsla(b)) => Ok(Color::Okhsla(a.mix(b, t))),
+            (Color::Okhsva(a), Color::Okhsva(b)) => Ok(Color::Okhsva(a.mix(b, t))),
+            (Color::Okhwba(a), Color::Okhwba(b)) => Ok(Color::Okhwba(a.mix(b, t))),
             _ => Err(MismatchedUnitsError),
         }
     }

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -20,6 +20,8 @@
 //! - [`Oklaba`] (lightness, a-axis, b-axis, alpha)
 //! - [`Oklcha`] (lightness, chroma, hue, alpha)
 //! - [`Xyza`] (x-axis, y-axis, z-axis, alpha)
+//! - [`Okhsla`] (hue, saturation, lightness, alpha)
+//! - [`Okhsva`] (hue, saturation, value, alpha)
 //! - [`Okhwba`] (hue, whiteness, blackness, alpha)
 //!
 //! Each of these color spaces is represented as a distinct Rust type.


### PR DESCRIPTION
# Objective

Some ok color spaces are missing in `try_interpolate_stable` and mod docs

## Solution

Add them.

## Testing

CI