### PR TITLE
Usage Example: Use `ui_widgets` to power a Character Creation Screen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5463,6 +5463,17 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "character_creation"
+path = "examples/usage/character_creation.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.character_creation]
+name = "Character Creation with UI Widgets"
+description = "Demonstrates how to use headless widgets to power a Character Creation Menu"
+category = "Usage"
+wasm = true
+
+[[example]]
 name = "standard_widgets_observers"
 path = "examples/ui/widgets/standard_widgets_observers.rs"
 doc-scrape-examples = true

--- a/examples/README.md
+++ b/examples/README.md
@@ -657,6 +657,7 @@ Example | Description
 
 Example | Description
 --- | ---
+[Character Creation with UI Widgets](../examples/usage/character_creation.rs) | Demonstrates how to use headless widgets to power a Character Creation Menu
 [Context Menu](../examples/usage/context_menu.rs) | Example of a context menu
 [Cooldown](../examples/usage/cooldown.rs) | Example for cooldown on button clicks
 [Debug Frustum Culling](../examples/usage/debug_frustum_culling.rs) | Example demonstrating how to debug frustum culling

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -64,7 +64,7 @@ fn setup(mut commands: Commands, character: Res<Character>) {
         // This scene will serve as the other half of our "View" in our MVC design.
         // The user will see the character they are creating.
         character_view(&character),
-    })
+    });
 }
 
 /// This resource serves as the "Model" in our MVC Design.
