### PR TITLE
Fix `binding_arrays_are_usable` check

### DIFF
--- a/crates/bevy_pbr/src/light_probe/mod.rs
+++ b/crates/bevy_pbr/src/light_probe/mod.rs
@@ -788,7 +788,14 @@ pub(crate) fn binding_arrays_are_usable(
 
     !cfg!(feature = "shader_format_glsl")
         && bevy_render::get_adreno_model(&adapter_info).is_none_or(|model| model > 610)
-        && render_device.limits().max_storage_textures_per_shader_stage
+        && render_device
+            .limits()
+            .max_binding_array_elements_per_shader_stage
+            >= (STANDARD_MATERIAL_FRAGMENT_SHADER_MIN_TEXTURE_BINDINGS + MAX_VIEW_LIGHT_PROBES)
+                as u32
+        && render_device
+            .limits()
+            .max_binding_array_sampler_elements_per_shader_stage
             >= (STANDARD_MATERIAL_FRAGMENT_SHADER_MIN_TEXTURE_BINDINGS + MAX_VIEW_LIGHT_PROBES)
                 as u32
         && render_device.features().contains(


### PR DESCRIPTION
# Objective

`binding_arrays_are_usable` checks unrelated `max_storage_textures_per_shader_stage` limit (https://github.com/bevyengine/bevy/pull/10268), possibly because wgpu did not have relevant limits two years ago.

## Solution

Check `max_binding_array_elements_per_shader_stage` and `max_binding_array_sampler_elements_per_shader_stage`.

## Testing

None.