### PR TITLE
Use `None` instead of `Confined` fallback for `CursorGrabMode`

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -764,11 +764,9 @@ pub struct CursorOptions {
     ///
     /// ## Platform-specific
     ///
-    /// - **`macOS`** doesn't support [`CursorGrabMode::Confined`]
-    /// - **`X11`** doesn't support [`CursorGrabMode::Locked`]
+    /// - **`macOS`** doesn't support [`CursorGrabMode::Confined`] and falls back to [`CursorGrabMode::None`].
+    /// - **`X11`** doesn't support [`CursorGrabMode::Locked`] and falls back to [`CursorGrabMode::Confined`].
     /// - **`iOS/Android`** don't have cursors.
-    ///
-    /// Since `macOS` and `X11` don't have full [`CursorGrabMode`] support, we first try to set the grab mode that was asked for. If it doesn't work then use the alternate grab mode.
     pub grab_mode: CursorGrabMode,
 
     /// Set whether or not mouse events within *this* window are captured or fall through to the Window below.
@@ -1065,11 +1063,9 @@ impl From<UVec2> for WindowResolution {
 ///
 /// ## Platform-specific
 ///
-/// - **`macOS`** doesn't support [`CursorGrabMode::Confined`]
-/// - **`X11`** doesn't support [`CursorGrabMode::Locked`]
+/// - **`macOS`** doesn't support [`CursorGrabMode::Confined`] and falls back to [`CursorGrabMode::None`].
+/// - **`X11`** doesn't support [`CursorGrabMode::Locked`] and falls back to [`CursorGrabMode::Confined`].
 /// - **`iOS/Android`** don't have cursors.
-///
-/// Since `macOS` and `X11` don't have full [`CursorGrabMode`] support, we first try to set the grab mode that was asked for. If it doesn't work then use the alternate grab mode.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -444,7 +444,7 @@ pub(crate) fn attempt_grab(
         CursorGrabMode::None => winit_window.set_cursor_grab(WinitCursorGrabMode::None),
         CursorGrabMode::Confined => winit_window
             .set_cursor_grab(WinitCursorGrabMode::Confined)
-            .or_else(|_e| winit_window.set_cursor_grab(WinitCursorGrabMode::Locked)),
+            .or_else(|_e| winit_window.set_cursor_grab(WinitCursorGrabMode::None)),
         CursorGrabMode::Locked => winit_window
             .set_cursor_grab(WinitCursorGrabMode::Locked)
             .or_else(|_e| winit_window.set_cursor_grab(WinitCursorGrabMode::Confined)),


### PR DESCRIPTION
# Objective

MacOS does not support `CursorGrabMode::Confined`, and falls back to `Locked`. This is problematic, as `Confined` is used for dragging gizmos. The result is that Mac users cannot interact.

This should fix #18732 #24476

## Solution

This PR changes the fallback for when `Confined` does not exist to `None`, instead of `Confined`. There does not appear to be a nice fallback that retains the functionality of `Confined`, but I believe using `None` is an OK tradeoff, and will re-enable mac functionality.

## Testing

Changes were tested by changing the problematic line and testing an example on MacOS, setting the cursor to `Confined`. Before the change, the cursor is locked. After the change, it is freed.

I also tested the transform gizmo example on Mac which is now working.

Note this may have consequences if users are relying on this fallback behavior for Mac.

I have only tested this on Mac. Viewing the code, it appears that the other exception (X11) would be unaffected. I don't know much about web.

