### PR TITLE
Make `post_process_write()` take a mutable reference, fixing ordering footgun

### DIFF
--- a/crates/bevy_anti_alias/src/contrast_adaptive_sharpening/node.rs
+++ b/crates/bevy_anti_alias/src/contrast_adaptive_sharpening/node.rs
@@ -16,7 +16,7 @@ use super::{CasPipeline, CasUniform};
 pub fn cas(
     view: ViewQuery<
         (
-            &ViewTarget,
+            &mut ViewTarget,
             &ViewCasPipeline,
             &DynamicUniformIndex<CasUniform>,
         ),
@@ -28,7 +28,7 @@ pub fn cas(
     mut ctx: RenderContext,
     mut cached_bind_group: Local<Option<(BufferId, TextureViewId, BindGroup)>>,
 ) {
-    let (target, pipeline, uniform_index) = view.into_inner();
+    let (mut target, pipeline, uniform_index) = view.into_inner();
 
     let uniforms_id = uniforms.buffer().unwrap().id();
     let Some(uniforms_binding) = uniforms.binding() else {

--- a/crates/bevy_anti_alias/src/dlss/node.rs
+++ b/crates/bevy_anti_alias/src/dlss/node.rs
@@ -30,8 +30,14 @@ pub fn dlss_super_resolution(
     adapter: Res<RenderAdapter>,
     mut ctx: RenderContext,
 ) {
-    let (dlss, dlss_context, resolution_override, temporal_jitter, mut view_target, prepass_textures) =
-        view.into_inner();
+    let (
+        dlss,
+        dlss_context,
+        resolution_override,
+        temporal_jitter,
+        mut view_target,
+        prepass_textures,
+    ) = view.into_inner();
 
     let (Some(prepass_depth_texture), Some(prepass_motion_vectors_texture)) =
         (&prepass_textures.depth, &prepass_textures.motion_vectors)

--- a/crates/bevy_anti_alias/src/dlss/node.rs
+++ b/crates/bevy_anti_alias/src/dlss/node.rs
@@ -24,13 +24,13 @@ pub fn dlss_super_resolution(
         &DlssRenderContext<DlssSuperResolutionFeature>,
         &MainPassResolutionOverride,
         &TemporalJitter,
-        &ViewTarget,
+        &mut ViewTarget,
         &ViewPrepassTextures,
     )>,
     adapter: Res<RenderAdapter>,
     mut ctx: RenderContext,
 ) {
-    let (dlss, dlss_context, resolution_override, temporal_jitter, view_target, prepass_textures) =
+    let (dlss, dlss_context, resolution_override, temporal_jitter, mut view_target, prepass_textures) =
         view.into_inner();
 
     let (Some(prepass_depth_texture), Some(prepass_motion_vectors_texture)) =
@@ -74,7 +74,7 @@ pub fn dlss_ray_reconstruction(
         &DlssRenderContext<DlssRayReconstructionFeature>,
         &MainPassResolutionOverride,
         &TemporalJitter,
-        &ViewTarget,
+        &mut ViewTarget,
         &ViewPrepassTextures,
         &ViewDlssRayReconstructionTextures,
     )>,
@@ -86,7 +86,7 @@ pub fn dlss_ray_reconstruction(
         dlss_context,
         resolution_override,
         temporal_jitter,
-        view_target,
+        mut view_target,
         prepass_textures,
         ray_reconstruction_textures,
     ) = view.into_inner();

--- a/crates/bevy_anti_alias/src/fxaa/mod.rs
+++ b/crates/bevy_anti_alias/src/fxaa/mod.rs
@@ -102,11 +102,17 @@ impl Plugin for FxaaPlugin {
             )
             .add_systems(
                 Core3d,
-                fxaa.after(tonemapping).in_set(Core3dSystems::PostProcess),
+                fxaa.after(tonemapping)
+                    .in_set(Core3dSystems::PostProcess)
+                    .in_set(crate::AntiAliasingSystems)
+                    .ambiguous_with(crate::AntiAliasingSystems),
             )
             .add_systems(
                 Core2d,
-                fxaa.after(tonemapping).in_set(Core2dSystems::PostProcess),
+                fxaa.after(tonemapping)
+                    .in_set(Core2dSystems::PostProcess)
+                    .in_set(crate::AntiAliasingSystems)
+                    .ambiguous_with(crate::AntiAliasingSystems),
             );
     }
 }

--- a/crates/bevy_anti_alias/src/fxaa/node.rs
+++ b/crates/bevy_anti_alias/src/fxaa/node.rs
@@ -11,13 +11,13 @@ use bevy_render::{
 };
 
 pub fn fxaa(
-    view: ViewQuery<(&ViewTarget, &CameraFxaaPipeline, &Fxaa)>,
+    view: ViewQuery<(&mut ViewTarget, &CameraFxaaPipeline, &Fxaa)>,
     fxaa_pipeline: Res<FxaaPipeline>,
     pipeline_cache: Res<PipelineCache>,
     mut ctx: RenderContext,
     mut cached_bind_group: Local<Option<(TextureViewId, BindGroup)>>,
 ) {
-    let (target, pipeline, fxaa) = view.into_inner();
+    let (mut target, pipeline, fxaa) = view.into_inner();
 
     if !fxaa.enabled {
         return;

--- a/crates/bevy_anti_alias/src/lib.rs
+++ b/crates/bevy_anti_alias/src/lib.rs
@@ -6,6 +6,7 @@
 )]
 
 use bevy_app::Plugin;
+use bevy_ecs::schedule::SystemSet;
 use contrast_adaptive_sharpening::CasPlugin;
 use fxaa::FxaaPlugin;
 use smaa::SmaaPlugin;
@@ -17,6 +18,17 @@ pub mod dlss;
 pub mod fxaa;
 pub mod smaa;
 pub mod taa;
+
+/// A [`SystemSet`] for Anti-aliasing technique systems.
+///
+/// Nothing prevents a camera from enabling more than one of these, but in practice
+/// only one is usually active, and the ordering between them is not meaningful.
+///
+/// Members should declare `.ambiguous_with(AntiAliasingSystems)` to suppress the
+/// ambiguity report. These systems take `&mut ViewTarget` and so are never run
+/// concurrently.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AntiAliasingSystems;
 
 /// Adds fxaa, smaa, taa, contrast aware sharpening, and optional dlss support.
 #[derive(Default)]

--- a/crates/bevy_anti_alias/src/smaa/mod.rs
+++ b/crates/bevy_anti_alias/src/smaa/mod.rs
@@ -376,11 +376,17 @@ impl Plugin for SmaaPlugin {
             )
             .add_systems(
                 Core3d,
-                smaa.after(tonemapping).in_set(Core3dSystems::PostProcess),
+                smaa.after(tonemapping)
+                    .in_set(Core3dSystems::PostProcess)
+                    .in_set(crate::AntiAliasingSystems)
+                    .ambiguous_with(crate::AntiAliasingSystems),
             )
             .add_systems(
                 Core2d,
-                smaa.after(tonemapping).in_set(Core2dSystems::PostProcess),
+                smaa.after(tonemapping)
+                    .in_set(Core2dSystems::PostProcess)
+                    .in_set(crate::AntiAliasingSystems)
+                    .ambiguous_with(crate::AntiAliasingSystems),
             );
     }
 }

