### PR TITLE
Fix: replace fixed comps with comps calculation

### DIFF
--- a/crates/bevy_image/src/compressed_image_saver/universal.rs
+++ b/crates/bevy_image/src/compressed_image_saver/universal.rs
@@ -2,6 +2,7 @@ use bevy_asset::{io::Writer, saver::SavedAsset, AssetPath, AsyncWriteExt};
 
 use super::{CompressedImageSaverError, CompressedImageSaverSettings};
 use crate::{Image, ImageFormat, ImageFormatSetting, ImageLoaderSettings};
+use wgpu_types::TextureFormat;
 
 use basis_universal::{
     BasisTextureFormat, ColorSpace, Compressor, CompressorParams, UASTC_QUALITY_DEFAULT,
@@ -36,12 +37,48 @@ impl CompressedImageSaverUniversal {
                 compressor_params.tune_for_normal_maps();
             }
 
-            let mut source_image = compressor_params.source_image_mut(0);
+            let format = image.texture_descriptor.format;
             let size = image.size();
-            let Some(ref data) = image.data else {
-                return Err(CompressedImageSaverError::UninitializedImage);
-            };
-            source_image.init(data, size.x, size.y, 4);
+            let data = image
+                .data
+                .as_ref()
+                .ok_or(CompressedImageSaverError::UninitializedImage)?;
+            // Get the per-pixel channel count from the texture format.
+            let channel_count = pixel_channels(format)
+                .ok_or(CompressedImageSaverError::UnsupportedFormat(format))?;
+
+            if image.texture_descriptor.mip_level_count != 1 {
+                return Err(CompressedImageSaverError::CompressionFailed(
+                    "Expected texture_descriptor.mip_level_count to be 1".into(),
+                ));
+            }
+
+            if image.texture_descriptor.size.depth_or_array_layers != 1 {
+                return Err(CompressedImageSaverError::CompressionFailed(
+                    "Expected texture_descriptor.size.depth_or_array_layers to be 1".into(),
+                ));
+            }
+
+            let expected_data_len = (size.x as usize)
+                .checked_mul(size.y as usize)
+                .and_then(|len| len.checked_mul(channel_count as usize))
+                .ok_or_else(|| {
+                    CompressedImageSaverError::CompressionFailed(
+                        "Cannot compute the expected image data length without overflow".into(),
+                    )
+                })?;
+            if data.len() != expected_data_len {
+                return Err(CompressedImageSaverError::CompressionFailed(
+                    format!(
+                        "Image data length does not match the expected length: expected {expected_data_len} bytes, got {}",
+                        data.len()
+                    )
+                    .into(),
+                ));
+            }
+
+            let mut source_image = compressor_params.source_image_mut(0);
+            source_image.init(data, size.x, size.y, channel_count);
 
             let mut compressor = Compressor::new(4);
             #[expect(
@@ -69,5 +106,191 @@ impl CompressedImageSaverUniversal {
             texture_format: None,
             array_layout: None,
         })
