### PR TITLE
Fix #C-16: insert_by_ids accepts a documented-compliant short iterator

### DIFF
--- a/crates/bevy_ecs/src/world/entity_access/mod.rs
+++ b/crates/bevy_ecs/src/world/entity_access/mod.rs
@@ -455,6 +455,53 @@ mod tests {
         assert_eq!(dynamic_components, static_components);
     }
 
+    /// Regression test for C-16: passing a shorter iterator than `component_ids`
+    /// to `insert_by_ids` must panic in debug builds, as it would otherwise leave
+    /// component memory uninitialized via `zip` truncation.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "iter_components must yield exactly")]
+    fn insert_by_ids_short_iterator_panics_in_debug() {
+        let mut world = World::new();
+        let test_component_id = world.register_component::<TestComponent>();
+        let test_component_2_id = world.register_component::<TestComponent2>();
+
+        let component_ids = [test_component_id, test_component_2_id];
+        let mut entity = world.spawn_empty();
+
+        // Intentionally provide only 1 component for 2 component_ids.
+        OwningPtr::make(TestComponent(42), |ptr| {
+            // SAFETY: This is intentionally unsound — the debug assertion should
+            // catch the mismatch before any uninitialized memory is read.
+            unsafe {
+                entity.insert_by_ids(&component_ids, vec![ptr].into_iter());
+            }
+        });
+    }
+
+    /// Regression test for C-16: passing a longer iterator than `component_ids`
+    /// to `insert_by_ids` must also panic in debug builds.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "iter_components must yield exactly")]
+    fn insert_by_ids_long_iterator_panics_in_debug() {
+        let mut world = World::new();
+        let test_component_id = world.register_component::<TestComponent>();
+
+        let mut entity = world.spawn_empty();
+
+        // Intentionally provide 2 components for 1 component_id.
+        OwningPtr::make(TestComponent(42), |ptr1| {
+            OwningPtr::make(TestComponent(84), |ptr2| {
+                // SAFETY: This is intentionally unsound — the debug assertion should
+                // catch the mismatch.
+                unsafe {
+                    entity.insert_by_ids(&[test_component_id], vec![ptr1, ptr2].into_iter());
+                }
+            });
+        });
+    }
+
     #[test]
     fn entity_mut_remove_by_id() {
         let mut world = World::new();

--- a/crates/bevy_ecs/src/world/entity_access/mod.rs
+++ b/crates/bevy_ecs/src/world/entity_access/mod.rs
@@ -455,6 +455,53 @@ mod tests {
         assert_eq!(dynamic_components, static_components);
     }
 
+    /// Regression test: passing a shorter iterator than `component_ids`
+    /// to `insert_by_ids` must panic in debug builds, as it would otherwise leave
+    /// component memory uninitialized via `zip` truncation.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "iter_components must yield exactly")]
+    fn insert_by_ids_short_iterator_panics_in_debug() {
+        let mut world = World::new();
+        let test_component_id = world.register_component::<TestComponent>();
+        let test_component_2_id = world.register_component::<TestComponent2>();
+
+        let component_ids = [test_component_id, test_component_2_id];
+        let mut entity = world.spawn_empty();
+
+        // Intentionally provide only 1 component for 2 component_ids.
+        OwningPtr::make(TestComponent(42), |ptr| {
+            // SAFETY: This is intentionally unsound — the debug assertion should
+            // catch the mismatch before any uninitialized memory is read.
+            unsafe {
+                entity.insert_by_ids(&component_ids, vec![ptr].into_iter());
+            }
+        });
+    }
+
+    /// Regression test: passing a longer iterator than `component_ids`
+    /// to `insert_by_ids` must also panic in debug builds.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "iter_components must yield exactly")]
+    fn insert_by_ids_long_iterator_panics_in_debug() {
+        let mut world = World::new();
+        let test_component_id = world.register_component::<TestComponent>();
+
+        let mut entity = world.spawn_empty();
+
+        // Intentionally provide 2 components for 1 component_id.
+        OwningPtr::make(TestComponent(42), |ptr1| {
+            OwningPtr::make(TestComponent(84), |ptr2| {
+                // SAFETY: This is intentionally unsound — the debug assertion should
+                // catch the mismatch.
+                unsafe {
+                    entity.insert_by_ids(&[test_component_id], vec![ptr1, ptr2].into_iter());
+                }
+            });
+        });
+    }
+
     #[test]
     fn entity_mut_remove_by_id() {
         let mut world = World::new();

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -1196,10 +1196,17 @@ impl<'w> EntityWorldMut<'w> {
     /// # Safety
     /// - Each [`ComponentId`] must be from the same world as [`EntityWorldMut`]
     /// - Each [`OwningPtr`] must be a valid reference to the type represented by [`ComponentId`]
+    /// - `iter_components` must yield exactly `component_ids.len()` items. If it
+    ///   yields fewer, some component columns will be left uninitialized, resulting
+    ///   in undefined behavior. If it yields more, the extra items will be silently
+    ///   ignored.
     ///
     /// # Panics
     ///
     /// If the entity has been despawned while this `EntityWorldMut` is still alive.
+    ///
+    /// In debug builds, panics if `iter_components` does not yield exactly
+    /// `component_ids.len()` items.
     #[track_caller]
     pub unsafe fn insert_by_ids<'a, I: Iterator<Item = OwningPtr<'a>>>(
         &mut self,
@@ -1222,6 +1229,22 @@ impl<'w> EntityWorldMut<'w> {
         iter_components: I,
         relationship_hook_insert_mode: RelationshipHookMode,
     ) -> &mut Self {
+        // In debug builds, eagerly collect the iterator and verify that it yields
+        // exactly `component_ids.len()` items. A shorter iterator would leave
+        // component memory uninitialized via `zip` truncation — see C-16.
+        #[cfg(debug_assertions)]
+        let iter_components = {
+            let collected: Vec<_> = iter_components.collect();
+            debug_assert_eq!(
+                collected.len(),
+                component_ids.len(),
+                "iter_components must yield exactly {} items (one per ComponentId), but {} were yielded",
+                component_ids.len(),
+                collected.len()
+            );
+            collected.into_iter()
+        };
+
         let location = self.location();
         let change_tick = self.world.change_tick();
         let bundle_id = self.world.bundles.init_dynamic_info(
@@ -2394,6 +2417,9 @@ impl<'a> From<&'a mut EntityWorldMut<'_>> for FilteredEntityMut<'a, 'static> {
 ///
 /// - [`OwningPtr`] and [`StorageType`] iterators must correspond to the
 ///   [`BundleInfo`](crate::bundle::BundleInfo) used to construct [`BundleInserter`]
+/// - Both iterators must yield the same number of items. If the [`OwningPtr`]
+///   iterator is shorter, some component columns will be left uninitialized,
+///   resulting in undefined behavior.
 /// - [`Entity`] must correspond to [`EntityLocation`]
 unsafe fn insert_dynamic_bundle<
     'a,

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -1196,10 +1196,17 @@ impl<'w> EntityWorldMut<'w> {
     /// # Safety
     /// - Each [`ComponentId`] must be from the same world as [`EntityWorldMut`]
     /// - Each [`OwningPtr`] must be a valid reference to the type represented by [`ComponentId`]
+    /// - `iter_components` must yield exactly `component_ids.len()` items. If it
+    ///   yields fewer, some component columns will be left uninitialized, resulting
+    ///   in undefined behavior. If it yields more, the extra items will be silently
+    ///   ignored.
     ///
     /// # Panics
     ///
     /// If the entity has been despawned while this `EntityWorldMut` is still alive.
+    ///
+    /// In debug builds, panics if `iter_components` does not yield exactly
+    /// `component_ids.len()` items.
     #[track_caller]
     pub unsafe fn insert_by_ids<'a, I: Iterator<Item = OwningPtr<'a>>>(
         &mut self,
@@ -1222,6 +1229,22 @@ impl<'w> EntityWorldMut<'w> {
         iter_components: I,
         relationship_hook_insert_mode: RelationshipHookMode,
     ) -> &mut Self {
+        // In debug builds, eagerly collect the iterator and verify that it yields
+        // exactly `component_ids.len()` items. A shorter iterator would leave
+        // component memory uninitialized via `zip` truncation.
+        #[cfg(debug_assertions)]
+        let iter_components = {
+            let collected: Vec<_> = iter_components.collect();
+            debug_assert_eq!(
+                collected.len(),
+                component_ids.len(),
+                "iter_components must yield exactly {} items (one per ComponentId), but {} were yielded",
+                component_ids.len(),
+                collected.len()
+            );
+            collected.into_iter()
+        };
+
         let location = self.location();
         let change_tick = self.world.change_tick();
         let bundle_id = self.world.bundles.init_dynamic_info(
@@ -2394,6 +2417,9 @@ impl<'a> From<&'a mut EntityWorldMut<'_>> for FilteredEntityMut<'a, 'static> {
 ///
 /// - [`OwningPtr`] and [`StorageType`] iterators must correspond to the
 ///   [`BundleInfo`](crate::bundle::BundleInfo) used to construct [`BundleInserter`]
+/// - Both iterators must yield the same number of items. If the [`OwningPtr`]
+///   iterator is shorter, some component columns will be left uninitialized,
+///   resulting in undefined behavior.
 /// - [`Entity`] must correspond to [`EntityLocation`]
 unsafe fn insert_dynamic_bundle<
     'a,


### PR DESCRIPTION
`insert_by_ids` is `unsafe`, but its Safety docs never said the iterator has to match the length of `component_ids`. The internal pairing uses `zip`, so a short iterator silently gets truncated while `Table::allocate` has already reserved all the columns. Reading them later is UB.

Three changes in `crates/bevy_ecs/src/world/entity_access/`:

- Update the Safety docs on `insert_by_ids` to require an exact length match.
- Update the Safety docs on `insert_dynamic_bundle` to say both iterators must match.
- In `insert_by_ids_internal`, collect the iterator in debug builds and `debug_assert_eq!` its length against `component_ids.len()`. Gated on `#[cfg(debug_assertions)]`, so release builds are unchanged.

Added two `#[should_panic]` tests in `entity_access::mod.rs`:

- `insert_by_ids_short_iterator_panics_in_debug` (2 IDs, 1 component)
- `insert_by_ids_long_iterator_panics_in_debug` (1 ID, 2 components)

All 71 existing `entity_access` tests still pass. `cargo check -p bevy_ecs` is clean in both debug and release.

The other two callers of `insert_by_ids_internal` (`bundle::writer` and `entity::clone_entities`) always pass matching lengths, so they're unaffected.