@@ -356,7 +356,7 @@ fn age_slider(character: &Character) -> impl Scene {
 
 /// A system that implements Controller logic to update the Age.
 /// This particular system updates the Model upon any change in value to the Age Slider.
-/// Sliders emit a ValueChange<f32> event when the user drags the slider.
+/// Sliders emit a `ValueChange<f32>` event when the user drags the slider.
 /// The value of the event is the new value of the slider.
 /// The source of the event is the `Slider` parent entity.
 fn on_changed_age_slider(
@@ -461,7 +461,7 @@ fn hat_type_radio_button(hat_type: HatType, character: &Character) -> Box<dyn Sc
 
 /// This observer is part of the Controller logic.
 /// This observer will update the `Character` Resource based on a change to the Hat Type Radio Group.
-/// Radio groups emit a ValueChange<Entity> event when the user clicks on a radio button.
+/// Radio groups emit a `ValueChange<Entity>` event when the user clicks on a radio button.
 /// The value of the event is of the clicked radio button.
 /// The source of the event is the parent radio group.
 fn on_value_change_hat_type(
@@ -568,7 +568,7 @@ fn tint_yellow_checkbox(character: &Character) -> Box<dyn Scene> {
 
 /// This observer is part of the Controller logic.
 /// This observer will update the `Character` Resource based on a change to the Tint Yellow Checkbox.
-/// Checkboxes emit a ValueChange<bool> event when the user clicks on a checkbox.
+/// Checkboxes emit a `ValueChange<bool>` event when the user clicks on a checkbox.
 /// The value of the event is the value of the toggle.
 /// The source of the event is the checkbox.
 fn on_value_change_tint_yellow(

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -20,6 +20,7 @@ use bevy::{
     prelude::*,
     ui::Checked,
     ui_widgets::{Checkbox, RadioButton, RadioGroup, TextInput, ValueChange},
+    window::{CursorIcon, PrimaryWindow, SystemCursorIcon},
 };
 
 fn main() {
@@ -52,7 +53,7 @@ fn setup(mut commands: Commands, character: Res<Character>) {
 /// This resource serves as the "Model" in our MVC Design.
 /// It serves as our source of truth for the character being created.
 #[derive(Resource)]
-pub struct Character {
+struct Character {
     name: String,
     age: u32,
     hat_type: HatType,
@@ -83,38 +84,38 @@ enum HatType {
 
 const HAT_TYPES: [HatType; 3] = [HatType::None, HatType::TopHat, HatType::DunceCap];
 
-/// --- START MARKER COMPONENTS --- ///
+// --- START MARKER COMPONENTS --- //
 
 #[derive(Component, Clone, Default)]
-pub struct NameInput;
+struct NameInput;
 
 #[derive(Component, Clone, Default)]
-pub struct AgeSlider;
+struct AgeSlider;
 
 #[derive(Component, Clone, Default)]
-pub struct HatTypeRadioGroup;
+struct HatTypeRadioGroup;
 
 #[derive(Component, Clone, Default)]
-pub struct TintYellowCheckbox;
+struct TintYellowCheckbox;
 
 #[derive(Component, Clone, Default)]
-pub struct CharacterView;
+struct CharacterView;
 
-/// --- END MARKER COMPONENTS --- ///
+// --- END MARKER COMPONENTS --- //
 
-/// --- CONTROLLER --- ///
+// --- START CONTROLLER --- //
 
 /// Spawns the ui widgets that will serve as the "Controller"
 /// in our MVC design.
 fn ui(character: &Character) -> impl Scene {
     bsn! {
-        // UI will take up the left third of the screen.
+        // UI will take up the left half of the screen.
         Node {
             flex_direction: FlexDirection::Column,
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
             height: percent(100)
-            width: percent(33),
+            width: percent(50),
         }
         Children [
             // The character creation pane
@@ -124,6 +125,7 @@ fn ui(character: &Character) -> impl Scene {
                 align_items: AlignItems::Center,
                 margin: percent(5),
                 width: percent(90),
+                padding: UiRect::vertical(px(10)),
                 border_radius: BorderRadius::all(px(5)),
                 row_gap: px(10),
             }
@@ -135,15 +137,41 @@ fn ui(character: &Character) -> impl Scene {
                     Text::new("Character Creator")
                 ],
 
-                // Hat type radio group
-                hat_type_radio_group(character)
-                // This observer updates the Model based on user input.
-                on(on_value_change_hat_type),
+                hat_type_radio_group(character),
 
+                tint_yellow_checkbox_row(character),
             ]
         ]
     }
 }
+
+/// An observer that styles the cursor, used primarily for buttons / checkboxes
+fn on_pointer_over_pointer_cursor(
+    _event: On<Pointer<Over>>,
+    mut window_q: Query<Entity, With<PrimaryWindow>>,
+    mut commands: Commands,
+) {
+    for window in window_q.iter_mut() {
+        commands
+            .entity(window)
+            .insert(CursorIcon::System(SystemCursorIcon::Pointer));
+    }
+}
+
+/// An observer that styles the cursor, used for all widgets
+fn on_pointer_out_default_cursor(
+    _event: On<Pointer<Out>>,
+    mut window_q: Query<Entity, With<PrimaryWindow>>,
+    mut commands: Commands,
+) {
+    for window in window_q.iter_mut() {
+        commands
+            .entity(window)
+            .insert(CursorIcon::System(SystemCursorIcon::Default));
+    }
+}
+
+// --- START RADIO GROUP -- //
 
 /// Creates the radio group that allows the user to select a hat for the character.
 fn hat_type_radio_group(character: &Character) -> impl Scene {
@@ -155,6 +183,8 @@ fn hat_type_radio_group(character: &Character) -> impl Scene {
         }
         RadioGroup
         HatTypeRadioGroup
+        // This observer is important -- it reacts to the user's input!
+        on(on_value_change_hat_type)
         Children [
             Node
             Children [
@@ -181,6 +211,8 @@ fn hat_type_radio_button(hat_type: HatType, character: &Character) -> Box<dyn Sc
             RadioButton
             template_value(hat_type)
             BackgroundColor(Color::BLACK)
+            on(on_pointer_over_pointer_cursor)
+            on(on_pointer_out_default_cursor)
         }
     };
     if character.hat_type == hat_type {
@@ -217,6 +249,8 @@ fn on_value_change_hat_type(
     mut commands: Commands,
 ) {
     // Ensure this value change event is for the Hat Type Radio Group
+    // Although unnecessary in this example, apps with multiple radio groups need to distinguish
+    // what the value change is for.
     if event.source != hat_type_radio_group_q.entity() {
         return;
     }
@@ -237,6 +271,7 @@ fn on_value_change_hat_type(
     for (button_entity, hat_type, has_checked, children) in hat_type_value_q.iter() {
         if character.hat_type == *hat_type {
             commands.entity(button_entity).insert(Checked);
+            // The radio button only has one child for the text and color of the button
             commands
                 .entity(children[0])
                 .insert(TextColor(palettes::basic::GREEN.into()));
@@ -248,7 +283,106 @@ fn on_value_change_hat_type(
     // Because character has been modified, refresh_character will run and update the "View".
 }
 
-/// --- VIEW --- ///
+// --- END RADIO GROUP -- //
+
+// --- START CHECK BOX -- //
+
+/// Creates the checkbox that allows the user to toggle a yellow tint of the character.
+fn tint_yellow_checkbox_row(character: &Character) -> impl Scene {
+    bsn! {
+        Node {
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::SpaceBetween,
+        }
+        Children [
+            Node
+            Children [
+                Text::new("Tint Yellow: ")
+            ],
+
+            tint_yellow_checkbox(character)
+        ]
+    }
+}
+
+fn tint_yellow_checkbox(character: &Character) -> Box<dyn Scene> {
+    let base_checkbox = || {
+        bsn! {
+            Node {
+                padding: UiRect::horizontal(px(5)),
+            }
+            Checkbox
+            TintYellowCheckbox
+            BackgroundColor(Color::WHITE)
+            on(on_pointer_over_pointer_cursor)
+            on(on_pointer_out_default_cursor)
+            // This observer is important -- it reacts to the user's input!
+            on(on_value_change_tint_yellow)
+        }
+    };
+
+    if character.tint_yellow {
+        Box::new(bsn! {
+            base_checkbox()
+            Checked
+            Children [
+                Text::new("X")
+                TextColor(palettes::basic::GREEN)
+            ]
+        })
+    } else {
+        Box::new(bsn! {
+            base_checkbox()
+            Children [
+                Text::new(" ")
+                TextColor(palettes::basic::GREEN)
+            ]
+        })
+    }
+}
+
+/// This observer will update the `Character` Resource based on a change to the Tint Yellow Checkbox.
+/// Checkboxes emit a ValueChange<bool> event when the user clicks on a checkbox.
+/// The value of the event is the value of the toggle.
+/// The source of the event is the checkbox.
+fn on_value_change_tint_yellow(
+    event: On<ValueChange<bool>>,
+    tint_yellow_checkbox_q: Query<(Entity, &Children), With<TintYellowCheckbox>>,
+    mut character: ResMut<Character>,
+    mut commands: Commands,
+) {
+    let Ok((checkbox_entity, children)) = tint_yellow_checkbox_q.single_inner() else {
+        return;
+    };
+
+    // Ensure this value change event is for the checkbox.
+    // Although unnecessary in this example, apps with multiple checkboxes need to distinguish
+    // what the value change is for.
+    if event.source != checkbox_entity {
+        return;
+    }
+
+    // Update the Model
+    character.tint_yellow = event.value;
+
+    // Update the Controller
+    if character.tint_yellow {
+        commands.entity(event.source).insert(Checked);
+        // The checkbox only has one child for the X and its color
+        commands.entity(children[0]).insert(Text::new("X"));
+    } else {
+        commands.entity(event.source).remove::<Checked>();
+        commands.entity(children[0]).insert(Text::new(" "));
+    }
+    // Because character has been modified, refresh_character will run and update the "View".
+}
+
+// --- END CHECK BOX -- //
+
+// --- END CONTROLLER --- //
+
+// --- START VIEW --- //
 
 /// A system that updates the "View" whenever the "Model" has changed.
 fn refresh_character(
@@ -265,7 +399,7 @@ fn refresh_character(
 fn character_view(character: &Character) -> impl Scene {
     bsn! {
         CharacterView
-        Transform::default()
+        Transform::from_xyz(320., 0., 0.)
         template_value(Visibility::Inherited)
         Children [
             character_sprite_tint(&character),
@@ -335,3 +469,5 @@ fn character_name_and_age(character: &Character) -> impl Scene {
         template_value(Transform::from_xyz(0., -200., 0.))
     }
 }
+
+// --- END VIEW --- //

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -342,6 +342,7 @@ fn age_slider(character: &Character) -> impl Scene {
                     width: px(20),
                     height: px(10),
                     position_type: PositionType::Absolute,
+                    // Where the thumb is along the track will be updated by `on_value_change_age_slider`
                     left: percent((character.age as f32 - 1.) / (100. - 1.) * 100.),
                 }
                 BackgroundColor(Color::WHITE)

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -1,24 +1,25 @@
 //! This example illustrates how to manage data input from select
 //! widgets in the `ui_widgets` crate.
-//! 
+//!
 //! When a UI widget is interacted with by an application user,
 //! various events are triggered that that the user presumably wants
 //! to be recognized by the application. It is up to the application to
 //! handle and interpret these events, which usually means updating its own internal
 //! state and refreshing its user interface so that the user sees the most
 //! recent data.
-//! 
+//!
 //! The example will implement a traditional Model View Controller (MVC) design
 //! using the various ui widgets to power a character creation screen.
-//! 
+//!
 //! To read more about state management, consult the [`bevy::ui_widgets`]
 //! crate level documentation.
 
 use bevy::{
     color::palettes,
+    ecs::schedule::IntoScheduleConfigs,
     prelude::*,
     ui::Checked,
-    ui_widgets::{RadioGroup, RadioButton, Checkbox, TextInput, ValueChange},
+    ui_widgets::{Checkbox, RadioButton, RadioGroup, TextInput, ValueChange},
 };
 
 fn main() {
@@ -26,7 +27,26 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .init_resource::<Character>()
         .add_systems(Startup, setup)
+        .add_systems(
+            Update,
+            refresh_character.run_if(resource_changed::<Character>),
+        )
         .run();
+}
+
+fn setup(mut commands: Commands, character: Res<Character>) {
+    commands.spawn_scene_list(bsn_list! {
+        Camera2d,
+
+        // This scene will serve as our "Controller" in our MVC design.
+        // The user interacts with the controller, which will affect the
+        // "View" (the rendered character).
+        ui(&character),
+
+        // This scene will serve as our "View" in our MVC design.
+        // The user will see the character they are creating.
+        character_view(&character),
+    })
 }
 
 /// This resource serves as the "Model" in our MVC Design.
@@ -51,7 +71,7 @@ impl Default for Character {
 }
 
 /// Hat options for the character to have.
-/// This derives `Component` so that they can be placed on the individual radio buttons
+/// This derives `Component` so each enum value can be placed on individual radio buttons
 /// for ease of identifying which radio button was selected.
 #[derive(Component, Clone, Copy, Debug, Default, PartialEq)]
 enum HatType {
@@ -63,46 +83,32 @@ enum HatType {
 
 const HAT_TYPES: [HatType; 3] = [HatType::None, HatType::TopHat, HatType::DunceCap];
 
-/// Marker Component for the Name Input Field
+/// --- START MARKER COMPONENTS --- ///
+
 #[derive(Component, Clone, Default)]
 pub struct NameInput;
 
-/// Marker Component for the Age Slider
 #[derive(Component, Clone, Default)]
 pub struct AgeSlider;
 
-/// Marker Component for the HatType Radio Group
 #[derive(Component, Clone, Default)]
 pub struct HatTypeRadioGroup;
 
-/// Marker Component for the Tint Yellow Checkbox
 #[derive(Component, Clone, Default)]
 pub struct TintYellowCheckbox;
 
-/// Marker Component for the Character View
 #[derive(Component, Clone, Default)]
 pub struct CharacterView;
 
-fn setup(mut commands: Commands, character: Res<Character>) {
-    commands.spawn_scene_list(bsn_list! {
-        Camera2d,
+/// --- END MARKER COMPONENTS --- ///
 
-        // This scene will serve as our "Controller" in our MVC design.
-        // The user interacts with the controller, which will affect the
-        // "View" (the rendered character).
-        ui(&character),
+/// --- CONTROLLER --- ///
 
-        // This scene will serve as our "View" in our MVC design.
-        // The user can see the character they are creating.
-        base_character_view(&character),
-    })
-}
-
-/// Spawns the ui widgets that will serve as the "Controller" for the
-/// character "Model".
+/// Spawns the ui widgets that will serve as the "Controller"
+/// in our MVC design.
 fn ui(character: &Character) -> impl Scene {
     bsn! {
-        // ui will take up the left third of the screen.
+        // UI will take up the left third of the screen.
         Node {
             flex_direction: FlexDirection::Column,
             justify_content: JustifyContent::Center,
@@ -111,26 +117,41 @@ fn ui(character: &Character) -> impl Scene {
             width: percent(33),
         }
         Children [
-            // Holds the character creation pane
+            // The character creation pane
             Node {
                 flex_direction: FlexDirection::Column,
-                justify_content: JustifyContent::Center,
+                justify_content: JustifyContent::SpaceEvenly,
                 align_items: AlignItems::Center,
-                width: percent(100),
+                margin: percent(5),
+                width: percent(90),
                 border_radius: BorderRadius::all(px(5)),
+                row_gap: px(10),
             }
             BackgroundColor(palettes::basic::GRAY)
             Children [
-                hat_type_radio_group(character),
+                // Pane header
+                Node
+                Children[
+                    Text::new("Character Creator")
+                ],
+
+                // Hat type radio group
+                hat_type_radio_group(character)
+                // This observer updates the Model based on user input.
+                on(on_value_change_hat_type),
+
             ]
         ]
     }
 }
 
+/// Creates the radio group that allows the user to select a hat for the character.
 fn hat_type_radio_group(character: &Character) -> impl Scene {
     bsn! {
         Node {
             flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::SpaceBetween,
         }
         RadioGroup
         HatTypeRadioGroup
@@ -141,51 +162,176 @@ fn hat_type_radio_group(character: &Character) -> impl Scene {
             ],
 
             {
-                HAT_TYPES.iter().map(|hat_type| hat_type_radio_button(*hat_type, character)).collect::<Vec<_>>()
+                HAT_TYPES.iter()
+                    .map(|hat_type| hat_type_radio_button(*hat_type, character))
+                    .collect::<Vec<_>>()
             }
         ]
     }
 }
 
 fn hat_type_radio_button(hat_type: HatType, character: &Character) -> Box<dyn Scene> {
-    if character.hat_type == hat_type {
-        Box::new(bsn! {
+    let base_radio_button = || {
+        bsn! {
             Node {
                 border: px(5),
+                border_radius: BorderRadius::all(px(10)),
+                padding: UiRect::axes(px(5), px(2)),
             }
             RadioButton
-            Checked
             template_value(hat_type)
+            BackgroundColor(Color::BLACK)
+        }
+    };
+    if character.hat_type == hat_type {
+        Box::new(bsn! {
+            base_radio_button()
+            // The selected hat_type must have the `Checked` component.
+            Checked
             Children [
                 Text::new(format!("{hat_type:?}"))
+                // The selected hat_type's text is green as opposed to white.
                 TextColor(palettes::basic::GREEN)
             ]
-            BackgroundColor(Color::BLACK)
         })
     } else {
         Box::new(bsn! {
-            Node {
-                border: px(5),
-            }
-            RadioButton
-            template_value(hat_type)
+            base_radio_button()
             Children [
                 Text::new(format!("{hat_type:?}"))
                 TextColor(palettes::basic::WHITE)
             ]
-            BackgroundColor(Color::BLACK)
         })
     }
 }
 
-fn base_character_view(character: &Character) -> impl Scene {
+/// This observer will update the `Character` Resource based on a change to the Hat Type Radio Group.
+/// Radio groups emit a ValueChange<Entity> event when the user clicks on a radio button.
+/// The value of the event is of the clicked radio button.
+/// The source of the event is the parent radio group.
+fn on_value_change_hat_type(
+    event: On<ValueChange<Entity>>,
+    hat_type_value_q: Query<(Entity, &HatType, Has<Checked>, &Children), With<RadioButton>>,
+    hat_type_radio_group_q: Single<Entity, With<HatTypeRadioGroup>>,
+    mut character: ResMut<Character>,
+    mut commands: Commands,
+) {
+    // Ensure this value change event is for the Hat Type Radio Group
+    if event.source != hat_type_radio_group_q.entity() {
+        return;
+    }
+
+    let Ok((_, new_hat_type, has_checked, _)) = hat_type_value_q.get(event.value) else {
+        return;
+    };
+
+    if has_checked {
+        // The hat type has actually not changed, so we do not need to do anything.
+        return;
+    }
+
+    // Update the Model
+    character.hat_type = *new_hat_type;
+
+    // Update the Controller
+    for (button_entity, hat_type, has_checked, children) in hat_type_value_q.iter() {
+        if character.hat_type == *hat_type {
+            commands.entity(button_entity).insert(Checked);
+            commands
+                .entity(children[0])
+                .insert(TextColor(palettes::basic::GREEN.into()));
+        } else if has_checked {
+            commands.entity(button_entity).remove::<Checked>();
+            commands.entity(children[0]).insert(TextColor(Color::WHITE));
+        }
+    }
+    // Because character has been modified, refresh_character will run and update the "View".
+}
+
+/// --- VIEW --- ///
+
+/// A system that updates the "View" whenever the "Model" has changed.
+fn refresh_character(
+    mut commands: Commands,
+    query: Single<Entity, With<CharacterView>>,
+    character: Res<Character>,
+) {
+    commands.entity(query.entity()).despawn();
+
+    commands.spawn_scene(character_view(&character));
+}
+
+/// Returns the "View", powered by data from the `Character` Model.
+fn character_view(character: &Character) -> impl Scene {
     bsn! {
         CharacterView
+        Transform::default()
+        template_value(Visibility::Inherited)
         Children [
-            Sprite {
-                image: "branding/icon.png"
-            }
-            // Transform::from_xyz(426., 0., 0.)
+            character_sprite_tint(&character),
+            character_hat(&character),
+            character_name_and_age(&character),
         ]
+    }
+}
+
+fn character_sprite_tint(character: &Character) -> Box<dyn Scene> {
+    if character.tint_yellow {
+        Box::new(bsn! {
+            Sprite {
+                image: "branding/icon.png",
+                color: palettes::basic::YELLOW
+            }
+            Transform::default()
+        })
+    } else {
+        Box::new(bsn! {
+            Sprite {
+                image: "branding/icon.png",
+            }
+            Transform::default()
+        })
+    }
+}
+
+fn character_hat(character: &Character) -> Box<dyn Scene> {
+    match character.hat_type {
+        HatType::None => Box::new(bsn! {}),
+        HatType::TopHat => Box::new(bsn! {
+            Transform::from_rotation(Quat::from_rotation_z(0.78))
+            template_value(Visibility::Inherited)
+            Children [
+                Mesh2d(asset_value(Rectangle::new(
+                    40., 10.
+                )))
+                MeshMaterial2d<ColorMaterial>(asset_value(ColorMaterial::from_color(Color::BLACK)))
+                template_value(Transform::from_xyz(55., 60., 1.)),
+
+                Mesh2d(asset_value(Rectangle::new(
+                    20., 50.
+                )))
+                MeshMaterial2d<ColorMaterial>(asset_value(ColorMaterial::from_color(Color::BLACK)))
+                template_value(Transform::from_xyz(55., 85., 1.)),
+            ]
+        }),
+        HatType::DunceCap => Box::new(bsn! {
+            Mesh2d(asset_value(Triangle2d::new(
+                Vec2::new(0., 100.),
+                Vec2::new(-20., 0.),
+                Vec2::new(20., 0.)
+            )))
+            MeshMaterial2d<ColorMaterial>(asset_value(ColorMaterial::from_color(palettes::basic::TEAL)))
+            // 0.78 radians ~ PI / 4
+            template_value(Transform::from_xyz(0., 80., 1.).with_rotation(Quat::from_rotation_z(0.78)))
+        }),
+    }
+}
+
+fn character_name_and_age(character: &Character) -> impl Scene {
+    let name = character.name.clone();
+    let age = character.age;
+    bsn! {
+        Text2d::new(format!("Hi! My name is {name}.\nI am {age} years old."))
+        template_value(Transform::from_xyz(0., -200., 0.))
     }
 }

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -37,7 +37,9 @@ fn main() {
         .add_systems(
             Update,
             (
-                // Updates the Model if the user changed the name via text input
+                // Updates the Model if the user changed the name via text input.
+                // This is a Controller system, and is not an Observer because of
+                // the way the text input widget is designed.
                 on_changed_editable_text,
                 // Updates the View after any Model changes
                 refresh_character.run_if(resource_exists_and::<Character>(|character| {
@@ -54,9 +56,9 @@ fn setup(mut commands: Commands, character: Res<Character>) {
         Camera2d,
 
         // This scene will serve as one half of our "View"
-        // and all of the "Controller" in our MVC design.
+        // and most of the "Controller" in our MVC design.
         // The user interacts with UI widgets, which are processed by the "Controller"
-        // via observers and other systems. The observers and systems update the
+        // via observers and systems. The observers and systems update the
         // state and also update the look of the UI widgets
         // (i.e. changing text color of a selected option, inserting an X).
         ui(&character),
@@ -330,6 +332,7 @@ fn age_slider(character: &Character) -> impl Scene {
                 position_type: PositionType::Absolute,
                 left: px(0)
                 // Shortened by the slider thumb's width on the right side.
+                // This means that it is 200px in width.
                 right: px(20),
                 top: px(0),
                 bottom: px(0),
@@ -643,6 +646,8 @@ fn refresh_character(
     let (mut already_updated_name_age, mut already_updated_sprite, mut already_updated_hat) =
         (false, false, false);
     for changed_field in character.changed_fields.iter().copied() {
+        // First, find the correct child to despawn
+        // Then, add an updated child.
         match changed_field {
             ChangedField::Name | ChangedField::Age if !already_updated_name_age => {
                 for (child, _, _, is_name_and_age) in children

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -1,0 +1,191 @@
+//! This example illustrates how to manage data input from select
+//! widgets in the `ui_widgets` crate.
+//! 
+//! When a UI widget is interacted with by an application user,
+//! various events are triggered that that the user presumably wants
+//! to be recognized by the application. It is up to the application to
+//! handle and interpret these events, which usually means updating its own internal
+//! state and refreshing its user interface so that the user sees the most
+//! recent data.
+//! 
+//! The example will implement a traditional Model View Controller (MVC) design
+//! using the various ui widgets to power a character creation screen.
+//! 
+//! To read more about state management, consult the [`bevy::ui_widgets`]
+//! crate level documentation.
+
+use bevy::{
+    color::palettes,
+    prelude::*,
+    ui::Checked,
+    ui_widgets::{RadioGroup, RadioButton, Checkbox, TextInput, ValueChange},
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .init_resource::<Character>()
+        .add_systems(Startup, setup)
+        .run();
+}
+
+/// This resource serves as the "Model" in our MVC Design.
+/// It serves as our source of truth for the character being created.
+#[derive(Resource)]
+pub struct Character {
+    name: String,
+    age: u32,
+    hat_type: HatType,
+    tint_yellow: bool,
+}
+
+impl Default for Character {
+    fn default() -> Self {
+        Character {
+            name: "Bevy".into(),
+            age: 5,
+            hat_type: HatType::default(),
+            tint_yellow: false,
+        }
+    }
+}
+
+/// Hat options for the character to have.
+/// This derives `Component` so that they can be placed on the individual radio buttons
+/// for ease of identifying which radio button was selected.
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq)]
+enum HatType {
+    #[default]
+    None,
+    TopHat,
+    DunceCap,
+}
+
+const HAT_TYPES: [HatType; 3] = [HatType::None, HatType::TopHat, HatType::DunceCap];
+
+/// Marker Component for the Name Input Field
+#[derive(Component, Clone, Default)]
+pub struct NameInput;
+
+/// Marker Component for the Age Slider
+#[derive(Component, Clone, Default)]
+pub struct AgeSlider;
+
+/// Marker Component for the HatType Radio Group
+#[derive(Component, Clone, Default)]
+pub struct HatTypeRadioGroup;
+
+/// Marker Component for the Tint Yellow Checkbox
+#[derive(Component, Clone, Default)]
+pub struct TintYellowCheckbox;
+
+/// Marker Component for the Character View
+#[derive(Component, Clone, Default)]
+pub struct CharacterView;
+
+fn setup(mut commands: Commands, character: Res<Character>) {
+    commands.spawn_scene_list(bsn_list! {
+        Camera2d,
+
+        // This scene will serve as our "Controller" in our MVC design.
+        // The user interacts with the controller, which will affect the
+        // "View" (the rendered character).
+        ui(&character),
+
+        // This scene will serve as our "View" in our MVC design.
+        // The user can see the character they are creating.
+        base_character_view(&character),
+    })
+}
+
+/// Spawns the ui widgets that will serve as the "Controller" for the
+/// character "Model".
+fn ui(character: &Character) -> impl Scene {
+    bsn! {
+        // ui will take up the left third of the screen.
+        Node {
+            flex_direction: FlexDirection::Column,
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            height: percent(100)
+            width: percent(33),
+        }
+        Children [
+            // Holds the character creation pane
+            Node {
+                flex_direction: FlexDirection::Column,
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                width: percent(100),
+                border_radius: BorderRadius::all(px(5)),
+            }
+            BackgroundColor(palettes::basic::GRAY)
+            Children [
+                hat_type_radio_group(character),
+            ]
+        ]
+    }
+}
+
+fn hat_type_radio_group(character: &Character) -> impl Scene {
+    bsn! {
+        Node {
+            flex_direction: FlexDirection::Row,
+        }
+        RadioGroup
+        HatTypeRadioGroup
+        Children [
+            Node
+            Children [
+                Text::new("Hat: ")
+            ],
+
+            {
+                HAT_TYPES.iter().map(|hat_type| hat_type_radio_button(*hat_type, character)).collect::<Vec<_>>()
+            }
+        ]
+    }
+}
+
+fn hat_type_radio_button(hat_type: HatType, character: &Character) -> Box<dyn Scene> {
+    if character.hat_type == hat_type {
+        Box::new(bsn! {
+            Node {
+                border: px(5),
+            }
+            RadioButton
+            Checked
+            template_value(hat_type)
+            Children [
+                Text::new(format!("{hat_type:?}"))
+                TextColor(palettes::basic::GREEN)
+            ]
+            BackgroundColor(Color::BLACK)
+        })
+    } else {
+        Box::new(bsn! {
+            Node {
+                border: px(5),
+            }
+            RadioButton
+            template_value(hat_type)
+            Children [
+                Text::new(format!("{hat_type:?}"))
+                TextColor(palettes::basic::WHITE)
+            ]
+            BackgroundColor(Color::BLACK)
+        })
+    }
+}
+
+fn base_character_view(character: &Character) -> impl Scene {
+    bsn! {
+        CharacterView
+        Children [
+            Sprite {
+                image: "branding/icon.png"
+            }
+            // Transform::from_xyz(426., 0., 0.)
+        ]
+    }
+}

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -40,7 +40,9 @@ fn main() {
                 // Updates the Model if the user changed the name via text input
                 on_changed_editable_text,
                 // Updates the View after any Model changes
-                refresh_character.run_if(resource_changed::<Character>),
+                refresh_character.run_if(resource_exists_and::<Character>(|character| {
+                    !character.changed_fields.is_empty()
+                })),
             )
                 .chain(),
         )
@@ -73,6 +75,9 @@ struct Character {
     age: u32,
     hat_type: HatType,
     tint_yellow: bool,
+    // This is used by the app to more efficiently queue refreshes
+    // of the character view by only refreshing the necessary entities.
+    changed_fields: Vec<ChangedField>,
 }
 
 impl Default for Character {
@@ -82,6 +87,7 @@ impl Default for Character {
             age: 5,
             hat_type: HatType::default(),
             tint_yellow: false,
+            changed_fields: vec![],
         }
     }
 }
@@ -95,6 +101,14 @@ enum HatType {
     None,
     TopHat,
     DunceCap,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum ChangedField {
+    Name,
+    Age,
+    HatType,
+    TintYellow,
 }
 
 const HAT_TYPES: [HatType; 3] = [HatType::None, HatType::TopHat, HatType::DunceCap];
@@ -121,6 +135,15 @@ struct TintYellowCheckbox;
 
 #[derive(Component, Clone, Default)]
 struct CharacterView;
+
+#[derive(Component, Clone, Default)]
+struct CharacterSprite;
+
+#[derive(Component, Clone, Default)]
+struct CharacterHat;
+
+#[derive(Component, Clone, Default)]
+struct CharacterNameAndAge;
 
 // --- END MARKER COMPONENTS --- //
 
@@ -227,6 +250,7 @@ fn on_changed_editable_text(
     let new_name = editable_text.value().to_string();
     if character.name != new_name {
         character.name = new_name;
+        character.changed_fields.push(ChangedField::Name);
     }
 
     // We do not need to update the ui widget view because it updates itself.
@@ -353,6 +377,7 @@ fn on_changed_age_slider(
     // Update the Model
     // `SliderPrecision` ensures that this value is a whole number.
     character.age = event.value as u32;
+    character.changed_fields.push(ChangedField::Age);
 
     // Update the Widget portion of the View
     commands
@@ -464,6 +489,7 @@ fn on_value_change_hat_type(
 
     // Update the Model
     character.hat_type = *new_hat_type;
+    character.changed_fields.push(ChangedField::HatType);
 
     // Update the Widget portion of the View
     for (button_entity, hat_type, has_checked, children) in hat_type_value_q.iter() {
@@ -564,6 +590,7 @@ fn on_value_change_tint_yellow(
 
     // Update the Model
     character.tint_yellow = event.value;
+    character.changed_fields.push(ChangedField::TintYellow);
 
     // Update the Widget portion of the View
     if character.tint_yellow {
@@ -583,17 +610,6 @@ fn on_value_change_tint_yellow(
 
 // --- START CHARACTER VIEW --- //
 
-/// A system that updates the "View" whenever the "Model" has changed.
-fn refresh_character(
-    mut commands: Commands,
-    query: Single<Entity, With<CharacterView>>,
-    character: Res<Character>,
-) {
-    commands.entity(query.entity()).despawn();
-
-    commands.spawn_scene(character_view(&character));
-}
-
 /// Returns the "View", powered by data from the `Character` Model.
 fn character_view(character: &Character) -> impl Scene {
     bsn! {
@@ -601,7 +617,7 @@ fn character_view(character: &Character) -> impl Scene {
         Transform::from_xyz(320., 0., 0.)
         template_value(Visibility::Inherited)
         Children [
-            character_sprite_tint(&character),
+            character_sprite(&character),
 
             character_hat(&character),
 
@@ -610,9 +626,77 @@ fn character_view(character: &Character) -> impl Scene {
     }
 }
 
-fn character_sprite_tint(character: &Character) -> Box<dyn Scene> {
+/// A system that updates the "View" whenever the underlying `Character` "Model" has changed.
+fn refresh_character(
+    mut commands: Commands,
+    character_view_q: Single<(Entity, &Children), With<CharacterView>>,
+    view_type_q: Query<(
+        Entity,
+        Has<CharacterSprite>,
+        Has<CharacterHat>,
+        Has<CharacterNameAndAge>,
+    )>,
+    mut character: ResMut<Character>,
+) {
+    let (character_view, children) = character_view_q.into_inner();
+    let (mut already_updated_name_age, mut already_updated_sprite, mut already_updated_hat) =
+        (false, false, false);
+    for changed_field in character.changed_fields.iter().copied() {
+        match changed_field {
+            ChangedField::Name | ChangedField::Age if !already_updated_name_age => {
+                for (child, _, _, is_name_and_age) in children
+                    .iter()
+                    .filter_map(|child| view_type_q.get(child).ok())
+                {
+                    if is_name_and_age {
+                        commands.entity(child).try_despawn();
+                    }
+                }
+                let new_child = commands
+                    .spawn_scene(character_name_and_age(&character))
+                    .id();
+                commands.entity(character_view).add_child(new_child);
+
+                already_updated_name_age = true;
+            }
+            ChangedField::TintYellow if !already_updated_sprite => {
+                for (child, is_sprite, _, _) in children
+                    .iter()
+                    .filter_map(|child| view_type_q.get(child).ok())
+                {
+                    if is_sprite {
+                        commands.entity(child).try_despawn();
+                    }
+                }
+                let new_child = commands.spawn_scene(character_sprite(&character)).id();
+                commands.entity(character_view).add_child(new_child);
+
+                already_updated_sprite = true;
+            }
+            ChangedField::HatType if !already_updated_hat => {
+                for (child, _, is_hat, _) in children
+                    .iter()
+                    .filter_map(|child| view_type_q.get(child).ok())
+                {
+                    if is_hat {
+                        commands.entity(child).try_despawn();
+                    }
+                }
+                let new_child = commands.spawn_scene(character_hat(&character)).id();
+                commands.entity(character_view).add_child(new_child);
+
+                already_updated_hat = true;
+            }
+            _ => {}
+        }
+    }
+    character.changed_fields.clear();
+}
+
+fn character_sprite(character: &Character) -> Box<dyn Scene> {
     if character.tint_yellow {
         Box::new(bsn! {
+            CharacterSprite
             Sprite {
                 image: "branding/icon.png",
                 color: palettes::basic::YELLOW
@@ -621,6 +705,7 @@ fn character_sprite_tint(character: &Character) -> Box<dyn Scene> {
         })
     } else {
         Box::new(bsn! {
+            CharacterSprite
             Sprite {
                 image: "branding/icon.png",
             }
@@ -631,8 +716,11 @@ fn character_sprite_tint(character: &Character) -> Box<dyn Scene> {
 
 fn character_hat(character: &Character) -> Box<dyn Scene> {
     match character.hat_type {
-        HatType::None => Box::new(bsn! {}),
+        HatType::None => Box::new(bsn! {
+            CharacterHat
+        }),
         HatType::TopHat => Box::new(bsn! {
+            CharacterHat
             // 0.78 radians ~ PI / 4
             Transform::from_rotation(Quat::from_rotation_z(0.78))
             template_value(Visibility::Inherited)
@@ -653,6 +741,7 @@ fn character_hat(character: &Character) -> Box<dyn Scene> {
             ]
         }),
         HatType::DunceCap => Box::new(bsn! {
+            CharacterHat
             Mesh2d(asset_value(Triangle2d::new(
                 Vec2::new(0., 100.),
                 Vec2::new(-20., 0.),
@@ -669,6 +758,7 @@ fn character_name_and_age(character: &Character) -> impl Scene {
     let age = character.age;
     let years = if age == 1 { "year" } else { "years" };
     bsn! {
+        CharacterNameAndAge
         Text2d::new(format!("Hi! My name is {name}.\nI am {age} {years} old."))
         template_value(Transform::from_xyz(0., -200., 0.))
     }

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -255,8 +255,10 @@ fn on_changed_editable_text(
         character.changed_fields.push(ChangedField::Name);
     }
 
-    // We do not need to update the ui widget view because it updates itself.
-    // However, that is not the norm with headless widgets!
+    // We do not need to update the ui widget view in our app because `EditableText`
+    // manages its own state internally; it updates the text the user sees automatically.
+
+    // Because character has been modified, refresh_character will run and update the other half of the "View".
 }
 
 // --- END TEXT INPUT -- //
@@ -393,6 +395,8 @@ fn on_value_change_age_slider(
     for mut text in age_slider_text_q.iter_mut() {
         *text = Text::new(format!("{}", character.age));
     }
+
+    // Because character has been modified, refresh_character will run and update the other half of the "View".
 }
 
 // --- END SLIDER -- //

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -384,7 +384,7 @@ fn on_value_change_age_slider(
         .entity(event.source)
         .insert(SliderValue(character.age as f32));
     for mut node in age_slider_thumb_q.iter_mut() {
-        node.left = percent(slider_range.thumb_position(character.age as f32) * 100.0)
+        node.left = percent(slider_range.thumb_position(character.age as f32) * 100.0);
     }
     for mut text in age_slider_text_q.iter_mut() {
         *text = Text::new(format!("{}", character.age));

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -22,7 +22,10 @@ use bevy::{
     prelude::*,
     text::{EditableText, TextCursorStyle},
     ui::Checked,
-    ui_widgets::{Checkbox, RadioButton, RadioGroup, TextInput, ValueChange},
+    ui_widgets::{
+        Checkbox, RadioButton, RadioGroup, Slider, SliderOrientation, SliderPrecision, SliderRange,
+        SliderThumb, SliderValue, TextInput, TrackClick, ValueChange,
+    },
     window::{CursorIcon, PrimaryWindow, SystemCursorIcon},
 };
 
@@ -105,6 +108,12 @@ struct NameInput;
 struct AgeSlider;
 
 #[derive(Component, Clone, Default)]
+struct AgeSliderThumb;
+
+#[derive(Component, Clone, Default)]
+struct AgeSliderText;
+
+#[derive(Component, Clone, Default)]
 struct HatTypeRadioGroup;
 
 #[derive(Component, Clone, Default)]
@@ -151,7 +160,9 @@ fn ui(character: &Character) -> impl Scene {
 
                 name_text_input_row(character),
 
-                hat_type_radio_group(character),
+                age_slider_row(character),
+
+                hat_type_radio_group_row(character),
 
                 tint_yellow_checkbox_row(character),
             ]
@@ -159,51 +170,9 @@ fn ui(character: &Character) -> impl Scene {
     }
 }
 
-/// An observer that styles the cursor, used primarily for buttons / checkboxes.
-/// This is not part of the Controller.
-fn on_pointer_over_pointer_cursor(
-    _event: On<Pointer<Over>>,
-    mut window_q: Query<Entity, With<PrimaryWindow>>,
-    mut commands: Commands,
-) {
-    for window in window_q.iter_mut() {
-        commands
-            .entity(window)
-            .insert(CursorIcon::System(SystemCursorIcon::Pointer));
-    }
-}
-
-/// An observer that styles the cursor, used primarily for text input.
-/// This is not part of the Controller.
-fn on_pointer_over_text_cursor(
-    _event: On<Pointer<Over>>,
-    mut window_q: Query<Entity, With<PrimaryWindow>>,
-    mut commands: Commands,
-) {
-    for window in window_q.iter_mut() {
-        commands
-            .entity(window)
-            .insert(CursorIcon::System(SystemCursorIcon::Text));
-    }
-}
-
-/// An observer that styles the cursor, used for all widgets.
-/// This is not part of the Controller.
-fn on_pointer_out_default_cursor(
-    _event: On<Pointer<Out>>,
-    mut window_q: Query<Entity, With<PrimaryWindow>>,
-    mut commands: Commands,
-) {
-    for window in window_q.iter_mut() {
-        commands
-            .entity(window)
-            .insert(CursorIcon::System(SystemCursorIcon::Default));
-    }
-}
-
 // --- START TEXT INPUT -- //
 
-/// Creates the text input that allows the user to input a name for the character.
+/// Creates the text input row that allows the user to input a name for the character.
 fn name_text_input_row(character: &Character) -> impl Scene {
     bsn! {
         Node {
@@ -266,10 +235,143 @@ fn on_changed_editable_text(
 
 // --- END TEXT INPUT -- //
 
+// --- START SLIDER -- //
+
+/// Creates the age slider that allows the user to input the age of the character.
+fn age_slider_row(character: &Character) -> impl Scene {
+    let age = character.age;
+    bsn! {
+        Node {
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::SpaceBetween,
+            column_gap: px(10),
+        }
+        Children [
+            Node
+            Children [
+                Text::new("Age:")
+            ],
+
+            age_slider(character),
+
+            Node {
+                width: px(30),
+            }
+            Children [
+                AgeSliderText
+                Text::new(format!("{}", age))
+            ],
+        ]
+    }
+}
+
+fn age_slider(character: &Character) -> impl Scene {
+    bsn! {
+        Node {
+            width: px(220),
+            border: px(5),
+            padding: UiRect::axes(px(5), px(2)),
+        }
+        AgeSlider
+        Slider {
+            track_click: TrackClick::Snap,
+            orientation: SliderOrientation::Horizontal,
+        }
+        SliderValue({character.age as f32})
+        // Move every whole number.
+        SliderPrecision(0)
+        SliderRange::new(1., 100.)
+        BackgroundColor(Color::BLACK)
+        // This observer is part of the Controller -- it reacts to the user's input!
+        on(on_changed_age_slider)
+        on(on_pointer_over_pointer_cursor)
+        on(on_pointer_drag_start_grabbing_cursor)
+        on(on_pointer_drag_end_grab_cursor)
+        on(on_pointer_out_default_cursor)
+        Children [
+            // Visible Slider Track
+            // It is 220px in width via its parent.
+            Node {
+                height: px(5),
+                border_radius: BorderRadius::all(px(3)),
+            }
+            BackgroundColor(Color::BLACK),
+
+            // Invisible shorter track (does not have background color) that the
+            // SliderThumb glides on. This is so that the thumb
+            // does not go past the left and right sides of the visible slider track.
+            Node {
+                display: Display::Flex,
+                position_type: PositionType::Absolute,
+                left: px(0)
+                // Shortened by the slider thumb's width on the right side.
+                right: px(20),
+                top: px(0),
+                bottom: px(0),
+            }
+            Children [
+                AgeSliderThumb
+                SliderThumb
+                Node {
+                    display: Display::Flex,
+                    width: px(20),
+                    height: px(10),
+                    position_type: PositionType::Absolute,
+                    left: percent(0), // This will be updated by the slider's value
+                }
+                BackgroundColor(Color::WHITE)
+                on(on_pointer_over_grab_cursor)
+                on(on_pointer_out_default_cursor)
+                on(on_pointer_drag_start_grabbing_cursor)
+                on(on_pointer_drag_end_grab_cursor)
+            ]
+        ]
+    }
+}
+
+/// A system that implements Controller logic to update the Age.
+/// This particular system updates the Model upon any change in value to the Age Slider.
+/// Sliders emit a ValueChange<f32> event when the user drags the slider.
+/// The value of the event is the new value of the slider.
+/// The source of the event is the `Slider` parent entity.
+fn on_changed_age_slider(
+    event: On<ValueChange<f32>>,
+    age_slider_q: Query<(Entity, &SliderRange), With<AgeSlider>>,
+    mut age_slider_text_q: Query<&mut Text, With<AgeSliderText>>,
+    mut age_slider_thumb_q: Query<&mut Node, With<AgeSliderThumb>>,
+    mut character: ResMut<Character>,
+    mut commands: Commands,
+) {
+    let Ok((entity, slider_range)) = age_slider_q.single_inner() else {
+        return;
+    };
+    if event.source != entity {
+        return;
+    }
+
+    // Update the Model
+    // `SliderPrecision` ensures that this value is a whole number.
+    character.age = event.value as u32;
+
+    // Update the Widget portion of the View
+    commands
+        .entity(event.source)
+        .insert(SliderValue(character.age as f32));
+    for mut node in age_slider_thumb_q.iter_mut() {
+        node.left = percent(slider_range.thumb_position(character.age as f32) * 100.0)
+    }
+    for mut text in age_slider_text_q.iter_mut() {
+        *text = Text::new(format!("{}", character.age));
+    }
+}
+
+// --- END SLIDER -- //
+
 // --- START RADIO GROUP -- //
 
-/// Creates the radio group that allows the user to select a hat for the character.
-fn hat_type_radio_group(character: &Character) -> impl Scene {
+/// Creates the radio group row that allows the user to select a hat for the character.
+fn hat_type_radio_group_row(character: &Character) -> impl Scene {
     bsn! {
         Node {
             flex_direction: FlexDirection::Row,
@@ -383,7 +485,7 @@ fn on_value_change_hat_type(
 
 // --- START CHECK BOX -- //
 
-/// Creates the checkbox that allows the user to toggle a yellow tint of the character.
+/// Creates the checkbox row that allows the user to toggle a yellow tint of the character.
 fn tint_yellow_checkbox_row(character: &Character) -> impl Scene {
     bsn! {
         Node {
@@ -500,7 +602,9 @@ fn character_view(character: &Character) -> impl Scene {
         template_value(Visibility::Inherited)
         Children [
             character_sprite_tint(&character),
+
             character_hat(&character),
+
             character_name_and_age(&character),
         ]
     }
@@ -529,15 +633,18 @@ fn character_hat(character: &Character) -> Box<dyn Scene> {
     match character.hat_type {
         HatType::None => Box::new(bsn! {}),
         HatType::TopHat => Box::new(bsn! {
+            // 0.78 radians ~ PI / 4
             Transform::from_rotation(Quat::from_rotation_z(0.78))
             template_value(Visibility::Inherited)
             Children [
+                // bottom wider portion of the top hat.
                 Mesh2d(asset_value(Rectangle::new(
                     40., 10.
                 )))
                 MeshMaterial2d<ColorMaterial>(asset_value(ColorMaterial::from_color(Color::BLACK)))
                 template_value(Transform::from_xyz(55., 60., 1.)),
 
+                // top longer portion of the top hat
                 Mesh2d(asset_value(Rectangle::new(
                     20., 50.
                 )))
@@ -552,7 +659,6 @@ fn character_hat(character: &Character) -> Box<dyn Scene> {
                 Vec2::new(20., 0.)
             )))
             MeshMaterial2d<ColorMaterial>(asset_value(ColorMaterial::from_color(palettes::basic::TEAL)))
-            // 0.78 radians ~ PI / 4
             template_value(Transform::from_xyz(0., 80., 1.).with_rotation(Quat::from_rotation_z(0.78)))
         }),
     }
@@ -561,10 +667,110 @@ fn character_hat(character: &Character) -> Box<dyn Scene> {
 fn character_name_and_age(character: &Character) -> impl Scene {
     let name = character.name.clone();
     let age = character.age;
+    let years = if age == 1 { "year" } else { "years" };
     bsn! {
-        Text2d::new(format!("Hi! My name is {name}.\nI am {age} years old."))
+        Text2d::new(format!("Hi! My name is {name}.\nI am {age} {years} old."))
         template_value(Transform::from_xyz(0., -200., 0.))
     }
 }
 
 // --- END CHARACTER VIEW --- //
+
+// --- START MISC OBSERVERS (STYLING) --- //
+
+/// An observer that styles the cursor, used primarily for text input.
+/// This is not part of the Controller.
+fn on_pointer_over_text_cursor(
+    mut event: On<Pointer<Over>>,
+    mut window_q: Query<Entity, With<PrimaryWindow>>,
+    mut commands: Commands,
+) {
+    for window in window_q.iter_mut() {
+        commands
+            .entity(window)
+            .insert(CursorIcon::System(SystemCursorIcon::Text));
+    }
+
+    event.propagate(false);
+}
+
+/// An observer that styles the cursor, used primarily for sliders.
+/// This is not part of the Controller.
+fn on_pointer_over_grab_cursor(
+    mut event: On<Pointer<Over>>,
+    mut window_q: Query<Entity, With<PrimaryWindow>>,
+    mut commands: Commands,
+) {
+    for window in window_q.iter_mut() {
+        commands
+            .entity(window)
+            .insert(CursorIcon::System(SystemCursorIcon::Grab));
+    }
+    event.propagate(false);
+}
+
+/// An observer that styles the cursor, used primarily for sliders.
+/// This is not part of the Controller.
+fn on_pointer_drag_start_grabbing_cursor(
+    _event: On<Pointer<DragStart>>,
+    mut window_q: Query<Entity, With<PrimaryWindow>>,
+    mut commands: Commands,
+) {
+    for window in window_q.iter_mut() {
+        commands
+            .entity(window)
+            .insert(CursorIcon::System(SystemCursorIcon::Grabbing));
+    }
+    // Note that this event does not stop propagation!
+    // This is because the slider widget processes drag events in order to
+    // emit value change events.
+}
+
+/// An observer that styles the cursor, used primarily for sliders.
+/// This is not part of the Controller.
+fn on_pointer_drag_end_grab_cursor(
+    _event: On<Pointer<DragEnd>>,
+    mut window_q: Query<Entity, With<PrimaryWindow>>,
+    mut commands: Commands,
+) {
+    for window in window_q.iter_mut() {
+        commands
+            .entity(window)
+            .insert(CursorIcon::System(SystemCursorIcon::Grab));
+    }
+    // Note that this event does not stop propagation!
+    // This is because the slider widget processes drag events in order to
+    // emit value change events.
+}
+
+/// An observer that styles the cursor, used primarily for buttons / checkboxes.
+/// This is not part of the Controller.
+fn on_pointer_over_pointer_cursor(
+    mut event: On<Pointer<Over>>,
+    mut window_q: Query<Entity, With<PrimaryWindow>>,
+    mut commands: Commands,
+) {
+    for window in window_q.iter_mut() {
+        commands
+            .entity(window)
+            .insert(CursorIcon::System(SystemCursorIcon::Pointer));
+    }
+    event.propagate(false);
+}
+
+/// An observer that styles the cursor, used for all widgets.
+/// This is not part of the Controller.
+fn on_pointer_out_default_cursor(
+    mut event: On<Pointer<Out>>,
+    mut window_q: Query<Entity, With<PrimaryWindow>>,
+    mut commands: Commands,
+) {
+    for window in window_q.iter_mut() {
+        commands
+            .entity(window)
+            .insert(CursorIcon::System(SystemCursorIcon::Default));
+    }
+    event.propagate(false);
+}
+
+// --- END MISC OBSERVERS (STYLING) --- //

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -2,9 +2,10 @@
 //! widgets in the `ui_widgets` crate.
 //!
 //! When a UI widget is interacted with by an application user,
-//! various events are triggered that that the user presumably wants
-//! to be recognized by the application. It is up to the application to
-//! handle and interpret these events, which usually means updating its own internal
+//! various events may be triggered that that the user presumably wants
+//! to be recognized by the application. State may be directly changed
+//! on the widgets themselves depending on the widget. It is up to the application to
+//! handle and interpret these events and changes, which usually means updating its own internal
 //! state and refreshing its user interface so that the user sees the most
 //! recent data.
 //!
@@ -17,7 +18,9 @@
 use bevy::{
     color::palettes,
     ecs::schedule::IntoScheduleConfigs,
+    input_focus::tab_navigation::TabIndex,
     prelude::*,
+    text::{EditableText, TextCursorStyle},
     ui::Checked,
     ui_widgets::{Checkbox, RadioButton, RadioGroup, TextInput, ValueChange},
     window::{CursorIcon, PrimaryWindow, SystemCursorIcon},
@@ -30,7 +33,13 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(
             Update,
-            refresh_character.run_if(resource_changed::<Character>),
+            (
+                // Updates the Model if the user changed the name via text input
+                on_changed_editable_text,
+                // Updates the View after any Model changes
+                refresh_character.run_if(resource_changed::<Character>),
+            )
+                .chain(),
         )
         .run();
 }
@@ -39,12 +48,15 @@ fn setup(mut commands: Commands, character: Res<Character>) {
     commands.spawn_scene_list(bsn_list! {
         Camera2d,
 
-        // This scene will serve as our "Controller" in our MVC design.
-        // The user interacts with the controller, which will affect the
-        // "View" (the rendered character).
+        // This scene will serve as one half of our "View"
+        // and all of the "Controller" in our MVC design.
+        // The user interacts with UI widgets, which are processed by the "Controller"
+        // via observers and other systems. The observers and systems update the
+        // state and also update the look of the UI widgets
+        // (i.e. changing text color of a selected option, inserting an X).
         ui(&character),
 
-        // This scene will serve as our "View" in our MVC design.
+        // This scene will serve as the other half of our "View" in our MVC design.
         // The user will see the character they are creating.
         character_view(&character),
     })
@@ -103,10 +115,10 @@ struct CharacterView;
 
 // --- END MARKER COMPONENTS --- //
 
-// --- START CONTROLLER --- //
+// --- WIDGET VIEW & CONTROLLER --- //
 
-/// Spawns the ui widgets that will serve as the "Controller"
-/// in our MVC design.
+/// Spawns the ui widgets that will serve as half of our "View",
+/// with "Controller" logic as important observers in our MVC design.
 fn ui(character: &Character) -> impl Scene {
     bsn! {
         // UI will take up the left half of the screen.
@@ -137,6 +149,8 @@ fn ui(character: &Character) -> impl Scene {
                     Text::new("Character Creator")
                 ],
 
+                name_text_input_row(character),
+
                 hat_type_radio_group(character),
 
                 tint_yellow_checkbox_row(character),
@@ -145,7 +159,8 @@ fn ui(character: &Character) -> impl Scene {
     }
 }
 
-/// An observer that styles the cursor, used primarily for buttons / checkboxes
+/// An observer that styles the cursor, used primarily for buttons / checkboxes.
+/// This is not part of the Controller.
 fn on_pointer_over_pointer_cursor(
     _event: On<Pointer<Over>>,
     mut window_q: Query<Entity, With<PrimaryWindow>>,
@@ -158,7 +173,22 @@ fn on_pointer_over_pointer_cursor(
     }
 }
 
-/// An observer that styles the cursor, used for all widgets
+/// An observer that styles the cursor, used primarily for text input.
+/// This is not part of the Controller.
+fn on_pointer_over_text_cursor(
+    _event: On<Pointer<Over>>,
+    mut window_q: Query<Entity, With<PrimaryWindow>>,
+    mut commands: Commands,
+) {
+    for window in window_q.iter_mut() {
+        commands
+            .entity(window)
+            .insert(CursorIcon::System(SystemCursorIcon::Text));
+    }
+}
+
+/// An observer that styles the cursor, used for all widgets.
+/// This is not part of the Controller.
 fn on_pointer_out_default_cursor(
     _event: On<Pointer<Out>>,
     mut window_q: Query<Entity, With<PrimaryWindow>>,
@@ -170,6 +200,71 @@ fn on_pointer_out_default_cursor(
             .insert(CursorIcon::System(SystemCursorIcon::Default));
     }
 }
+
+// --- START TEXT INPUT -- //
+
+/// Creates the text input that allows the user to input a name for the character.
+fn name_text_input_row(character: &Character) -> impl Scene {
+    bsn! {
+        Node {
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::SpaceBetween,
+        }
+        Children [
+            Node
+            Children [
+                Text::new("Name: ")
+            ],
+
+            name_text_input(character)
+        ]
+    }
+}
+
+fn name_text_input(character: &Character) -> impl Scene {
+    let name = character.name.clone();
+    bsn! {
+        Node {
+            width: px(200),
+            border: px(5),
+            border_radius: BorderRadius::all(px(10)),
+            padding: UiRect::axes(px(5), px(2)),
+        }
+        NameInput
+        TextInput
+        EditableText::new(name)
+        // TabIndex Component is necessary for the text input to receive focus for typing.
+        TabIndex(0)
+        // This is necessary so that the text cursor pops up when the input has focus.
+        TextCursorStyle::default()
+        BackgroundColor(Color::BLACK)
+        on(on_pointer_over_text_cursor)
+        on(on_pointer_out_default_cursor)
+    }
+}
+
+/// A system that implements Controller logic to update the Name Input.
+/// This particular system updates the Model upon any change in value to the text input's `EditableText`.
+/// The text input widget does not regularly emit any events on value change. Instead, the
+/// `EditableText`'s value can be polled under app-specific conditions to update the Model when appropriate.
+fn on_changed_editable_text(
+    name_input_q: Query<&EditableText, With<NameInput>>,
+    mut character: ResMut<Character>,
+) {
+    let Ok(editable_text) = name_input_q.single_inner() else {
+        return;
+    };
+    let new_name = editable_text.value().to_string();
+    if character.name != new_name {
+        character.name = new_name;
+    }
+
+    // We do not need to update the ui widget view because it updates itself.
+    // However, that is not the norm with headless widgets!
+}
+
+// --- END TEXT INPUT -- //
 
 // --- START RADIO GROUP -- //
 
@@ -183,7 +278,7 @@ fn hat_type_radio_group(character: &Character) -> impl Scene {
         }
         RadioGroup
         HatTypeRadioGroup
-        // This observer is important -- it reacts to the user's input!
+        // This observer is part of the Controller -- it reacts to the user's input!
         on(on_value_change_hat_type)
         Children [
             Node
@@ -237,6 +332,7 @@ fn hat_type_radio_button(hat_type: HatType, character: &Character) -> Box<dyn Sc
     }
 }
 
+/// This observer is part of the Controller logic.
 /// This observer will update the `Character` Resource based on a change to the Hat Type Radio Group.
 /// Radio groups emit a ValueChange<Entity> event when the user clicks on a radio button.
 /// The value of the event is of the clicked radio button.
@@ -267,7 +363,7 @@ fn on_value_change_hat_type(
     // Update the Model
     character.hat_type = *new_hat_type;
 
-    // Update the Controller
+    // Update the Widget portion of the View
     for (button_entity, hat_type, has_checked, children) in hat_type_value_q.iter() {
         if character.hat_type == *hat_type {
             commands.entity(button_entity).insert(Checked);
@@ -280,7 +376,7 @@ fn on_value_change_hat_type(
             commands.entity(children[0]).insert(TextColor(Color::WHITE));
         }
     }
-    // Because character has been modified, refresh_character will run and update the "View".
+    // Because character has been modified, refresh_character will run and update the other half of the "View".
 }
 
 // --- END RADIO GROUP -- //
@@ -317,7 +413,7 @@ fn tint_yellow_checkbox(character: &Character) -> Box<dyn Scene> {
             BackgroundColor(Color::WHITE)
             on(on_pointer_over_pointer_cursor)
             on(on_pointer_out_default_cursor)
-            // This observer is important -- it reacts to the user's input!
+            // This observer is part of the controller -- it reacts to the user's input!
             on(on_value_change_tint_yellow)
         }
     };
@@ -342,6 +438,7 @@ fn tint_yellow_checkbox(character: &Character) -> Box<dyn Scene> {
     }
 }
 
+/// This observer is part of the Controller logic.
 /// This observer will update the `Character` Resource based on a change to the Tint Yellow Checkbox.
 /// Checkboxes emit a ValueChange<bool> event when the user clicks on a checkbox.
 /// The value of the event is the value of the toggle.
@@ -366,7 +463,7 @@ fn on_value_change_tint_yellow(
     // Update the Model
     character.tint_yellow = event.value;
 
-    // Update the Controller
+    // Update the Widget portion of the View
     if character.tint_yellow {
         commands.entity(event.source).insert(Checked);
         // The checkbox only has one child for the X and its color
@@ -375,14 +472,14 @@ fn on_value_change_tint_yellow(
         commands.entity(event.source).remove::<Checked>();
         commands.entity(children[0]).insert(Text::new(" "));
     }
-    // Because character has been modified, refresh_character will run and update the "View".
+    // Because character has been modified, refresh_character will run and update the other half of the "View".
 }
 
 // --- END CHECK BOX -- //
 
-// --- END CONTROLLER --- //
+// --- END WIDGET VIEW & CONTROLLER --- //
 
-// --- START VIEW --- //
+// --- START CHARACTER VIEW --- //
 
 /// A system that updates the "View" whenever the "Model" has changed.
 fn refresh_character(
@@ -470,4 +567,4 @@ fn character_name_and_age(character: &Character) -> impl Scene {
     }
 }
 
-// --- END VIEW --- //
+// --- END CHARACTER VIEW --- //

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -308,7 +308,7 @@ fn age_slider(character: &Character) -> impl Scene {
         SliderRange::new(1., 100.)
         BackgroundColor(Color::BLACK)
         // This observer is part of the Controller -- it reacts to the user's input!
-        on(on_changed_age_slider)
+        on(on_value_change_age_slider)
         on(on_pointer_over_pointer_cursor)
         on(on_pointer_drag_start_grabbing_cursor)
         on(on_pointer_drag_end_grab_cursor)
@@ -342,7 +342,7 @@ fn age_slider(character: &Character) -> impl Scene {
                     width: px(20),
                     height: px(10),
                     position_type: PositionType::Absolute,
-                    left: percent(0), // This will be updated by the slider's value
+                    left: percent((character.age as f32 - 1.) / (100. - 1.) * 100.),
                 }
                 BackgroundColor(Color::WHITE)
                 on(on_pointer_over_grab_cursor)
@@ -359,7 +359,7 @@ fn age_slider(character: &Character) -> impl Scene {
 /// Sliders emit a `ValueChange<f32>` event when the user drags the slider.
 /// The value of the event is the new value of the slider.
 /// The source of the event is the `Slider` parent entity.
-fn on_changed_age_slider(
+fn on_value_change_age_slider(
     event: On<ValueChange<f32>>,
     age_slider_q: Query<(Entity, &SliderRange), With<AgeSlider>>,
     mut age_slider_text_q: Query<&mut Text, With<AgeSliderText>>,


### PR DESCRIPTION
# Objective

- Follow up from #24112 
- @viridia mentioned drafting some of my learnings from porting examples into a good introduction to using ui widgets for data binding. This is a culmination of that work.

## Solution

- Created a usage example that uses various UI widgets to power a character creation screen. It’s supposed to be for beginners to UI so please review with that in mind!

## Testing

- `cargo run --example character_creation`

---

## Showcase

<img width="1277" height="746" alt="Screenshot 2026-08-01 at 11 29 22 AM" src="https://github.com/user-attachments/assets/f297e333-7cb1-469f-a906-9721b1b7fdc1" />
