### PR TITLE
Fix 2D flicker by always dequeueing retained phase items (#25163)

### DIFF
--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -969,10 +969,6 @@ pub fn queue_material2d_meshes(
     specialized_material_pipeline_cache: ResMut<SpecializedMaterial2dPipelineCache>,
     mut mesh_instances_queued_this_iteration_scratch_space: Local<MainEntityHashSet>,
 ) {
-    if render_material_instances.is_empty() {
-        return;
-    }
-
     for (view, visible_entities) in &views {
         let Some(view_specialized_material_pipeline_cache) =
             specialized_material_pipeline_cache.get(&view.retained_view_entity)
@@ -1021,6 +1017,14 @@ pub fn queue_material2d_meshes(
             transparent_phase.remove(Entity::PLACEHOLDER, *main_entity);
             opaque_phase.remove(*main_entity);
             alpha_mask_phase.remove(*main_entity);
+        }
+
+        // With no entity using this material there is nothing to queue, but the
+        // dequeue above still has to run: it is the only thing that takes items
+        // of despawned entities out of the retained phases, and it has to run on
+        // the very frame the last such entity goes away.
+        if render_material_instances.is_empty() {
+            continue;
         }
 
         // Now iterate over all newly-visible entities and those that need


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/25163.

`queue_material2d_meshes` is the only system that takes items out of the
retained 2D phases, and it returns early when `render_material_instances`
is empty. That is the frame the last entity using that material type gets
despawned, so its items never get removed and stay in the phase for good.

They also keep the `batch_range` they had when they were last batched,
since `batch_and_prepare_sorted_render_phase` only rewrites the range of
items that still have a `RenderMesh2dInstance`. `render_range` advances the
index by `batch_range.len()` after every draw, so an item left over from a
batch of three hides the two live items behind it. With equal sort keys the
order changes from frame to frame, which is why it shows up as flicker
instead of something permanently missing.

The early return is older than the dequeue loop (https://github.com/bevyengine/bevy/pull/17567 added it back when
the system only queued, https://github.com/bevyengine/bevy/pull/23083 added the removal). The 3D
`queue_material_meshes` doesn't have one.

## Solution

Move the check below the dequeue loop and make it a `continue`. There is
still nothing to queue when no entity uses the material, but removal now
always happens.

## Testing

In my own app after applying the patch tree shadows stopped flickering
<img width="1717" height="1224" alt="image" src="https://github.com/user-attachments/assets/26022cbc-bc82-4894-9d43-5fffa311cedd" />