### PR TITLE
Fix: clearcoat make emissive materials too dark

### DIFF
--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -845,7 +845,8 @@ fn apply_pbr_lighting(
     //
     // <https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_clearcoat/README.md#emission>
 #ifdef STANDARD_MATERIAL_CLEARCOAT
-    emissive_light = emissive_light * (0.04 + (1.0 - 0.04) * pow(1.0 - clearcoat_NdotV, 5.0));
+    let clearcoat_fresnel = (0.04 + (1.0 - 0.04) * pow(1.0 - clearcoat_NdotV, 5.0));
+    emissive_light = emissive_light * (1.0 - clearcoat * clearcoat_fresnel);
 #endif
 
     emissive_light = emissive_light * mix(1.0, view_bindings::view.exposure, emissive.a);


### PR DESCRIPTION
# Objective

https://github.com/bevyengine/bevy/blob/25368b78ce5e9b15dc770cdf2af4595602cc8a7b/crates/bevy_pbr/src/render/pbr_functions.wgsl#L843-L848

This mistakenly applies `emissive_light = emissive_light * clearcoat_fresnel` instead of `emissive_light = emissive_light * (1 - clearcoat * clearcoat_fresnel)`. The formula to compute the emissive_light is taken from https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_clearcoat/README.md#emission (the link from the code comment in the code snippet above).

Minimal Repo:
```rust
use bevy::prelude::*;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .run();
}

fn setup(
    mut commands: Commands,
    mut meshes: ResMut<Assets<Mesh>>,
    mut materials: ResMut<Assets<StandardMaterial>>,
) {
    let sphere = meshes.add(Sphere::new(1.0).mesh().ico(16).unwrap());

    let base = StandardMaterial {
        base_color: Color::BLACK,
        emissive: LinearRgba::rgb(1.0, 1.0, 1.0),
        ..default()
    };

    // Left: no clearcoat.
    commands.spawn((
        Mesh3d(sphere.clone()),
        MeshMaterial3d(materials.add(base.clone())),
        Transform::from_xyz(-1.5, 0.0, 0.0),
    ));

    // Right: clearcoat 0.5 — per spec this should dim emission only slightly.
    commands.spawn((
        Mesh3d(sphere),
        MeshMaterial3d(materials.add(StandardMaterial {
            clearcoat: 0.5,
            clearcoat_perceptual_roughness: 0.1,
            ..base
        })),
        Transform::from_xyz(1.5, 0.0, 0.0),
    ));

    commands.spawn((
        Camera3d::default(),
        Transform::from_xyz(0.0, 0.0, 7.0).looking_at(Vec3::ZERO, Vec3::Y),
    ));
}
```

---

## Showcase

Before:
<img width="2560" height="1440" alt="Screenshot From 2026-08-02 20-40-33" src="https://github.com/user-attachments/assets/b0342f2c-6393-41bd-a65e-d9799579f51a" />

After:
<img width="2560" height="1440" alt="Screenshot From 2026-08-02 20-40-12" src="https://github.com/user-attachments/assets/24551cd8-5226-48fd-b4be-cfff30421111" />
