### PR TITLE
Fix: remove unnecessary unsafe of ErasedBundleTemplate::apply

### DIFF
--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -335,13 +335,9 @@ impl ResolvedScene {
         }
 
         for template in &self.bundle_templates {
-            // SAFETY: bundle_writer is used with the same World across all template.apply calls,
-            // and the next bundle_writer.write call
-            unsafe {
-                template
-                    .apply(context)
-                    .map_err(ApplySceneError::TemplateBuildError)?;
-            }
+            template
+                .apply(context)
+                .map_err(ApplySceneError::TemplateBuildError)?;
         }
         Ok(())
     }
@@ -735,20 +731,14 @@ impl<T: Template<Output: Component> + Send + Sync + 'static> ErasedComponentTemp
 /// immediately to a given `entity`.
 pub trait ErasedBundleTemplate: Any + Send + Sync {
     /// Applies this template to the given `entity`.
-    ///
-    /// # Safety
-    ///
-    /// `bundle_writer` must always be used with the same World that is stored in `context`. This
-    /// is intended to be used by a scene system in a scoped / controlled / easily verifiable context.
-    /// If you are calling it outside of that context, you are almost certainly doing something wrong!
-    unsafe fn apply(&self, context: &mut TemplateContext) -> Result<(), BevyError>;
+    fn apply(&self, context: &mut TemplateContext) -> Result<(), BevyError>;
 
     /// Clones this template. See [`Clone`].
     fn clone_template(&self) -> Box<dyn ErasedBundleTemplate>;
 }
 
 impl<T: Template<Output: Bundle> + Send + Sync + 'static> ErasedBundleTemplate for T {
-    unsafe fn apply(&self, context: &mut TemplateContext) -> Result<(), BevyError> {
+    fn apply(&self, context: &mut TemplateContext) -> Result<(), BevyError> {
         let bundle = self.build_template(context)?;
         context.entity.insert(bundle);
         Ok(())


### PR DESCRIPTION
# Objective

`ErasedBundleTemplate::apply` in `bevy_scene` was declared `unsafe fn`, but its `# Safety` contract was stale and unenforceable. The documented precondition referenced a `bundle_writer` parameter that this method does not have — the wording seems copied from [ErasedComponentTemplate::apply](https://github.com/bevyengine/bevy/blob/main/crates/bevy_scene/src/resolved_scene.rs#L704), which *does* take a `bundle_writer: &mut BundleWriter` and uses it inside an unsafe call. On [ErasedBundleTemplate::apply](https://github.com/bevyengine/bevy/blob/main/crates/bevy_scene/src/resolved_scene.rs#L744) there is no `bundle_writer`, so the stated caller-side obligation cannot be satisfied or verified.

The default blanket impl only performs safe operations:

```rust
impl<T: Template<Output: Bundle> + Send + Sync + 'static> ErasedBundleTemplate for T {
    unsafe fn apply(&self, context: &mut TemplateContext) -> Result<(), BevyError> {
        let bundle = self.build_template(context)?;
        context.entity.insert(bundle);
        Ok(())
    }
}
```

`build_template` and `EntityWorldMut::insert` are both safe, so the `unsafe` marker imposed a caller obligation the body never needed. 

## Solution

Drop the unnecessary `unsafe` and remove the stale `# Safety` documentation, since no real caller-verifiable invariant exists for this method:

## Testing

The computer I use don't install the msvc, so I use the following command to test

- `cargo +nightly-x86_64-pc-windows-gnu build -p bevy_scene`: Successfully build
- `cargo +nightly-x86_64-pc-windows-gnu test -p bevy_scene`: Pass 



---