--- a/crates/bevy_anti_alias/src/smaa/mod.rs
+++ b/crates/bevy_anti_alias/src/smaa/mod.rs
@@ -834,7 +834,7 @@ impl SmaaPreset {
 
 pub fn smaa(
     view: ViewQuery<(
-        &ViewTarget,
+        &mut ViewTarget,
         &ViewSmaaPipelines,
         &SmaaInfoUniformOffset,
         &SmaaTextures,
@@ -846,7 +846,7 @@ pub fn smaa(
     mut ctx: RenderContext,
 ) {
     let (
-        view_target,
+        mut view_target,
         view_pipelines,
         view_smaa_uniform_offset,
         smaa_textures,

--- a/crates/bevy_anti_alias/src/taa/mod.rs
+++ b/crates/bevy_anti_alias/src/taa/mod.rs
@@ -136,7 +136,7 @@ impl SyncComponent<RenderApp> for TemporalAntiAliasing {
 pub fn temporal_anti_alias(
     view: ViewQuery<(
         &ExtractedCamera,
-        &ViewTarget,
+        &mut ViewTarget,
         &TemporalAntiAliasHistoryTextures,
         &ViewPrepassTextures,
         &TemporalAntiAliasPipelineId,
@@ -146,7 +146,7 @@ pub fn temporal_anti_alias(
     pipeline_cache: Res<PipelineCache>,
     mut ctx: RenderContext,
 ) {
-    let (camera, view_target, taa_history_textures, prepass_textures, taa_pipeline_id, msaa) =
+    let (camera, mut view_target, taa_history_textures, prepass_textures, taa_pipeline_id, msaa) =
         view.into_inner();
 
     if *msaa != Msaa::Off {

--- a/crates/bevy_anti_alias/src/taa/mod.rs
+++ b/crates/bevy_anti_alias/src/taa/mod.rs
@@ -69,7 +69,10 @@ impl Plugin for TemporalAntiAliasPlugin {
 
         render_app.add_systems(
             Core3d,
-            temporal_anti_alias.in_set(Core3dSystems::EarlyPostProcess),
+            temporal_anti_alias
+                .in_set(Core3dSystems::EarlyPostProcess)
+                .in_set(crate::AntiAliasingSystems)
+                .ambiguous_with(crate::AntiAliasingSystems),
         );
     }
 }

--- a/crates/bevy_core_pipeline/src/fullscreen_material.rs
+++ b/crates/bevy_core_pipeline/src/fullscreen_material.rs
@@ -234,7 +234,7 @@ fn prepare_bind_groups<T: FullscreenMaterial>(
     mut commands: Commands,
     mut view: Query<(
         Entity,
-        &ViewTarget,
+        &mut ViewTarget,
         Option<&mut FullscreenMaterialBindGroup<T>>,
         Option<&T>,
     )>,
@@ -274,12 +274,12 @@ fn prepare_bind_groups<T: FullscreenMaterial>(
         });
 
         if let Some(bind_groups) = &mut maybe_bind_groups {
-            if bind_groups.cache.should_update(view_target) {
-                bind_groups.cache.update(view_target, builder);
+            if bind_groups.cache.should_update(&view_target) {
+                bind_groups.cache.update(&view_target, builder);
             }
         } else {
             commands.entity(entity).insert(FullscreenMaterialBindGroup {
-                cache: builder.generate_bind_groups(view_target),
+                cache: builder.generate_bind_groups(&view_target),
                 _marker: PhantomData::<T>,
             });
         }
@@ -288,7 +288,7 @@ fn prepare_bind_groups<T: FullscreenMaterial>(
 
 pub fn fullscreen_material_system<T: FullscreenMaterial>(
     view: ViewQuery<(
-        &ViewTarget,
+        &mut ViewTarget,
         &DynamicUniformIndex<T>,
         &FullscreenMaterialBindGroup<T>,
         &FullscreenMaterialPipelineId,
@@ -296,7 +296,7 @@ pub fn fullscreen_material_system<T: FullscreenMaterial>(
     pipeline_cache: Res<PipelineCache>,
     mut ctx: RenderContext,
 ) {
-    let (view_target, settings_index, bind_groups, pipeline_id) = view.into_inner();
+    let (mut view_target, settings_index, bind_groups, pipeline_id) = view.into_inner();
 
     let Some(pipeline) = pipeline_cache.get_render_pipeline(pipeline_id.0) else {
         return;

--- a/crates/bevy_core_pipeline/src/tonemapping/node.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/node.rs
@@ -27,7 +27,7 @@ pub fn tonemapping(
     view: ViewQuery<(
         &ExtractedCamera,
         &ViewUniformOffset,
-        &ViewTarget,
+        &mut ViewTarget,
         &ViewTonemappingPipeline,
         &Tonemapping,
     )>,
@@ -40,7 +40,7 @@ pub fn tonemapping(
     mut cache: Local<TonemappingBindGroupCache>,
     mut ctx: RenderContext,
 ) {
-    let (camera, view_uniform_offset, target, view_tonemapping_pipeline, tonemapping) =
+    let (camera, view_uniform_offset, mut target, view_tonemapping_pipeline, tonemapping) =
         view.into_inner();
 
     if *tonemapping == Tonemapping::None {

--- a/crates/bevy_dev_tools/src/render_debug.rs
+++ b/crates/bevy_dev_tools/src/render_debug.rs
@@ -629,7 +629,7 @@ fn prepare_debug_overlay_resources(
 
 fn render_debug_overlay(
     view: ViewQuery<(
-        &ViewTarget,
+        &mut ViewTarget,
         &RenderDebugOverlay,
         &RenderDebugOverlayPipelineId,
         &RenderDebugOverlayUniformOffset,
@@ -642,7 +642,7 @@ fn render_debug_overlay(
     fallback_image: Res<FallbackImage>,
     mut ctx: RenderContext,
 ) {
-    let (target, config, pipeline_id, uniform_offset, mesh_view_bind_group, depth_pyramid) =
+    let (mut target, config, pipeline_id, uniform_offset, mesh_view_bind_group, depth_pyramid) =
         view.into_inner();
 
     if !config.enabled {

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -413,19 +413,21 @@ impl Plugin for PbrPlugin {
                 per_view_shadow_pass::<EARLY_SHADOW_PASS>
                     .after(early_prepass_build_indirect_parameters)
                     .before(early_downsample_depth)
-                    .before(per_view_shadow_pass::<LATE_SHADOW_PASS>),
+                    .before(per_view_shadow_pass::<LATE_SHADOW_PASS>)
+                    .in_set(Core3dSystems::Prepass),
                 per_view_shadow_pass::<LATE_SHADOW_PASS>
                     .after(late_prepass_build_indirect_parameters)
                     .before(main_build_indirect_parameters)
-                    .before(Core3dSystems::MainPass),
+                    .in_set(Core3dSystems::Prepass),
                 shared_shadow_pass::<EARLY_SHADOW_PASS>
                     .after(early_prepass_build_indirect_parameters)
                     .before(early_downsample_depth)
-                    .before(shared_shadow_pass::<LATE_SHADOW_PASS>),
+                    .before(shared_shadow_pass::<LATE_SHADOW_PASS>)
+                    .in_set(Core3dSystems::Prepass),
                 shared_shadow_pass::<LATE_SHADOW_PASS>
                     .after(late_prepass_build_indirect_parameters)
                     .before(main_build_indirect_parameters)
-                    .before(Core3dSystems::MainPass),
+                    .in_set(Core3dSystems::Prepass),
             ),
         );
     }

--- a/crates/bevy_pbr/src/ssr/mod.rs
+++ b/crates/bevy_pbr/src/ssr/mod.rs
@@ -244,7 +244,7 @@ impl Default for ScreenSpaceReflections {
 
 pub fn screen_space_reflections(
     view: ViewQuery<(
-        &ViewTarget,
+        &mut ViewTarget,
         &MeshViewBindGroup,
         &ScreenSpaceReflectionsPipelineId,
     )>,
@@ -254,7 +254,7 @@ pub fn screen_space_reflections(
     render_images: Res<RenderAssets<GpuImage>>,
     mut ctx: RenderContext,
 ) {
-    let (view_target, view_bind_group, ssr_pipeline_id) = view.into_inner();
+    let (mut view_target, view_bind_group, ssr_pipeline_id) = view.into_inner();
 
     // Grab the render pipeline.
     let Some(render_pipeline) = pipeline_cache.get_render_pipeline(**ssr_pipeline_id) else {

--- a/crates/bevy_post_process/src/dof/mod.rs
+++ b/crates/bevy_post_process/src/dof/mod.rs
@@ -763,7 +763,7 @@ impl DepthOfFieldPipelines {
 pub(crate) fn depth_of_field(
     view: ViewQuery<(
         &ViewUniformOffset,
-        &ViewTarget,
+        &mut ViewTarget,
         &ViewDepthStencilTexture,
         &DepthOfFieldPipelines,
         &ViewDepthOfFieldBindGroupLayouts,
@@ -777,7 +777,7 @@ pub(crate) fn depth_of_field(
 ) {
     let (
         view_uniform_offset,
-        view_target,
+        mut view_target,
         view_depth_texture,
         view_pipelines,
         view_bind_group_layouts,

--- a/crates/bevy_post_process/src/effect_stack/mod.rs
+++ b/crates/bevy_post_process/src/effect_stack/mod.rs
@@ -242,7 +242,7 @@ impl SpecializedRenderPipeline for PostProcessingPipeline {
 
 pub(crate) fn post_processing(
     view: ViewQuery<(
-        &ViewTarget,
+        &mut ViewTarget,
         &PostProcessingPipelineId,
         AnyOf<(&ChromaticAberration, &Vignette, &LensDistortion)>,
         &PostProcessingUniformBufferOffsets,
@@ -254,7 +254,7 @@ pub(crate) fn post_processing(
     default_lut: Res<DefaultChromaticAberrationLut>,
     mut ctx: RenderContext,
 ) {
-    let (view_target, pipeline_id, post_effects, post_processing_uniform_buffer_offsets) =
+    let (mut view_target, pipeline_id, post_effects, post_processing_uniform_buffer_offsets) =
         view.into_inner();
 
     let (maybe_chromatic_aberration, maybe_vignette, maybe_lens_distortion) = post_effects;

--- a/crates/bevy_post_process/src/motion_blur/mod.rs
+++ b/crates/bevy_post_process/src/motion_blur/mod.rs
@@ -183,7 +183,7 @@ impl Plugin for MotionBlurPlugin {
 
 pub fn motion_blur(
     view: ViewQuery<(
-        &ViewTarget,
+        &mut ViewTarget,
         &MotionBlurPipelineId,
         &ViewPrepassTextures,
         &ViewDepthStencilTexture,
@@ -196,7 +196,7 @@ pub fn motion_blur(
     globals_buffer: Res<GlobalsBuffer>,
     mut ctx: RenderContext,
 ) {
-    let (view_target, pipeline_id, prepass_textures, depth, motion_blur_uniform, msaa) =
+    let (mut view_target, pipeline_id, prepass_textures, depth, motion_blur_uniform, msaa) =
         view.into_inner();
     let Some(depth_view) = depth.attachment.depth_stencil_views().depth_only_view() else {
         return;

--- a/crates/bevy_post_process/src/msaa_writeback.rs
+++ b/crates/bevy_post_process/src/msaa_writeback.rs
@@ -35,12 +35,12 @@ impl Plugin for MsaaWritebackPlugin {
 }
 
 pub(crate) fn msaa_writeback(
-    view: ViewQuery<(&ViewTarget, &MsaaWritebackBlitPipeline, &Msaa)>,
+    view: ViewQuery<(&mut ViewTarget, &MsaaWritebackBlitPipeline, &Msaa)>,
     blit_pipeline: Res<BlitPipeline>,
     pipeline_cache: Res<PipelineCache>,
     mut ctx: RenderContext,
 ) {
-    let (target, blit_pipeline_id, msaa) = view.into_inner();
+    let (mut target, blit_pipeline_id, msaa) = view.into_inner();
 
     if *msaa == Msaa::Off {
         return;
@@ -49,6 +49,10 @@ pub(crate) fn msaa_writeback(
     let Some(pipeline) = pipeline_cache.get_render_pipeline(blit_pipeline_id.0) else {
         return;
     };
+
+    // If MSAA is enabled, then the sampled texture will always exist
+    // (We must clone the `TextureView` here since the target will be mutably borrowed below)
+    let sampled_view = target.sampled_main_texture_view().unwrap().clone();
 
     // The current "main texture" needs to be bound as an input resource, and we need the "other"
     // unused target to be the "resolve target" for the MSAA write. Therefore this is the same
@@ -61,8 +65,7 @@ pub(crate) fn msaa_writeback(
         // We will indirectly write the results to the "destination" using
         // the MSAA resolve step.
         color_attachments: &[Some(RenderPassColorAttachment {
-            // If MSAA is enabled, then the sampled texture will always exist
-            view: target.sampled_main_texture_view().unwrap(),
+            view: &sampled_view,
             depth_slice: None,
             resolve_target: Some(post_process.destination),
             ops: Operations {
@@ -102,7 +105,7 @@ fn prepare_msaa_writeback_pipelines(
     pipeline_cache: Res<PipelineCache>,
     mut pipelines: ResMut<SpecializedRenderPipelines<BlitPipeline>>,
     blit_pipeline: Res<BlitPipeline>,
-    view_targets: Query<(Entity, &ViewTarget, &ExtractedCamera, &Msaa)>,
+    view_targets: Query<(Entity, &mut ViewTarget, &ExtractedCamera, &Msaa)>,
 ) {
     for (entity, view_target, camera, msaa) in view_targets.iter() {
         // Determine if we should do MSAA writeback based on the camera's setting

--- a/crates/bevy_post_process/src/msaa_writeback.rs
+++ b/crates/bevy_post_process/src/msaa_writeback.rs
@@ -29,7 +29,7 @@ impl Plugin for MsaaWritebackPlugin {
             Render,
             prepare_msaa_writeback_pipelines.in_set(RenderSystems::Prepare),
         );
-        render_app.add_systems(Core3d, msaa_writeback.before(Core3dSystems::MainPass));
+        render_app.add_systems(Core3d, msaa_writeback.before(Core3dSystems::Prepass));
         render_app.add_systems(Core2d, msaa_writeback.before(Core2dSystems::MainPass));
     }
 }

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -950,7 +950,7 @@ impl ViewTarget {
     /// [`ViewTarget`]'s main texture to the `destination` texture, so the caller
     /// _must_ ensure `source` is copied to `destination`, with or without modifications.
     /// Failing to do so will cause the current main texture information to be lost.
-    pub fn post_process_write(&self) -> PostProcessWrite<'_> {
+    pub fn post_process_write(&mut self) -> PostProcessWrite<'_> {
         let old_is_a_main_texture = self.main_texture.fetch_xor(1, Ordering::SeqCst);
         // if the old main texture is a, then the post processing must write from a to b
         if old_is_a_main_texture == 0 {

--- a/examples/shader_advanced/custom_post_processing.rs
+++ b/examples/shader_advanced/custom_post_processing.rs
@@ -74,7 +74,7 @@ struct PostProcessBindGroupCache {
 
 fn post_process_system(
     view: ViewQuery<(
-        &ViewTarget,
+        &mut ViewTarget,
         &PostProcessSettings,
         &DynamicUniformIndex<PostProcessSettings>,
     )>,
@@ -88,7 +88,7 @@ fn post_process_system(
         return;
     };
 
-    let (view_target, _post_process_settings, settings_index) = view.into_inner();
+    let (mut view_target, _post_process_settings, settings_index) = view.into_inner();
 
     let Some(pipeline) = pipeline_cache.get_render_pipeline(post_process_pipeline.pipeline_id)
     else {


### PR DESCRIPTION
While experimenting with a custom lens flare post-processing effect, I hit erratic behavior related to system order, that turned out to be a previously reported interior mutability footgun (#24839): `post_process_write()` doesn't require a mutable ref, so it allows multiple systems to concurrently hold write access to the same view target, unless you carefully specify ordering.

Previously this wasn't really an issue because of the render graph, but #22144 made it easy to hit by accident if you forget to add the relevant `.before()`/`.after()`. (And you get no ambiguity warnings because the systems don't share mutable access)

# Objective

Fixes #24839. An alternative approach to #24961 (but we probably still want to make the system order explicit in the example)

## Solution

- Make `post_process_write()` mutable
- Update all relevant queries to be &mut
- Resolve now reported system order ambiguities:
  - Moved `msaa_writeback` and various shadow passes to `Prepass`
  - Added an `AntiAliasingSystems` set, as proposed [here](https://github.com/bevyengine/bevy/pull/22144#discussion_r2702914550) by @IceSentry, flagged systems in the set as ambiguous with each other

## Testing

- Did you test these changes? If so, how? Yes, visually compared the output of various rendering examples against `main` to avoid regressions, and verified the HDR post processing issue is no more.
- Are there any parts that need more testing? DLSS (since I don't have nvidia hardware to test this on)
- How can other people (reviewers) test your changes? Is there anything specific they need to know? Verify the ordering is correct and behavior is still consistent
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? Tested on macOS, on an M3 Pro. Ideally need PC hardware/verification on other platforms