### PR TITLE
Add explicit transfer safety requirement

### DIFF
--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -477,6 +477,10 @@ impl<'a, T, A: IsAligned> MovingPtr<'a, T, A> {
     /// - `inner` must have correct provenance to allow read and writes of the pointee type.
     /// - The lifetime `'a` must be constrained such that this [`MovingPtr`] will stay valid and nothing
     ///   else can read or mutate the pointee while this [`MovingPtr`] is live.
+    /// - This call transfers the right to move out of or drop the pointee to the returned
+    ///   [`MovingPtr`]. Once it has been used (moved out of, dropped, or forgotten), whatever
+    ///   previously owned `inner` must treat it as uninitialized and must not access or drop it
+    ///   as `T` again unless that location is properly reinitialized first.
     ///
     /// [properly aligned]: https://doc.rust-lang.org/std/ptr/index.html#alignment
     #[inline]
@@ -917,7 +921,13 @@ impl<'a, A: IsAligned> PtrMut<'a, A> {
     /// Transforms this [`PtrMut`] into an [`OwningPtr`]
     ///
     /// # Safety
-    /// Must have right to drop or move out of [`PtrMut`].
+    /// - The caller must have the right to drop or move out of the value behind this
+    ///   [`PtrMut`], i.e. no other code may treat that value as still being owned by
+    ///   whatever `self` was borrowed from.
+    /// - This call transfers that right to the returned [`OwningPtr`]. Once it has been
+    ///   used (read, dropped, or forgotten), whatever `self` was borrowed from must treat
+    ///   the pointee as uninitialized and must not access or drop it again unless that
+    ///   location is properly reinitialized first.
     #[inline]
     pub unsafe fn promote(self) -> OwningPtr<'a, A> {
         OwningPtr(self.0, PhantomData)
@@ -1002,6 +1012,10 @@ impl<'a, A: IsAligned> OwningPtr<'a, A> {
     /// - `inner` must have correct provenance to allow read and writes of the pointee type.
     /// - The lifetime `'a` must be constrained such that this [`OwningPtr`] will stay valid and nothing
     ///   else can read or mutate the pointee while this [`OwningPtr`] is live.
+    /// - This call transfers the right to move out of or drop the pointee to the returned
+    ///   [`OwningPtr`]. Once it has been used (read, dropped, or forgotten), whatever
+    ///   previously owned `inner` must treat it as uninitialized and must not access or drop
+    ///   it again unless that location is properly reinitialized first.
     ///
     /// [properly aligned]: https://doc.rust-lang.org/std/ptr/index.html#alignment
     #[inline]


### PR DESCRIPTION
# Objective

- In bevy_ptr, [MovingPtr::new](https://github.com/bevyengine/bevy/blob/main/crates/bevy_ptr/src/lib.rs#L483), [PtrMut::promote](https://github.com/bevyengine/bevy/blob/main/crates/bevy_ptr/src/lib.rs#L922), and [OwningPtr::new](https://github.com/bevyengine/bevy/blob/main/crates/bevy_ptr/src/lib.rs#L1008) are unsafe methods that transfer the right to move out of / drop a pointee to the returned pointer type, but their `# Safety` docs never say so explicitly. They only state validity/alignment/provenance requirements for the pointer while it is live, and omit what the caller (or whatever previously owned the pointee) is required to do after the returned pointer has been consumed.
- This is a real contract gap: a caller could satisfy every bullet point as literally written, and still trigger a double-drop or use-after-move by continuing to access/drop the pointee through its original location after handing ownership to the new pointer. [MovingPtr::from_value](https://github.com/bevyengine/bevy/blob/main/crates/bevy_ptr/src/lib.rs#L461) already documents this exact invariant ("Once the returned MovingPtr has been used, value must be treated as if it were uninitialized unless it was explicitly leaked via mem::forget"), so the three sibling constructors were simply inconsistent/incomplete by comparison.

## Solution

- Added an explicit bullet to the # Safety docs of MovingPtr::new, PtrMut::promote, and OwningPtr::new stating that the call transfers move/drop rights to the returned pointer, and that once it has been used (moved out of, read, dropped, or forgotten), whatever previously owned the pointee must treat it as uninitialized and must not access or drop it again unless that location is properly reinitialized — matching the wording already used by MovingPtr::from_value.
- Doc-only change; no behavior was modified.

## Testing

- `cargo check -p bevy_ptr` passes; this is a doc comment change only, so no functional testing is needed.
- This is doc-only change, so I don't check any other tests.

Thank you for your review, and looking forward to your suggestion!
