### PR TITLE
Mark RawHandleWrapper::set_display_handle as unsafe

### DIFF
--- a/crates/bevy_window/src/raw_handle.rs
+++ b/crates/bevy_window/src/raw_handle.rs
@@ -112,7 +112,7 @@ impl RawHandleWrapper {
     /// # Safety
     ///
     /// The passed in [`RawDisplayHandle`] must be a valid display handle.
-    pub fn set_display_handle(&mut self, display_handle: RawDisplayHandle) -> &mut Self {
+    pub unsafe fn set_display_handle(&mut self, display_handle: RawDisplayHandle) -> &mut Self {
         self.display_handle = display_handle;
 
         self


### PR DESCRIPTION
# Objective

- Fix a soundness issue in `RawHandleWrapper::set_display_handle`.
- `set_display_handle` is currently a safe function even though its documentation requires the provided `RawDisplayHandle` to be valid.
- Safe Rust can construct a `RawDisplayHandle` containing a non-null but invalid platform pointer and pass it to this method. Bevy may later use that value with `DisplayHandle::borrow_raw` or `wgpu::Instance::create_surface_unsafe`, both of which rely on the raw display handle being valid.
- This allows safe code to violate an invariant relied upon by unsafe code.
- This also makes `set_display_handle` inconsistent with `set_window_handle`, which already enforces the equivalent requirement through an unsafe function.

## Solution

I take the minimal fix:

- Mark `RawHandleWrapper::set_display_handle` as `unsafe`.

## Testing

I didn't check any test about this PR because I can't find any place that use `set_display_handle`. So I think this change no need to do any test. 