### PR TITLE
Feathers: `NumberInputWrap` on `HardLimit` should wrap *after* range end

### DIFF
--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -378,19 +378,19 @@ impl NumberInputRange {
     pub fn wrap(&self, n: NumberInputValue) -> NumberInputValue {
         match (self, n) {
             (Self::F32(r), NumberInputValue::F32(v)) => {
-                let range = r.end() - r.start();
+                let range = r.end().next_up() - r.start();
                 NumberInputValue::F32(r.start() + (v - r.start()).rem_euclid(range))
             }
             (Self::F64(r), NumberInputValue::F64(v)) => {
-                let range = r.end() - r.start();
+                let range = r.end().next_up() - r.start();
                 NumberInputValue::F64(r.start() + (v - r.start()).rem_euclid(range))
             }
             (Self::I32(r), NumberInputValue::I32(v)) => {
-                let range = r.end() - r.start();
+                let range = r.end() - r.start() + 1;
                 NumberInputValue::I32(r.start() + (v - r.start()).rem_euclid(range))
             }
             (Self::I64(r), NumberInputValue::I64(v)) => {
-                let range = r.end() - r.start();
+                let range = r.end() - r.start() + 1;
                 NumberInputValue::I64(r.start() + (v - r.start()).rem_euclid(range))
             }
             (range, value) => {

--- a/examples/ui/widgets/feathers_number_input.rs
+++ b/examples/ui/widgets/feathers_number_input.rs
@@ -84,8 +84,12 @@ fn demo_root() -> impl Scene {
                 InteractionDisabled
                 template_value(SoftLimit(NumberInputRange::F32(0.0..=10.0)))
             )),
-            demo_field_f32("hard limit + wrap", 0.0, bsn!(
+            demo_field_f32("f32: hard limit + wrap", 0.0, bsn!(
                 template_value(HardLimit(NumberInputRange::F32(-180.0..=180.0)))
+                template_value(NumberInputWrap::Wrap)
+            )),
+            demo_field_i32("i32: hard limit + wrap", 0, bsn!(
+                template_value(HardLimit(NumberInputRange::I32(0..=10)))
                 template_value(NumberInputWrap::Wrap)
             )),
         ]


### PR DESCRIPTION
# Objective

- Address this comment https://github.com/bevyengine/bevy/pull/25237#discussion_r3714707478
> this is not right for a inclusive range, the range of values would be r.end() - r.start() + 1

## Solution

- Wrap happens after the inclusive endpoint. This means that, for example, an i32 number input with a HardLimit of `0..=10` will cycle when scrubbed to “11” instead of “10”
- For F32, we use `next_up()` instead of incrementing by 1 since it’s the next f32 number after the range end that should wrap over to the beginning.

## Testing

- `cargo run --example feathers_number_input --features=“bevy_feathers"`