### PR TITLE
Add missing safety requirement

### DIFF
--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -1121,7 +1121,12 @@ impl<'a, T> ThinSlicePtr<'a, T> {
     ///
     /// # Safety
     ///
-    /// `index` must be in-bounds.
+    /// - `index` must be in-bounds.
+    /// - For the entire lifetime `'a` of the returned reference, the value at `index` must not
+    ///   be mutated through any means other than the pointee's own interior mutability (e.g. if
+    ///   `T` is itself an [`UnsafeCell`]). This includes writes through a raw pointer and writes
+    ///   through an [`UnsafeCell`] this `ThinSlicePtr` was [cast](Self::cast) from: once cast,
+    ///   the memory is no longer treated as containing an `UnsafeCell` for aliasing purposes.
     #[inline]
     pub unsafe fn get_unchecked(&self, index: usize) -> &'a T {
         // We cannot use `debug_assert!` here because `self.len` does not exist when not in debug
@@ -1183,6 +1188,13 @@ impl<'a, T> ThinSlicePtr<'a, UnsafeCell<T>> {
     }
 
     /// Returns a slice pointer to the underlying type `T`.
+    ///
+    /// This does not by itself require `unsafe`, but it discards the [`UnsafeCell`] from the
+    /// pointee's type. Any subsequent unsafe call on the result (e.g.
+    /// [`get_unchecked`](ThinSlicePtr::get_unchecked) or
+    /// [`as_slice_unchecked`](ThinSlicePtr::as_slice_unchecked)) that hands out a `&T` therefore
+    /// requires, as part of its own safety contract, that nothing mutates the pointee through the
+    /// original [`UnsafeCell`] for as long as that `&T` is live.
     pub fn cast(&self) -> ThinSlicePtr<'a, T> {
         ThinSlicePtr {
             // SAFETY: `self.ptr` is non null hence `UnsafeCell::raw_get` always returns a non null pointer
@@ -1227,12 +1239,18 @@ mod private {
 /// Extension trait for helper methods on [`UnsafeCell`]
 pub trait UnsafeCellDeref<'a, T>: private::SealedUnsafeCell {
     /// # Safety
-    /// - The returned value must be unique and not alias any mutable or immutable references to the contents of the [`UnsafeCell`].
+    /// - For the entire lifetime `'a` of the returned reference, no other access to the contents
+    ///   of the [`UnsafeCell`] may exist or be created — neither a reference (mutable or
+    ///   immutable) nor a read or write through a raw pointer (e.g. via [`UnsafeCell::get`] or
+    ///   [`UnsafeCell::raw_get`]).
     /// - At all times, you must avoid data races. If multiple threads have access to the same [`UnsafeCell`], then any writes must have a proper happens-before relation to all other accesses or use atomics ([`UnsafeCell`] docs for reference).
     unsafe fn deref_mut(self) -> &'a mut T;
 
     /// # Safety
-    /// - For the lifetime `'a` of the returned value you must not construct a mutable reference to the contents of the [`UnsafeCell`].
+    /// - For the entire lifetime `'a` of the returned reference, the contents of the
+    ///   [`UnsafeCell`] must not be mutated by any means — neither by constructing a mutable
+    ///   reference to them, nor by writing through a raw pointer (e.g. via [`UnsafeCell::get`] or
+    ///   [`UnsafeCell::raw_get`]) — whether through this alias of the [`UnsafeCell`] or any other.
     /// - At all times, you must avoid data races. If multiple threads have access to the same [`UnsafeCell`], then any writes must have a proper happens-before relation to all other accesses or use atomics ([`UnsafeCell`] docs for reference).
     unsafe fn deref(self) -> &'a T;
 


### PR DESCRIPTION
# Objective

`bevy_ptr` exposes several `unsafe fn`s that hand out a plain `&T` (or `&mut T`) derived from memory that is, or was, wrapped in an `UnsafeCell`. Their `# Safety` sections document only part of what's actually required for soundness, omitting that the referenced memory must not be accessed *through a raw pointer* for the duration of the reference's lifetime. A caller who does nothing more than satisfy the contract as literally written can still produce undefined behavior.

This affects two independent call sites:

**1. `ThinSlicePtr::get_unchecked`**

```rust
/// # Safety
///
/// `index` must be in-bounds.
pub unsafe fn get_unchecked(&self, index: usize) -> &'a T { ... }
```

The only stated precondition is bounds-checking. `ThinSlicePtr<UnsafeCell<T>>` also exposes a fully **safe** `cast()` that returns a `ThinSlicePtr<T>` by discarding the `UnsafeCell` from the pointee's type via `UnsafeCell::raw_get`. Chaining `cast()` (safe) with `get_unchecked()` (unsafe, contract satisfied by bounds-checking alone) yields a `&T` while the original `UnsafeCell` handle is still around and can be legally written to — nothing in `get_unchecked`'s contract forbids it.

I reproduced this under Miri in a standalone crate (path dependency on `bevy_ptr`, no modification to this crate needed to trigger it):

```rust
use bevy_ptr::ThinSlicePtr;
use core::cell::UnsafeCell;

fn main() {
    let data = [UnsafeCell::new(1i32), UnsafeCell::new(2i32)];
    let cell_ptr: ThinSlicePtr<UnsafeCell<i32>> = ThinSlicePtr::from(&data[..]);
    let plain_ptr: ThinSlicePtr<i32> = cell_ptr.cast();          // safe
    let shared_ref: &i32 = unsafe { plain_ptr.get_unchecked(0) }; // contract: index in-bounds
    unsafe { *data[0].get() = 42; }                               // legal UnsafeCell write
    println!("{shared_ref}");                                     // UB
}
```

```text
error: Undefined Behavior: trying to retag from <470> for SharedReadOnly permission at alloc181[0x0], but that tag does not exist in the borrow stack for this location
    --> C:\Users\14798\.rustup\toolchains\nightly-x86_64-pc-windows-gnu\lib\rustlib\src\rust\library\core\src\fmt\mod.rs:2872:71
     |
2872 |             fn fmt(&self, f: &mut Formatter<'_>) -> Result { $tr::fmt(&**self, f) }
     |                                                                       ^^^^^^^ this error occurs as part of retag at alloc181[0x0..0x4]
...
2882 | fmt_refs! { Debug, Display, Octal, Binary, LowerHex, UpperHex, LowerExp, UpperExp }
     | ----------------------------------------------------------------------------------- in this macro invocation
     |
     = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
     = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <470> was created by a SharedReadOnly retag at offsets [0x0..0x4]
    --> src\main.rs:28:37
     |
  28 |     let shared_ref: &i32 = unsafe { plain_ptr.get_unchecked(0) };
     |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
help: <470> was later invalidated at offsets [0x0..0x4] by a write access
    --> src\main.rs:35:9
     |
  35 |         *data[0].get() = 42;
     |         ^^^^^^^^^^^^^^^^^^^
error: aborting due to 1 previous error

```

**2. `UnsafeCellDeref::deref` and `UnsafeCellDeref::deref_mut`**

```rust
/// # Safety
/// - The returned value must be unique and not alias any mutable or immutable references to the contents of the [`UnsafeCell`].
/// - At all times, you must avoid data races. ...
unsafe fn deref_mut(self) -> &'a mut T;

/// # Safety
/// - For the lifetime `'a` of the returned value you must not construct a mutable reference to the contents of the [`UnsafeCell`].
/// - At all times, you must avoid data races. ...
unsafe fn deref(self) -> &'a T;
```

Both contracts are phrased in terms of *references*. `deref`'s wording forbids only *constructing a `&mut T`*; `deref_mut`'s wording forbids only *aliasing references*. Neither says anything about a raw pointer obtained from a *different* alias of the same `UnsafeCell` (e.g. via `UnsafeCell::get`/ `raw_get`) — which is not a "reference" under either wording, and is the ordinary, intended way to use an `UnsafeCell`. A caller can satisfy both contracts to the letter while still causing UB.

For `deref` — a raw-pointer *write* through a different alias, never
constructing a `&mut T`:

```rust
use bevy_ptr::UnsafeCellDeref;
use core::cell::UnsafeCell;

fn main() {
    let cell = UnsafeCell::new(1i32);
    let a: &UnsafeCell<i32> = &cell;
    let b: &UnsafeCell<i32> = &cell;

    let shared: &i32 = unsafe { a.deref() };   // contract: never construct a `&mut`
    unsafe { *b.get() = 42; }                  // legal UnsafeCell write via a different alias
    println!("{shared}");                      // UB
}
```

```text
error: Undefined Behavior: trying to retag from <441> for SharedReadOnly permission
       at alloc180[0x0], but that tag does not exist in the borrow stack for this location
help: <441> was created by a SharedReadOnly retag at offsets [0x0..0x4]
    --> examples\deref.rs:19:33
     |  let shared: &i32 = unsafe { a.deref() };
help: <441> was later invalidated at offsets [0x0..0x4] by a write access
    --> examples\deref.rs:25:9
     |  *b.get() = 42;
```

For `deref_mut` the same gap exists but is sharper: a mutable reference forbids *any* other access — not just writes, reads too — yet the wording only mentions "references", so a raw-pointer *read* through a different alias also violates the real contract while complying with the stated one:

```rust
use bevy_ptr::UnsafeCellDeref;
use core::cell::UnsafeCell;

fn main() {
    let cell = UnsafeCell::new(1i32);
    let a: &UnsafeCell<i32> = &cell;
    let b: &UnsafeCell<i32> = &cell;

    let exclusive: &mut i32 = unsafe { a.deref_mut() }; // contract: no aliasing *references*
    *exclusive = 10;
    let snooped = unsafe { *b.get() };                  // not a reference, just a raw-pointer read
    *exclusive += 1;                                     // UB
}
```

```text
error: Undefined Behavior: attempting a read access using <444> at alloc180[0x0],
       but that tag does not exist in the borrow stack for this location
  --> examples\deref_mut.rs:26:5
   |  *exclusive += 1;
help: <444> was created by a Unique retag at offsets [0x0..0x4]
  --> examples\deref_mut.rs:18:40
   |  let exclusive: &mut i32 = unsafe { a.deref_mut() };
help: <444> was later invalidated at offsets [0x0..0x4] by a read access
  --> examples\deref_mut.rs:22:28
   |  let snooped = unsafe { *b.get() };
```

Note the invalidating event here is a **read**, not a write. The read at `*b.get()` is a plain raw-pointer access — it does not construct any reference — but it still counts as "access... through another pointer" under Rust's aliasing rule for the mutable reference `exclusive` already holds, and that rule is what the old wording ("not alias any... references") failed to make explicit:

- Shared reference: "while this reference exists, the memory it points to must not get mutated (except inside `UnsafeCell`)."
- Mutable reference: "while this reference exists, the memory it points to must not get accessed (read or written) through any other pointer or reference not derived from this reference."

Both are "public unsafe contract gap" issues: not a currently-exploited bug in this crate's own callers, but an incomplete `# Safety` section that a compliant downstream caller could follow to undefined behavior.

## Solution

Complete the `# Safety` documentation on all three already-`unsafe fn`s so they state the actual precondition Rust's aliasing rules require, not just "don't construct a `&mut`" / "don't alias a reference":

- `ThinSlicePtr::get_unchecked`: added the missing no-concurrent-mutation clause, explicitly calling out that this also covers writes through an `UnsafeCell` the pointer was `cast()` from.
- `ThinSlicePtr<UnsafeCell<T>>::cast()`: added an explanatory (non-`# Safety`, since the function itself does no dereference) doc note connecting it to the contract above, so a reader doesn't have to piece the two together.
- `UnsafeCellDeref::deref`: replaced "must not construct a mutable reference" with the full "must not be mutated by any means, including a raw-pointer write" wording.
- `UnsafeCellDeref::deref_mut`: replaced "must be unique and not alias any mutable or immutable references" with wording that also covers raw-pointer reads and writes, matching the "no access at all" requirement of a real mutable reference.

This is a documentation-only change. 

## Testing

- `cargo check -p bevy_ptr` — passes.
- All three pocs prove trigger UB. 
