### PR TITLE
Fix: overlapping light probes overwrite (instead of accumulate) diffuse IBL

### DIFF
--- a/crates/bevy_pbr/src/light_probe/environment_map.wgsl
+++ b/crates/bevy_pbr/src/light_probe/environment_map.wgsl
@@ -181,7 +181,7 @@ fn compute_radiances(
                 parallax_correct,
                 view_rotation,
             );
-            radiances.irradiance = textureSampleLevel(
+            radiances.irradiance += textureSampleLevel(
                 bindings::diffuse_environment_maps[query_result.texture_index],
                 bindings::environment_map_sampler,
                 irradiance_sample_dir,


### PR DESCRIPTION
# Objective

Fix a typo in `bevy_pbr/light_probe/environment_map.wgsl` where illumination from diffused image based lighting was being assigned (=) instead of add assigned (+=).

Minimal repo:
```rust
use bevy::prelude::*;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .run();
}

fn setup(
    mut commands: Commands,
    mut meshes: ResMut<Assets<Mesh>>,
    mut materials: ResMut<Assets<StandardMaterial>>,
    mut images: ResMut<Assets<Image>>,
) {
    commands.spawn((
        LightProbe {
            falloff: Vec3::new(0.125, 0.0, 0.0),
        },
        EnvironmentMapLight::solid_color(&mut images, Srgba::RED).with_intensity(4000.0),
        Transform::from_xyz(-0.5, 0.0, 0.0).with_scale(Vec3::splat(2.0)),
    ));

    commands.spawn((
        LightProbe {
            falloff: Vec3::new(0.125, 0.0, 0.0),
        },
        EnvironmentMapLight::solid_color(&mut images, Srgba::GREEN).with_intensity(4000.0),
        Transform::from_xyz(0.5, 0.0, 0.0).with_scale(Vec3::splat(2.0)),
    ));

    commands.spawn((
        Mesh3d(meshes.add(Sphere::new(1.0).mesh().ico(16).unwrap())),
        MeshMaterial3d(materials.add(StandardMaterial::default())),
    ));

    commands.spawn((
        Camera3d::default(),
        Transform::from_xyz(0.0, 0.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
    ));
}
```

---

## Showcase

Before:

https://github.com/user-attachments/assets/c2b4d344-609e-4f2f-9a30-d262f459415d

After:

<img width="2560" height="1440" alt="Screenshot From 2026-08-02 19-53-03" src="https://github.com/user-attachments/assets/ca36db3f-5b94-4621-b178-5e32ab2d834f" />
