### PR TITLE
Feathers `HardLimit` and `SoftLimit` now accept a `RangeInclusive`

### DIFF
--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -378,20 +378,20 @@ impl NumberInputRange {
     pub fn wrap(&self, n: NumberInputValue) -> NumberInputValue {
         match (self, n) {
             (Self::F32(r), NumberInputValue::F32(v)) => {
-                let range = r.end - r.start;
-                NumberInputValue::F32(r.start + (v - r.start).rem_euclid(range))
+                let range = r.end() - r.start();
+                NumberInputValue::F32(r.start() + (v - r.start()).rem_euclid(range))
             }
             (Self::F64(r), NumberInputValue::F64(v)) => {
-                let range = r.end - r.start;
-                NumberInputValue::F64(r.start + (v - r.start).rem_euclid(range))
+                let range = r.end() - r.start();
+                NumberInputValue::F64(r.start() + (v - r.start()).rem_euclid(range))
             }
             (Self::I32(r), NumberInputValue::I32(v)) => {
-                let range = r.end - r.start;
-                NumberInputValue::I32(r.start + (v - r.start).rem_euclid(range))
+                let range = r.end() - r.start();
+                NumberInputValue::I32(r.start() + (v - r.start()).rem_euclid(range))
             }
             (Self::I64(r), NumberInputValue::I64(v)) => {
-                let range = r.end - r.start;
-                NumberInputValue::I64(r.start + (v - r.start).rem_euclid(range))
+                let range = r.end() - r.start();
+                NumberInputValue::I64(r.start() + (v - r.start()).rem_euclid(range))
             }
             (range, value) => {
                 warn_once!("Number input range type mismatch: {range:?} {value:?}");

--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -1,4 +1,4 @@
-use std::{f32::consts::PI, ops::Range};
+use std::{f32::consts::PI, ops::RangeInclusive};
 
 use bevy_app::{Plugin, PreUpdate, PropagateOver};
 use bevy_color::Color;
@@ -330,13 +330,13 @@ impl Default for NumberInputValue {
 #[derive(Debug, PartialEq, Clone, Reflect)]
 pub enum NumberInputRange {
     /// An 'f32' range.
-    F32(Range<f32>),
+    F32(RangeInclusive<f32>),
     /// An 'f64' range.
-    F64(Range<f64>),
+    F64(RangeInclusive<f64>),
     /// An 'i32' range.
-    I32(Range<i32>),
+    I32(RangeInclusive<i32>),
     /// An 'i64' range.
-    I64(Range<i64>),
+    I64(RangeInclusive<i64>),
 }
 
 impl NumberInputRange {
@@ -344,16 +344,16 @@ impl NumberInputRange {
     pub fn clamp(&self, n: NumberInputValue) -> NumberInputValue {
         match (self, n) {
             (Self::F32(r), NumberInputValue::F32(v)) => {
-                NumberInputValue::F32(v.clamp(r.start, r.end))
+                NumberInputValue::F32(v.clamp(*r.start(), *r.end()))
             }
             (Self::F64(r), NumberInputValue::F64(v)) => {
-                NumberInputValue::F64(v.clamp(r.start, r.end))
+                NumberInputValue::F64(v.clamp(*r.start(), *r.end()))
             }
             (Self::I32(r), NumberInputValue::I32(v)) => {
-                NumberInputValue::I32(v.clamp(r.start, r.end))
+                NumberInputValue::I32(v.clamp(*r.start(), *r.end()))
             }
             (Self::I64(r), NumberInputValue::I64(v)) => {
-                NumberInputValue::I64(v.clamp(r.start, r.end))
+                NumberInputValue::I64(v.clamp(*r.start(), *r.end()))
             }
             (range, value) => {
                 warn_once!("Number input range type mismatch: {range:?} {value:?}");
@@ -367,32 +367,32 @@ impl NumberInputRange {
     pub fn thumb_position(&self, value: NumberInputValue) -> f32 {
         match (self, value) {
             (Self::F32(range), NumberInputValue::F32(n)) => {
-                if range.end > range.start {
-                    (n - range.start) / (range.end - range.start)
+                if range.end() > range.start() {
+                    (n - range.start()) / (range.end() - range.start())
                 } else {
                     0.5
                 }
             }
 
             (Self::F64(range), NumberInputValue::F64(n)) => {
-                if range.end > range.start {
-                    ((n - range.start) / (range.end - range.start)) as f32
+                if range.end() > range.start() {
+                    ((n - range.start()) / (range.end() - range.start())) as f32
                 } else {
                     0.5
                 }
             }
 
             (Self::I32(range), NumberInputValue::I32(n)) => {
-                if range.end > range.start {
-                    (n - range.start) as f32 / (range.end - range.start) as f32
+                if range.end() > range.start() {
+                    (n - range.start()) as f32 / (range.end() - range.start()) as f32
                 } else {
                     0.5
                 }
             }
 
             (Self::I64(range), NumberInputValue::I64(n)) => {
-                if range.end > range.start {
-                    (n - range.start) as f32 / (range.end - range.start) as f32
+                if range.end() > range.start() {
+                    (n - range.start()) as f32 / (range.end() - range.start()) as f32
                 } else {
                     0.5
                 }
@@ -408,7 +408,7 @@ impl NumberInputRange {
 
 impl Default for NumberInputRange {
     fn default() -> Self {
-        Self::F32(0.0..0.0)
+        Self::F32(0.0..=0.0)
     }
 }
 
@@ -419,22 +419,22 @@ pub struct SoftLimit(pub NumberInputRange);
 
 impl SoftLimit {
     /// Create a [`SoftLimit`] for `f32` values.
-    pub fn f32(range: Range<f32>) -> Self {
+    pub fn f32(range: RangeInclusive<f32>) -> Self {
         Self(NumberInputRange::F32(range))
     }
 
     /// Create a [`SoftLimit`] for `f64` values.
-    pub fn f64(range: Range<f64>) -> Self {
+    pub fn f64(range: RangeInclusive<f64>) -> Self {
         Self(NumberInputRange::F64(range))
     }
 
     /// Create a [`SoftLimit`] for `i32` values.
-    pub fn i32(range: Range<i32>) -> Self {
+    pub fn i32(range: RangeInclusive<i32>) -> Self {
         Self(NumberInputRange::I32(range))
     }
 
     /// Create a [`SoftLimit`] for `i64` values.
-    pub fn i64(range: Range<i64>) -> Self {
+    pub fn i64(range: RangeInclusive<i64>) -> Self {
         Self(NumberInputRange::I64(range))
     }
 }
@@ -447,22 +447,22 @@ pub struct HardLimit(pub NumberInputRange);
 
 impl HardLimit {
     /// Create a [`HardLimit`] for `f32` values.
-    pub fn f32(range: Range<f32>) -> Self {
+    pub fn f32(range: RangeInclusive<f32>) -> Self {
         Self(NumberInputRange::F32(range))
     }
 
     /// Create a [`HardLimit`] for `f64` values.
-    pub fn f64(range: Range<f64>) -> Self {
+    pub fn f64(range: RangeInclusive<f64>) -> Self {
         Self(NumberInputRange::F64(range))
     }
 
     /// Create a [`HardLimit`] for `i32` values.
-    pub fn i32(range: Range<i32>) -> Self {
+    pub fn i32(range: RangeInclusive<i32>) -> Self {
         Self(NumberInputRange::I32(range))
     }
 
     /// Create a [`HardLimit`] for `i64` values.
-    pub fn i64(range: Range<i64>) -> Self {
+    pub fn i64(range: RangeInclusive<i64>) -> Self {
         Self(NumberInputRange::I64(range))
     }
 }
@@ -955,10 +955,10 @@ fn scrubber_on_drag_start(
         // Use various heuristics to determine drag speed based on which components are present.
         drag.drag_speed = if let Some(SoftLimit(nrange)) = soft_limit {
             match nrange {
-                NumberInputRange::F32(range) => (range.end - range.start) as f64 / slider_size,
-                NumberInputRange::F64(range) => (range.end - range.start) / slider_size,
-                NumberInputRange::I32(range) => (range.end - range.start) as f64 / slider_size,
-                NumberInputRange::I64(range) => (range.end - range.start) as f64 / slider_size,
+                NumberInputRange::F32(range) => (range.end() - range.start()) as f64 / slider_size,
+                NumberInputRange::F64(range) => (range.end() - range.start()) / slider_size,
+                NumberInputRange::I32(range) => (range.end() - range.start()) as f64 / slider_size,
+                NumberInputRange::I64(range) => (range.end() - range.start()) as f64 / slider_size,
             }
         } else if let Some(NumberInputStep(step)) = step {
             *step * BASE_DRAG_SPEED

--- a/examples/3d/clustered_decals.rs
+++ b/examples/3d/clustered_decals.rs
@@ -246,7 +246,8 @@ fn spawn_buttons(commands: &mut Commands) {
             ,
 
             Visibility::Hidden
-            number_input_f32("Roll (-π to π)", Some(AppNumberInput::Roll), 0.0, NumberInputPrecision(2), -PI.next_up()..=PI.next_down())
+            // + epsilon and next_down are used since roll recalculation likes to switch between -PI and PI upon recalculating roll.
+            number_input_f32("Roll (-π to π)", Some(AppNumberInput::Roll), 0.0, NumberInputPrecision(2), -PI + f32::EPSILON ..=PI.next_down())
             ,
         ]
     });

--- a/examples/3d/clustered_decals.rs
+++ b/examples/3d/clustered_decals.rs
@@ -242,11 +242,11 @@ fn spawn_buttons(commands: &mut Commands) {
 
             // The number inputs start off hidden because Camera is selected first.
             Visibility::Hidden
-            number_input_f32("Scale Multiplier", Some(AppNumberInput::Scale), 1.0, NumberInputPrecision(2), 0.05..10.)
+            number_input_f32("Scale Multiplier", Some(AppNumberInput::Scale), 1.0, NumberInputPrecision(2), 0.05..=10.)
             ,
 
             Visibility::Hidden
-            number_input_f32("Roll (-π to π)", Some(AppNumberInput::Roll), 0.0, NumberInputPrecision(2), -PI..PI)
+            number_input_f32("Roll (-π to π)", Some(AppNumberInput::Roll), 0.0, NumberInputPrecision(2), -PI.next_up()..=PI.next_down())
             ,
         ]
     });

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -225,7 +225,7 @@ fn number_input_for_value(
             template_value(NumberInputValue::F32(setting.get(color_grading)))
             template_value(setting)
             NumberInputPrecision(2)
-            HardLimit::f32(0. ..10.)
+            HardLimit::f32(0. ..=10.)
         ]
     }
 }

--- a/examples/3d/light_textures.rs
+++ b/examples/3d/light_textures.rs
@@ -299,11 +299,11 @@ fn spawn_buttons(commands: &mut Commands) {
 
             // The number inputs start off hidden because Camera is selected first.
             Visibility::Hidden
-            number_input_f32("Scale Multiplier", Some(AppNumberInput::Scale), 1.0, NumberInputPrecision(2), 0.01..5.)
+            number_input_f32("Scale Multiplier", Some(AppNumberInput::Scale), 1.0, NumberInputPrecision(2), 0.01..=5.)
             ,
 
             Visibility::Hidden
-            number_input_f32("Roll (-π to π)", Some(AppNumberInput::Roll), 0.0, NumberInputPrecision(2), -PI..PI)
+            number_input_f32("Roll (-π to π)", Some(AppNumberInput::Roll), 0.0, NumberInputPrecision(2), -PI.next_up()..=PI.next_down())
             ,
         ]
     });

--- a/examples/3d/light_textures.rs
+++ b/examples/3d/light_textures.rs
@@ -303,7 +303,8 @@ fn spawn_buttons(commands: &mut Commands) {
             ,
 
             Visibility::Hidden
-            number_input_f32("Roll (-π to π)", Some(AppNumberInput::Roll), 0.0, NumberInputPrecision(2), -PI.next_up()..=PI.next_down())
+            // + epsilon and next_down are used since roll recalculation likes to switch between -PI and PI upon recalculating roll.
+            number_input_f32("Roll (-π to π)", Some(AppNumberInput::Roll), 0.0, NumberInputPrecision(2), -PI + f32::EPSILON ..=PI.next_down())
             ,
         ]
     });

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -560,7 +560,7 @@ fn range_controls(value: f32, app_number_input: AppNumberInput) -> impl Scene {
         template_value(NumberInputValue::F32(value))
         template_value(app_number_input)
         NumberInputPrecision(3)
-        HardLimit::f32(0.0..1.0)
+        HardLimit::f32(0.0..=1.0)
         Node {
             align_items: AlignItems::Center,
         }

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -310,7 +310,7 @@ fn setup_node_rects(commands: &mut Commands) {
                     Children [
                         ZIndex(1)
                         number_input_f32(clip.text, Some(clip.clone()),
-                            ExampleAnimationWeights::default().weights[clip.index], NumberInputPrecision(2), 0. ..1.),
+                            ExampleAnimationWeights::default().weights[clip.index], NumberInputPrecision(2), 0. ..=1.),
 
                         // The background node that fills up based on the number input value.
                         WeightBackground

--- a/examples/helpers/number_input_f32.rs
+++ b/examples/helpers/number_input_f32.rs
@@ -22,7 +22,7 @@ pub fn number_input_f32<T>(
     number_input_identifier: Option<T>,
     value: f32,
     precision: NumberInputPrecision,
-    limits: core::ops::Range<f32>,
+    limits: core::ops::RangeInclusive<f32>,
 ) -> Box<dyn Scene>
 where
     T: Template<Output: Component> + Send + Sync + Unpin + 'static,

--- a/examples/helpers/number_input_i32.rs
+++ b/examples/helpers/number_input_i32.rs
@@ -22,7 +22,7 @@ pub fn number_input_i32<T>(
     number_input_identifier: Option<T>,
     value: i32,
     precision: NumberInputPrecision,
-    limits: core::ops::Range<i32>,
+    limits: core::ops::RangeInclusive<i32>,
 ) -> Box<dyn Scene>
 where
     T: Template<Output: Component> + Send + Sync + Unpin + 'static,

--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -247,42 +247,42 @@ fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
                     Some(AppNumberInputF32::XOffset),
                     app_settings.x_offset,
                     NumberInputPrecision(0),
-                    -200. ..200.
+                    -200. ..=200.
                 ),
                 number_input_f32(
                     AppNumberInputF32::YOffset.label(),
                     Some(AppNumberInputF32::YOffset),
                     app_settings.y_offset,
                     NumberInputPrecision(0),
-                    -200. ..200.
+                    -200. ..=200.
                 ),
                 number_input_f32(
                     AppNumberInputF32::Blur.label(),
                     Some(AppNumberInputF32::Blur),
                     app_settings.blur,
                     NumberInputPrecision(0),
-                    0. ..100.
+                    0. ..=100.
                 ),
                 number_input_f32(
                     AppNumberInputF32::Spread.label(),
                     Some(AppNumberInputF32::Spread),
                     app_settings.spread,
                     NumberInputPrecision(0),
-                    -200. ..200.
+                    -200. ..=200.
                 ),
                 number_input_i32(
                     AppNumberInputI32::Count.label(),
                     Some(AppNumberInputI32::Count),
                     app_settings.count as i32,
                     NumberInputPrecision(0),
-                    1..3
+                    1..=3
                 ),
                 number_input_i32(
                     AppNumberInputI32::Samples.label(),
                     Some(AppNumberInputI32::Samples),
                     app_settings.samples as i32,
                     NumberInputPrecision(0),
-                    0..15
+                    0..=15
                 ),
                 // Reset button
                 @FeathersButton {

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -812,7 +812,7 @@ fn demo_column_2() -> impl Scene {
                                                 @FeathersNumberInput
                                                 DemoScalarField
                                                 NumberInputPrecision(2)
-                                                HardLimit::f32(0.0..100.0)
+                                                HardLimit::f32(0.0..=100.0)
                                                 Node {
                                                     flex_grow: 1.0,
                                                     max_width: px(100),

--- a/examples/ui/widgets/feathers_number_input.rs
+++ b/examples/ui/widgets/feathers_number_input.rs
@@ -85,7 +85,7 @@ fn demo_root() -> impl Scene {
                 template_value(SoftLimit(NumberInputRange::F32(0.0..=10.0)))
             )),
             demo_field_f32("hard limit + wrap", 0.0, bsn!(
-                template_value(HardLimit(NumberInputRange::F32(-180.0..180.0)))
+                template_value(HardLimit(NumberInputRange::F32(-180.0..=180.0)))
                 template_value(NumberInputWrap::Wrap)
             )),
         ]

--- a/examples/ui/widgets/feathers_number_input.rs
+++ b/examples/ui/widgets/feathers_number_input.rs
@@ -45,14 +45,14 @@ fn demo_root() -> impl Scene {
         Children[
             demo_field_f32("none (bare)", 1.0, bsn!()),
             demo_field_f32("soft limit", 2.0, bsn!(
-                template_value(SoftLimit(NumberInputRange::F32(0.0..10.0)))
+                template_value(SoftLimit(NumberInputRange::F32(0.0..=10.0)))
             )),
             demo_field_f32("hard limit", 3.0, bsn!(
-                template_value(HardLimit(NumberInputRange::F32(-100.0..100.0)))
+                template_value(HardLimit(NumberInputRange::F32(-100.0..=100.0)))
             )),
             demo_field_f32("soft + hard", 4.0, bsn!(
-                template_value(SoftLimit(NumberInputRange::F32(0.0..10.0)))
-                template_value(HardLimit(NumberInputRange::F32(-100.0..100.0)))
+                template_value(SoftLimit(NumberInputRange::F32(0.0..=10.0)))
+                template_value(HardLimit(NumberInputRange::F32(-100.0..=100.0)))
             )),
             demo_field_f32("precision(0)", 5.0, bsn!(
                 NumberInputPrecision(0)
@@ -67,22 +67,22 @@ fn demo_root() -> impl Scene {
                 NumberInputStep(1.0f64)
             )),
             demo_field_f64("f64: soft limit", 1.0f64, bsn!(
-                template_value(SoftLimit(NumberInputRange::F64(0.0f64..10.0f64)))
+                template_value(SoftLimit(NumberInputRange::F64(0.0f64..=10.0f64)))
             )),
             demo_field_f64("f64: soft limit + precision(2)", 1.0f64, bsn!(
-                template_value(SoftLimit(NumberInputRange::F64(0.0f64..10.0f64)))
+                template_value(SoftLimit(NumberInputRange::F64(0.0f64..=10.0f64)))
                 NumberInputPrecision(2)
             )),
             demo_field_i32("i32: bare", 1, bsn!()),
             demo_field_i32("i32: soft limit", 1, bsn!(
-                template_value(SoftLimit(NumberInputRange::I32(0..10)))
+                template_value(SoftLimit(NumberInputRange::I32(0..=10)))
             )),
             demo_field_f32_with_sigil("precision(2) + sigil", 6.0, bsn!(
                 NumberInputPrecision(2)
             )),
             demo_field_f32("soft limit + disabled", 2.0, bsn!(
                 InteractionDisabled
-                template_value(SoftLimit(NumberInputRange::F32(0.0..10.0)))
+                template_value(SoftLimit(NumberInputRange::F32(0.0..=10.0)))
             )),
         ]
     }


### PR DESCRIPTION
# Objective

- Fixes #25107 

## Solution

- After talking with @viridia , it makes sense just to update the `Range` to be a `RangeInclusive` so that the user understands it is an inclusive range for `HardLimit` and `SoftLimit`. There’s no need to accommodate exclusive ranges at this point so we can park #25236 for now. The changes are now very straightforward because of it.

## Testing

- `cargo run --example clustered_decals --features="pbr_clustered_decals bevy_feathers”` has good behavior with number inputs
- `cargo run --example box_shadow --features=“bevy_feathers”` works as expected
- `cargo run --example feathers_gallery --features=“bevy_feathers”` works as expected