### PR TITLE
Fix UB detected by Miri when running the multi-threaded executor

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -331,7 +331,9 @@ impl<'scope, 'env: 'scope, 'sys> Context<'scope, 'env, 'sys> {
         &self,
         system_index: usize,
         res: Result<(), Box<dyn Any + Send>>,
-        system: &ScheduleSystem,
+        // This must not take `&ScheduleSystem`, because Rust requires references to be valid for the entire function,
+        // and the system may be accessed by another thread running `apply_deferred` after `tick_executor()` runs.
+        system: &SyncUnsafeCell<SystemWithAccess>,
     ) {
         // tell the executor that the system finished
         self.environment
@@ -343,6 +345,8 @@ impl<'scope, 'env: 'scope, 'sys> Context<'scope, 'env, 'sys> {
             #[cfg(feature = "std")]
             #[expect(clippy::print_stderr, reason = "Allowed behind `std` feature gate.")]
             {
+                // SAFETY: this system is not running, no other reference exists
+                let system = unsafe { &(*system.get()).system };
                 eprintln!("Encountered a panic in system `{}`!", system.name());
             }
             // set the payload to propagate the error
@@ -654,8 +658,7 @@ impl ExecutorState {
     /// - `world` must have permission to access the world data
     ///   used by the specified system.
     unsafe fn spawn_system_task(&mut self, context: &Context, system_index: usize) {
-        // SAFETY: this system is not running, no other reference exists
-        let system = &mut unsafe { &mut *context.environment.systems[system_index].get() }.system;
+        let system = &context.environment.systems[system_index];
         // Move the full context object into the new future.
         let context = *context;
 
@@ -675,7 +678,8 @@ impl ExecutorState {
                         )
                     }
                 },
-                system,
+                // SAFETY: this system is not running, no other reference exists
+                unsafe { &mut (*system.get()).system },
                 context.error_handler,
                 "System panicked",
             );
@@ -693,12 +697,12 @@ impl ExecutorState {
     /// # Safety
     /// Caller must ensure no systems are currently borrowed.
     unsafe fn spawn_exclusive_system_task(&mut self, context: &Context, system_index: usize) {
-        // SAFETY: this system is not running, no other reference exists
-        let system = &mut unsafe { &mut *context.environment.systems[system_index].get() }.system;
+        let system = &context.environment.systems[system_index];
         // Move the full context object into the new future.
         let context = *context;
 
-        if is_apply_deferred(&**system) {
+        // SAFETY: this system is not running, no other reference exists
+        if is_apply_deferred(unsafe { &*(*system.get()).system }) {
             // TODO: avoid allocation
             let unapplied_systems = self.unapplied_systems.clone();
             self.unapplied_systems.clear();
@@ -723,7 +727,8 @@ impl ExecutorState {
                 let world = unsafe { context.environment.world_cell.world_mut() };
                 let res = handle_errors(
                     |system| __rust_begin_short_backtrace::run(system, world),
-                    system,
+                    // SAFETY: this system is not running, no other reference exists
+                    unsafe { &mut (*system.get()).system },
                     context.error_handler,
                     "Exclusive system panicked",
                 );


### PR DESCRIPTION
# Objective

Fix UB detected by Miri when running the multi-threaded executor.  It intermittently fails with: 
```
error: Undefined Behavior: not granting access to tag <5526305> because that would remove [SharedReadOnly for <5518830>] which is strongly protected
   --> crates\bevy_ecs\src\schedule\executor\multi_threaded.rs:785:36
    |
785 |         let system = &mut unsafe { &mut *systems[system_index].get() }.system;
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <5526305> was created by a SharedReadWrite retag at offsets [0x0..0x80]
   --> crates\bevy_platform\src\cell\sync_unsafe_cell.rs:58:8
help: <5518830> is this argument
   --> crates\bevy_ecs\src\schedule\executor\multi_threaded.rs:334:9
    |
334 |         system: &ScheduleSystem,
    |         ^^^^^^
    = note: this is on thread `schedule::executor::multi_threaded::tests::check_spawn_exclusive_system_task_miri`
    = note: stack backtrace:

```

The issue is that `system_completed()` calls `self.tick_executor();`, which spawns new tasks.  It may spawn a task to execute `apply_deferred`, which will create a `&mut` to systems with unapplied buffers.  If that task is scheduled before `system_completed()` completes, then that `&mut` will invalidate the `&ScheduleSystem` parameter while it's [strongly protected](https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md#retagging).  

## Solution

Pass the `&SyncUnsafeCell<SystemWithAccess>` around directly, and only convert it to a `&mut SystemWithAccess` when it is used.  This ensures that all references have ended before the call to `tick_executor()`.  The conversion just reinterprets the pointers and has no runtime effect, so doing it at different times should not affect performance.  