### PR TITLE
Implement: Modulus support for FeathersNumberInput

### DIFF
--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -254,6 +254,17 @@ pub enum NumberInputValue {
     I64(i64),
 }
 
+/// Indicates whether the number input should wrap around the min/max value.
+#[derive(Component, Default, Debug, PartialEq, Clone, Copy, Reflect)]
+#[reflect(Component, Default)]
+pub enum NumberInputWrap {
+    /// The number input will not wrap around the min/max value.
+    #[default]
+    NoWrap,
+    /// The number input will wrap around the min/max value.
+    Wrap,
+}
+
 impl core::fmt::Display for NumberInputValue {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
@@ -354,6 +365,32 @@ impl NumberInputRange {
             }
             (Self::I64(r), NumberInputValue::I64(v)) => {
                 NumberInputValue::I64(v.clamp(r.start, r.end))
+            }
+            (range, value) => {
+                warn_once!("Number input range type mismatch: {range:?} {value:?}");
+                n
+            }
+        }
+    }
+
+    /// Wrap a numeric value of varying type to be within this range.
+    pub fn wrap(&self, n: NumberInputValue) -> NumberInputValue {
+        match (self, n) {
+            (Self::F32(r), NumberInputValue::F32(v)) => {
+                let range = r.end - r.start;
+                NumberInputValue::F32(r.start + (v - r.start).rem_euclid(range))
+            }
+            (Self::F64(r), NumberInputValue::F64(v)) => {
+                let range = r.end - r.start;
+                NumberInputValue::F64(r.start + (v - r.start).rem_euclid(range))
+            }
+            (Self::I32(r), NumberInputValue::I32(v)) => {
+                let range = r.end - r.start;
+                NumberInputValue::I32(r.start + (v - r.start).rem_euclid(range))
+            }
+            (Self::I64(r), NumberInputValue::I64(v)) => {
+                let range = r.end - r.start;
+                NumberInputValue::I64(r.start + (v - r.start).rem_euclid(range))
             }
             (range, value) => {
                 warn_once!("Number input range type mismatch: {range:?} {value:?}");
@@ -753,7 +790,14 @@ fn number_input_hovered(
 fn number_input_on_enter_key(
     key_input: On<FocusedInput<KeyboardInput>>,
     q_parent: Query<&ChildOf>,
-    q_number_input: Query<(&NumberInputValue, Option<&HardLimit>), With<FeathersNumberInput>>,
+    q_number_input: Query<
+        (
+            &NumberInputValue,
+            Option<&HardLimit>,
+            Option<&NumberInputWrap>,
+        ),
+        With<FeathersNumberInput>,
+    >,
     mut q_text_input: Query<(&EditableText, &mut DragState)>,
     mut commands: Commands,
 ) {
@@ -763,7 +807,7 @@ fn number_input_on_enter_key(
 
     let text_id = key_input.event_target();
     if let Ok(&ChildOf(root)) = q_parent.get(text_id)
-        && let Ok((input_value, hard_limit)) = q_number_input.get(root)
+        && let Ok((input_value, hard_limit, wrap)) = q_number_input.get(root)
         && let Ok((editable_text, mut drag_state)) = q_text_input.get_mut(text_id)
     {
         let text_value = editable_text.value().to_string();
@@ -779,6 +823,7 @@ fn number_input_on_enter_key(
             input_value.format(),
             root,
             hard_limit,
+            wrap,
             &mut commands,
             true,
         );
@@ -801,6 +846,7 @@ fn number_input_on_focus_lost(
             &NumberInputValue,
             Has<InteractionDisabled>,
             Option<&HardLimit>,
+            Option<&NumberInputWrap>,
         ),
         With<FeathersNumberInput>,
     >,
@@ -810,7 +856,7 @@ fn number_input_on_focus_lost(
     let editable_text_id = focus_lost.event_target();
 
     if let Ok(&ChildOf(root)) = q_parent.get(editable_text_id)
-        && let Ok((input_value, disabled, hard_limit)) = q_number_input.get(root)
+        && let Ok((input_value, disabled, hard_limit, wrap)) = q_number_input.get(root)
         && let Ok((editable_text, mut drag_state)) = q_text_input.get_mut(editable_text_id)
     {
         let text_value = editable_text.value().to_string();
@@ -819,6 +865,7 @@ fn number_input_on_focus_lost(
             input_value.format(),
             root,
             hard_limit,
+            wrap,
             &mut commands,
             true,
         );
@@ -997,6 +1044,7 @@ fn scrubber_on_drag(
         Option<&HardLimit>,
         Option<&NumberInputPrecision>,
         Has<InteractionDisabled>,
+        Option<&NumberInputWrap>,
     )>,
     mut q_text_input: Query<&mut DragState>,
     mut q_scrubber: Query<&UiGlobalTransform>,
@@ -1007,7 +1055,7 @@ fn scrubber_on_drag(
 ) {
     if let Ok(&ChildOf(text_id)) = q_parent.get(drag.event_target())
         && let Ok(&ChildOf(root_id)) = q_parent.get(text_id)
-        && let Ok((soft_limit, hard_limit, precision, disabled)) = q_root.get(root_id)
+        && let Ok((soft_limit, hard_limit, precision, disabled, wrap)) = q_root.get(root_id)
         && let Ok(mut drag_state) = q_text_input.get_mut(text_id)
         && let Ok(transform) = q_scrubber.get_mut(drag.entity)
         && drag_state.mode == EditMode::Scrubbing
@@ -1027,6 +1075,7 @@ fn scrubber_on_drag(
                 soft_limit,
                 hard_limit,
                 precision,
+                wrap,
                 &mut drag_state,
                 false,
             );
@@ -1041,6 +1090,7 @@ fn scrubber_on_drag_end(
         Option<&HardLimit>,
         Option<&NumberInputPrecision>,
         Has<InteractionDisabled>,
+        Option<&NumberInputWrap>,
         Option<&ThemeContext>,
     )>,
     mut q_text_input: Query<(&Hovered, &mut BackgroundGradient, &mut DragState)>,
@@ -1050,7 +1100,7 @@ fn scrubber_on_drag_end(
 ) {
     if let Ok(&ChildOf(text_id)) = q_parent.get(drag_end.event_target())
         && let Ok(&ChildOf(root_id)) = q_parent.get(text_id)
-        && let Ok((soft_limit, hard_limit, precision, disabled, theme_context)) =
+        && let Ok((soft_limit, hard_limit, precision, disabled, wrap, theme_context)) =
             q_root.get(root_id)
         && let Ok((&Hovered(hovered), mut gradient, mut drag_state)) = q_text_input.get_mut(text_id)
         && drag_state.mode == EditMode::Scrubbing
@@ -1063,6 +1113,7 @@ fn scrubber_on_drag_end(
                 soft_limit,
                 hard_limit,
                 precision,
+                wrap,
                 &mut drag_state,
                 true,
             );
@@ -1200,6 +1251,7 @@ fn emit_drag_value_change(
     soft_limit: Option<&SoftLimit>,
     hard_limit: Option<&HardLimit>,
     precision: Option<&NumberInputPrecision>,
+    wrap: Option<&NumberInputWrap>,
     drag_state: &mut DragState,
     is_final: bool,
 ) {
@@ -1214,9 +1266,15 @@ fn emit_drag_value_change(
         value = precision.round(value);
     }
     // Hard limit is absolute and always applied last.
-    if let Some(HardLimit(range)) = hard_limit {
-        value = range.clamp(value);
-    }
+    let value = match (wrap, hard_limit) {
+        (Some(NumberInputWrap::Wrap), Some(HardLimit(range))) => range.wrap(value),
+        (Some(NumberInputWrap::Wrap), None) => {
+            warn_once!("NumberInputWrap::Wrap specified without a HardLimit; ignoring wrap");
+            value
+        }
+        (_, Some(HardLimit(range))) => range.clamp(value),
+        (_, None) => value,
+    };
 
     trigger_value_change(commands, value, source, is_final);
 }
@@ -1226,6 +1284,7 @@ fn emit_value_change(
     format: NumberFormat,
     source: Entity,
     hard_limit: Option<&HardLimit>,
+    wrap: Option<&NumberInputWrap>,
     commands: &mut Commands,
     is_final: bool,
 ) {
@@ -1240,12 +1299,17 @@ fn emit_value_change(
         return;
     };
 
-    let clamped_value = match hard_limit {
-        Some(limit) => limit.0.clamp(new_value),
-        None => new_value,
+    let value = match (wrap, hard_limit) {
+        (Some(NumberInputWrap::Wrap), Some(HardLimit(range))) => range.wrap(new_value),
+        (Some(NumberInputWrap::Wrap), None) => {
+            warn_once!("NumberInputWrap::Wrap specified without a HardLimit; ignoring wrap");
+            new_value
+        }
+        (_, Some(HardLimit(range))) => range.clamp(new_value),
+        (_, None) => new_value,
     };
 
-    trigger_value_change(commands, clamped_value, source, is_final);
+    trigger_value_change(commands, value, source, is_final);
 }
 
 /// Decompose the input value enum and trigger a [`ValueChange`] with the appropriate generic

--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -255,6 +255,7 @@ pub enum NumberInputValue {
 }
 
 /// Indicates whether the number input should wrap around the min/max value.
+/// This component only applies to [`HardLimit`].
 #[derive(Component, Default, Debug, PartialEq, Clone, Copy, Reflect)]
 #[reflect(Component, Default)]
 pub enum NumberInputWrap {

--- a/examples/ui/widgets/feathers_number_input.rs
+++ b/examples/ui/widgets/feathers_number_input.rs
@@ -84,6 +84,10 @@ fn demo_root() -> impl Scene {
                 InteractionDisabled
                 template_value(SoftLimit(NumberInputRange::F32(0.0..10.0)))
             )),
+            demo_field_f32("hard limit + wrap", 0.0, bsn!(
+                template_value(HardLimit(NumberInputRange::F32(-180.0..180.0)))
+                template_value(NumberInputWrap::Wrap)
+            )),
         ]
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #25240 
- Currently, `FeathersNumberInput` does not support wrapping.
- This PR adds wrapping support when using `FeathersNumberInput` to edit rotation values.

## Solution
### `crates/bevy_feathers/src/controls/number_input.rs`
- Added `NumberInputWrap` for value wrapping.
- Added `wrap` method to `NumberInputRange` to distinguish it from `clamp`.
- Updated `emit_drag_value_change` and `emit_value_change` to handle wrapping.

## Testing
- Added a new demo_field designed for rotation in the `feathers_number_input` example.
- Tested manually using `cargo run --example feathers_number_input --features="bevy_feathers"`.

---

## Showcase
https://github.com/user-attachments/assets/2449dd20-50fd-4172-a085-9053a74ea192