+    }
+}
+
+/// Returns the channel_count of `format` passed to basis-universal's `CompressorImageRef::init`,
+/// which internally calls the FFI `image_init`, or `None` if `format` can't be fed to `CompressorImageRef` at all.
+///
+/// The FFI `image_init` blindly reads `width * height * comps` bytes as `u8` channels.
+/// Only 8-bit-per-channel, RGBA-ordered, unpacked formats (`R8*`, `Rg8*`, `Rgba8*`) satisfy "one byte = one channel"
+/// -- everything else (wider/float/packed formats, `Bgra8*`'s reversed order, block-compressed formats,
+/// depth/stencil formats) would make `image_init` overread the buffer or read the wrong bytes as channels,
+/// and these cases return `None`.
+fn pixel_channels(format: TextureFormat) -> Option<u8> {
+    match format {
+        TextureFormat::R8Unorm
+        | TextureFormat::R8Snorm
+        | TextureFormat::R8Uint
+        | TextureFormat::R8Sint => Some(1),
+        TextureFormat::Rg8Unorm
+        | TextureFormat::Rg8Snorm
+        | TextureFormat::Rg8Uint
+        | TextureFormat::Rg8Sint => Some(2),
+        TextureFormat::Rgba8Unorm
+        | TextureFormat::Rgba8UnormSrgb
+        | TextureFormat::Rgba8Snorm
+        | TextureFormat::Rgba8Uint
+        | TextureFormat::Rgba8Sint => Some(4),
+        // Every other TextureFormat (16/32-bit, float, packed, BGRA-order,
+        // block-compressed, depth/stencil, ...) is not safely feedable to
+        // basis-universal as raw bytes.
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_asset::saver::SavedAsset;
+    use bevy_asset::RenderAssetUsages;
+    use futures_lite::future::block_on;
+    use futures_lite::io::AssertAsync;
+    use wgpu_types::{Extent3d, TextureDimension};
+
+    /// Helper function: run the saver on a 1x1 image of `format` with `data`,
+    /// returning the produced basis bytes (or the saver error).
+    /// `AssertAsync<Vec<u8>>` adapts `Vec<u8>`'s `std::io::Write` into
+    /// the `AsyncWrite` the saver expects and lets us inspect the output.
+    fn compress_1x1(
+        format: TextureFormat,
+        data: Vec<u8>,
+    ) -> Result<Vec<u8>, CompressedImageSaverError> {
+        let image = Image::new(
+            Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            TextureDimension::D2,
+            data,
+            format,
+            RenderAssetUsages::default(),
+        );
+        compress(image)
+    }
+
+    fn compress(image: Image) -> Result<Vec<u8>, CompressedImageSaverError> {
+        block_on(async move {
+            let mut writer = AssertAsync::new(Vec::<u8>::new());
+            let saved = SavedAsset::from_asset(&image);
+            let settings = CompressedImageSaverSettings::default();
+            CompressedImageSaverUniversal::default()
+                .save(&mut writer, saved, &settings, "x.basis".into())
+                .await?;
+            Ok(writer.into_inner())
+        })
+    }
+
+    /// Every format `pixel_channels` accepts must let the saver run to completion and
+    /// produce a compressed result. Each case below is one representative of the formats
+    /// mapped to a given `comps` value (1, 2, and 4 channels respectively).
+    #[test]
+    fn saver_compresses_supported_formats() {
+        let out = compress_1x1(TextureFormat::R8Unorm, vec![0]);
+        assert!(out.is_ok(), "R8Unorm should compress: {out:?}");
+
+        let out = compress_1x1(TextureFormat::Rg8Unorm, vec![0, 0]);
+        assert!(out.is_ok(), "Rg8Unorm should compress: {out:?}");
+
+        let out = compress_1x1(TextureFormat::Rgba8Unorm, vec![0, 0, 0, 255]);
+        assert!(out.is_ok(), "Rgba8Unorm should compress: {out:?}");
+    }
+
+    /// Formats `pixel_channels` cannot map to a byte-per-channel layout must be rejected
+    /// with `UnsupportedFormat` rather than fed to `source_image.init`. Each case below
+    /// covers one of the rejection reasons listed in `pixel_channels`'s doc comment, so
+    /// removing one silently drops coverage for that entire reason, not just one format.
+    #[test]
+    fn saver_rejects_unsupported_formats() {
+        // Wider-than-8-bit / float: bytes-per-channel != 1, so reading one byte per channel
+        // would split/misread the data.
+        let err = compress_1x1(TextureFormat::Rgba16Float, vec![0; 8]);
+        assert!(
+            matches!(
+                err,
+                Err(CompressedImageSaverError::UnsupportedFormat(
+                    TextureFormat::Rgba16Float
+                ))
+            ),
+            "Rgba16Float should be rejected: {err:?}"
+        );
+
+        // Reversed channel order: same byte size as Rgba8Unorm, but B-G-R-A instead of
+        // R-G-B-A, so `image_init` (which always reads R-G-B-A) would swap red and blue.
+        let err = compress_1x1(TextureFormat::Bgra8Unorm, vec![0, 0, 0, 0]);
+        assert!(
+            matches!(err, Err(CompressedImageSaverError::UnsupportedFormat(_))),
+            "Bgra8Unorm should be rejected: {err:?}"
+        );
+
+        // Packed: channels aren't byte-aligned, so there is no valid comps at all.
+        let err = compress_1x1(TextureFormat::Rgb10a2Unorm, vec![0; 4]);
+        assert!(
+            matches!(err, Err(CompressedImageSaverError::UnsupportedFormat(_))),
+            "Rgb10a2Unorm should be rejected: {err:?}"
+        );
+
+        // Block-compressed: bytes are a compressed block, not raw per-pixel channels.
+        let err = compress_1x1(TextureFormat::Bc7RgbaUnorm, vec![0; 16]);
+        assert!(
+            matches!(err, Err(CompressedImageSaverError::UnsupportedFormat(_))),
+            "Bc7RgbaUnorm should be rejected: {err:?}"
+        );
+
+        // Depth/stencil: bytes encode a depth value, not per-pixel color channels.
+        let err = compress_1x1(TextureFormat::Depth32Float, vec![0; 4]);
+        assert!(
+            matches!(err, Err(CompressedImageSaverError::UnsupportedFormat(_))),
+            "Depth32Float should be rejected: {err:?}"
+        );
+    }
+
+    #[test]
+    fn saver_rejects_invalid_image_layout() {
+        let mut image = Image::new(
+            Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            TextureDimension::D2,
+            vec![0],
+            TextureFormat::R8Unorm,
+            RenderAssetUsages::default(),
+        );
+        image.data = Some(Vec::new());
+        assert!(compress(image).is_err(), "short data must be rejected");
+
+        let mut image = Image::new(
+            Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            TextureDimension::D2,
+            vec![0],
+            TextureFormat::R8Unorm,
+            RenderAssetUsages::default(),
+        );
+        image.texture_descriptor.mip_level_count = 2;
+        assert!(
+            compress(image).is_err(),
+            "mipmapped images must be rejected"
+        );
+
+        let mut image = Image::new(
+            Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            TextureDimension::D2,
+            vec![0],
+            TextureFormat::R8Unorm,
+            RenderAssetUsages::default(),
+        );
+        image.texture_descriptor.size.depth_or_array_layers = 2;
+        assert!(compress(image).is_err(), "layered images must be rejected");
     }
 }


### PR DESCRIPTION
# Objective

- Fix a safe-API soundness issue in the bevy_image::universal.rs: universal image saver [CompressedImageSaverUniversal](https://github.com/bevyengine/bevy/blob/main/crates/bevy_image/src/compressed_image_saver/universal.rs#L44).
- `CompressedImageSaverUniversal::save` called `source_image.init(data, size.x, size.y, 4)` with the channel count **hardcoded to `4`** for every input image, regardless of its `TextureFormat`. basis-universal's `image::init` reads exactly `width * height * comps` bytes from the source buffer, so for any format whose pixel size is not 4 bytes this is an out-of-bounds read. For example, a 1×1 `R8Unorm` image (1 byte of data) causes the encoder to read 4 bytes — a 3-byte overread per pixel, reachable entirely through safe code (`Image::new` + `CompressedImageSaver::save`). Larger images amplify the overread proportionally (e.g. a 4096×4096 `R8Unorm` image overreads by ~48 MiB). Affected formats include every non-4-byte-per-pixel uncompressed format: `R8*` (1 B/px), `Rg8*` (2 B/px), `R16*` (2 B/px), etc.

## Solution

- Calculate `comps` (the channel count `source_image` reads per pixel) according to the image's `TextureFormat` instead of hardcoding `4`.  `source_image.init` is byte-oriented (each `comps` is one `u8` channel), so only 8-bit-per-channel uncompressed formats can be fed correctly:
  - `R8{Unorm,Snorm,Uint,Sint}` → `comps = 1`
  - `Rg8{Unorm,Snorm,Uint,Sint}` → `comps = 2`
  - `Rgba8{Unorm,UnormSrgb,Snorm,Uint,Sint}` → `comps = 4`
- All other formats are rejected with the existing `CompressedImageSaverError::UnsupportedFormat`. 
- The buggy `source_image.init(data, size.x, size.y, 4)` becomes `source_image.init(data, size.x, size.y, comps)`.

### Additional possible soundness issue

- Because `Image::data` is a public field and `Image::new`'s length check is only a `debug_assert_eq!` (skipped in release), a safe-constructed `Image` can still have `data` shorter than its declared `size`×`format`, which would let `init` overread even with the correct `comps`. I don't know whether this is a intentional design to reduce check in release mode, but if not I can provide a new PR to fix it.

## Testing

I'm trying to build a PoC to prove that it did read out-of-bounds memory, and I use miri to detect this UB. But Miri don't support FFI, so I can't prove this is a true Bug. 