### PR TITLE
Fix from raw parts

### DIFF
--- a/crates/bevy_platform/src/collections/aligned_vec.rs
+++ b/crates/bevy_platform/src/collections/aligned_vec.rs
@@ -185,7 +185,7 @@ impl AlignedVec {
     ///
     /// Usually the safe methods `reserve` or `reserve_exact` are a better
     /// choice. This method only exists as a micro-optimization for very
-    /// performance-sensitive code where where the calculation of capacity
+    /// performance-sensitive code where the calculation of capacity
     /// required has already been performed, and you want to avoid doing it
     /// again, or if you want to implement a different growth strategy.
     ///
@@ -449,7 +449,7 @@ impl AlignedVec {
     ///
     /// Usually the safe methods `reserve` or `reserve_exact` are a better
     /// choice. This method only exists as a micro-optimization for very
-    /// performance-sensitive code where where the calculation of capacity
+    /// performance-sensitive code where the calculation of capacity
     /// required has already been performed, and you want to avoid doing it
     /// again.
     ///
@@ -875,19 +875,19 @@ impl AlignedVec {
     /// This is highly unsafe, due to the number of invariants that aren't
     /// checked:
     ///
-    /// * If the capacity is nonzero, `ptr` must have
-    ///   been allocated using the global allocator, such as via the [`alloc::alloc`]
-    ///   function. If the capacity is zero, `ptr` need only be aligned.
-    /// * `align` needs to be equal to the alignment as what `ptr` was allocated with,
-    ///   if the pointer is required to be allocated.
-    /// * The `capacity` (i.e. the allocated size in bytes), if
-    ///   nonzero, needs to be the same size as the pointer was allocated with.
-    ///   (Because similar to alignment, [`dealloc`] must be called with the same
-    ///   layout `size`.)
+    /// * `align` must be a non-zero power of two, and must be less than
+    ///   `isize::MAX`.
+    /// * `capacity`, when rounded up to the nearest multiple of `align`, must
+    ///   not overflow `isize`.
+    /// * If the capacity is nonzero, `ptr` must have been allocated using
+    ///   the global allocator, such as via the [`alloc::alloc`] function,
+    ///   with a [`Layout`] using this exact `align` and a `size` of `capacity`.
+    ///   (Because similar to alignment, [`dealloc`] must be called with the
+    ///   same layout `size`.)
+    /// * If the capacity is zero, `ptr` need not point to allocated memory,
+    ///   but it must still be aligned to `align` bytes (i.e.
+    ///   `ptr.as_ptr() as usize % align == 0`).
     /// * `length` needs to be less than or equal to `capacity`.
-    /// * `capacity` needs to be the capacity that the pointer was allocated with,
-    ///   if the pointer is required to be allocated.
-    /// * The allocated size in bytes must be no larger than `isize::MAX`.
     ///
     /// # Example
     ///


### PR DESCRIPTION
# Objective

`AlignedVec::from_raw_parts`'s safety documentation has a contract gap: when `capacity == 0`, it only said `ptr` "need only be aligned" and never required `align` itself to be a non-zero power of two. This means a caller can construct an `AlignedVec` that satisfies the *documented* contract literally (e.g. `align = 3`, `capacity = 0`), yet later trigger undefined behavior through purely safe method calls (e.g. `push`), because internal methods like `layout()` unconditionally build a `Layout` via `Layout::from_size_align_unchecked(self.cap, self.align)`, which requires `align` to be a non-zero power of two regardless of `capacity`.

The old docs were also imprecise about:
- there being no upper bound stated on `align` independent of allocation
- what "capacity ... needs to be the same size" meant when the pointer isn't required to be allocated
- what exact byte alignment `ptr` must satisfy when `capacity == 0`

## Solution

Rewrote the `# Safety` section of `from_raw_parts` to state the invariants unconditionally and precisely:

- `align` must be a non-zero power of two, and less than `isize::MAX` — regardless of `capacity`, since `align` is used to build a `Layout` even when the vector currently has zero capacity.
- `capacity`, rounded up to the nearest multiple of `align`, must not overflow `isize`.
- If `capacity != 0`, `ptr` must have been allocated with a `Layout` using this exact `align` and a `size` of `capacity` (merging the two previously-separate, overlapping clauses about matching align/size on dealloc).
- If `capacity == 0`, `ptr` need not point to allocated memory, but must still satisfy `ptr.as_ptr() as usize % align == 0` (replacing the ambiguous "need only be aligned").

No functional code changed — this is a documentation-only fix to close the public unsafe contract gap.

## Testing

- Verified the change compiles: `cargo doc -p bevy_platform --no-deps` passes, and the existing doctest on `from_raw_parts` still passes.
- To confirm the gap in the *original* docs was real (not just a theoretical wording nitpick), I built a standalone reproduction outside this repo: 

```rust
use bevy_platform::collections::AlignedVec;
use core::ptr::NonNull;

fn test_align_not_power_of_two() {
    unsafe {
        let ptr = NonNull::new(3usize as *mut u8).unwrap();
        let mut vec = AlignedVec::from_raw_parts(ptr, 3, 0, 0);
        // Triggers UB: Layout::from_size_align_unchecked(new_cap, 3)
        // requires align to be power of 2.
        vec.push(1);
    }
}

fn main() {
    test_align_not_power_of_two();
}
```

I use the command `cargo +nightly-x86_64-pc-windows-gnu miri run` to test the above code, and it trigger the unsafe precondition(s) violation:

```
thread 'main' (1) panicked at D:\projects\bevy\crates\bevy_platform\src\collections\aligned_vec.rs:227:30:
unsafe precondition(s) violated: Layout::from_size_align_unchecked requires that align is a power of 2 and the rounded-up allocation size does not exceed isize::MAX

This indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
note: in Miri, you may have to set `MIRIFLAGS=-Zmiri-env-forward=RUST_BACKTRACE` for the environment variable to have an effect
thread caused non-unwinding panic. aborting.
```