### PR TITLE
Mutate Event/Hook

### DIFF
--- a/crates/bevy_ecs/macro_logic/src/component.rs
+++ b/crates/bevy_ecs/macro_logic/src/component.rs
@@ -33,6 +33,8 @@ pub struct DeriveComponent {
     pub on_add: Option<HookAttributeKind>,
     /// The `on_insert` hook.
     pub on_insert: Option<HookAttributeKind>,
+    /// The "on_mutate" hook.
+    pub on_mutate: Option<HookAttributeKind>,
     /// The `on_discard` hook.
     pub on_discard: Option<HookAttributeKind>,
     /// The `on_remove` hook.
@@ -62,6 +64,7 @@ impl DeriveComponent {
             storage: None,
             on_add: None,
             on_insert: None,
+            on_mutate: None,
             on_discard: None,
             on_remove: None,
             on_despawn: None,
@@ -100,6 +103,11 @@ impl DeriveComponent {
                     } else if nested.path.is_ident(ON_INSERT) {
                         attrs.on_insert = Some(HookAttributeKind::parse(nested.input, || {
                             parse_quote! { Self::on_insert }
+                        })?);
+                        Ok(())
+                    } else if nested.path.is_ident(ON_MUTATE) {
+                        attrs.on_mutate = Some(HookAttributeKind::parse(nested.input, || {
+                            parse_quote! { Self::on_mutate }
                         })?);
                         Ok(())
                     } else if nested.path.is_ident(ON_DISCARD) {
@@ -240,14 +248,18 @@ impl DeriveComponent {
         let storage = storage_path(bevy_ecs, self.storage.unwrap_or(default_storage));
 
         let on_add_path = Vec::from_iter(self.on_add.map(|path| path.to_token_stream(bevy_ecs)));
-        let on_remove_path =
-            Vec::from_iter(self.on_remove.map(|path| path.to_token_stream(bevy_ecs)));
 
         let mut on_insert_path =
             Vec::from_iter(self.on_insert.map(|path| path.to_token_stream(bevy_ecs)));
 
+        let on_mutate_path =
+            Vec::from_iter(self.on_mutate.map(|path| path.to_token_stream(bevy_ecs)));
+
         let mut on_discard_path =
             Vec::from_iter(self.on_discard.map(|path| path.to_token_stream(bevy_ecs)));
+
+        let on_remove_path =
+            Vec::from_iter(self.on_remove.map(|path| path.to_token_stream(bevy_ecs)));
 
         let mut on_despawn_path =
             Vec::from_iter(self.on_despawn.map(|path| path.to_token_stream(bevy_ecs)));
@@ -269,6 +281,7 @@ impl DeriveComponent {
 
         let on_add = hook_register_function_call(bevy_ecs, quote! {on_add}, &on_add_path);
         let on_insert = hook_register_function_call(bevy_ecs, quote! {on_insert}, &on_insert_path);
+        let on_mutate = hook_register_function_call(bevy_ecs, quote! {on_mutate}, &on_mutate_path);
         let on_discard =
             hook_register_function_call(bevy_ecs, quote! {on_discard}, &on_discard_path);
         let on_remove = hook_register_function_call(bevy_ecs, quote! {on_remove}, &on_remove_path);
@@ -373,6 +386,7 @@ impl DeriveComponent {
 
                 #on_add
                 #on_insert
+                #on_mutate
                 #on_discard
                 #on_remove
                 #on_despawn
@@ -529,6 +543,7 @@ const RELATIONSHIP_TARGET: &str = "relationship_target";
 
 const ON_ADD: &str = "on_add";
 const ON_INSERT: &str = "on_insert";
+const ON_MUTATE: &str = "on_mutate";
 const ON_DISCARD: &str = "on_discard";
 const ON_REMOVE: &str = "on_remove";
 const ON_DESPAWN: &str = "on_despawn";

--- a/crates/bevy_ecs/macro_logic/src/component.rs
+++ b/crates/bevy_ecs/macro_logic/src/component.rs
@@ -33,6 +33,8 @@ pub struct DeriveComponent {
     pub on_add: Option<HookAttributeKind>,
     /// The `on_insert` hook.
     pub on_insert: Option<HookAttributeKind>,
+    /// The "on_mutate" hook.
+    pub on_mutate: Option<HookAttributeKind>,
     /// The `on_discard` hook.
     pub on_discard: Option<HookAttributeKind>,
     /// The `on_remove` hook.
@@ -60,6 +62,7 @@ impl DeriveComponent {
             storage: None,
             on_add: None,
             on_insert: None,
+            on_mutate: None,
             on_discard: None,
             on_remove: None,
             on_despawn: None,
@@ -97,6 +100,11 @@ impl DeriveComponent {
                     } else if nested.path.is_ident(ON_INSERT) {
                         attrs.on_insert = Some(HookAttributeKind::parse(nested.input, || {
                             parse_quote! { Self::on_insert }
+                        })?);
+                        Ok(())
+                    } else if nested.path.is_ident(ON_MUTATE) {
+                        attrs.on_mutate = Some(HookAttributeKind::parse(nested.input, || {
+                            parse_quote! { Self::on_mutate }
                         })?);
                         Ok(())
                     } else if nested.path.is_ident(ON_DISCARD) {
@@ -216,14 +224,18 @@ impl DeriveComponent {
         let storage = storage_path(bevy_ecs, self.storage.unwrap_or(default_storage));
 
         let on_add_path = Vec::from_iter(self.on_add.map(|path| path.to_token_stream(bevy_ecs)));
-        let on_remove_path =
-            Vec::from_iter(self.on_remove.map(|path| path.to_token_stream(bevy_ecs)));
 
         let mut on_insert_path =
             Vec::from_iter(self.on_insert.map(|path| path.to_token_stream(bevy_ecs)));
 
+        let on_mutate_path =
+            Vec::from_iter(self.on_mutate.map(|path| path.to_token_stream(bevy_ecs)));
+
         let mut on_discard_path =
             Vec::from_iter(self.on_discard.map(|path| path.to_token_stream(bevy_ecs)));
+
+        let on_remove_path =
+            Vec::from_iter(self.on_remove.map(|path| path.to_token_stream(bevy_ecs)));
 
         let mut on_despawn_path =
             Vec::from_iter(self.on_despawn.map(|path| path.to_token_stream(bevy_ecs)));
@@ -245,6 +257,7 @@ impl DeriveComponent {
 
         let on_add = hook_register_function_call(bevy_ecs, quote! {on_add}, &on_add_path);
         let on_insert = hook_register_function_call(bevy_ecs, quote! {on_insert}, &on_insert_path);
+        let on_mutate = hook_register_function_call(bevy_ecs, quote! {on_mutate}, &on_mutate_path);
         let on_discard =
             hook_register_function_call(bevy_ecs, quote! {on_discard}, &on_discard_path);
         let on_remove = hook_register_function_call(bevy_ecs, quote! {on_remove}, &on_remove_path);
@@ -349,6 +362,7 @@ impl DeriveComponent {
 
                 #on_add
                 #on_insert
+                #on_mutate
                 #on_discard
                 #on_remove
                 #on_despawn
@@ -503,6 +517,7 @@ const RELATIONSHIP_TARGET: &str = "relationship_target";
 
 const ON_ADD: &str = "on_add";
 const ON_INSERT: &str = "on_insert";
+const ON_MUTATE: &str = "on_mutate";
 const ON_DISCARD: &str = "on_discard";
 const ON_REMOVE: &str = "on_remove";
 const ON_DESPAWN: &str = "on_despawn";

--- a/crates/bevy_ecs/macro_logic/src/component.rs
+++ b/crates/bevy_ecs/macro_logic/src/component.rs
@@ -33,7 +33,7 @@ pub struct DeriveComponent {
     pub on_add: Option<HookAttributeKind>,
     /// The `on_insert` hook.
     pub on_insert: Option<HookAttributeKind>,
-    /// The "on_mutate" hook.
+    /// The `on_mutate` hook.
     pub on_mutate: Option<HookAttributeKind>,
     /// The `on_discard` hook.
     pub on_discard: Option<HookAttributeKind>,

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -324,6 +324,7 @@ impl Edges {
 }
 
 /// Metadata about an [`Entity`] in a [`Archetype`].
+#[derive(Clone, Copy)]
 pub struct ArchetypeEntity {
     entity: Entity,
     table_row: TableRow,
@@ -369,14 +370,16 @@ bitflags::bitflags! {
     pub(crate) struct ArchetypeFlags: u32 {
         const ON_ADD_HOOK    = (1 << 0);
         const ON_INSERT_HOOK = (1 << 1);
-        const ON_DISCARD_HOOK = (1 << 2);
-        const ON_REMOVE_HOOK = (1 << 3);
-        const ON_DESPAWN_HOOK = (1 << 4);
-        const ON_ADD_OBSERVER = (1 << 5);
-        const ON_INSERT_OBSERVER = (1 << 6);
-        const ON_DISCARD_OBSERVER = (1 << 7);
-        const ON_REMOVE_OBSERVER = (1 << 8);
-        const ON_DESPAWN_OBSERVER = (1 << 9);
+        const ON_MUTATE_HOOK = (1 << 2);
+        const ON_DISCARD_HOOK = (1 << 3);
+        const ON_REMOVE_HOOK = (1 << 4);
+        const ON_DESPAWN_HOOK = (1 << 5);
+        const ON_ADD_OBSERVER = (1 << 6);
+        const ON_INSERT_OBSERVER = (1 << 7);
+        const ON_MUTATE_OBSERVER = (1 << 8);
+        const ON_DISCARD_OBSERVER = (1 << 9);
+        const ON_REMOVE_OBSERVER = (1 << 10);
+        const ON_DESPAWN_OBSERVER = (1 << 11);
     }
 }
 
@@ -686,6 +689,12 @@ impl Archetype {
         self.flags().contains(ArchetypeFlags::ON_INSERT_HOOK)
     }
 
+    /// Returns true if any of the components in this archetype have `on_mutate` hooks
+    #[inline]
+    pub fn has_mutate_hook(&self) -> bool {
+        self.flags().contains(ArchetypeFlags::ON_MUTATE_HOOK)
+    }
+
     /// Returns true if any of the components in this archetype have `on_discard` hooks
     #[inline]
     pub fn has_discard_hook(&self) -> bool {
@@ -718,6 +727,14 @@ impl Archetype {
     #[inline]
     pub fn has_insert_observer(&self) -> bool {
         self.flags().contains(ArchetypeFlags::ON_INSERT_OBSERVER)
+    }
+
+    /// Returns true if any of the components in this archetype have at least one [`Mutate`] observer
+    ///
+    /// [`Mutate`]: crate::lifecycle::Mutate
+    #[inline]
+    pub fn has_mutate_observer(&self) -> bool {
+        self.flags().contains(ArchetypeFlags::ON_MUTATE_OBSERVER)
     }
 
     /// Returns true if any of the components in this archetype have at least one [`Discard`] observer
@@ -785,6 +802,7 @@ pub struct Archetypes {
 }
 
 /// Metadata about how a component is stored in an [`Archetype`].
+#[derive(Clone, Copy)]
 pub struct ArchetypeRecord {
     /// Index of the component in the archetype's [`Table`](crate::storage::Table),
     /// or None if the component is a sparse set component.

--- a/crates/bevy_ecs/src/component/constants.rs
+++ b/crates/bevy_ecs/src/component/constants.rs
@@ -4,13 +4,15 @@
 pub const ADD: usize = 0;
 /// `usize` for the [`Insert`](crate::lifecycle::Insert) component used in lifecycle observers.
 pub const INSERT: usize = 1;
+/// `usize` for the [`Mutate`](crate::lifecycle::Mutate) component used in lifecycle observers.
+pub const MUTATE: usize = 2;
 /// `usize` for the [`Discard`](crate::lifecycle::Discard) component used in lifecycle observers.
-pub const DISCARD: usize = 2;
+pub const DISCARD: usize = 3;
 /// `usize` for the [`Remove`](crate::lifecycle::Remove) component used in lifecycle observers.
-pub const REMOVE: usize = 3;
+pub const REMOVE: usize = 4;
 /// `usize` for [`Despawn`](crate::lifecycle::Despawn) component used in lifecycle observers.
-pub const DESPAWN: usize = 4;
+pub const DESPAWN: usize = 5;
 /// `usize` of the [`IsResource`](crate::resource::IsResource) component used to mark entities with resources.
-pub const IS_RESOURCE: usize = 5;
+pub const IS_RESOURCE: usize = 6;
 /// `usize` for [`ArchetypeCreated`](crate::archetype::ArchetypeCreated) component used as an observer event key.
-pub(crate) const ARCHETYPE_CREATED: usize = 6;
+pub(crate) const ARCHETYPE_CREATED: usize = 7;

--- a/crates/bevy_ecs/src/component/info.rs
+++ b/crates/bevy_ecs/src/component/info.rs
@@ -129,6 +129,9 @@ impl ComponentInfo {
         if self.hooks().on_insert.is_some() {
             flags.insert(ArchetypeFlags::ON_INSERT_HOOK);
         }
+        if self.hooks().on_mutate.is_some() {
+            flags.insert(ArchetypeFlags::ON_MUTATE_HOOK);
+        }
         if self.hooks().on_discard.is_some() {
             flags.insert(ArchetypeFlags::ON_DISCARD_HOOK);
         }

--- a/crates/bevy_ecs/src/component/info.rs
+++ b/crates/bevy_ecs/src/component/info.rs
@@ -121,6 +121,9 @@ impl ComponentInfo {
         if self.hooks().on_insert.is_some() {
             flags.insert(ArchetypeFlags::ON_INSERT_HOOK);
         }
+        if self.hooks().on_mutate.is_some() {
+            flags.insert(ArchetypeFlags::ON_MUTATE_HOOK);
+        }
         if self.hooks().on_discard.is_some() {
             flags.insert(ArchetypeFlags::ON_DISCARD_HOOK);
         }

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -549,6 +549,11 @@ pub trait Component: Send + Sync + 'static {
         None
     }
 
+    /// Gets the `on_mutate` [`ComponentHook`] for this [`Component`] if one is defined.
+    fn on_mutate() -> Option<ComponentHook> {
+        None
+    }
+
     /// Gets the `on_discard` [`ComponentHook`] for this [`Component`] if one is defined.
     fn on_discard() -> Option<ComponentHook> {
         None
@@ -770,6 +775,12 @@ pub enum StorageType {
     Table,
     /// Provides fast addition and removal of components, but slower iteration.
     SparseSet,
+}
+
+/// A trait to get the [`ComponentId`]s an type contains.
+pub trait ContainsComponents {
+    /// Gets the [`ComponentId`]s
+    fn components(&self) -> &[ComponentId];
 }
 
 /// A [`SystemParam`] that provides access to the [`ComponentId`] for a specific component type.

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -530,6 +530,11 @@ pub trait Component: Send + Sync + 'static {
         None
     }
 
+    /// Gets the `on_mutate` [`ComponentHook`] for this [`Component`] if one is defined.
+    fn on_mutate() -> Option<ComponentHook> {
+        None
+    }
+
     /// Gets the `on_discard` [`ComponentHook`] for this [`Component`] if one is defined.
     fn on_discard() -> Option<ComponentHook> {
         None
@@ -732,6 +737,12 @@ pub enum StorageType {
     Table,
     /// Provides fast addition and removal of components, but slower iteration.
     SparseSet,
+}
+
+/// A trait to get the [`ComponentId`]s an type contains.
+pub trait ContainsComponents {
+    /// Gets the [`ComponentId`]s
+    fn components(&self) -> &[ComponentId];
 }
 
 /// A [`SystemParam`] that provides access to the [`ComponentId`] for a specific component type.

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -1,3 +1,4 @@
+use crate::component::ContainsComponents;
 use crate::event::{EventPattern, SetEntityEventTarget};
 use crate::{
     archetype::Archetype,
@@ -8,6 +9,7 @@ use crate::{
     traversal::Traversal,
     world::DeferredWorld,
 };
+use alloc::vec::Vec;
 use bevy_ptr::PtrMut;
 use core::{fmt, marker::PhantomData};
 
@@ -480,6 +482,123 @@ impl<'a> EntityComponentsTrigger<'a> {
 
         // Trigger observers watching for a specific component
         for id in self.components {
+            if let Some(component_observers) = observers.component_observers().get(id) {
+                for (observer, runner) in component_observers.global_observers() {
+                    // SAFETY:
+                    // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
+                    // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
+                    // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
+                    // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
+                    unsafe {
+                        (runner)(
+                            world.reborrow(),
+                            *observer,
+                            trigger_context,
+                            event.reborrow(),
+                            self.into(),
+                        );
+                    }
+                }
+
+                if let Some(map) = component_observers
+                    .entity_component_observers()
+                    .get(&entity)
+                {
+                    for (observer, runner) in map {
+                        // SAFETY:
+                        // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
+                        // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
+                        // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
+                        // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
+                        unsafe {
+                            (runner)(
+                                world.reborrow(),
+                                *observer,
+                                trigger_context,
+                                event.reborrow(),
+                                self.into(),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// An [`EntityEvent`] [`Trigger`] that, in addition to behaving like a normal [`EntityTrigger`], _also_ runs observers
+/// that watch for components that match the [`impl Iterator<Item=ComponentId>`] returned by [`ContainsComponents::components`]. This includes
+/// both _global_ observers of those components and "entity scoped" observers that watch the [`EntityEvent::event_target`].
+///
+/// This is used by Bevy's built-in [lifecycle events](crate::lifecycle).
+#[derive(Default, Debug)]
+pub struct EntityMutateTrigger;
+
+// SAFETY:
+// - `E`'s [`Event::Trigger`] is constrained to [`EntityComponentsTrigger`]
+unsafe impl<E: EntityEvent + for<'a> Event<Trigger<'a> = EntityMutateTrigger> + ContainsComponents>
+    Trigger<E> for EntityMutateTrigger
+{
+    unsafe fn trigger(
+        &mut self,
+        world: DeferredWorld,
+        observers: &CachedObservers,
+        trigger_context: &TriggerContext,
+        event: &mut E,
+    ) {
+        let entity = event.event_target();
+        let components: Vec<ComponentId> = event.components().into();
+        // SAFETY:
+        // - `observers` come from `world` and match the event type `E`, enforced by the call to `trigger`
+        // - the passed in event pointer comes from `event`, which is an `Event`
+        // - the passed in components comes from 'event', and will live not outlive the event pointer.
+        // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger`
+        unsafe {
+            self.trigger_internal(
+                world,
+                observers,
+                event.into(),
+                entity,
+                &components,
+                trigger_context,
+            );
+        }
+    }
+}
+
+impl EntityMutateTrigger {
+    /// # Safety
+    /// - `observers` must come from the `world` [`DeferredWorld`]
+    /// - `event` must point to an [`Event`] whose [`Event::Trigger`] is [`EntityComponentsTrigger`]
+    /// - `trigger_context`'s [`TriggerContext::event_key`] must correspond to the `event` type.
+    #[inline(never)]
+    unsafe fn trigger_internal(
+        &mut self,
+        mut world: DeferredWorld,
+        observers: &CachedObservers,
+        mut event: PtrMut,
+        entity: Entity,
+        components: &[ComponentId],
+        trigger_context: &TriggerContext,
+    ) {
+        // SAFETY:
+        // - `observers` come from `world` and match the event type `E`, enforced by the call to `trigger`
+        // - the passed in event pointer comes from `event`, which is an `Event`
+        // - `trigger` is a matching trigger type, as it comes from `self`, which is the Trigger for `E`
+        // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger`
+        unsafe {
+            trigger_entity_internal(
+                world.reborrow(),
+                observers,
+                event.reborrow(),
+                self.into(),
+                entity,
+                trigger_context,
+            );
+        }
+
+        // Trigger observers watching for a specific component
+        for id in components {
             if let Some(component_observers) = observers.component_observers().get(id) {
                 for (observer, runner) in component_observers.global_observers() {
                     // SAFETY:

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -1,3 +1,4 @@
+use crate::component::ContainsComponents;
 use crate::event::SetEntityEventTarget;
 use crate::{
     archetype::Archetype,
@@ -8,6 +9,7 @@ use crate::{
     traversal::Traversal,
     world::DeferredWorld,
 };
+use alloc::vec::Vec;
 use bevy_ptr::PtrMut;
 use core::{fmt, marker::PhantomData};
 
@@ -477,6 +479,123 @@ impl<'a> EntityComponentsTrigger<'a> {
 
         // Trigger observers watching for a specific component
         for id in self.components {
+            if let Some(component_observers) = observers.component_observers().get(id) {
+                for (observer, runner) in component_observers.global_observers() {
+                    // SAFETY:
+                    // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
+                    // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
+                    // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
+                    // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
+                    unsafe {
+                        (runner)(
+                            world.reborrow(),
+                            *observer,
+                            trigger_context,
+                            event.reborrow(),
+                            self.into(),
+                        );
+                    }
+                }
+
+                if let Some(map) = component_observers
+                    .entity_component_observers()
+                    .get(&entity)
+                {
+                    for (observer, runner) in map {
+                        // SAFETY:
+                        // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
+                        // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
+                        // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
+                        // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
+                        unsafe {
+                            (runner)(
+                                world.reborrow(),
+                                *observer,
+                                trigger_context,
+                                event.reborrow(),
+                                self.into(),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// An [`EntityEvent`] [`Trigger`] that, in addition to behaving like a normal [`EntityTrigger`], _also_ runs observers
+/// that watch for components that match the [`impl Iterator<Item=ComponentId>`] returned by [`ContainsComponents::components`]. This includes
+/// both _global_ observers of those components and "entity scoped" observers that watch the [`EntityEvent::event_target`].
+///
+/// This is used by Bevy's built-in [lifecycle events](crate::lifecycle).
+#[derive(Default, Debug)]
+pub struct EntityMutateTrigger;
+
+// SAFETY:
+// - `E`'s [`Event::Trigger`] is constrained to [`EntityComponentsTrigger`]
+unsafe impl<E: EntityEvent + for<'a> Event<Trigger<'a> = EntityMutateTrigger> + ContainsComponents>
+    Trigger<E> for EntityMutateTrigger
+{
+    unsafe fn trigger(
+        &mut self,
+        world: DeferredWorld,
+        observers: &CachedObservers,
+        trigger_context: &TriggerContext,
+        event: &mut E,
+    ) {
+        let entity = event.event_target();
+        let components: Vec<ComponentId> = event.components().into();
+        // SAFETY:
+        // - `observers` come from `world` and match the event type `E`, enforced by the call to `trigger`
+        // - the passed in event pointer comes from `event`, which is an `Event`
+        // - the passed in components comes from 'event', and will live not outlive the event pointer.
+        // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger`
+        unsafe {
+            self.trigger_internal(
+                world,
+                observers,
+                event.into(),
+                entity,
+                &components,
+                trigger_context,
+            );
+        }
+    }
+}
+
+impl EntityMutateTrigger {
+    /// # Safety
+    /// - `observers` must come from the `world` [`DeferredWorld`]
+    /// - `event` must point to an [`Event`] whose [`Event::Trigger`] is [`EntityComponentsTrigger`]
+    /// - `trigger_context`'s [`TriggerContext::event_key`] must correspond to the `event` type.
+    #[inline(never)]
+    unsafe fn trigger_internal(
+        &mut self,
+        mut world: DeferredWorld,
+        observers: &CachedObservers,
+        mut event: PtrMut,
+        entity: Entity,
+        components: &[ComponentId],
+        trigger_context: &TriggerContext,
+    ) {
+        // SAFETY:
+        // - `observers` come from `world` and match the event type `E`, enforced by the call to `trigger`
+        // - the passed in event pointer comes from `event`, which is an `Event`
+        // - `trigger` is a matching trigger type, as it comes from `self`, which is the Trigger for `E`
+        // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger`
+        unsafe {
+            trigger_entity_internal(
+                world.reborrow(),
+                observers,
+                event.reborrow(),
+                self.into(),
+                entity,
+                trigger_context,
+            );
+        }
+
+        // Trigger observers watching for a specific component
+        for id in components {
             if let Some(component_observers) = observers.component_observers().get(id) {
                 for (observer, runner) in component_observers.global_observers() {
                     // SAFETY:

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -77,7 +77,7 @@ pub mod prelude {
         error::{BevyError, ContextExt, Result, ResultSeverityExt, Severity},
         event::{EntityEvent, Event},
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
-        lifecycle::{Add, Despawn, Discard, Insert, Remove, RemovedComponents},
+        lifecycle::{Add, Despawn, Discard, Insert, Mutate, Remove, RemovedComponents},
         message::{
             Message, MessageMutator, MessageReader, MessageWriter, Messages, PopulatedMessageReader,
         },

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -77,7 +77,7 @@ pub mod prelude {
         error::{BevyError, ContextExt, Result, ResultSeverityExt, Severity},
         event::{EntityEvent, Event, EventPattern},
         hierarchy::{ChildOf, ChildSpawner, ChildSpawnerCommands, Children},
-        lifecycle::{Add, Despawn, Discard, Insert, Remove, RemovedComponents},
+        lifecycle::{Add, Despawn, Discard, Insert, MutateEvent, Remove, RemovedComponents},
         message::{
             Message, MessageMutator, MessageReader, MessageWriter, Messages, PopulatedMessageReader,
         },

--- a/crates/bevy_ecs/src/lifecycle.rs
+++ b/crates/bevy_ecs/src/lifecycle.rs
@@ -53,9 +53,9 @@
 use crate::{
     bundle::Bundle,
     change_detection::{MaybeLocation, Tick},
-    component::{Component, ComponentId, ComponentIdFor},
+    component::{Component, ComponentId, ComponentIdFor, ContainsComponents},
     entity::Entity,
-    event::{EntityComponentsTrigger, EntityEvent, EventKey, EventPattern},
+    event::{EntityComponentsTrigger, EntityEvent, EntityMutateTrigger, EventKey, EventPattern},
     message::{
         Message, MessageCursor, MessageId, MessageIterator, MessageIteratorWithId, Messages,
     },
@@ -66,6 +66,7 @@ use crate::{
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
 };
 
+use alloc::vec::Vec;
 use derive_more::derive::Into;
 
 #[cfg(feature = "bevy_reflect")]
@@ -151,6 +152,7 @@ pub struct HookContext {
 pub struct ComponentHooks {
     pub(crate) on_add: Option<ComponentHook>,
     pub(crate) on_insert: Option<ComponentHook>,
+    pub(crate) on_mutate: Option<ComponentHook>,
     pub(crate) on_discard: Option<ComponentHook>,
     pub(crate) on_remove: Option<ComponentHook>,
     pub(crate) on_despawn: Option<ComponentHook>,
@@ -163,6 +165,9 @@ impl ComponentHooks {
         }
         if let Some(hook) = C::on_insert() {
             self.on_insert(hook);
+        }
+        if let Some(hook) = C::on_mutate() {
+            self.on_mutate(hook);
         }
         if let Some(hook) = C::on_discard() {
             self.on_discard(hook);
@@ -205,6 +210,16 @@ impl ComponentHooks {
     pub fn on_insert(&mut self, hook: ComponentHook) -> &mut Self {
         self.try_on_insert(hook)
             .expect("Component already has an on_insert hook")
+    }
+
+    /// Register a [`ComponentHook`] that will be run when this component is mutated (from mutable SystemParams).
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the component already has an `on_mutate` hook
+    pub fn on_mutate(&mut self, hook: ComponentHook) -> &mut Self {
+        self.try_on_mutate(hook)
+            .expect("Component already has an on_mutate hook")
     }
 
     /// Register a [`ComponentHook`] that will be run when this component is about to be dropped,
@@ -276,6 +291,19 @@ impl ComponentHooks {
         Some(self)
     }
 
+    /// Attempt to register a [`ComponentHook`] that will be run when this component is mutated (from mutable SystemParams)
+    ///
+    /// This is a fallible version of [`Self::on_mutate`].
+    ///
+    /// Returns `None` if the component already has an `on_mutate` hook.
+    pub fn try_on_mutate(&mut self, hook: ComponentHook) -> Option<&mut Self> {
+        if self.on_mutate.is_some() {
+            return None;
+        }
+        self.on_mutate = Some(hook);
+        Some(self)
+    }
+
     /// Attempt to register a [`ComponentHook`] that will be run when this component is replaced (with `.insert`) or removed
     ///
     /// This is a fallible version of [`Self::on_discard`].
@@ -320,6 +348,8 @@ impl ComponentHooks {
 pub const ADD: EventKey = EventKey(ComponentId::new(crate::component::ADD));
 /// [`EventKey`] for [`Insert`]
 pub const INSERT: EventKey = EventKey(ComponentId::new(crate::component::INSERT));
+/// [`EventKey`] for [`Mutate`]
+pub const MUTATE: EventKey = EventKey(ComponentId::new(crate::component::MUTATE));
 /// [`EventKey`] for [`Discard`]
 pub const DISCARD: EventKey = EventKey(ComponentId::new(crate::component::DISCARD));
 /// [`EventKey`] for [`Remove`]
@@ -381,6 +411,40 @@ impl<B: Bundle> EventPattern for Insert<B> {
     type Components = B;
 }
 
+/// Trigger emitted when a component is mutated.
+/// See [`ComponentHooks::on_mutate`](`crate::lifecycle::ComponentHooks::on_mutate`) for more information.
+#[derive(Debug, Clone, EntityEvent)]
+#[entity_event(trigger = EntityMutateTrigger)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
+pub struct MutateEvent {
+    /// Target Entity of the event.
+    pub entity: Entity,
+    /// Target Components of the event.
+    pub components: Vec<ComponentId>,
+}
+
+impl ContainsComponents for MutateEvent {
+    fn components(&self) -> &[ComponentId] {
+        return &self.components;
+    }
+}
+
+/// [`EventPattern`] for an [`MutateEvent`] on a given bundle of components.
+///
+/// # Note
+///
+/// All components specified in the [`Bundle`] are treated as an `OR` filter
+/// **not** an `AND` filter. For example, `Insert<(A, B)>` will trigger if
+/// either component `A` or component `B` is inserted into an entity.
+#[doc(alias = "OnMutate")]
+pub struct Mutate<B: Bundle>(PhantomData<B>);
+
+impl<B: Bundle> EventPattern for Mutate<B> {
+    type Event = MutateEvent;
+    type Components = B;
+}
+
 /// Trigger emitted when a component is removed from an entity, regardless
 /// of whether or not it is later replaced.
 ///
@@ -390,7 +454,6 @@ impl<B: Bundle> EventPattern for Insert<B> {
 #[entity_event(trigger = EntityComponentsTrigger<'a>)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
-
 pub struct DiscardEvent {
     /// The entity that held this component before it was discarded.
     pub entity: Entity,

--- a/crates/bevy_ecs/src/lifecycle.rs
+++ b/crates/bevy_ecs/src/lifecycle.rs
@@ -51,9 +51,9 @@
 //! This is used to skip [`TypeId`](core::any::TypeId) lookups in hot paths.
 use crate::{
     change_detection::{MaybeLocation, Tick},
-    component::{Component, ComponentId, ComponentIdFor},
+    component::{Component, ComponentId, ComponentIdFor, ContainsComponents},
     entity::Entity,
-    event::{EntityComponentsTrigger, EntityEvent, EventKey},
+    event::{EntityComponentsTrigger, EntityEvent, EntityMutateTrigger, EventKey},
     message::{
         Message, MessageCursor, MessageId, MessageIterator, MessageIteratorWithId, Messages,
     },
@@ -64,6 +64,7 @@ use crate::{
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
 };
 
+use alloc::vec::Vec;
 use derive_more::derive::Into;
 
 #[cfg(feature = "bevy_reflect")]
@@ -149,6 +150,7 @@ pub struct HookContext {
 pub struct ComponentHooks {
     pub(crate) on_add: Option<ComponentHook>,
     pub(crate) on_insert: Option<ComponentHook>,
+    pub(crate) on_mutate: Option<ComponentHook>,
     pub(crate) on_discard: Option<ComponentHook>,
     pub(crate) on_remove: Option<ComponentHook>,
     pub(crate) on_despawn: Option<ComponentHook>,
@@ -161,6 +163,9 @@ impl ComponentHooks {
         }
         if let Some(hook) = C::on_insert() {
             self.on_insert(hook);
+        }
+        if let Some(hook) = C::on_mutate() {
+            self.on_mutate(hook);
         }
         if let Some(hook) = C::on_discard() {
             self.on_discard(hook);
@@ -203,6 +208,16 @@ impl ComponentHooks {
     pub fn on_insert(&mut self, hook: ComponentHook) -> &mut Self {
         self.try_on_insert(hook)
             .expect("Component already has an on_insert hook")
+    }
+
+    /// Register a [`ComponentHook`] that will be run when this component is mutated (from mutable SystemParams).
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the component already has an `on_mutate` hook
+    pub fn on_mutate(&mut self, hook: ComponentHook) -> &mut Self {
+        self.try_on_mutate(hook)
+            .expect("Component already has an on_mutate hook")
     }
 
     /// Register a [`ComponentHook`] that will be run when this component is about to be dropped,
@@ -274,6 +289,19 @@ impl ComponentHooks {
         Some(self)
     }
 
+    /// Attempt to register a [`ComponentHook`] that will be run when this component is mutated (from mutable SystemParams)
+    ///
+    /// This is a fallible version of [`Self::on_mutate`].
+    ///
+    /// Returns `None` if the component already has an `on_mutate` hook.
+    pub fn try_on_mutate(&mut self, hook: ComponentHook) -> Option<&mut Self> {
+        if self.on_mutate.is_some() {
+            return None;
+        }
+        self.on_mutate = Some(hook);
+        Some(self)
+    }
+
     /// Attempt to register a [`ComponentHook`] that will be run when this component is replaced (with `.insert`) or removed
     ///
     /// This is a fallible version of [`Self::on_discard`].
@@ -318,6 +346,8 @@ impl ComponentHooks {
 pub const ADD: EventKey = EventKey(ComponentId::new(crate::component::ADD));
 /// [`EventKey`] for [`Insert`]
 pub const INSERT: EventKey = EventKey(ComponentId::new(crate::component::INSERT));
+/// [`EventKey`] for [`Mutate`]
+pub const MUTATE: EventKey = EventKey(ComponentId::new(crate::component::MUTATE));
 /// [`EventKey`] for [`Discard`]
 pub const DISCARD: EventKey = EventKey(ComponentId::new(crate::component::DISCARD));
 /// [`EventKey`] for [`Remove`]
@@ -349,6 +379,26 @@ pub struct Add {
 pub struct Insert {
     /// The entity this component was inserted into.
     pub entity: Entity,
+}
+
+/// Trigger emitted when a component is mutated.
+/// See [`ComponentHooks::on_mutate`](`crate::lifecycle::ComponentHooks::on_mutate`) for more information.
+#[derive(Debug, Clone, EntityEvent)]
+#[entity_event(trigger = EntityMutateTrigger)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
+#[doc(alias = "OnMutate")]
+pub struct Mutate {
+    /// Target Entity of the event.
+    pub entity: Entity,
+    /// Target Components of the event.
+    pub components: Vec<ComponentId>,
+}
+
+impl ContainsComponents for Mutate {
+    fn components(&self) -> &[ComponentId] {
+        return &self.components;
+    }
 }
 
 /// Trigger emitted when a component is removed from an entity, regardless

--- a/crates/bevy_ecs/src/lifecycle.rs
+++ b/crates/bevy_ecs/src/lifecycle.rs
@@ -212,7 +212,7 @@ impl ComponentHooks {
             .expect("Component already has an on_insert hook")
     }
 
-    /// Register a [`ComponentHook`] that will be run when this component is mutated (from mutable SystemParams).
+    /// Register a [`ComponentHook`] that will be run when this component is mutated (from mutable `SystemParams`).
     ///
     /// # Panics
     ///
@@ -291,7 +291,7 @@ impl ComponentHooks {
         Some(self)
     }
 
-    /// Attempt to register a [`ComponentHook`] that will be run when this component is mutated (from mutable SystemParams)
+    /// Attempt to register a [`ComponentHook`] that will be run when this component is mutated (from mutable `SystemParams`)
     ///
     /// This is a fallible version of [`Self::on_mutate`].
     ///
@@ -426,7 +426,7 @@ pub struct MutateEvent {
 
 impl ContainsComponents for MutateEvent {
     fn components(&self) -> &[ComponentId] {
-        return &self.components;
+        &self.components
     }
 }
 

--- a/crates/bevy_ecs/src/observer/centralized_storage.rs
+++ b/crates/bevy_ecs/src/observer/centralized_storage.rs
@@ -28,6 +28,7 @@ pub struct Observers {
     // Cached ECS observers to save a lookup for high-traffic built-in event types.
     add: CachedObservers,
     insert: CachedObservers,
+    mutate: CachedObservers,
     discard: CachedObservers,
     remove: CachedObservers,
     despawn: CachedObservers,
@@ -42,6 +43,7 @@ impl Observers {
         match event_key {
             ADD => &mut self.add,
             INSERT => &mut self.insert,
+            MUTATE => &mut self.mutate,
             DISCARD => &mut self.discard,
             REMOVE => &mut self.remove,
             DESPAWN => &mut self.despawn,
@@ -65,6 +67,7 @@ impl Observers {
         match event_key {
             ADD => Some(&self.add),
             INSERT => Some(&self.insert),
+            MUTATE => Some(&self.mutate),
             DISCARD => Some(&self.discard),
             REMOVE => Some(&self.remove),
             DESPAWN => Some(&self.despawn),
@@ -78,6 +81,7 @@ impl Observers {
         match event_key {
             ADD => Some(ArchetypeFlags::ON_ADD_OBSERVER),
             INSERT => Some(ArchetypeFlags::ON_INSERT_OBSERVER),
+            MUTATE => Some(ArchetypeFlags::ON_MUTATE_OBSERVER),
             DISCARD => Some(ArchetypeFlags::ON_DISCARD_OBSERVER),
             REMOVE => Some(ArchetypeFlags::ON_REMOVE_OBSERVER),
             DESPAWN => Some(ArchetypeFlags::ON_DESPAWN_OBSERVER),
@@ -96,6 +100,10 @@ impl Observers {
 
         if self.insert.component_observers.contains_key(&component_id) {
             flags.insert(ArchetypeFlags::ON_INSERT_OBSERVER);
+        }
+
+        if self.mutate.component_observers.contains_key(&component_id) {
+            flags.insert(ArchetypeFlags::ON_MUTATE_OBSERVER);
         }
 
         if self.discard.component_observers.contains_key(&component_id) {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -5,14 +5,19 @@
 
 pub use crate::change_detection::{NonSend, NonSendMut, Res, ResMut};
 use crate::{
-    archetype::Archetypes,
+    archetype::{ArchetypeEntity, Archetypes},
     bundle::Bundles,
-    change_detection::{ComponentTicksMut, ComponentTicksRef, Tick},
-    component::{ComponentId, Components, Mutable},
+    change_detection::{ComponentTicksMut, ComponentTicksRef, MaybeLocation, Tick},
+    component::{
+        ComponentId, Components, Mutable,
+        StorageType::{SparseSet, Table},
+    },
     entity::{Entities, EntityAllocator},
+    lifecycle::{Mutate, MUTATE},
     query::{
-        Access, FilteredAccess, FilteredAccessSet, IterQueryData, QueryData, QueryFilter,
-        QuerySingleError, QueryState, ReadOnlyQueryData,
+        Access, FilteredAccess, FilteredAccessSet,
+        InvertibleComponentIdSet::{Excluded, Included},
+        IterQueryData, QueryData, QueryFilter, QuerySingleError, QueryState, ReadOnlyQueryData,
     },
     resource::{Resource, IS_RESOURCE},
     system::{Query, Single, SystemMeta},
@@ -334,6 +339,263 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
         // The caller ensures the world matches the one used in init_state.
         Ok(unsafe { state.query_unchecked_with_ticks(world, system_meta.last_run, change_tick) })
     }
+
+    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        let muts = state.component_access().access().writes();
+        if let Included(m) = muts
+            && m.is_clear()
+        {
+            return;
+        }
+
+        let last_run = system_meta.get_last_run();
+        let archs = state.matched_archetypes();
+        let tables = &raw const world.storages().tables;
+        let sparse_sets = &raw const world.storages().sparse_sets;
+        let archetypes = &raw const *world.archetypes();
+        let has_global_or_entity_observer =
+            if let Some(o) = world.observers().try_get_observers(MUTATE) {
+                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+            } else {
+                false
+            };
+
+        archs
+            .filter_map(|arch| unsafe { (*archetypes).get(arch) })
+            .for_each(|a| {
+                let has_hook = a.has_mutate_hook();
+                let has_observer = a.has_mutate_observer() || has_global_or_entity_observer;
+                if !has_hook && !has_observer {
+                    return;
+                }
+                a.entities().iter().for_each(|e| {
+                    let entity = e.id();
+                    let table_row = e.table_row();
+                    let comps = match muts {
+                        Included(m) => m
+                            .iter()
+                            .filter(|c| {
+                                if let Some(s) = a.get_storage_type(*c) {
+                                    match s {
+                                        Table => {
+                                            let tables = unsafe { &*tables };
+                                            if let Some(t) = tables.get(a.table_id()) {
+                                                if let Some(tick) =
+                                                    t.get_changed_tick(*c, table_row)
+                                                {
+                                                    unsafe {
+                                                        return *(tick.get()) == last_run;
+                                                    }
+                                                }
+                                            }
+                                        }
+
+                                        SparseSet => {
+                                            let sparse_sets = unsafe { &*sparse_sets };
+                                            if let Some(s_s) = sparse_sets.get(*c) {
+                                                if let Some(tick) = s_s.get_changed_tick(entity) {
+                                                    unsafe {
+                                                        return *(tick.get()) == last_run;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                return false;
+                            })
+                            .collect::<Vec<_>>(),
+                        Excluded(m) => {
+                            // Unbounded Access, so naively scan all components not excluded.
+                            a.iter_components()
+                                .filter(|c| m.contains(*c))
+                                .filter(|c| {
+                                    if let Some(s) = a.get_storage_type(*c) {
+                                        match s {
+                                            Table => {
+                                                let tables = unsafe { &*tables };
+                                                if let Some(t) = tables.get(a.table_id()) {
+                                                    if let Some(tick) =
+                                                        t.get_changed_tick(*c, table_row)
+                                                    {
+                                                        unsafe {
+                                                            return *(tick.get()) == last_run;
+                                                        }
+                                                    }
+                                                }
+                                            }
+
+                                            SparseSet => {
+                                                let sparse_sets = unsafe { &*sparse_sets };
+                                                if let Some(s_s) = sparse_sets.get(*c) {
+                                                    if let Some(tick) = s_s.get_changed_tick(entity)
+                                                    {
+                                                        unsafe {
+                                                            return *(tick.get()) == last_run;
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    return false;
+                                })
+                                .collect::<Vec<_>>()
+                        }
+                    };
+                    if !comps.is_empty() {
+                        if has_hook {
+                            unsafe {
+                                world
+                                    .as_unsafe_world_cell()
+                                    .into_deferred()
+                                    .trigger_on_mutate(
+                                        entity,
+                                        comps.iter().copied(),
+                                        MaybeLocation::caller(),
+                                    );
+                            }
+                        }
+                        if has_observer {
+                            world.trigger(Mutate {
+                                entity,
+                                components: comps,
+                            });
+                        }
+                    }
+                });
+            });
+    }
+
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, mut world: DeferredWorld) {
+        let muts = state.component_access().access().writes();
+        if let Included(m) = muts
+            && m.is_clear()
+        {
+            return;
+        }
+
+        let last_run = system_meta.get_last_run();
+        let archs = state.matched_archetypes();
+        let tables = &raw const world.storages().tables;
+        let sparse_sets = &raw const world.storages().sparse_sets;
+        let archetypes = &raw const *world.archetypes();
+        let has_global_or_entity_observer =
+            if let Some(o) = world.observers().try_get_observers(MUTATE) {
+                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+            } else {
+                false
+            };
+        let mut commands = world.commands();
+
+        archs
+            .filter_map(|arch| unsafe { (*archetypes).get(arch) })
+            .for_each(|a| {
+                let has_hook = a.has_mutate_hook();
+                let has_observer = a.has_mutate_observer() || has_global_or_entity_observer;
+                if !has_hook && !has_observer {
+                    return;
+                }
+                a.entities().iter().for_each(|e| {
+                    let entity = e.id();
+                    let table_row = e.table_row();
+                    let comps = match muts {
+                        Included(m) => m
+                            .iter()
+                            .filter(|c| {
+                                if let Some(s) = a.get_storage_type(*c) {
+                                    match s {
+                                        Table => {
+                                            let tables = unsafe { &*tables };
+                                            if let Some(t) = tables.get(a.table_id()) {
+                                                if let Some(tick) =
+                                                    t.get_changed_tick(*c, table_row)
+                                                {
+                                                    unsafe {
+                                                        return *(tick.get()) == last_run;
+                                                    }
+                                                }
+                                            }
+                                        }
+
+                                        SparseSet => {
+                                            let sparse_sets = unsafe { &*sparse_sets };
+                                            if let Some(s_s) = sparse_sets.get(*c) {
+                                                if let Some(tick) = s_s.get_changed_tick(entity) {
+                                                    unsafe {
+                                                        return *(tick.get()) == last_run;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                return false;
+                            })
+                            .collect::<Vec<_>>(),
+                        Excluded(m) => {
+                            // Unbounded Access, so naively scan all components not excluded.
+                            a.iter_components()
+                                .filter(|c| m.contains(*c))
+                                .filter(|c| {
+                                    if let Some(s) = a.get_storage_type(*c) {
+                                        match s {
+                                            Table => {
+                                                let tables = unsafe { &*tables };
+                                                if let Some(t) = tables.get(a.table_id()) {
+                                                    if let Some(tick) =
+                                                        t.get_changed_tick(*c, table_row)
+                                                    {
+                                                        unsafe {
+                                                            return *(tick.get()) == last_run;
+                                                        }
+                                                    }
+                                                }
+                                            }
+
+                                            SparseSet => {
+                                                let sparse_sets = unsafe { &*sparse_sets };
+                                                if let Some(s_s) = sparse_sets.get(*c) {
+                                                    if let Some(tick) = s_s.get_changed_tick(entity)
+                                                    {
+                                                        unsafe {
+                                                            return *(tick.get()) == last_run;
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    return false;
+                                })
+                                .collect::<Vec<_>>()
+                        }
+                    };
+                    if !comps.is_empty() {
+                        commands.queue(move |world: &mut World| {
+                            if has_hook {
+                                unsafe {
+                                    world
+                                        .as_unsafe_world_cell()
+                                        .into_deferred()
+                                        .trigger_on_mutate(
+                                            entity,
+                                            comps.iter().copied(),
+                                            MaybeLocation::caller(),
+                                        );
+                                }
+                            }
+                            if has_observer {
+                                world.trigger(Mutate {
+                                    entity,
+                                    components: comps,
+                                });
+                            }
+                        });
+                    }
+                });
+            });
+    }
 }
 
 // SAFETY: Relevant query ComponentId access is applied to SystemMeta. If
@@ -381,6 +643,14 @@ unsafe impl<'a, 'b, D: IterQueryData + 'static, F: QueryFilter + 'static> System
             ),
         }
     }
+
+    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        Query::apply(state, system_meta, world);
+    }
+
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
+        Query::queue(state, system_meta, world);
+    }
 }
 
 // SAFETY: QueryState is constrained to read-only fetches, so it only reads World.
@@ -426,6 +696,14 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         } else {
             Ok(Populated(query))
         }
+    }
+
+    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        Query::apply(state, system_meta, world);
+    }
+
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
+        Query::queue(state, system_meta, world);
     }
 }
 
@@ -778,6 +1056,202 @@ unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T>
                 this_run: change_tick,
             },
         })
+    }
+
+    fn apply(&mut component_id: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        let (entity, table_row, storage, table_id, has_hook, has_observer) = {
+            let archetype = if let Some(h) = world.archetypes().component_index().get(&component_id)
+            {
+                let a = h.iter().next().unwrap();
+                if let Some(a) = world.archetypes().get(*a.0) {
+                    a
+                } else {
+                    return;
+                }
+            } else {
+                return;
+            };
+            let arch_entity = archetype.entities()[0];
+            let has_observer = archetype.has_mutate_observer()
+                || world
+                    .observers()
+                    .try_get_observers(MUTATE)
+                    .map_or(false, |o| {
+                        !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+                    });
+
+            (
+                arch_entity.id(),
+                arch_entity.table_row(),
+                archetype.get_storage_type(component_id).unwrap(),
+                archetype.table_id(),
+                archetype.has_mutate_hook(),
+                has_observer,
+            )
+        };
+        if !has_hook && !has_observer {
+            return;
+        }
+
+        let last_run = system_meta.last_run;
+        match storage {
+            Table => {
+                let tables = &world.storages().tables;
+                if let Some(t) = tables.get(table_id) {
+                    if let Some(tick) = t.get_changed_tick(component_id, table_row) {
+                        unsafe {
+                            if *(tick.get()) == last_run {
+                                if has_hook {
+                                    world
+                                        .as_unsafe_world_cell()
+                                        .into_deferred()
+                                        .trigger_on_mutate(
+                                            entity,
+                                            [component_id].iter().copied(),
+                                            MaybeLocation::caller(),
+                                        );
+                                }
+                                if has_observer {
+                                    world.trigger(Mutate {
+                                        entity,
+                                        components: [component_id].into(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            SparseSet => {
+                let sparse_sets = &world.storages().sparse_sets;
+                if let Some(s) = sparse_sets.get(component_id) {
+                    if let Some(tick) = s.get_changed_tick(entity) {
+                        unsafe {
+                            if *(tick.get()) == last_run {
+                                if has_hook {
+                                    world
+                                        .as_unsafe_world_cell()
+                                        .into_deferred()
+                                        .trigger_on_mutate(
+                                            entity,
+                                            [component_id].iter().copied(),
+                                            MaybeLocation::caller(),
+                                        );
+                                }
+                                if has_observer {
+                                    world.trigger(Mutate {
+                                        entity,
+                                        components: [component_id].into(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn queue(
+        &mut component_id: &mut Self::State,
+        system_meta: &SystemMeta,
+        mut world: DeferredWorld,
+    ) {
+        let (entity, table_row, storage, table_id, has_hook, has_observer) = {
+            let archetype = if let Some(h) = world.archetypes().component_index().get(&component_id)
+            {
+                let a = h.iter().next().unwrap();
+                if let Some(a) = world.archetypes().get(*a.0) {
+                    a
+                } else {
+                    return;
+                }
+            } else {
+                return;
+            };
+            let arch_entity = archetype.entities()[0];
+            let has_observer = archetype.has_mutate_observer()
+                || world
+                    .observers()
+                    .try_get_observers(MUTATE)
+                    .map_or(false, |o| {
+                        !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+                    });
+
+            (
+                arch_entity.id(),
+                arch_entity.table_row(),
+                archetype.get_storage_type(component_id).unwrap(),
+                archetype.table_id(),
+                archetype.has_mutate_hook(),
+                has_observer,
+            )
+        };
+        if !has_hook && !has_observer {
+            return;
+        }
+
+        let last_run = system_meta.last_run;
+        match storage {
+            Table => {
+                let tables = &world.storages().tables;
+                if let Some(t) = tables.get(table_id) {
+                    if let Some(tick) = t.get_changed_tick(component_id, table_row) {
+                        unsafe {
+                            if *(tick.get()) == last_run {
+                                world.commands().queue(move |world: &mut World| {
+                                    if has_hook {
+                                        world
+                                            .as_unsafe_world_cell()
+                                            .into_deferred()
+                                            .trigger_on_mutate(
+                                                entity,
+                                                [component_id].iter().copied(),
+                                                MaybeLocation::caller(),
+                                            );
+                                    }
+                                    if has_observer {
+                                        world.trigger(Mutate {
+                                            entity,
+                                            components: [component_id].into(),
+                                        });
+                                    }
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            SparseSet => {
+                let sparse_sets = &world.storages().sparse_sets;
+                if let Some(s) = sparse_sets.get(component_id) {
+                    if let Some(tick) = s.get_changed_tick(entity) {
+                        unsafe {
+                            if *(tick.get()) == last_run {
+                                world.commands().queue(move |world: &mut World| {
+                                    if has_hook {
+                                        world
+                                            .as_unsafe_world_cell()
+                                            .into_deferred()
+                                            .trigger_on_mutate(
+                                                entity,
+                                                [component_id].iter().copied(),
+                                                MaybeLocation::caller(),
+                                            );
+                                    }
+                                    if has_observer {
+                                        world.trigger(Mutate {
+                                            entity,
+                                            components: [component_id].into(),
+                                        });
+                                    }
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -2651,6 +3125,422 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
         // SAFETY: The caller ensures that `world` has access to anything registered in `init_access`,
         // and we registered all resource access in `state``.
         Ok(unsafe { FilteredResourcesMut::new(world, state, system_meta.last_run, change_tick) })
+    }
+
+    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        let muts = state.writes();
+        if let Included(m) = muts
+            && m.is_clear()
+        {
+            return;
+        }
+
+        let last_run = system_meta.get_last_run();
+        let tables = &raw const world.storages().tables;
+        let sparse_sets = &raw const world.storages().sparse_sets;
+        let archetypes = &raw const *world.archetypes();
+        let has_global_or_entity_observer =
+            if let Some(o) = world.observers().try_get_observers(MUTATE) {
+                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+            } else {
+                false
+            };
+
+        match muts {
+            Included(m) => {
+                m.iter()
+                    .filter_map(|c| unsafe {
+                        let a = *(*archetypes)
+                            .component_index()
+                            .get(&c)
+                            .unwrap()
+                            .iter()
+                            .next()
+                            .unwrap()
+                            .0;
+                        Some((c, (*archetypes).get(a)?))
+                    })
+                    .for_each(|(c, a)| {
+                        let has_hook = a.has_mutate_hook();
+                        let has_observer = a.has_mutate_observer() || has_global_or_entity_observer;
+                        if !has_hook && !has_observer {
+                            return;
+                        }
+                        a.entities().iter().for_each(|e| {
+                            let entity = e.id();
+                            let table_row = e.table_row();
+                            if let Some(s) = a.get_storage_type(c) {
+                                match s {
+                                    Table => {
+                                        let tables = unsafe { &*tables };
+                                        if let Some(t) = tables.get(a.table_id()) {
+                                            if let Some(tick) = t.get_changed_tick(c, table_row) {
+                                                unsafe {
+                                                    if *(tick.get()) == last_run {
+                                                        if has_hook {
+                                                            world
+                                                                .as_unsafe_world_cell()
+                                                                .into_deferred()
+                                                                .trigger_on_mutate(
+                                                                    entity,
+                                                                    [c].iter().copied(),
+                                                                    MaybeLocation::caller(),
+                                                                );
+                                                        }
+                                                        if has_observer {
+                                                            world.trigger(Mutate {
+                                                                entity,
+                                                                components: [c].into(),
+                                                            });
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    SparseSet => {
+                                        let sparse_sets = unsafe { &*sparse_sets };
+                                        if let Some(s_s) = sparse_sets.get(c) {
+                                            if let Some(tick) = s_s.get_changed_tick(entity) {
+                                                unsafe {
+                                                    if *(tick.get()) == last_run {
+                                                        if has_hook {
+                                                            world
+                                                                .as_unsafe_world_cell()
+                                                                .into_deferred()
+                                                                .trigger_on_mutate(
+                                                                    entity,
+                                                                    [c].iter().copied(),
+                                                                    MaybeLocation::caller(),
+                                                                );
+                                                        }
+                                                        if has_observer {
+                                                            world.trigger(Mutate {
+                                                                entity,
+                                                                components: [c].into(),
+                                                            });
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                    });
+            }
+            Excluded(m) => world
+                .resource_entities()
+                .iter()
+                .filter_map(|(c, _)| if m.contains(c) { Some(c) } else { None })
+                .collect::<Vec<_>>()
+                .iter()
+                .copied()
+                .for_each(|c| {
+                    let (entity, table_row, table_id, storage, has_hook, has_observer) = {
+                        let arch = *world
+                            .archetypes()
+                            .component_index()
+                            .get(&c)
+                            .unwrap()
+                            .iter()
+                            .next()
+                            .unwrap()
+                            .0;
+                        let a = world.archetypes().get(arch).unwrap();
+                        let arch_entity = a.entities()[0];
+                        let has_global_or_entity_observer = world
+                            .observers()
+                            .try_get_observers(MUTATE)
+                            .map_or(false, |o| {
+                                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+                            });
+                        (
+                            arch_entity.id(),
+                            arch_entity.table_row(),
+                            a.table_id(),
+                            a.get_storage_type(c),
+                            a.has_mutate_hook(),
+                            a.has_mutate_observer() || has_global_or_entity_observer,
+                        )
+                    };
+                    if let Some(s) = storage {
+                        match s {
+                            Table => {
+                                let tables = unsafe { &*tables };
+                                if let Some(t) = tables.get(table_id) {
+                                    if let Some(tick) = t.get_changed_tick(c, table_row) {
+                                        unsafe {
+                                            if *(tick.get()) == last_run {
+                                                if has_hook {
+                                                    world
+                                                        .as_unsafe_world_cell()
+                                                        .into_deferred()
+                                                        .trigger_on_mutate(
+                                                            entity,
+                                                            [c].iter().copied(),
+                                                            MaybeLocation::caller(),
+                                                        );
+                                                }
+                                                if has_observer {
+                                                    world.trigger(Mutate {
+                                                        entity,
+                                                        components: [c].into(),
+                                                    });
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            SparseSet => {
+                                let sparse_sets = unsafe { &*sparse_sets };
+                                if let Some(s_s) = sparse_sets.get(c) {
+                                    if let Some(tick) = s_s.get_changed_tick(entity) {
+                                        unsafe {
+                                            if *(tick.get()) == last_run {
+                                                if has_hook {
+                                                    world
+                                                        .as_unsafe_world_cell()
+                                                        .into_deferred()
+                                                        .trigger_on_mutate(
+                                                            entity,
+                                                            [c].iter().copied(),
+                                                            MaybeLocation::caller(),
+                                                        );
+                                                }
+                                                if has_observer {
+                                                    world.trigger(Mutate {
+                                                        entity,
+                                                        components: [c].into(),
+                                                    });
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }),
+        };
+    }
+
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, mut world: DeferredWorld) {
+        let muts = state.writes();
+        if let Included(m) = muts
+            && m.is_clear()
+        {
+            return;
+        }
+
+        let last_run = system_meta.get_last_run();
+        let tables = &raw const world.storages().tables;
+        let sparse_sets = &raw const world.storages().sparse_sets;
+        let archetypes = &raw const *world.archetypes();
+        let has_global_or_entity_observer =
+            if let Some(o) = world.observers().try_get_observers(MUTATE) {
+                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+            } else {
+                false
+            };
+
+        match muts {
+            Included(m) => {
+                m.iter()
+                    .filter_map(|c| unsafe {
+                        let a = *(*archetypes)
+                            .component_index()
+                            .get(&c)
+                            .unwrap()
+                            .iter()
+                            .next()
+                            .unwrap()
+                            .0;
+                        Some((c, (*archetypes).get(a)?))
+                    })
+                    .for_each(|(c, a)| {
+                        let has_hook = a.has_mutate_hook();
+                        let has_observer = a.has_mutate_observer() || has_global_or_entity_observer;
+                        if !has_hook && !has_observer {
+                            return;
+                        }
+                        a.entities().iter().for_each(|e| {
+                            let entity = e.id();
+                            let table_row = e.table_row();
+                            if let Some(s) = a.get_storage_type(c) {
+                                match s {
+                                    Table => {
+                                        let tables = unsafe { &*tables };
+                                        if let Some(t) = tables.get(a.table_id()) {
+                                            if let Some(tick) = t.get_changed_tick(c, table_row) {
+                                                unsafe {
+                                                    if *(tick.get()) == last_run {
+                                                        world.commands().queue(
+                                                            move |world: &mut World| {
+                                                                if has_hook {
+                                                                    world
+                                                                        .as_unsafe_world_cell()
+                                                                        .into_deferred()
+                                                                        .trigger_on_mutate(
+                                                                            entity,
+                                                                            [c].iter().copied(),
+                                                                            MaybeLocation::caller(),
+                                                                        );
+                                                                }
+                                                                if has_observer {
+                                                                    world.trigger(Mutate {
+                                                                        entity,
+                                                                        components: [c].into(),
+                                                                    });
+                                                                }
+                                                            },
+                                                        );
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    SparseSet => {
+                                        let sparse_sets = unsafe { &*sparse_sets };
+                                        if let Some(s_s) = sparse_sets.get(c) {
+                                            if let Some(tick) = s_s.get_changed_tick(entity) {
+                                                unsafe {
+                                                    if *(tick.get()) == last_run {
+                                                        world.commands().queue(
+                                                            move |world: &mut World| {
+                                                                if has_hook {
+                                                                    world
+                                                                        .as_unsafe_world_cell()
+                                                                        .into_deferred()
+                                                                        .trigger_on_mutate(
+                                                                            entity,
+                                                                            [c].iter().copied(),
+                                                                            MaybeLocation::caller(),
+                                                                        );
+                                                                }
+                                                                if has_observer {
+                                                                    world.trigger(Mutate {
+                                                                        entity,
+                                                                        components: [c].into(),
+                                                                    });
+                                                                }
+                                                            },
+                                                        );
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                    });
+            }
+            Excluded(m) => world
+                .resource_entities()
+                .iter()
+                .filter_map(|(c, _)| if m.contains(c) { Some(c) } else { None })
+                .collect::<Vec<_>>()
+                .iter()
+                .copied()
+                .for_each(|c| {
+                    let (entity, table_row, table_id, storage, has_hook, has_observer) = {
+                        let arch = *world
+                            .archetypes()
+                            .component_index()
+                            .get(&c)
+                            .unwrap()
+                            .iter()
+                            .next()
+                            .unwrap()
+                            .0;
+                        let a = world.archetypes().get(arch).unwrap();
+                        let arch_entity = a.entities()[0];
+                        let has_global_or_entity_observer = world
+                            .observers()
+                            .try_get_observers(MUTATE)
+                            .map_or(false, |o| {
+                                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+                            });
+                        (
+                            arch_entity.id(),
+                            arch_entity.table_row(),
+                            a.table_id(),
+                            a.get_storage_type(c),
+                            a.has_mutate_hook(),
+                            a.has_mutate_observer() || has_global_or_entity_observer,
+                        )
+                    };
+                    if let Some(s) = storage {
+                        match s {
+                            Table => {
+                                let tables = unsafe { &*tables };
+                                if let Some(t) = tables.get(table_id) {
+                                    if let Some(tick) = t.get_changed_tick(c, table_row) {
+                                        unsafe {
+                                            if *(tick.get()) == last_run {
+                                                world.commands().queue(move |world: &mut World| {
+                                                    if has_hook {
+                                                        world
+                                                            .as_unsafe_world_cell()
+                                                            .into_deferred()
+                                                            .trigger_on_mutate(
+                                                                entity,
+                                                                [c].iter().copied(),
+                                                                MaybeLocation::caller(),
+                                                            );
+                                                    }
+                                                    if has_observer {
+                                                        world.trigger(Mutate {
+                                                            entity,
+                                                            components: [c].into(),
+                                                        });
+                                                    }
+                                                });
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            SparseSet => {
+                                let sparse_sets = unsafe { &*sparse_sets };
+                                if let Some(s_s) = sparse_sets.get(c) {
+                                    if let Some(tick) = s_s.get_changed_tick(entity) {
+                                        unsafe {
+                                            if *(tick.get()) == last_run {
+                                                world.commands().queue(move |world: &mut World| {
+                                                    if has_hook {
+                                                        world
+                                                            .as_unsafe_world_cell()
+                                                            .into_deferred()
+                                                            .trigger_on_mutate(
+                                                                entity,
+                                                                [c].iter().copied(),
+                                                                MaybeLocation::caller(),
+                                                            );
+                                                    }
+                                                    if has_observer {
+                                                        world.trigger(Mutate {
+                                                            entity,
+                                                            components: [c].into(),
+                                                        });
+                                                    }
+                                                });
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }),
+        };
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -300,7 +300,7 @@ pub unsafe trait ReadOnlySystemParam: SystemParam {}
 pub type SystemParamItem<'w, 's, P> = <P as SystemParam>::Item<'w, 's>;
 
 impl DeferredWorld<'_> {
-    /// Triggers both Hooks and Observers for a given ["Entity"] and set of ["ComponentId"]s, depending on whether ["has_hooks"] or ["has_observers"] is true.
+    /// Triggers both Hooks and Observers for a given [`Entity`] and set of [`ComponentId`]s, depending on whether `has_hooks` or `has_observers` is true.
     #[inline(always)]
     fn trigger_mutate<const APPLY: bool>(
         &mut self,
@@ -312,11 +312,13 @@ impl DeferredWorld<'_> {
     ) {
         if APPLY {
             if has_hooks {
+                // SAFETY: DeferredWorld-Access
                 unsafe {
                     self.trigger_on_mutate(entity, comps.iter().copied(), loc);
                 }
             }
             if has_observers {
+                // SAFETY: DeferredWorld-Access
                 unsafe {
                     self.trigger_raw(
                         MUTATE,
@@ -331,13 +333,16 @@ impl DeferredWorld<'_> {
             }
         } else {
             self.commands().queue(move |world: &mut World| {
+                // SAFETY: We have exclusive access to [`World`] in [`Command`]s
                 let mut world = unsafe { world.as_unsafe_world_cell().into_deferred() };
                 if has_hooks {
+                    // SAFETY: DeferredWorld-Access
                     unsafe {
                         world.trigger_on_mutate(entity, comps.iter().copied(), loc);
                     }
                 }
                 if has_observers {
+                    // SAFETY: DeferredWorld-Access
                     unsafe {
                         world.trigger_raw(
                             MUTATE,
@@ -399,6 +404,7 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
 
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
         Query::trigger_mutate::<true>(
+            // SAFETY: We have exclusive [`World`] access during [`SystemParam::apply`]
             unsafe { world.as_unsafe_world_cell().into_deferred() },
             state,
             system_meta,
@@ -431,15 +437,16 @@ impl<D: QueryData + 'static, F: QueryFilter + 'static> Query<'_, '_, D, F> {
         let tables = &raw const world.storages().tables;
         let sparse_sets = &raw const world.storages().sparse_sets;
         let archetypes = &raw const world.archetypes;
-        let has_global_or_entity_observers =
-            if let Some(o) = world.observers().try_get_observers(MUTATE) {
-                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
-            } else {
-                false
-            };
+        let has_global_or_entity_observers = world
+            .observers()
+            .try_get_observers(MUTATE)
+            .is_some_and(|o| !o.global_observers().is_empty() || !o.entity_observers().is_empty());
 
         archs
-            .filter_map(|arch| unsafe { (*archetypes).get(arch) })
+            .filter_map(|arch| /* SAFETY: DeferredWorld-Access */
+            unsafe {
+                (*archetypes).get(arch)
+            })
             .for_each(|a| {
                 let has_hooks = a.has_mutate_hook();
                 let has_observers = a.has_mutate_observer() || has_global_or_entity_observers;
@@ -449,78 +456,79 @@ impl<D: QueryData + 'static, F: QueryFilter + 'static> Query<'_, '_, D, F> {
                 a.entities().iter().for_each(|e| {
                     let entity = e.id();
                     let table_row = e.table_row();
-                    let comps = match muts {
-                        Included(m) => m
-                            .iter()
-                            .filter(|c| {
-                                if let Some(s) = a.get_storage_type(*c) {
-                                    match s {
-                                        Table => {
-                                            let tables = unsafe { &*tables };
-                                            if let Some(t) = tables.get(a.table_id()) {
-                                                if let Some(tick) =
-                                                    t.get_changed_tick(*c, table_row)
-                                                {
-                                                    unsafe {
-                                                        return *(tick.get()) == last_run;
-                                                    }
-                                                }
-                                            }
-                                        }
-
-                                        SparseSet => {
-                                            let sparse_sets = unsafe { &*sparse_sets };
-                                            if let Some(s_s) = sparse_sets.get(*c) {
-                                                if let Some(tick) = s_s.get_changed_tick(entity) {
-                                                    unsafe {
-                                                        return *(tick.get()) == last_run;
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                return false;
-                            })
-                            .collect::<Vec<_>>(),
-                        Excluded(m) => {
-                            // Unbounded Access, so naively scan all components not excluded.
-                            a.iter_components()
-                                .filter(|c| m.contains(*c))
-                                .filter(|c| {
-                                    if let Some(s) = a.get_storage_type(*c) {
-                                        match s {
-                                            Table => {
-                                                let tables = unsafe { &*tables };
-                                                if let Some(t) = tables.get(a.table_id()) {
-                                                    if let Some(tick) =
+                    let comps =
+                        match muts {
+                            Included(m) => {
+                                m.iter()
+                                    .filter(|c| {
+                                        a.get_storage_type(*c).is_some_and(|s| {
+                                            match s {
+                                                Table => {
+                                                    // SAFETY: DeferredWorld-Access
+                                                    let tables = unsafe { &*tables };
+                                                    tables.get(a.table_id()).is_some_and(|t| {
                                                         t.get_changed_tick(*c, table_row)
-                                                    {
-                                                        unsafe {
-                                                            return *(tick.get()) == last_run;
-                                                        }
-                                                    }
+                                                            .is_some_and(|tick| {
+                                                                // SAFETY: DeferredWorld-Access
+                                                                unsafe { *(tick.get()) == last_run }
+                                                            })
+                                                    })
                                                 }
-                                            }
 
-                                            SparseSet => {
-                                                let sparse_sets = unsafe { &*sparse_sets };
-                                                if let Some(s_s) = sparse_sets.get(*c) {
-                                                    if let Some(tick) = s_s.get_changed_tick(entity)
-                                                    {
-                                                        unsafe {
-                                                            return *(tick.get()) == last_run;
-                                                        }
-                                                    }
+                                                SparseSet => {
+                                                    // SAFETY: DeferredWorld-Access
+                                                    let sparse_sets = unsafe { &*sparse_sets };
+                                                    sparse_sets.get(*c).is_some_and(|s_s| {
+                                                        s_s.get_changed_tick(entity).is_some_and(
+                                                            |tick| {
+                                                                // SAFETY: DeferredWorld-Access
+                                                                unsafe { *(tick.get()) == last_run }
+                                                            },
+                                                        )
+                                                    })
                                                 }
                                             }
-                                        }
-                                    }
-                                    return false;
-                                })
-                                .collect::<Vec<_>>()
-                        }
-                    };
+                                        })
+                                    })
+                                    .collect::<Vec<_>>()
+                            }
+                            Excluded(m) => {
+                                // Unbounded Access, so naively scan all components not excluded.
+                                a.iter_components()
+                                    .filter(|c| m.contains(*c))
+                                    .filter(|c| {
+                                        a.get_storage_type(*c).is_some_and(|s| {
+                                            match s {
+                                                Table => {
+                                                    // SAFETY: DeferredWorld-Access
+                                                    let tables = unsafe { &*tables };
+                                                    tables.get(a.table_id()).is_some_and(|t| {
+                                                        t.get_changed_tick(*c, table_row)
+                                                            .is_some_and(|tick| {
+                                                                // SAFETY: DeferredWorld-Access
+                                                                unsafe { *(tick.get()) == last_run }
+                                                            })
+                                                    })
+                                                }
+
+                                                SparseSet => {
+                                                    // SAFETY: DeferredWorld-Access
+                                                    let sparse_sets = unsafe { &*sparse_sets };
+                                                    sparse_sets.get(*c).is_some_and(|s_s| {
+                                                        s_s.get_changed_tick(entity).is_some_and(
+                                                            |tick| {
+                                                                // SAFETY: DeferredWorld-Access
+                                                                unsafe { *(tick.get()) == last_run }
+                                                            },
+                                                        )
+                                                    })
+                                                }
+                                            }
+                                        })
+                                    })
+                                    .collect::<Vec<_>>()
+                            }
+                        };
                     if !comps.is_empty() {
                         world.trigger_mutate::<APPLY>(entity, comps, has_hooks, has_observers, loc);
                     }
@@ -992,6 +1000,7 @@ unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T>
 
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
         Self::trigger_mutate::<true>(
+            // SAFETY: We have exclusive [`World`] access during [`SystemParam::apply`]
             unsafe { world.as_unsafe_world_cell().into_deferred() },
             state,
             system_meta,
@@ -1013,40 +1022,33 @@ impl<'a, T: Resource<Mutability = Mutable>> ResMut<'a, T> {
         loc: MaybeLocation,
     ) {
         let (entity, table_row, storage, table_id, has_hooks, has_observers) = {
-            let archetype = if let Some(h) = world.archetypes().component_index().get(&component_id)
+            if let Some(h) = world.archetypes().component_index().get(&component_id)
+                && let Some(a_t) = h.iter().next()
+                && let Some(a) = world.archetypes().get(*a_t.0)
+                && let Some(s) = a.get_storage_type(component_id)
+                && let e = a.entities()
+                && !e.is_empty()
             {
-                let a = h.iter().next().unwrap();
-                if let Some(a) = world.archetypes().get(*a.0) {
-                    a
-                } else {
-                    return;
-                }
+                let has_observers = a.has_mutate_observer()
+                    || world
+                        .observers()
+                        .try_get_observers(MUTATE)
+                        .is_some_and(|o| {
+                            !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+                        });
+                // SAFETY: !e.is_empty() is checked above
+                let a_e = e[0];
+                (
+                    a_e.id(),
+                    a_e.table_row(),
+                    s,
+                    a.table_id(),
+                    a.has_mutate_hook(),
+                    has_observers,
+                )
             } else {
                 return;
-            };
-            let arch_entity = if let ents = archetype.entities()
-                && ents.len() > 0
-            {
-                ents[0]
-            } else {
-                return;
-            };
-            let has_observers = archetype.has_mutate_observer()
-                || world
-                    .observers()
-                    .try_get_observers(MUTATE)
-                    .map_or(false, |o| {
-                        !o.global_observers().is_empty() || !o.entity_observers().is_empty()
-                    });
-
-            (
-                arch_entity.id(),
-                arch_entity.table_row(),
-                archetype.get_storage_type(component_id).unwrap(),
-                archetype.table_id(),
-                archetype.has_mutate_hook(),
-                has_observers,
-            )
+            }
         };
         if !has_hooks && !has_observers {
             return;
@@ -1056,36 +1058,38 @@ impl<'a, T: Resource<Mutability = Mutable>> ResMut<'a, T> {
         match storage {
             Table => {
                 let tables = &world.storages().tables;
-                if let Some(t) = tables.get(table_id) {
-                    if let Some(tick) = t.get_changed_tick(component_id, table_row) {
-                        unsafe {
-                            if *(tick.get()) == last_run {
-                                world.trigger_mutate::<APPLY>(
-                                    entity,
-                                    [component_id].into(),
-                                    has_hooks,
-                                    has_observers,
-                                    loc,
-                                );
-                            }
+                if let Some(t) = tables.get(table_id)
+                    && let Some(tick) = t.get_changed_tick(component_id, table_row)
+                {
+                    // SAFETY: DeferredWorld-Access
+                    unsafe {
+                        if *(tick.get()) == last_run {
+                            world.trigger_mutate::<APPLY>(
+                                entity,
+                                [component_id].into(),
+                                has_hooks,
+                                has_observers,
+                                loc,
+                            );
                         }
                     }
                 }
             }
             SparseSet => {
                 let sparse_sets = &world.storages().sparse_sets;
-                if let Some(s) = sparse_sets.get(component_id) {
-                    if let Some(tick) = s.get_changed_tick(entity) {
-                        unsafe {
-                            if *(tick.get()) == last_run {
-                                world.trigger_mutate::<APPLY>(
-                                    entity,
-                                    [component_id].into(),
-                                    has_hooks,
-                                    has_observers,
-                                    loc,
-                                );
-                            }
+                if let Some(s) = sparse_sets.get(component_id)
+                    && let Some(tick) = s.get_changed_tick(entity)
+                {
+                    // SAFETY: DeferredWorld-Access
+                    unsafe {
+                        if *(tick.get()) == last_run {
+                            world.trigger_mutate::<APPLY>(
+                                entity,
+                                [component_id].into(),
+                                has_hooks,
+                                has_observers,
+                                loc,
+                            );
                         }
                     }
                 }
@@ -2968,6 +2972,7 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
 
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
         Self::trigger_mutate::<true>(
+            // SAFETY: We have exclusive [`World`] access during [`SystemParam::apply`]
             unsafe { world.as_unsafe_world_cell().into_deferred() },
             state,
             system_meta,
@@ -2998,19 +3003,20 @@ impl FilteredResourcesMut<'_, '_> {
         let tables = &raw const world.storages().tables;
         let sparse_sets = &raw const world.storages().sparse_sets;
         let archetypes = &raw const world.archetypes;
-        let has_global_or_entity_observers =
-            if let Some(o) = world.observers().try_get_observers(MUTATE) {
-                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
-            } else {
-                false
-            };
+        let has_global_or_entity_observers = world
+            .observers()
+            .try_get_observers(MUTATE)
+            .is_some_and(|o| !o.global_observers().is_empty() || !o.entity_observers().is_empty());
 
         match muts {
             Included(m) => {
                 m.iter()
-                    .filter_map(|c| unsafe {
-                        let a = *(&*archetypes).component_index().get(&c)?.iter().next()?.0;
-                        Some((c, (&*archetypes).get(a)?))
+                    .filter_map(|c| {
+                        /* SAFETY: DeferredWorld-Access */
+                        unsafe {
+                            let a = *(&*archetypes).component_index().get(&c)?.iter().next()?.0;
+                            Some((c, (&*archetypes).get(a)?))
+                        }
                     })
                     .for_each(|(c, a)| {
                         let has_hooks = a.has_mutate_hook();
@@ -3025,38 +3031,42 @@ impl FilteredResourcesMut<'_, '_> {
                             if let Some(s) = a.get_storage_type(c) {
                                 match s {
                                     Table => {
+                                        // SAFETY: DeferredWorld-Access
                                         let tables = unsafe { &*tables };
-                                        if let Some(t) = tables.get(a.table_id()) {
-                                            if let Some(tick) = t.get_changed_tick(c, table_row) {
-                                                unsafe {
-                                                    if *(tick.get()) == last_run {
-                                                        world.trigger_mutate::<APPLY>(
-                                                            entity,
-                                                            [c].into(),
-                                                            has_hooks,
-                                                            has_observers,
-                                                            loc,
-                                                        );
-                                                    }
+                                        if let Some(t) = tables.get(a.table_id())
+                                            && let Some(tick) = t.get_changed_tick(c, table_row)
+                                        {
+                                            // SAFETY: DeferredWorld-Access
+                                            unsafe {
+                                                if *(tick.get()) == last_run {
+                                                    world.trigger_mutate::<APPLY>(
+                                                        entity,
+                                                        [c].into(),
+                                                        has_hooks,
+                                                        has_observers,
+                                                        loc,
+                                                    );
                                                 }
                                             }
                                         }
                                     }
 
                                     SparseSet => {
+                                        // SAFETY: DeferredWorld-Access
                                         let sparse_sets = unsafe { &*sparse_sets };
-                                        if let Some(s_s) = sparse_sets.get(c) {
-                                            if let Some(tick) = s_s.get_changed_tick(entity) {
-                                                unsafe {
-                                                    if *(tick.get()) == last_run {
-                                                        world.trigger_mutate::<APPLY>(
-                                                            entity,
-                                                            [c].into(),
-                                                            has_hooks,
-                                                            has_observers,
-                                                            loc,
-                                                        );
-                                                    }
+                                        if let Some(s_s) = sparse_sets.get(c)
+                                            && let Some(tick) = s_s.get_changed_tick(entity)
+                                        {
+                                            // SAFETY: DeferredWorld-Access
+                                            unsafe {
+                                                if *(tick.get()) == last_run {
+                                                    world.trigger_mutate::<APPLY>(
+                                                        entity,
+                                                        [c].into(),
+                                                        has_hooks,
+                                                        has_observers,
+                                                        loc,
+                                                    );
                                                 }
                                             }
                                         }
@@ -3074,96 +3084,77 @@ impl FilteredResourcesMut<'_, '_> {
                 .iter()
                 .copied()
                 .for_each(|c| {
-                    let (entity, table_row, table_id, storage, has_hook, has_observer) = {
-                        let (arch, arch_entity) =
-                            if let Some(a_i) = world.archetypes().component_index().get(&c) {
-                                if let Some(a) = a_i.iter().next() {
-                                    if let Some(a) = world.archetypes().get(*a.0) {
-                                        if let ents = a.entities()
-                                            && ents.len() > 0
-                                        {
-                                            (a, ents[0])
-                                        } else {
-                                            return;
-                                        }
-                                    } else {
-                                        return;
-                                    }
-                                } else {
-                                    return;
-                                }
-                            } else {
-                                return;
-                            };
-                        let has_global_or_entity_observer = world
-                            .observers()
-                            .try_get_observers(MUTATE)
-                            .map_or(false, |o| {
-                                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
-                            });
-                        (
-                            arch_entity.id(),
-                            arch_entity.table_row(),
-                            arch.table_id(),
-                            arch.get_storage_type(c),
-                            arch.has_mutate_hook(),
-                            arch.has_mutate_observer() || has_global_or_entity_observer,
-                        )
-                    };
-                    if let Some(s) = storage {
-                        match s {
-                            Table => {
-                                let tables = unsafe { &*tables };
-                                if let Some(t) = tables.get(table_id) {
-                                    if let Some(tick) = t.get_changed_tick(c, table_row) {
-                                        unsafe {
-                                            if *(tick.get()) == last_run {
-                                                if has_hook {
-                                                    world
-                                                        .as_unsafe_world_cell()
-                                                        .into_deferred()
-                                                        .trigger_on_mutate(
-                                                            entity,
-                                                            [c].iter().copied(),
-                                                            MaybeLocation::caller(),
-                                                        );
-                                                }
-                                                if has_observer {
-                                                    world.trigger(MutateEvent {
-                                                        entity,
-                                                        components: [c].into(),
-                                                    });
-                                                }
-                                            }
-                                        }
+                    let (entity, table_row, storage, table_id, has_hooks, has_observers) =
+                        if let Some(a_i) = world.archetypes().component_index().get(&c)
+                            && let Some(a) = a_i.iter().next()
+                            && let Some(a) = world.archetypes().get(*a.0)
+                            && let Some(s) = a.get_storage_type(c)
+                            && let e = a.entities()
+                            && !e.is_empty()
+                        {
+                            let has_observers = a.has_mutate_observer()
+                                || world
+                                    .observers()
+                                    .try_get_observers(MUTATE)
+                                    .is_some_and(|o| {
+                                        !o.global_observers().is_empty()
+                                            || !o.entity_observers().is_empty()
+                                    });
+                            // SAFETY: !e.is_empty is checked above
+                            let a_e = e[0];
+                            (
+                                a_e.id(),
+                                a_e.table_row(),
+                                s,
+                                a.table_id(),
+                                a.has_mutate_hook(),
+                                has_observers,
+                            )
+                        } else {
+                            return;
+                        };
+                    if !has_hooks && !has_observers {
+                        return;
+                    }
+
+                    match storage {
+                        Table => {
+                            // SAFETY: DeferredWorld-Access
+                            let tables = unsafe { &*tables };
+                            if let Some(t) = tables.get(table_id)
+                                && let Some(tick) = t.get_changed_tick(c, table_row)
+                            {
+                                // SAFETY: DeferredWorld-Access
+                                unsafe {
+                                    if *(tick.get()) == last_run {
+                                        world.trigger_mutate::<APPLY>(
+                                            entity,
+                                            [c].into(),
+                                            has_hooks,
+                                            has_observers,
+                                            loc,
+                                        );
                                     }
                                 }
                             }
+                        }
 
-                            SparseSet => {
-                                let sparse_sets = unsafe { &*sparse_sets };
-                                if let Some(s_s) = sparse_sets.get(c) {
-                                    if let Some(tick) = s_s.get_changed_tick(entity) {
-                                        unsafe {
-                                            if *(tick.get()) == last_run {
-                                                if has_hook {
-                                                    world
-                                                        .as_unsafe_world_cell()
-                                                        .into_deferred()
-                                                        .trigger_on_mutate(
-                                                            entity,
-                                                            [c].iter().copied(),
-                                                            MaybeLocation::caller(),
-                                                        );
-                                                }
-                                                if has_observer {
-                                                    world.trigger(MutateEvent {
-                                                        entity,
-                                                        components: [c].into(),
-                                                    });
-                                                }
-                                            }
-                                        }
+                        SparseSet => {
+                            // SAFETY: DeferredWorld-Access
+                            let sparse_sets = unsafe { &*sparse_sets };
+                            if let Some(s_s) = sparse_sets.get(c)
+                                && let Some(tick) = s_s.get_changed_tick(entity)
+                            {
+                                // SAFETY: DeferredWorld-Access
+                                unsafe {
+                                    if *(tick.get()) == last_run {
+                                        world.trigger_mutate::<APPLY>(
+                                            entity,
+                                            [c].into(),
+                                            has_hooks,
+                                            has_observers,
+                                            loc,
+                                        );
                                     }
                                 }
                             }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1024,7 +1024,13 @@ impl<'a, T: Resource<Mutability = Mutable>> ResMut<'a, T> {
             } else {
                 return;
             };
-            let arch_entity = archetype.entities()[0];
+            let arch_entity = if let ents = archetype.entities()
+                && ents.len() > 0
+            {
+                ents[0]
+            } else {
+                return;
+            };
             let has_observers = archetype.has_mutate_observer()
                 || world
                     .observers()
@@ -2991,7 +2997,7 @@ impl FilteredResourcesMut<'_, '_> {
         let last_run = system_meta.get_last_run();
         let tables = &raw const world.storages().tables;
         let sparse_sets = &raw const world.storages().sparse_sets;
-        let archetypes = &raw const *world.archetypes();
+        let archetypes = &raw const world.archetypes;
         let has_global_or_entity_observers =
             if let Some(o) = world.observers().try_get_observers(MUTATE) {
                 !o.global_observers().is_empty() || !o.entity_observers().is_empty()
@@ -3003,15 +3009,8 @@ impl FilteredResourcesMut<'_, '_> {
             Included(m) => {
                 m.iter()
                     .filter_map(|c| unsafe {
-                        let a = *(*archetypes)
-                            .component_index()
-                            .get(&c)
-                            .unwrap()
-                            .iter()
-                            .next()
-                            .unwrap()
-                            .0;
-                        Some((c, (*archetypes).get(a)?))
+                        let a = *(&*archetypes).component_index().get(&c)?.iter().next()?.0;
+                        Some((c, (&*archetypes).get(a)?))
                     })
                     .for_each(|(c, a)| {
                         let has_hooks = a.has_mutate_hook();
@@ -3076,17 +3075,26 @@ impl FilteredResourcesMut<'_, '_> {
                 .copied()
                 .for_each(|c| {
                     let (entity, table_row, table_id, storage, has_hook, has_observer) = {
-                        let arch = *world
-                            .archetypes()
-                            .component_index()
-                            .get(&c)
-                            .unwrap()
-                            .iter()
-                            .next()
-                            .unwrap()
-                            .0;
-                        let a = world.archetypes().get(arch).unwrap();
-                        let arch_entity = a.entities()[0];
+                        let (arch, arch_entity) =
+                            if let Some(a_i) = world.archetypes().component_index().get(&c) {
+                                if let Some(a) = a_i.iter().next() {
+                                    if let Some(a) = world.archetypes().get(*a.0) {
+                                        if let ents = a.entities()
+                                            && ents.len() > 0
+                                        {
+                                            (a, ents[0])
+                                        } else {
+                                            return;
+                                        }
+                                    } else {
+                                        return;
+                                    }
+                                } else {
+                                    return;
+                                }
+                            } else {
+                                return;
+                            };
                         let has_global_or_entity_observer = world
                             .observers()
                             .try_get_observers(MUTATE)
@@ -3096,10 +3104,10 @@ impl FilteredResourcesMut<'_, '_> {
                         (
                             arch_entity.id(),
                             arch_entity.table_row(),
-                            a.table_id(),
-                            a.get_storage_type(c),
-                            a.has_mutate_hook(),
-                            a.has_mutate_observer() || has_global_or_entity_observer,
+                            arch.table_id(),
+                            arch.get_storage_type(c),
+                            arch.has_mutate_hook(),
+                            arch.has_mutate_observer() || has_global_or_entity_observer,
                         )
                     };
                     if let Some(s) = storage {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -5,14 +5,15 @@
 
 pub use crate::change_detection::{NonSend, NonSendMut, Res, ResMut};
 use crate::{
-    archetype::{ArchetypeEntity, Archetypes},
+    archetype::Archetypes,
     bundle::Bundles,
     change_detection::{ComponentTicksMut, ComponentTicksRef, MaybeLocation, Tick},
     component::{
         ComponentId, Components, Mutable,
         StorageType::{SparseSet, Table},
     },
-    entity::{Entities, EntityAllocator},
+    entity::{Entities, Entity, EntityAllocator},
+    event::EntityMutateTrigger,
     lifecycle::{MutateEvent, MUTATE},
     query::{
         Access, FilteredAccess, FilteredAccessSet,
@@ -298,6 +299,62 @@ pub unsafe trait ReadOnlySystemParam: SystemParam {}
 /// Shorthand way of accessing the associated type [`SystemParam::Item`] for a given [`SystemParam`].
 pub type SystemParamItem<'w, 's, P> = <P as SystemParam>::Item<'w, 's>;
 
+impl DeferredWorld<'_> {
+    /// Triggers both Hooks and Observers for a given ["Entity"] and set of ["ComponentId"]s, depending on whether ["has_hooks"] or ["has_observers"] is true.
+    #[inline(always)]
+    fn trigger_mutate<const APPLY: bool>(
+        &mut self,
+        entity: Entity,
+        comps: Vec<ComponentId>,
+        has_hooks: bool,
+        has_observers: bool,
+        loc: MaybeLocation,
+    ) {
+        if APPLY {
+            if has_hooks {
+                unsafe {
+                    self.trigger_on_mutate(entity, comps.iter().copied(), loc);
+                }
+            }
+            if has_observers {
+                unsafe {
+                    self.trigger_raw(
+                        MUTATE,
+                        &mut MutateEvent {
+                            entity,
+                            components: comps,
+                        },
+                        &mut EntityMutateTrigger,
+                        loc,
+                    );
+                }
+            }
+        } else {
+            self.commands().queue(move |world: &mut World| {
+                let mut world = unsafe { world.as_unsafe_world_cell().into_deferred() };
+                if has_hooks {
+                    unsafe {
+                        world.trigger_on_mutate(entity, comps.iter().copied(), loc);
+                    }
+                }
+                if has_observers {
+                    unsafe {
+                        world.trigger_raw(
+                            MUTATE,
+                            &mut MutateEvent {
+                                entity,
+                                components: comps,
+                            },
+                            &mut EntityMutateTrigger,
+                            loc,
+                        );
+                    }
+                }
+            });
+        }
+    }
+}
+
 // SAFETY: QueryState is constrained to read-only fetches, so it only reads World.
 unsafe impl<'w, 's, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> ReadOnlySystemParam
     for Query<'w, 's, D, F>
@@ -341,133 +398,27 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
     }
 
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
-        let muts = state.component_access().access().writes();
-        if let Included(m) = muts
-            && m.is_clear()
-        {
-            return;
-        }
-
-        let last_run = system_meta.get_last_run();
-        let archs = state.matched_archetypes();
-        let tables = &raw const world.storages().tables;
-        let sparse_sets = &raw const world.storages().sparse_sets;
-        let archetypes = &raw const *world.archetypes();
-        let has_global_or_entity_observer =
-            if let Some(o) = world.observers().try_get_observers(MUTATE) {
-                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
-            } else {
-                false
-            };
-
-        archs
-            .filter_map(|arch| unsafe { (*archetypes).get(arch) })
-            .for_each(|a| {
-                let has_hook = a.has_mutate_hook();
-                let has_observer = a.has_mutate_observer() || has_global_or_entity_observer;
-                if !has_hook && !has_observer {
-                    return;
-                }
-                a.entities().iter().for_each(|e| {
-                    let entity = e.id();
-                    let table_row = e.table_row();
-                    let comps = match muts {
-                        Included(m) => m
-                            .iter()
-                            .filter(|c| {
-                                if let Some(s) = a.get_storage_type(*c) {
-                                    match s {
-                                        Table => {
-                                            let tables = unsafe { &*tables };
-                                            if let Some(t) = tables.get(a.table_id()) {
-                                                if let Some(tick) =
-                                                    t.get_changed_tick(*c, table_row)
-                                                {
-                                                    unsafe {
-                                                        return *(tick.get()) == last_run;
-                                                    }
-                                                }
-                                            }
-                                        }
-
-                                        SparseSet => {
-                                            let sparse_sets = unsafe { &*sparse_sets };
-                                            if let Some(s_s) = sparse_sets.get(*c) {
-                                                if let Some(tick) = s_s.get_changed_tick(entity) {
-                                                    unsafe {
-                                                        return *(tick.get()) == last_run;
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                return false;
-                            })
-                            .collect::<Vec<_>>(),
-                        Excluded(m) => {
-                            // Unbounded Access, so naively scan all components not excluded.
-                            a.iter_components()
-                                .filter(|c| m.contains(*c))
-                                .filter(|c| {
-                                    if let Some(s) = a.get_storage_type(*c) {
-                                        match s {
-                                            Table => {
-                                                let tables = unsafe { &*tables };
-                                                if let Some(t) = tables.get(a.table_id()) {
-                                                    if let Some(tick) =
-                                                        t.get_changed_tick(*c, table_row)
-                                                    {
-                                                        unsafe {
-                                                            return *(tick.get()) == last_run;
-                                                        }
-                                                    }
-                                                }
-                                            }
-
-                                            SparseSet => {
-                                                let sparse_sets = unsafe { &*sparse_sets };
-                                                if let Some(s_s) = sparse_sets.get(*c) {
-                                                    if let Some(tick) = s_s.get_changed_tick(entity)
-                                                    {
-                                                        unsafe {
-                                                            return *(tick.get()) == last_run;
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                    return false;
-                                })
-                                .collect::<Vec<_>>()
-                        }
-                    };
-                    if !comps.is_empty() {
-                        if has_hook {
-                            unsafe {
-                                world
-                                    .as_unsafe_world_cell()
-                                    .into_deferred()
-                                    .trigger_on_mutate(
-                                        entity,
-                                        comps.iter().copied(),
-                                        MaybeLocation::caller(),
-                                    );
-                            }
-                        }
-                        if has_observer {
-                            world.trigger(MutateEvent {
-                                entity,
-                                components: comps,
-                            });
-                        }
-                    }
-                });
-            });
+        Query::trigger_mutate::<true>(
+            unsafe { world.as_unsafe_world_cell().into_deferred() },
+            state,
+            system_meta,
+            MaybeLocation::caller(),
+        );
     }
 
-    fn queue(state: &mut Self::State, system_meta: &SystemMeta, mut world: DeferredWorld) {
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
+        Query::trigger_mutate::<false>(world, state, system_meta, MaybeLocation::caller());
+    }
+}
+
+impl<D: QueryData + 'static, F: QueryFilter + 'static> Query<'_, '_, D, F> {
+    #[inline(always)]
+    fn trigger_mutate<const APPLY: bool>(
+        mut world: DeferredWorld,
+        state: &mut <Self as SystemParam>::State,
+        system_meta: &SystemMeta,
+        loc: MaybeLocation,
+    ) {
         let muts = state.component_access().access().writes();
         if let Included(m) = muts
             && m.is_clear()
@@ -479,21 +430,20 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
         let archs = state.matched_archetypes();
         let tables = &raw const world.storages().tables;
         let sparse_sets = &raw const world.storages().sparse_sets;
-        let archetypes = &raw const *world.archetypes();
-        let has_global_or_entity_observer =
+        let archetypes = &raw const world.archetypes;
+        let has_global_or_entity_observers =
             if let Some(o) = world.observers().try_get_observers(MUTATE) {
                 !o.global_observers().is_empty() || !o.entity_observers().is_empty()
             } else {
                 false
             };
-        let mut commands = world.commands();
 
         archs
             .filter_map(|arch| unsafe { (*archetypes).get(arch) })
             .for_each(|a| {
-                let has_hook = a.has_mutate_hook();
-                let has_observer = a.has_mutate_observer() || has_global_or_entity_observer;
-                if !has_hook && !has_observer {
+                let has_hooks = a.has_mutate_hook();
+                let has_observers = a.has_mutate_observer() || has_global_or_entity_observers;
+                if !has_hooks && !has_observers {
                     return;
                 }
                 a.entities().iter().for_each(|e| {
@@ -572,26 +522,7 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
                         }
                     };
                     if !comps.is_empty() {
-                        commands.queue(move |world: &mut World| {
-                            if has_hook {
-                                unsafe {
-                                    world
-                                        .as_unsafe_world_cell()
-                                        .into_deferred()
-                                        .trigger_on_mutate(
-                                            entity,
-                                            comps.iter().copied(),
-                                            MaybeLocation::caller(),
-                                        );
-                                }
-                            }
-                            if has_observer {
-                                world.trigger(MutateEvent {
-                                    entity,
-                                    components: comps,
-                                });
-                            }
-                        });
+                        world.trigger_mutate::<APPLY>(entity, comps, has_hooks, has_observers, loc);
                     }
                 });
             });
@@ -1059,106 +990,29 @@ unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T>
         })
     }
 
-    fn apply(&mut component_id: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
-        let (entity, table_row, storage, table_id, has_hook, has_observer) = {
-            let archetype = if let Some(h) = world.archetypes().component_index().get(&component_id)
-            {
-                let a = h.iter().next().unwrap();
-                if let Some(a) = world.archetypes().get(*a.0) {
-                    a
-                } else {
-                    return;
-                }
-            } else {
-                return;
-            };
-            let arch_entity = archetype.entities()[0];
-            let has_observer = archetype.has_mutate_observer()
-                || world
-                    .observers()
-                    .try_get_observers(MUTATE)
-                    .map_or(false, |o| {
-                        !o.global_observers().is_empty() || !o.entity_observers().is_empty()
-                    });
-
-            (
-                arch_entity.id(),
-                arch_entity.table_row(),
-                archetype.get_storage_type(component_id).unwrap(),
-                archetype.table_id(),
-                archetype.has_mutate_hook(),
-                has_observer,
-            )
-        };
-        if !has_hook && !has_observer {
-            return;
-        }
-
-        let last_run = system_meta.last_run;
-        match storage {
-            Table => {
-                let tables = &world.storages().tables;
-                if let Some(t) = tables.get(table_id) {
-                    if let Some(tick) = t.get_changed_tick(component_id, table_row) {
-                        unsafe {
-                            if *(tick.get()) == last_run {
-                                if has_hook {
-                                    world
-                                        .as_unsafe_world_cell()
-                                        .into_deferred()
-                                        .trigger_on_mutate(
-                                            entity,
-                                            [component_id].iter().copied(),
-                                            MaybeLocation::caller(),
-                                        );
-                                }
-                                if has_observer {
-                                    world.trigger(MutateEvent {
-                                        entity,
-                                        components: [component_id].into(),
-                                    });
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            SparseSet => {
-                let sparse_sets = &world.storages().sparse_sets;
-                if let Some(s) = sparse_sets.get(component_id) {
-                    if let Some(tick) = s.get_changed_tick(entity) {
-                        unsafe {
-                            if *(tick.get()) == last_run {
-                                if has_hook {
-                                    world
-                                        .as_unsafe_world_cell()
-                                        .into_deferred()
-                                        .trigger_on_mutate(
-                                            entity,
-                                            [component_id].iter().copied(),
-                                            MaybeLocation::caller(),
-                                        );
-                                }
-                                if has_observer {
-                                    world.trigger(MutateEvent {
-                                        entity,
-                                        components: [component_id].into(),
-                                    });
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        Self::trigger_mutate::<true>(
+            unsafe { world.as_unsafe_world_cell().into_deferred() },
+            state,
+            system_meta,
+            MaybeLocation::caller(),
+        );
     }
 
-    fn queue(
-        &mut component_id: &mut Self::State,
-        system_meta: &SystemMeta,
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
+        Self::trigger_mutate::<false>(world, state, system_meta, MaybeLocation::caller());
+    }
+}
+
+impl<'a, T: Resource<Mutability = Mutable>> ResMut<'a, T> {
+    #[inline(always)]
+    fn trigger_mutate<const APPLY: bool>(
         mut world: DeferredWorld,
+        &mut component_id: &mut <Self as SystemParam>::State,
+        system_meta: &SystemMeta,
+        loc: MaybeLocation,
     ) {
-        let (entity, table_row, storage, table_id, has_hook, has_observer) = {
+        let (entity, table_row, storage, table_id, has_hooks, has_observers) = {
             let archetype = if let Some(h) = world.archetypes().component_index().get(&component_id)
             {
                 let a = h.iter().next().unwrap();
@@ -1171,7 +1025,7 @@ unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T>
                 return;
             };
             let arch_entity = archetype.entities()[0];
-            let has_observer = archetype.has_mutate_observer()
+            let has_observers = archetype.has_mutate_observer()
                 || world
                     .observers()
                     .try_get_observers(MUTATE)
@@ -1185,10 +1039,10 @@ unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T>
                 archetype.get_storage_type(component_id).unwrap(),
                 archetype.table_id(),
                 archetype.has_mutate_hook(),
-                has_observer,
+                has_observers,
             )
         };
-        if !has_hook && !has_observer {
+        if !has_hooks && !has_observers {
             return;
         }
 
@@ -1200,24 +1054,13 @@ unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T>
                     if let Some(tick) = t.get_changed_tick(component_id, table_row) {
                         unsafe {
                             if *(tick.get()) == last_run {
-                                world.commands().queue(move |world: &mut World| {
-                                    if has_hook {
-                                        world
-                                            .as_unsafe_world_cell()
-                                            .into_deferred()
-                                            .trigger_on_mutate(
-                                                entity,
-                                                [component_id].iter().copied(),
-                                                MaybeLocation::caller(),
-                                            );
-                                    }
-                                    if has_observer {
-                                        world.trigger(MutateEvent {
-                                            entity,
-                                            components: [component_id].into(),
-                                        });
-                                    }
-                                });
+                                world.trigger_mutate::<APPLY>(
+                                    entity,
+                                    [component_id].into(),
+                                    has_hooks,
+                                    has_observers,
+                                    loc,
+                                );
                             }
                         }
                     }
@@ -1229,24 +1072,13 @@ unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T>
                     if let Some(tick) = s.get_changed_tick(entity) {
                         unsafe {
                             if *(tick.get()) == last_run {
-                                world.commands().queue(move |world: &mut World| {
-                                    if has_hook {
-                                        world
-                                            .as_unsafe_world_cell()
-                                            .into_deferred()
-                                            .trigger_on_mutate(
-                                                entity,
-                                                [component_id].iter().copied(),
-                                                MaybeLocation::caller(),
-                                            );
-                                    }
-                                    if has_observer {
-                                        world.trigger(MutateEvent {
-                                            entity,
-                                            components: [component_id].into(),
-                                        });
-                                    }
-                                });
+                                world.trigger_mutate::<APPLY>(
+                                    entity,
+                                    [component_id].into(),
+                                    has_hooks,
+                                    has_observers,
+                                    loc,
+                                );
                             }
                         }
                     }
@@ -3129,208 +2961,26 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
     }
 
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
-        let muts = state.writes();
-        if let Included(m) = muts
-            && m.is_clear()
-        {
-            return;
-        }
-
-        let last_run = system_meta.get_last_run();
-        let tables = &raw const world.storages().tables;
-        let sparse_sets = &raw const world.storages().sparse_sets;
-        let archetypes = &raw const *world.archetypes();
-        let has_global_or_entity_observer =
-            if let Some(o) = world.observers().try_get_observers(MUTATE) {
-                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
-            } else {
-                false
-            };
-
-        match muts {
-            Included(m) => {
-                m.iter()
-                    .filter_map(|c| unsafe {
-                        let a = *(*archetypes)
-                            .component_index()
-                            .get(&c)
-                            .unwrap()
-                            .iter()
-                            .next()
-                            .unwrap()
-                            .0;
-                        Some((c, (*archetypes).get(a)?))
-                    })
-                    .for_each(|(c, a)| {
-                        let has_hook = a.has_mutate_hook();
-                        let has_observer = a.has_mutate_observer() || has_global_or_entity_observer;
-                        if !has_hook && !has_observer {
-                            return;
-                        }
-                        a.entities().iter().for_each(|e| {
-                            let entity = e.id();
-                            let table_row = e.table_row();
-                            if let Some(s) = a.get_storage_type(c) {
-                                match s {
-                                    Table => {
-                                        let tables = unsafe { &*tables };
-                                        if let Some(t) = tables.get(a.table_id()) {
-                                            if let Some(tick) = t.get_changed_tick(c, table_row) {
-                                                unsafe {
-                                                    if *(tick.get()) == last_run {
-                                                        if has_hook {
-                                                            world
-                                                                .as_unsafe_world_cell()
-                                                                .into_deferred()
-                                                                .trigger_on_mutate(
-                                                                    entity,
-                                                                    [c].iter().copied(),
-                                                                    MaybeLocation::caller(),
-                                                                );
-                                                        }
-                                                        if has_observer {
-                                                            world.trigger(MutateEvent {
-                                                                entity,
-                                                                components: [c].into(),
-                                                            });
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    SparseSet => {
-                                        let sparse_sets = unsafe { &*sparse_sets };
-                                        if let Some(s_s) = sparse_sets.get(c) {
-                                            if let Some(tick) = s_s.get_changed_tick(entity) {
-                                                unsafe {
-                                                    if *(tick.get()) == last_run {
-                                                        if has_hook {
-                                                            world
-                                                                .as_unsafe_world_cell()
-                                                                .into_deferred()
-                                                                .trigger_on_mutate(
-                                                                    entity,
-                                                                    [c].iter().copied(),
-                                                                    MaybeLocation::caller(),
-                                                                );
-                                                        }
-                                                        if has_observer {
-                                                            world.trigger(MutateEvent {
-                                                                entity,
-                                                                components: [c].into(),
-                                                            });
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        });
-                    });
-            }
-            Excluded(m) => world
-                .resource_entities()
-                .iter()
-                .filter_map(|(c, _)| if m.contains(c) { Some(c) } else { None })
-                .collect::<Vec<_>>()
-                .iter()
-                .copied()
-                .for_each(|c| {
-                    let (entity, table_row, table_id, storage, has_hook, has_observer) = {
-                        let arch = *world
-                            .archetypes()
-                            .component_index()
-                            .get(&c)
-                            .unwrap()
-                            .iter()
-                            .next()
-                            .unwrap()
-                            .0;
-                        let a = world.archetypes().get(arch).unwrap();
-                        let arch_entity = a.entities()[0];
-                        let has_global_or_entity_observer = world
-                            .observers()
-                            .try_get_observers(MUTATE)
-                            .map_or(false, |o| {
-                                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
-                            });
-                        (
-                            arch_entity.id(),
-                            arch_entity.table_row(),
-                            a.table_id(),
-                            a.get_storage_type(c),
-                            a.has_mutate_hook(),
-                            a.has_mutate_observer() || has_global_or_entity_observer,
-                        )
-                    };
-                    if let Some(s) = storage {
-                        match s {
-                            Table => {
-                                let tables = unsafe { &*tables };
-                                if let Some(t) = tables.get(table_id) {
-                                    if let Some(tick) = t.get_changed_tick(c, table_row) {
-                                        unsafe {
-                                            if *(tick.get()) == last_run {
-                                                if has_hook {
-                                                    world
-                                                        .as_unsafe_world_cell()
-                                                        .into_deferred()
-                                                        .trigger_on_mutate(
-                                                            entity,
-                                                            [c].iter().copied(),
-                                                            MaybeLocation::caller(),
-                                                        );
-                                                }
-                                                if has_observer {
-                                                    world.trigger(MutateEvent {
-                                                        entity,
-                                                        components: [c].into(),
-                                                    });
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            SparseSet => {
-                                let sparse_sets = unsafe { &*sparse_sets };
-                                if let Some(s_s) = sparse_sets.get(c) {
-                                    if let Some(tick) = s_s.get_changed_tick(entity) {
-                                        unsafe {
-                                            if *(tick.get()) == last_run {
-                                                if has_hook {
-                                                    world
-                                                        .as_unsafe_world_cell()
-                                                        .into_deferred()
-                                                        .trigger_on_mutate(
-                                                            entity,
-                                                            [c].iter().copied(),
-                                                            MaybeLocation::caller(),
-                                                        );
-                                                }
-                                                if has_observer {
-                                                    world.trigger(MutateEvent {
-                                                        entity,
-                                                        components: [c].into(),
-                                                    });
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }),
-        };
+        Self::trigger_mutate::<true>(
+            unsafe { world.as_unsafe_world_cell().into_deferred() },
+            state,
+            system_meta,
+            MaybeLocation::caller(),
+        );
     }
 
-    fn queue(state: &mut Self::State, system_meta: &SystemMeta, mut world: DeferredWorld) {
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
+        Self::trigger_mutate::<false>(world, state, system_meta, MaybeLocation::caller());
+    }
+}
+
+impl FilteredResourcesMut<'_, '_> {
+    fn trigger_mutate<const APPLY: bool>(
+        mut world: DeferredWorld,
+        state: &mut <Self as SystemParam>::State,
+        system_meta: &SystemMeta,
+        loc: MaybeLocation,
+    ) {
         let muts = state.writes();
         if let Included(m) = muts
             && m.is_clear()
@@ -3342,7 +2992,7 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
         let tables = &raw const world.storages().tables;
         let sparse_sets = &raw const world.storages().sparse_sets;
         let archetypes = &raw const *world.archetypes();
-        let has_global_or_entity_observer =
+        let has_global_or_entity_observers =
             if let Some(o) = world.observers().try_get_observers(MUTATE) {
                 !o.global_observers().is_empty() || !o.entity_observers().is_empty()
             } else {
@@ -3364,9 +3014,10 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
                         Some((c, (*archetypes).get(a)?))
                     })
                     .for_each(|(c, a)| {
-                        let has_hook = a.has_mutate_hook();
-                        let has_observer = a.has_mutate_observer() || has_global_or_entity_observer;
-                        if !has_hook && !has_observer {
+                        let has_hooks = a.has_mutate_hook();
+                        let has_observers =
+                            a.has_mutate_observer() || has_global_or_entity_observers;
+                        if !has_hooks && !has_observers {
                             return;
                         }
                         a.entities().iter().for_each(|e| {
@@ -3380,25 +3031,12 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
                                             if let Some(tick) = t.get_changed_tick(c, table_row) {
                                                 unsafe {
                                                     if *(tick.get()) == last_run {
-                                                        world.commands().queue(
-                                                            move |world: &mut World| {
-                                                                if has_hook {
-                                                                    world
-                                                                        .as_unsafe_world_cell()
-                                                                        .into_deferred()
-                                                                        .trigger_on_mutate(
-                                                                            entity,
-                                                                            [c].iter().copied(),
-                                                                            MaybeLocation::caller(),
-                                                                        );
-                                                                }
-                                                                if has_observer {
-                                                                    world.trigger(MutateEvent {
-                                                                        entity,
-                                                                        components: [c].into(),
-                                                                    });
-                                                                }
-                                                            },
+                                                        world.trigger_mutate::<APPLY>(
+                                                            entity,
+                                                            [c].into(),
+                                                            has_hooks,
+                                                            has_observers,
+                                                            loc,
                                                         );
                                                     }
                                                 }
@@ -3412,25 +3050,12 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
                                             if let Some(tick) = s_s.get_changed_tick(entity) {
                                                 unsafe {
                                                     if *(tick.get()) == last_run {
-                                                        world.commands().queue(
-                                                            move |world: &mut World| {
-                                                                if has_hook {
-                                                                    world
-                                                                        .as_unsafe_world_cell()
-                                                                        .into_deferred()
-                                                                        .trigger_on_mutate(
-                                                                            entity,
-                                                                            [c].iter().copied(),
-                                                                            MaybeLocation::caller(),
-                                                                        );
-                                                                }
-                                                                if has_observer {
-                                                                    world.trigger(MutateEvent {
-                                                                        entity,
-                                                                        components: [c].into(),
-                                                                    });
-                                                                }
-                                                            },
+                                                        world.trigger_mutate::<APPLY>(
+                                                            entity,
+                                                            [c].into(),
+                                                            has_hooks,
+                                                            has_observers,
+                                                            loc,
                                                         );
                                                     }
                                                 }
@@ -3438,7 +3063,7 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
                                         }
                                     }
                                 }
-                            }
+                            };
                         });
                     });
             }
@@ -3485,24 +3110,22 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
                                     if let Some(tick) = t.get_changed_tick(c, table_row) {
                                         unsafe {
                                             if *(tick.get()) == last_run {
-                                                world.commands().queue(move |world: &mut World| {
-                                                    if has_hook {
-                                                        world
-                                                            .as_unsafe_world_cell()
-                                                            .into_deferred()
-                                                            .trigger_on_mutate(
-                                                                entity,
-                                                                [c].iter().copied(),
-                                                                MaybeLocation::caller(),
-                                                            );
-                                                    }
-                                                    if has_observer {
-                                                        world.trigger(MutateEvent {
+                                                if has_hook {
+                                                    world
+                                                        .as_unsafe_world_cell()
+                                                        .into_deferred()
+                                                        .trigger_on_mutate(
                                                             entity,
-                                                            components: [c].into(),
-                                                        });
-                                                    }
-                                                });
+                                                            [c].iter().copied(),
+                                                            MaybeLocation::caller(),
+                                                        );
+                                                }
+                                                if has_observer {
+                                                    world.trigger(MutateEvent {
+                                                        entity,
+                                                        components: [c].into(),
+                                                    });
+                                                }
                                             }
                                         }
                                     }
@@ -3515,24 +3138,22 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
                                     if let Some(tick) = s_s.get_changed_tick(entity) {
                                         unsafe {
                                             if *(tick.get()) == last_run {
-                                                world.commands().queue(move |world: &mut World| {
-                                                    if has_hook {
-                                                        world
-                                                            .as_unsafe_world_cell()
-                                                            .into_deferred()
-                                                            .trigger_on_mutate(
-                                                                entity,
-                                                                [c].iter().copied(),
-                                                                MaybeLocation::caller(),
-                                                            );
-                                                    }
-                                                    if has_observer {
-                                                        world.trigger(MutateEvent {
+                                                if has_hook {
+                                                    world
+                                                        .as_unsafe_world_cell()
+                                                        .into_deferred()
+                                                        .trigger_on_mutate(
                                                             entity,
-                                                            components: [c].into(),
-                                                        });
-                                                    }
-                                                });
+                                                            [c].iter().copied(),
+                                                            MaybeLocation::caller(),
+                                                        );
+                                                }
+                                                if has_observer {
+                                                    world.trigger(MutateEvent {
+                                                        entity,
+                                                        components: [c].into(),
+                                                    });
+                                                }
                                             }
                                         }
                                     }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -5,14 +5,19 @@
 
 pub use crate::change_detection::{NonSend, NonSendMut, Res, ResMut};
 use crate::{
-    archetype::Archetypes,
+    archetype::{ArchetypeEntity, Archetypes},
     bundle::Bundles,
-    change_detection::{ComponentTicksMut, ComponentTicksRef, Tick},
-    component::{ComponentId, Components, Mutable},
+    change_detection::{ComponentTicksMut, ComponentTicksRef, MaybeLocation, Tick},
+    component::{
+        ComponentId, Components, Mutable,
+        StorageType::{SparseSet, Table},
+    },
     entity::{Entities, EntityAllocator},
+    lifecycle::{MutateEvent, MUTATE},
     query::{
-        Access, FilteredAccess, FilteredAccessSet, IterQueryData, QueryData, QueryFilter,
-        QuerySingleError, QueryState, ReadOnlyQueryData,
+        Access, FilteredAccess, FilteredAccessSet,
+        InvertibleComponentIdSet::{Excluded, Included},
+        IterQueryData, QueryData, QueryFilter, QuerySingleError, QueryState, ReadOnlyQueryData,
     },
     resource::{Resource, IS_RESOURCE},
     system::{Query, Single, SystemMeta},
@@ -334,6 +339,263 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
         // The caller ensures the world matches the one used in init_state.
         Ok(unsafe { state.query_unchecked_with_ticks(world, system_meta.last_run, change_tick) })
     }
+
+    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        let muts = state.component_access().access().writes();
+        if let Included(m) = muts
+            && m.is_clear()
+        {
+            return;
+        }
+
+        let last_run = system_meta.get_last_run();
+        let archs = state.matched_archetypes();
+        let tables = &raw const world.storages().tables;
+        let sparse_sets = &raw const world.storages().sparse_sets;
+        let archetypes = &raw const *world.archetypes();
+        let has_global_or_entity_observer =
+            if let Some(o) = world.observers().try_get_observers(MUTATE) {
+                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+            } else {
+                false
+            };
+
+        archs
+            .filter_map(|arch| unsafe { (*archetypes).get(arch) })
+            .for_each(|a| {
+                let has_hook = a.has_mutate_hook();
+                let has_observer = a.has_mutate_observer() || has_global_or_entity_observer;
+                if !has_hook && !has_observer {
+                    return;
+                }
+                a.entities().iter().for_each(|e| {
+                    let entity = e.id();
+                    let table_row = e.table_row();
+                    let comps = match muts {
+                        Included(m) => m
+                            .iter()
+                            .filter(|c| {
+                                if let Some(s) = a.get_storage_type(*c) {
+                                    match s {
+                                        Table => {
+                                            let tables = unsafe { &*tables };
+                                            if let Some(t) = tables.get(a.table_id()) {
+                                                if let Some(tick) =
+                                                    t.get_changed_tick(*c, table_row)
+                                                {
+                                                    unsafe {
+                                                        return *(tick.get()) == last_run;
+                                                    }
+                                                }
+                                            }
+                                        }
+
+                                        SparseSet => {
+                                            let sparse_sets = unsafe { &*sparse_sets };
+                                            if let Some(s_s) = sparse_sets.get(*c) {
+                                                if let Some(tick) = s_s.get_changed_tick(entity) {
+                                                    unsafe {
+                                                        return *(tick.get()) == last_run;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                return false;
+                            })
+                            .collect::<Vec<_>>(),
+                        Excluded(m) => {
+                            // Unbounded Access, so naively scan all components not excluded.
+                            a.iter_components()
+                                .filter(|c| m.contains(*c))
+                                .filter(|c| {
+                                    if let Some(s) = a.get_storage_type(*c) {
+                                        match s {
+                                            Table => {
+                                                let tables = unsafe { &*tables };
+                                                if let Some(t) = tables.get(a.table_id()) {
+                                                    if let Some(tick) =
+                                                        t.get_changed_tick(*c, table_row)
+                                                    {
+                                                        unsafe {
+                                                            return *(tick.get()) == last_run;
+                                                        }
+                                                    }
+                                                }
+                                            }
+
+                                            SparseSet => {
+                                                let sparse_sets = unsafe { &*sparse_sets };
+                                                if let Some(s_s) = sparse_sets.get(*c) {
+                                                    if let Some(tick) = s_s.get_changed_tick(entity)
+                                                    {
+                                                        unsafe {
+                                                            return *(tick.get()) == last_run;
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    return false;
+                                })
+                                .collect::<Vec<_>>()
+                        }
+                    };
+                    if !comps.is_empty() {
+                        if has_hook {
+                            unsafe {
+                                world
+                                    .as_unsafe_world_cell()
+                                    .into_deferred()
+                                    .trigger_on_mutate(
+                                        entity,
+                                        comps.iter().copied(),
+                                        MaybeLocation::caller(),
+                                    );
+                            }
+                        }
+                        if has_observer {
+                            world.trigger(MutateEvent {
+                                entity,
+                                components: comps,
+                            });
+                        }
+                    }
+                });
+            });
+    }
+
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, mut world: DeferredWorld) {
+        let muts = state.component_access().access().writes();
+        if let Included(m) = muts
+            && m.is_clear()
+        {
+            return;
+        }
+
+        let last_run = system_meta.get_last_run();
+        let archs = state.matched_archetypes();
+        let tables = &raw const world.storages().tables;
+        let sparse_sets = &raw const world.storages().sparse_sets;
+        let archetypes = &raw const *world.archetypes();
+        let has_global_or_entity_observer =
+            if let Some(o) = world.observers().try_get_observers(MUTATE) {
+                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+            } else {
+                false
+            };
+        let mut commands = world.commands();
+
+        archs
+            .filter_map(|arch| unsafe { (*archetypes).get(arch) })
+            .for_each(|a| {
+                let has_hook = a.has_mutate_hook();
+                let has_observer = a.has_mutate_observer() || has_global_or_entity_observer;
+                if !has_hook && !has_observer {
+                    return;
+                }
+                a.entities().iter().for_each(|e| {
+                    let entity = e.id();
+                    let table_row = e.table_row();
+                    let comps = match muts {
+                        Included(m) => m
+                            .iter()
+                            .filter(|c| {
+                                if let Some(s) = a.get_storage_type(*c) {
+                                    match s {
+                                        Table => {
+                                            let tables = unsafe { &*tables };
+                                            if let Some(t) = tables.get(a.table_id()) {
+                                                if let Some(tick) =
+                                                    t.get_changed_tick(*c, table_row)
+                                                {
+                                                    unsafe {
+                                                        return *(tick.get()) == last_run;
+                                                    }
+                                                }
+                                            }
+                                        }
+
+                                        SparseSet => {
+                                            let sparse_sets = unsafe { &*sparse_sets };
+                                            if let Some(s_s) = sparse_sets.get(*c) {
+                                                if let Some(tick) = s_s.get_changed_tick(entity) {
+                                                    unsafe {
+                                                        return *(tick.get()) == last_run;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                return false;
+                            })
+                            .collect::<Vec<_>>(),
+                        Excluded(m) => {
+                            // Unbounded Access, so naively scan all components not excluded.
+                            a.iter_components()
+                                .filter(|c| m.contains(*c))
+                                .filter(|c| {
+                                    if let Some(s) = a.get_storage_type(*c) {
+                                        match s {
+                                            Table => {
+                                                let tables = unsafe { &*tables };
+                                                if let Some(t) = tables.get(a.table_id()) {
+                                                    if let Some(tick) =
+                                                        t.get_changed_tick(*c, table_row)
+                                                    {
+                                                        unsafe {
+                                                            return *(tick.get()) == last_run;
+                                                        }
+                                                    }
+                                                }
+                                            }
+
+                                            SparseSet => {
+                                                let sparse_sets = unsafe { &*sparse_sets };
+                                                if let Some(s_s) = sparse_sets.get(*c) {
+                                                    if let Some(tick) = s_s.get_changed_tick(entity)
+                                                    {
+                                                        unsafe {
+                                                            return *(tick.get()) == last_run;
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    return false;
+                                })
+                                .collect::<Vec<_>>()
+                        }
+                    };
+                    if !comps.is_empty() {
+                        commands.queue(move |world: &mut World| {
+                            if has_hook {
+                                unsafe {
+                                    world
+                                        .as_unsafe_world_cell()
+                                        .into_deferred()
+                                        .trigger_on_mutate(
+                                            entity,
+                                            comps.iter().copied(),
+                                            MaybeLocation::caller(),
+                                        );
+                                }
+                            }
+                            if has_observer {
+                                world.trigger(MutateEvent {
+                                    entity,
+                                    components: comps,
+                                });
+                            }
+                        });
+                    }
+                });
+            });
+    }
 }
 
 // SAFETY: Relevant query ComponentId access is applied to SystemMeta. If
@@ -381,6 +643,14 @@ unsafe impl<'a, 'b, D: IterQueryData + 'static, F: QueryFilter + 'static> System
             ),
         }
     }
+
+    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        Query::apply(state, system_meta, world);
+    }
+
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
+        Query::queue(state, system_meta, world);
+    }
 }
 
 // SAFETY: QueryState is constrained to read-only fetches, so it only reads World.
@@ -426,6 +696,14 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         } else {
             Ok(Populated(query))
         }
+    }
+
+    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        Query::apply(state, system_meta, world);
+    }
+
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
+        Query::queue(state, system_meta, world);
     }
 }
 
@@ -779,6 +1057,202 @@ unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T>
                 summary_tick: None,
             },
         })
+    }
+
+    fn apply(&mut component_id: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        let (entity, table_row, storage, table_id, has_hook, has_observer) = {
+            let archetype = if let Some(h) = world.archetypes().component_index().get(&component_id)
+            {
+                let a = h.iter().next().unwrap();
+                if let Some(a) = world.archetypes().get(*a.0) {
+                    a
+                } else {
+                    return;
+                }
+            } else {
+                return;
+            };
+            let arch_entity = archetype.entities()[0];
+            let has_observer = archetype.has_mutate_observer()
+                || world
+                    .observers()
+                    .try_get_observers(MUTATE)
+                    .map_or(false, |o| {
+                        !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+                    });
+
+            (
+                arch_entity.id(),
+                arch_entity.table_row(),
+                archetype.get_storage_type(component_id).unwrap(),
+                archetype.table_id(),
+                archetype.has_mutate_hook(),
+                has_observer,
+            )
+        };
+        if !has_hook && !has_observer {
+            return;
+        }
+
+        let last_run = system_meta.last_run;
+        match storage {
+            Table => {
+                let tables = &world.storages().tables;
+                if let Some(t) = tables.get(table_id) {
+                    if let Some(tick) = t.get_changed_tick(component_id, table_row) {
+                        unsafe {
+                            if *(tick.get()) == last_run {
+                                if has_hook {
+                                    world
+                                        .as_unsafe_world_cell()
+                                        .into_deferred()
+                                        .trigger_on_mutate(
+                                            entity,
+                                            [component_id].iter().copied(),
+                                            MaybeLocation::caller(),
+                                        );
+                                }
+                                if has_observer {
+                                    world.trigger(MutateEvent {
+                                        entity,
+                                        components: [component_id].into(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            SparseSet => {
+                let sparse_sets = &world.storages().sparse_sets;
+                if let Some(s) = sparse_sets.get(component_id) {
+                    if let Some(tick) = s.get_changed_tick(entity) {
+                        unsafe {
+                            if *(tick.get()) == last_run {
+                                if has_hook {
+                                    world
+                                        .as_unsafe_world_cell()
+                                        .into_deferred()
+                                        .trigger_on_mutate(
+                                            entity,
+                                            [component_id].iter().copied(),
+                                            MaybeLocation::caller(),
+                                        );
+                                }
+                                if has_observer {
+                                    world.trigger(MutateEvent {
+                                        entity,
+                                        components: [component_id].into(),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn queue(
+        &mut component_id: &mut Self::State,
+        system_meta: &SystemMeta,
+        mut world: DeferredWorld,
+    ) {
+        let (entity, table_row, storage, table_id, has_hook, has_observer) = {
+            let archetype = if let Some(h) = world.archetypes().component_index().get(&component_id)
+            {
+                let a = h.iter().next().unwrap();
+                if let Some(a) = world.archetypes().get(*a.0) {
+                    a
+                } else {
+                    return;
+                }
+            } else {
+                return;
+            };
+            let arch_entity = archetype.entities()[0];
+            let has_observer = archetype.has_mutate_observer()
+                || world
+                    .observers()
+                    .try_get_observers(MUTATE)
+                    .map_or(false, |o| {
+                        !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+                    });
+
+            (
+                arch_entity.id(),
+                arch_entity.table_row(),
+                archetype.get_storage_type(component_id).unwrap(),
+                archetype.table_id(),
+                archetype.has_mutate_hook(),
+                has_observer,
+            )
+        };
+        if !has_hook && !has_observer {
+            return;
+        }
+
+        let last_run = system_meta.last_run;
+        match storage {
+            Table => {
+                let tables = &world.storages().tables;
+                if let Some(t) = tables.get(table_id) {
+                    if let Some(tick) = t.get_changed_tick(component_id, table_row) {
+                        unsafe {
+                            if *(tick.get()) == last_run {
+                                world.commands().queue(move |world: &mut World| {
+                                    if has_hook {
+                                        world
+                                            .as_unsafe_world_cell()
+                                            .into_deferred()
+                                            .trigger_on_mutate(
+                                                entity,
+                                                [component_id].iter().copied(),
+                                                MaybeLocation::caller(),
+                                            );
+                                    }
+                                    if has_observer {
+                                        world.trigger(MutateEvent {
+                                            entity,
+                                            components: [component_id].into(),
+                                        });
+                                    }
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            SparseSet => {
+                let sparse_sets = &world.storages().sparse_sets;
+                if let Some(s) = sparse_sets.get(component_id) {
+                    if let Some(tick) = s.get_changed_tick(entity) {
+                        unsafe {
+                            if *(tick.get()) == last_run {
+                                world.commands().queue(move |world: &mut World| {
+                                    if has_hook {
+                                        world
+                                            .as_unsafe_world_cell()
+                                            .into_deferred()
+                                            .trigger_on_mutate(
+                                                entity,
+                                                [component_id].iter().copied(),
+                                                MaybeLocation::caller(),
+                                            );
+                                    }
+                                    if has_observer {
+                                        world.trigger(MutateEvent {
+                                            entity,
+                                            components: [component_id].into(),
+                                        });
+                                    }
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -2652,6 +3126,422 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
         // SAFETY: The caller ensures that `world` has access to anything registered in `init_access`,
         // and we registered all resource access in `state``.
         Ok(unsafe { FilteredResourcesMut::new(world, state, system_meta.last_run, change_tick) })
+    }
+
+    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        let muts = state.writes();
+        if let Included(m) = muts
+            && m.is_clear()
+        {
+            return;
+        }
+
+        let last_run = system_meta.get_last_run();
+        let tables = &raw const world.storages().tables;
+        let sparse_sets = &raw const world.storages().sparse_sets;
+        let archetypes = &raw const *world.archetypes();
+        let has_global_or_entity_observer =
+            if let Some(o) = world.observers().try_get_observers(MUTATE) {
+                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+            } else {
+                false
+            };
+
+        match muts {
+            Included(m) => {
+                m.iter()
+                    .filter_map(|c| unsafe {
+                        let a = *(*archetypes)
+                            .component_index()
+                            .get(&c)
+                            .unwrap()
+                            .iter()
+                            .next()
+                            .unwrap()
+                            .0;
+                        Some((c, (*archetypes).get(a)?))
+                    })
+                    .for_each(|(c, a)| {
+                        let has_hook = a.has_mutate_hook();
+                        let has_observer = a.has_mutate_observer() || has_global_or_entity_observer;
+                        if !has_hook && !has_observer {
+                            return;
+                        }
+                        a.entities().iter().for_each(|e| {
+                            let entity = e.id();
+                            let table_row = e.table_row();
+                            if let Some(s) = a.get_storage_type(c) {
+                                match s {
+                                    Table => {
+                                        let tables = unsafe { &*tables };
+                                        if let Some(t) = tables.get(a.table_id()) {
+                                            if let Some(tick) = t.get_changed_tick(c, table_row) {
+                                                unsafe {
+                                                    if *(tick.get()) == last_run {
+                                                        if has_hook {
+                                                            world
+                                                                .as_unsafe_world_cell()
+                                                                .into_deferred()
+                                                                .trigger_on_mutate(
+                                                                    entity,
+                                                                    [c].iter().copied(),
+                                                                    MaybeLocation::caller(),
+                                                                );
+                                                        }
+                                                        if has_observer {
+                                                            world.trigger(MutateEvent {
+                                                                entity,
+                                                                components: [c].into(),
+                                                            });
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    SparseSet => {
+                                        let sparse_sets = unsafe { &*sparse_sets };
+                                        if let Some(s_s) = sparse_sets.get(c) {
+                                            if let Some(tick) = s_s.get_changed_tick(entity) {
+                                                unsafe {
+                                                    if *(tick.get()) == last_run {
+                                                        if has_hook {
+                                                            world
+                                                                .as_unsafe_world_cell()
+                                                                .into_deferred()
+                                                                .trigger_on_mutate(
+                                                                    entity,
+                                                                    [c].iter().copied(),
+                                                                    MaybeLocation::caller(),
+                                                                );
+                                                        }
+                                                        if has_observer {
+                                                            world.trigger(MutateEvent {
+                                                                entity,
+                                                                components: [c].into(),
+                                                            });
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                    });
+            }
+            Excluded(m) => world
+                .resource_entities()
+                .iter()
+                .filter_map(|(c, _)| if m.contains(c) { Some(c) } else { None })
+                .collect::<Vec<_>>()
+                .iter()
+                .copied()
+                .for_each(|c| {
+                    let (entity, table_row, table_id, storage, has_hook, has_observer) = {
+                        let arch = *world
+                            .archetypes()
+                            .component_index()
+                            .get(&c)
+                            .unwrap()
+                            .iter()
+                            .next()
+                            .unwrap()
+                            .0;
+                        let a = world.archetypes().get(arch).unwrap();
+                        let arch_entity = a.entities()[0];
+                        let has_global_or_entity_observer = world
+                            .observers()
+                            .try_get_observers(MUTATE)
+                            .map_or(false, |o| {
+                                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+                            });
+                        (
+                            arch_entity.id(),
+                            arch_entity.table_row(),
+                            a.table_id(),
+                            a.get_storage_type(c),
+                            a.has_mutate_hook(),
+                            a.has_mutate_observer() || has_global_or_entity_observer,
+                        )
+                    };
+                    if let Some(s) = storage {
+                        match s {
+                            Table => {
+                                let tables = unsafe { &*tables };
+                                if let Some(t) = tables.get(table_id) {
+                                    if let Some(tick) = t.get_changed_tick(c, table_row) {
+                                        unsafe {
+                                            if *(tick.get()) == last_run {
+                                                if has_hook {
+                                                    world
+                                                        .as_unsafe_world_cell()
+                                                        .into_deferred()
+                                                        .trigger_on_mutate(
+                                                            entity,
+                                                            [c].iter().copied(),
+                                                            MaybeLocation::caller(),
+                                                        );
+                                                }
+                                                if has_observer {
+                                                    world.trigger(MutateEvent {
+                                                        entity,
+                                                        components: [c].into(),
+                                                    });
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            SparseSet => {
+                                let sparse_sets = unsafe { &*sparse_sets };
+                                if let Some(s_s) = sparse_sets.get(c) {
+                                    if let Some(tick) = s_s.get_changed_tick(entity) {
+                                        unsafe {
+                                            if *(tick.get()) == last_run {
+                                                if has_hook {
+                                                    world
+                                                        .as_unsafe_world_cell()
+                                                        .into_deferred()
+                                                        .trigger_on_mutate(
+                                                            entity,
+                                                            [c].iter().copied(),
+                                                            MaybeLocation::caller(),
+                                                        );
+                                                }
+                                                if has_observer {
+                                                    world.trigger(MutateEvent {
+                                                        entity,
+                                                        components: [c].into(),
+                                                    });
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }),
+        };
+    }
+
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, mut world: DeferredWorld) {
+        let muts = state.writes();
+        if let Included(m) = muts
+            && m.is_clear()
+        {
+            return;
+        }
+
+        let last_run = system_meta.get_last_run();
+        let tables = &raw const world.storages().tables;
+        let sparse_sets = &raw const world.storages().sparse_sets;
+        let archetypes = &raw const *world.archetypes();
+        let has_global_or_entity_observer =
+            if let Some(o) = world.observers().try_get_observers(MUTATE) {
+                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+            } else {
+                false
+            };
+
+        match muts {
+            Included(m) => {
+                m.iter()
+                    .filter_map(|c| unsafe {
+                        let a = *(*archetypes)
+                            .component_index()
+                            .get(&c)
+                            .unwrap()
+                            .iter()
+                            .next()
+                            .unwrap()
+                            .0;
+                        Some((c, (*archetypes).get(a)?))
+                    })
+                    .for_each(|(c, a)| {
+                        let has_hook = a.has_mutate_hook();
+                        let has_observer = a.has_mutate_observer() || has_global_or_entity_observer;
+                        if !has_hook && !has_observer {
+                            return;
+                        }
+                        a.entities().iter().for_each(|e| {
+                            let entity = e.id();
+                            let table_row = e.table_row();
+                            if let Some(s) = a.get_storage_type(c) {
+                                match s {
+                                    Table => {
+                                        let tables = unsafe { &*tables };
+                                        if let Some(t) = tables.get(a.table_id()) {
+                                            if let Some(tick) = t.get_changed_tick(c, table_row) {
+                                                unsafe {
+                                                    if *(tick.get()) == last_run {
+                                                        world.commands().queue(
+                                                            move |world: &mut World| {
+                                                                if has_hook {
+                                                                    world
+                                                                        .as_unsafe_world_cell()
+                                                                        .into_deferred()
+                                                                        .trigger_on_mutate(
+                                                                            entity,
+                                                                            [c].iter().copied(),
+                                                                            MaybeLocation::caller(),
+                                                                        );
+                                                                }
+                                                                if has_observer {
+                                                                    world.trigger(MutateEvent {
+                                                                        entity,
+                                                                        components: [c].into(),
+                                                                    });
+                                                                }
+                                                            },
+                                                        );
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    SparseSet => {
+                                        let sparse_sets = unsafe { &*sparse_sets };
+                                        if let Some(s_s) = sparse_sets.get(c) {
+                                            if let Some(tick) = s_s.get_changed_tick(entity) {
+                                                unsafe {
+                                                    if *(tick.get()) == last_run {
+                                                        world.commands().queue(
+                                                            move |world: &mut World| {
+                                                                if has_hook {
+                                                                    world
+                                                                        .as_unsafe_world_cell()
+                                                                        .into_deferred()
+                                                                        .trigger_on_mutate(
+                                                                            entity,
+                                                                            [c].iter().copied(),
+                                                                            MaybeLocation::caller(),
+                                                                        );
+                                                                }
+                                                                if has_observer {
+                                                                    world.trigger(MutateEvent {
+                                                                        entity,
+                                                                        components: [c].into(),
+                                                                    });
+                                                                }
+                                                            },
+                                                        );
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        });
+                    });
+            }
+            Excluded(m) => world
+                .resource_entities()
+                .iter()
+                .filter_map(|(c, _)| if m.contains(c) { Some(c) } else { None })
+                .collect::<Vec<_>>()
+                .iter()
+                .copied()
+                .for_each(|c| {
+                    let (entity, table_row, table_id, storage, has_hook, has_observer) = {
+                        let arch = *world
+                            .archetypes()
+                            .component_index()
+                            .get(&c)
+                            .unwrap()
+                            .iter()
+                            .next()
+                            .unwrap()
+                            .0;
+                        let a = world.archetypes().get(arch).unwrap();
+                        let arch_entity = a.entities()[0];
+                        let has_global_or_entity_observer = world
+                            .observers()
+                            .try_get_observers(MUTATE)
+                            .map_or(false, |o| {
+                                !o.global_observers().is_empty() || !o.entity_observers().is_empty()
+                            });
+                        (
+                            arch_entity.id(),
+                            arch_entity.table_row(),
+                            a.table_id(),
+                            a.get_storage_type(c),
+                            a.has_mutate_hook(),
+                            a.has_mutate_observer() || has_global_or_entity_observer,
+                        )
+                    };
+                    if let Some(s) = storage {
+                        match s {
+                            Table => {
+                                let tables = unsafe { &*tables };
+                                if let Some(t) = tables.get(table_id) {
+                                    if let Some(tick) = t.get_changed_tick(c, table_row) {
+                                        unsafe {
+                                            if *(tick.get()) == last_run {
+                                                world.commands().queue(move |world: &mut World| {
+                                                    if has_hook {
+                                                        world
+                                                            .as_unsafe_world_cell()
+                                                            .into_deferred()
+                                                            .trigger_on_mutate(
+                                                                entity,
+                                                                [c].iter().copied(),
+                                                                MaybeLocation::caller(),
+                                                            );
+                                                    }
+                                                    if has_observer {
+                                                        world.trigger(MutateEvent {
+                                                            entity,
+                                                            components: [c].into(),
+                                                        });
+                                                    }
+                                                });
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            SparseSet => {
+                                let sparse_sets = unsafe { &*sparse_sets };
+                                if let Some(s_s) = sparse_sets.get(c) {
+                                    if let Some(tick) = s_s.get_changed_tick(entity) {
+                                        unsafe {
+                                            if *(tick.get()) == last_run {
+                                                world.commands().queue(move |world: &mut World| {
+                                                    if has_hook {
+                                                        world
+                                                            .as_unsafe_world_cell()
+                                                            .into_deferred()
+                                                            .trigger_on_mutate(
+                                                                entity,
+                                                                [c].iter().copied(),
+                                                                MaybeLocation::caller(),
+                                                            );
+                                                    }
+                                                    if has_observer {
+                                                        world.trigger(MutateEvent {
+                                                            entity,
+                                                            components: [c].into(),
+                                                        });
+                                                    }
+                                                });
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }),
+        };
     }
 }
 

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -654,6 +654,35 @@ impl<'w> DeferredWorld<'w> {
         }
     }
 
+    /// Triggers all `on_mutate` hooks for [`ComponentId`] in target.
+    ///
+    /// Unlike other `trigger_on_*` methods, it does not check [`Archetype::has_mutate_hook`].
+    /// # Safety
+    /// Caller must ensure [`ComponentId`] in target exist in self.
+    #[inline]
+    pub(crate) unsafe fn trigger_on_mutate(
+        &mut self,
+        entity: Entity,
+        targets: impl Iterator<Item = ComponentId>,
+        caller: MaybeLocation,
+    ) {
+        for component_id in targets {
+            // SAFETY: Caller ensures that these components exist
+            let hooks = unsafe { self.components().get_info_unchecked(component_id) }.hooks();
+            if let Some(hook) = hooks.on_mutate {
+                hook(
+                    DeferredWorld { world: self.world },
+                    HookContext {
+                        entity,
+                        component_id,
+                        caller,
+                        relationship_hook_mode: RelationshipHookMode::Run,
+                    },
+                );
+            }
+        }
+    }
+
     /// Triggers all `on_discard` hooks for [`ComponentId`] in target.
     ///
     /// # Safety

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -666,6 +666,35 @@ impl<'w> DeferredWorld<'w> {
         }
     }
 
+    /// Triggers all `on_mutate` hooks for [`ComponentId`] in target.
+    ///
+    /// Unlike other `trigger_on_*` methods, it does not check [`Archetype::has_mutate_hook`].
+    /// # Safety
+    /// Caller must ensure [`ComponentId`] in target exist in self.
+    #[inline]
+    pub(crate) unsafe fn trigger_on_mutate(
+        &mut self,
+        entity: Entity,
+        targets: impl Iterator<Item = ComponentId>,
+        caller: MaybeLocation,
+    ) {
+        for component_id in targets {
+            // SAFETY: Caller ensures that these components exist
+            let hooks = unsafe { self.components().get_info_unchecked(component_id) }.hooks();
+            if let Some(hook) = hooks.on_mutate {
+                hook(
+                    DeferredWorld { world: self.world },
+                    HookContext {
+                        entity,
+                        component_id,
+                        caller,
+                        relationship_hook_mode: RelationshipHookMode::Run,
+                    },
+                );
+            }
+        }
+    }
+
     /// Triggers all `on_discard` hooks for [`ComponentId`] in target.
     ///
     /// # Safety

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -47,8 +47,8 @@ use crate::{
     entity_disabling::DefaultQueryFilters,
     error::{ErrorHandler, FallbackErrorHandler},
     lifecycle::{
-        AddEvent, ComponentHooks, DespawnEvent, DiscardEvent, InsertEvent, RemoveEvent,
-        RemovedComponentMessages, ADD, DESPAWN, DISCARD, INSERT, MUTATE, REMOVE,
+        AddEvent, ComponentHooks, DespawnEvent, DiscardEvent, InsertEvent, MutateEvent,
+        RemoveEvent, RemovedComponentMessages, ADD, DESPAWN, DISCARD, INSERT, MUTATE, REMOVE,
     },
     message::{Message, MessageId, Messages, WriteBatchIds},
     observer::Observers,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -46,10 +46,12 @@ use crate::{
     entity::{Entities, Entity, EntityAllocator, EntityNotSpawnedError, SpawnError},
     entity_disabling::DefaultQueryFilters,
     error::{ErrorHandler, FallbackErrorHandler},
-    lifecycle::{ComponentHooks, RemovedComponentMessages, ADD, DESPAWN, DISCARD, INSERT, REMOVE},
+    lifecycle::{
+        ComponentHooks, RemovedComponentMessages, ADD, DESPAWN, DISCARD, INSERT, MUTATE, REMOVE,
+    },
     message::{Message, MessageId, Messages, WriteBatchIds},
     observer::Observers,
-    prelude::{Add, Despawn, Discard, Insert, Remove},
+    prelude::{Add, Despawn, Discard, Insert, Mutate, Remove},
     query::{DebugCheckedUnwrap, QueryData, QueryFilter, QueryState},
     relationship::RelationshipHookMode,
     resource::{IsResource, Resource, ResourceEntities, IS_RESOURCE},
@@ -158,6 +160,9 @@ impl World {
 
         let on_insert = self.register_event_key::<Insert>();
         assert_eq!(INSERT, on_insert);
+
+        let on_mutate = self.register_event_key::<Mutate>();
+        assert_eq!(MUTATE, on_mutate);
 
         let on_discard = self.register_event_key::<Discard>();
         assert_eq!(DISCARD, on_discard);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -48,7 +48,7 @@ use crate::{
     error::{ErrorHandler, FallbackErrorHandler},
     lifecycle::{
         AddEvent, ComponentHooks, DespawnEvent, DiscardEvent, InsertEvent, RemoveEvent,
-        RemovedComponentMessages, ADD, DESPAWN, DISCARD, INSERT, REMOVE,
+        RemovedComponentMessages, ADD, DESPAWN, DISCARD, INSERT, MUTATE, REMOVE,
     },
     message::{Message, MessageId, Messages, WriteBatchIds},
     observer::Observers,
@@ -165,6 +165,9 @@ impl World {
 
         let on_insert = self.register_event_key::<InsertEvent>();
         assert_eq!(INSERT, on_insert);
+
+        let on_mutate = self.register_event_key::<MutateEvent>();
+        assert_eq!(MUTATE, on_mutate);
 
         let on_discard = self.register_event_key::<DiscardEvent>();
         assert_eq!(DISCARD, on_discard);


### PR DESCRIPTION
Mutate Event/Hook

# Objective
Lifecycle Hooks/Events currently cover Immutable Components changing value and changing structurally for all Components, but often times we would like it if it also covered Mutable Components changing value.

So that Lifecycle Hooks/Events cover All Components changing value or structurally.

## Solution

Prior PR/Approach: https://github.com/bevyengine/bevy/pull/16143
Arrived at the same solution, didnt actually look at the code.

This approach attempts to give `SystemParam::apply/queue` the responsibility of triggering/queuing Mutate Events via Change Tick scans of their mutably-accessed Components.

Some things to note:
1. Mutate Events are grouped by individual SystemParam, which in most cases is fine and leads to normal results, although some wierdness can occur when using a collection of SystemParams that happen to overlap. ex. `ParamSet` with two identical queries.
2. The main driver for knowledge of access is, `Access`, which can contain `Unbounded` acessess's (ex. `EntityMutExcept<...>`). In these cases we are not given any definite knowledge as to what was accessed and what wasn't so we must scan every component, except the ones excluded if any.

Impled for Query, ResMut, FilteredResourcesMut.

## Testing

- Did you test these changes? If so, how? Barely, just ran bevy_city with and without. I'm not a good tester.
- Are there any parts that need more testing? All of it, please.

---

## Showcase

```rust
fn mutate_observer(mutate: On<Mutate>) {
    let entity = mutate.entity;
    let components = &mutate.components;
    println!("{mutate:?}");
}

fn mutate_component_observer(mutate: On<Mutate, Transform>) {
    let entity = mutate.entity;
    let components = &mutate.components;
    println!("{mutate:?}");
}

#[derive(Component)]
struct MyComponent {
    // ...
}

impl MyComponent {
    fn on_mutate(mut world: DeferredWorld, hook: HookContext) {
        // ...
    }
}
```
