### PR TITLE
Make major line interval configurable in `InfiniteGrid`

### DIFF
--- a/crates/bevy_dev_tools/src/infinite_grid.rs
+++ b/crates/bevy_dev_tools/src/infinite_grid.rs
@@ -111,7 +111,7 @@ pub struct InfiniteGridSettings {
     pub z_axis_color: Color,
     /// The color of the minor lines of the grid
     pub minor_line_color: Color,
-    /// The color of the major lines of the grid. Every 10th line is considered major
+    /// The color of the major lines of the grid
     pub major_line_color: Color,
     /// How far the grid will be visible relative to the camera
     pub fadeout_distance: f32,
@@ -120,6 +120,8 @@ pub struct InfiniteGridSettings {
     /// The scale of the distance between the lines. A smaller value increases the distance between
     /// the lines
     pub scale: f32,
+    /// The interval at which major lines are drawn
+    pub major_line_interval: u32,
 }
 
 impl Default for InfiniteGridSettings {
@@ -134,6 +136,7 @@ impl Default for InfiniteGridSettings {
             fadeout_distance: 100.,
             dot_fadeout_strength: 0.25,
             scale: 1.0,
+            major_line_interval: 10,
         }
     }
 }
@@ -152,6 +155,8 @@ struct InfiniteGridSettingsUniform {
     one_over_fadeout_distance: f32,
     // 1 / dot_fadeout_strength
     one_over_dot_fadeout: f32,
+    // 1 / major_line_interval
+    one_over_major_line_interval: f32,
     x_axis_color: Vec3,
     z_axis_color: Vec3,
     minor_line_color: Vec4,
@@ -164,6 +169,7 @@ impl InfiniteGridSettingsUniform {
             scale: settings.scale,
             one_over_fadeout_distance: 1. / settings.fadeout_distance,
             one_over_dot_fadeout: 1. / settings.dot_fadeout_strength,
+            one_over_major_line_interval: 1. / settings.major_line_interval.max(1) as f32,
             x_axis_color: settings.x_axis_color.to_linear().to_vec3(),
             z_axis_color: settings.z_axis_color.to_linear().to_vec3(),
             minor_line_color: settings.minor_line_color.to_linear().to_vec4(),

--- a/crates/bevy_dev_tools/src/infinite_grid.wesl
+++ b/crates/bevy_dev_tools/src/infinite_grid.wesl
@@ -13,6 +13,8 @@ struct InfiniteGridSettings {
     one_over_fadeout_distance: f32,
     // 1 / dot_fadeout_strength
     one_over_dot_fadeout: f32,
+    // 1 / major_line_interval
+    one_over_major_line_interval: f32,
     x_axis_col: vec3<f32>,
     z_axis_col: vec3<f32>,
     minor_line_col: vec4<f32>,
@@ -80,8 +82,9 @@ fn fragment(in: FullscreenVertexOutput) -> FragmentOutput {
     let minor_line = min(grid.x, grid.y);
 
     // Compute major lines
-    let derivative2 = fwidth(coord * 0.1);
-    let grid2 = abs(fract((coord * 0.1) - 0.5) - 0.5) / derivative2;
+    let major_scale = grid_settings.one_over_major_line_interval;
+    let derivative2 = fwidth(coord * major_scale);
+    let grid2 = abs(fract((coord * major_scale) - 0.5) - 0.5) / derivative2;
     let major_line = min(grid2.x, grid2.y);
 
     // Compute axis lines


### PR DESCRIPTION
# Objective

Currently `InfiniteGrid` draws major lines at a hardcoded interval of 10.
While it's a reasonable default, it's still opinianated against editors who might value other intervals like chunks of 8 or 16.

## Solution

Introduce a new variable setting in `InfiniteGridSettings` which is used for inverse value in the shader.

## Testing

Ran `infinite_grid` example with altered major line intervals.

## Showcase

<img width="1280" height="720" alt="infinite_grid_screenshot" src="https://github.com/user-attachments/assets/d4ca17ab-e7ad-4100-8f8b-c0b4e8151a5e" />

Infinite grid with major line interval set to 2 for exaggeration, (minor lines are somewhat hard to notice).
