### PR TITLE
Simplify command queue implementation by removing `RawCommandQueue`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod entity_command;
 #[cfg(feature = "std")]
 mod parallel_scope;
 
+use bevy_ecs_macros::SystemParam;
 use bevy_ptr::move_as_ptr;
 pub use command::Command;
 pub use entity_command::EntityCommand;
@@ -15,7 +16,6 @@ use alloc::boxed::Box;
 use core::marker::PhantomData;
 
 use crate::{
-    self as bevy_ecs,
     bundle::{Bundle, InsertMode, NoBundleEffect},
     change_detection::{MaybeLocation, Mut},
     component::{Component, ComponentId, Mutable},
@@ -30,14 +30,8 @@ use crate::{
     relationship::RelationshipHookMode,
     resource::Resource,
     schedule::ScheduleLabel,
-    system::{
-        BoxedSystem, Deferred, IntoSystem, RegisteredSystem, SystemId, SystemInput,
-        SystemParamValidationError,
-    },
-    world::{
-        command_queue::RawCommandQueue, unsafe_world_cell::UnsafeWorldCell, CommandQueue,
-        EntityWorldMut, FromWorld, World,
-    },
+    system::{BoxedSystem, Deferred, IntoSystem, RegisteredSystem, SystemId, SystemInput},
+    world::{CommandQueue, EntityWorldMut, FromWorld, World},
 };
 
 /// A [`Command`] queue to perform structural changes to the [`World`].
@@ -103,8 +97,13 @@ use crate::{
 /// The [`error`](crate::error) module provides some simple error handlers for convenience.
 ///
 /// [`ApplyDeferred`]: crate::schedule::ApplyDeferred
+#[derive(SystemParam)]
 pub struct Commands<'w, 's> {
-    queue: InternalQueue<'s>,
+    /// The command queue that commands will be pushed to.
+    ///
+    /// This must not be exposed as a `&mut` to untrusted code,
+    /// as calling `apply()` on it could execute commands before [`World::command_queue_start`].
+    queue: Deferred<'s, CommandQueue>,
     entities: &'w Entities,
     allocator: &'w EntityAllocator,
 }
@@ -114,107 +113,6 @@ unsafe impl Send for Commands<'_, '_> {}
 
 // SAFETY: `Commands` never gives access to the inner commands.
 unsafe impl Sync for Commands<'_, '_> {}
-
-const _: () = {
-    type __StructFieldsAlias<'w, 's> = (
-        Deferred<'s, CommandQueue>,
-        &'w EntityAllocator,
-        &'w Entities,
-    );
-    #[doc(hidden)]
-    pub struct FetchState {
-        state: <__StructFieldsAlias<'static, 'static> as bevy_ecs::system::SystemParam>::State,
-    }
-    // SAFETY: Only reads Entities
-    unsafe impl bevy_ecs::system::SystemParam for Commands<'_, '_> {
-        type State = FetchState;
-
-        type Item<'w, 's> = Commands<'w, 's>;
-
-        #[track_caller]
-        fn init_state(world: &mut World) -> Self::State {
-            FetchState {
-                state: <__StructFieldsAlias<'_, '_> as bevy_ecs::system::SystemParam>::init_state(
-                    world,
-                ),
-            }
-        }
-
-        fn init_access(
-            state: &Self::State,
-            system_meta: &mut bevy_ecs::system::SystemMeta,
-            component_access_set: &mut bevy_ecs::query::FilteredAccessSet,
-            world: &mut World,
-        ) {
-            <__StructFieldsAlias<'_, '_> as bevy_ecs::system::SystemParam>::init_access(
-                &state.state,
-                system_meta,
-                component_access_set,
-                world,
-            );
-        }
-
-        fn apply(
-            state: &mut Self::State,
-            system_meta: &bevy_ecs::system::SystemMeta,
-            world: &mut World,
-        ) {
-            <__StructFieldsAlias<'_, '_> as bevy_ecs::system::SystemParam>::apply(
-                &mut state.state,
-                system_meta,
-                world,
-            );
-        }
-
-        fn queue(
-            state: &mut Self::State,
-            system_meta: &bevy_ecs::system::SystemMeta,
-            world: bevy_ecs::world::DeferredWorld,
-        ) {
-            <__StructFieldsAlias<'_, '_> as bevy_ecs::system::SystemParam>::queue(
-                &mut state.state,
-                system_meta,
-                world,
-            );
-        }
-
-        #[inline]
-        #[track_caller]
-        unsafe fn get_param<'w, 's>(
-            state: &'s mut Self::State,
-            system_meta: &bevy_ecs::system::SystemMeta,
-            world: UnsafeWorldCell<'w>,
-            change_tick: bevy_ecs::change_detection::Tick,
-        ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
-            // SAFETY: Upheld by caller
-            let params = unsafe {
-                <__StructFieldsAlias as bevy_ecs::system::SystemParam>::get_param(
-                    &mut state.state,
-                    system_meta,
-                    world,
-                    change_tick,
-                )?
-            };
-            Ok(Commands {
-                queue: InternalQueue::CommandQueue(params.0),
-                allocator: params.1,
-                entities: params.2,
-            })
-        }
-    }
-    // SAFETY: Only reads Entities
-    unsafe impl<'w, 's> bevy_ecs::system::ReadOnlySystemParam for Commands<'w, 's>
-    where
-        Deferred<'s, CommandQueue>: bevy_ecs::system::ReadOnlySystemParam,
-        &'w Entities: bevy_ecs::system::ReadOnlySystemParam,
-    {
-    }
-};
-
-enum InternalQueue<'s> {
-    CommandQueue(Deferred<'s, CommandQueue>),
-    RawCommandQueue(RawCommandQueue),
-}
 
 impl<'w, 's> Commands<'w, 's> {
     /// Returns a new `Commands` instance from a [`CommandQueue`] and a [`World`].
@@ -229,26 +127,7 @@ impl<'w, 's> Commands<'w, 's> {
         entities: &'w Entities,
     ) -> Self {
         Self {
-            queue: InternalQueue::CommandQueue(Deferred(queue)),
-            allocator,
-            entities,
-        }
-    }
-
-    /// Returns a new `Commands` instance from a [`RawCommandQueue`] and an [`Entities`] reference.
-    ///
-    /// This is used when constructing [`Commands`] from a [`DeferredWorld`](crate::world::DeferredWorld).
-    ///
-    /// # Safety
-    ///
-    /// * Caller ensures that `queue` must outlive `'w`
-    pub(crate) unsafe fn new_raw_from_entities(
-        queue: RawCommandQueue,
-        allocator: &'w EntityAllocator,
-        entities: &'w Entities,
-    ) -> Self {
-        Self {
-            queue: InternalQueue::RawCommandQueue(queue),
+            queue: Deferred(queue),
             allocator,
             entities,
         }
@@ -289,12 +168,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// ```
     pub fn reborrow(&mut self) -> Commands<'w, '_> {
         Commands {
-            queue: match &mut self.queue {
-                InternalQueue::CommandQueue(queue) => InternalQueue::CommandQueue(queue.reborrow()),
-                InternalQueue::RawCommandQueue(queue) => {
-                    InternalQueue::RawCommandQueue(queue.clone())
-                }
-            },
+            queue: self.queue.reborrow(),
             allocator: self.allocator,
             entities: self.entities,
         }
@@ -302,13 +176,7 @@ impl<'w, 's> Commands<'w, 's> {
 
     /// Take all commands from `other` and append them to `self`, leaving `other` empty.
     pub fn append(&mut self, other: &mut CommandQueue) {
-        match &mut self.queue {
-            InternalQueue::CommandQueue(queue) => queue.bytes.append(&mut other.bytes),
-            InternalQueue::RawCommandQueue(queue) => {
-                // SAFETY: Pointers in `RawCommandQueue` are never null
-                unsafe { queue.bytes.as_mut() }.append(&mut other.bytes);
-            }
-        }
+        self.queue.bytes.append(&mut other.bytes);
     }
 
     /// Spawns a new empty [`Entity`] and returns its corresponding [`EntityCommands`].
@@ -706,18 +574,7 @@ impl<'w, 's> Commands<'w, 's> {
     }
 
     fn queue_internal(&mut self, command: impl Command<Out = ()>) {
-        match &mut self.queue {
-            InternalQueue::CommandQueue(queue) => {
-                queue.push(command);
-            }
-            InternalQueue::RawCommandQueue(queue) => {
-                // SAFETY: `RawCommandQueue` is only every constructed in `Commands::new_raw_from_entities`
-                // where the caller of that has ensured that `queue` outlives `self`
-                unsafe {
-                    queue.push(command);
-                }
-            }
-        }
+        self.queue.push(command);
     }
 
     /// Adds a series of [`Bundles`](Bundle) to each [`Entity`] they are paired with,

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -265,11 +265,11 @@ where
 {
     /// Constructs a new [`CommandQueueRunner`] for the given queue.
     ///
-    /// This runs commands from `start` to the end of the queue.
+    /// This runs commands from `start` to the current end of the queue.
     ///
-    /// To support running commands from the queue owned by the [`World`],
-    /// this stores references to the [`World`] and/or a [`CommandQueue`] as opaque `data`,
-    /// and uses the `command_queue` function to extract the reference to the queue.
+    /// Stores references to just the [`World`] (when running the world command queue), to just a [`CommandQueue`] (when dropping), or both (when running any other queues).
+    /// In the case of the world's command queue, this allows us to fetch a new reference to the queue after every command, as the command can invalidate it due to receiving the `&mut World`.
+    /// References to other command queues can be stored directly.
     ///
     /// # Safety
     ///

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -9,7 +9,7 @@ use bevy_ptr::{OwningPtr, Unaligned};
 use core::{
     fmt::Debug,
     mem::{size_of, MaybeUninit},
-    ptr::{addr_of_mut, NonNull},
+    ptr::NonNull,
 };
 use log::warn;
 
@@ -47,8 +47,6 @@ pub struct CommandQueue {
     /// to store the command itself. To interpret these bytes, a pointer must
     /// be passed to the corresponding `CommandMeta.apply_command_and_get_size` fn pointer.
     pub(crate) bytes: Vec<MaybeUninit<u8>>,
-    /// Index into `bytes` at which unapplied commands start.
-    pub(crate) cursor: usize,
     pub(crate) caller: MaybeLocation,
     /// Always emit a warning if a command is dropped before it is applied.
     /// Defaults to `true`.
@@ -63,19 +61,10 @@ impl Default for CommandQueue {
     fn default() -> Self {
         Self {
             bytes: Default::default(),
-            cursor: Default::default(),
             caller: MaybeLocation::caller(),
             warn_on_unapplied: true,
         }
     }
-}
-
-/// Wraps pointers to a [`CommandQueue`], used internally to avoid stacked borrow rules when
-/// partially applying the world's command queue recursively
-#[derive(Clone)]
-pub(crate) struct RawCommandQueue {
-    pub(crate) bytes: NonNull<Vec<MaybeUninit<u8>>>,
-    pub(crate) cursor: NonNull<usize>,
 }
 
 // CommandQueue needs to implement Debug manually, rather than deriving it, because the derived impl just prints
@@ -104,7 +93,6 @@ impl CommandQueue {
     pub fn silent() -> Self {
         CommandQueue {
             bytes: Default::default(),
-            cursor: Default::default(),
             caller: MaybeLocation::caller(),
             warn_on_unapplied: false,
         }
@@ -112,83 +100,7 @@ impl CommandQueue {
 
     /// Push a [`Command`] onto the queue.
     #[inline]
-    pub fn push(&mut self, command: impl Command<Out = ()>) {
-        // SAFETY: self is guaranteed to live for the lifetime of this method
-        unsafe {
-            self.get_raw().push(command);
-        }
-    }
-
-    /// Execute the queued [`Command`]s in the world after applying any commands in the world's internal queue.
-    /// This clears the queue.
-    #[inline]
-    pub fn apply(&mut self, world: &mut World) {
-        // flush the world's internal queue
-        world.flush_commands();
-
-        // SAFETY: A reference is always a valid pointer
-        unsafe {
-            self.get_raw().apply_or_drop_queued(Some(world));
-        }
-    }
-
-    /// Take all commands from `other` and append them to `self`, leaving `other` empty
-    pub fn append(&mut self, other: &mut CommandQueue) {
-        self.bytes.append(&mut other.bytes);
-    }
-
-    /// Returns false if there are any commands in the queue
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.cursor >= self.bytes.len()
-    }
-
-    /// Returns a [`RawCommandQueue`] instance sharing the underlying command queue.
-    pub(crate) fn get_raw(&mut self) -> RawCommandQueue {
-        // SAFETY: self is always valid memory
-        unsafe {
-            RawCommandQueue {
-                bytes: NonNull::new_unchecked(addr_of_mut!(self.bytes)),
-                cursor: NonNull::new_unchecked(addr_of_mut!(self.cursor)),
-            }
-        }
-    }
-
-    /// Silences drop warning if commands are unapplied.
-    pub fn silence_drop_warning(&mut self) {
-        self.warn_on_unapplied = false;
-    }
-}
-
-impl RawCommandQueue {
-    /// Returns a new `RawCommandQueue` instance, this must be manually dropped.
-    pub(crate) fn new() -> Self {
-        // SAFETY: Pointers returned by `Box::into_raw` are guaranteed to be non null
-        unsafe {
-            Self {
-                bytes: NonNull::new_unchecked(Box::into_raw(Box::default())),
-                cursor: NonNull::new_unchecked(Box::into_raw(Box::new(0usize))),
-            }
-        }
-    }
-
-    /// Returns true if the queue is empty.
-    ///
-    /// # Safety
-    /// - Caller ensures that `bytes` and `cursor` point to valid memory
-    /// - there is no other unsynchonized access to the same underlying queue
-    pub unsafe fn is_empty(&self) -> bool {
-        // SAFETY: Pointers are guaranteed to be valid by requirements on `.clone_unsafe`
-        (unsafe { *self.cursor.as_ref() }) >= (unsafe { self.bytes.as_ref() }).len()
-    }
-
-    /// Push a [`Command`] onto the queue.
-    ///
-    /// # Safety
-    /// - Caller ensures that `self` has not outlived the underlying queue
-    /// - there is no other unsynchonized access to the same underlying queue
-    #[inline]
-    pub unsafe fn push<C: Command<Out = ()>>(&mut self, command: C) {
+    pub fn push<C: Command<Out = ()>>(&mut self, command: C) {
         // Stores a command alongside its metadata.
         // `repr(C)` prevents the compiler from reordering the fields,
         // while `repr(packed)` prevents the compiler from inserting padding bytes.
@@ -237,17 +149,14 @@ impl RawCommandQueue {
             },
         };
 
-        // SAFETY: There are no outstanding references to self.bytes
-        let bytes = unsafe { self.bytes.as_mut() };
-
-        let old_len = bytes.len();
+        let old_len = self.bytes.len();
 
         // Reserve enough bytes for both the metadata and the command itself.
-        bytes.reserve(size_of::<Packed<C>>());
+        self.bytes.reserve(size_of::<Packed<C>>());
 
         // Pointer to the bytes at the end of the buffer.
         // SAFETY: We know it is within bounds of the allocation, due to the call to `.reserve()`.
-        let ptr = unsafe { bytes.as_mut_ptr().add(old_len) };
+        let ptr = unsafe { self.bytes.as_mut_ptr().add(old_len) };
 
         // Write the metadata into the buffer, followed by the command.
         // We are using a packed struct to write them both as one operation.
@@ -263,22 +172,43 @@ impl RawCommandQueue {
         // SAFETY: The new length is guaranteed to fit in the vector's capacity,
         // due to the call to `.reserve()` above.
         unsafe {
-            bytes.set_len(old_len + size_of::<Packed<C>>());
+            self.bytes.set_len(old_len + size_of::<Packed<C>>());
         }
     }
 
-    /// If `world` is [`Some`], this will apply the queued [commands](`Command`).
-    /// If `world` is [`None`], this will drop the queued [commands](`Command`) (without applying them).
+    /// Execute the queued [`Command`]s in the world after applying any commands in the world's internal queue.
     /// This clears the queue.
-    ///
-    /// # Safety
-    /// - `self` has not outlived the underlying queue
-    /// - there is no other unsynchonized access to the same underlying queue
     #[inline]
-    pub(crate) unsafe fn apply_or_drop_queued(&mut self, world: Option<&mut World>) {
-        // SAFETY: Caller ensures `self` has not outlived the queue.
-        // and that there is no other unsynchronized access.
-        unsafe { CommandQueueRunner::new(self).run(world) };
+    pub fn apply(&mut self, world: &mut World) {
+        // flush the world's internal queue
+        world.flush_commands();
+        // SAFETY:
+        // * `self` is always returned
+        // * The first command always start at 0
+        // * `&mut self` prevents all other access to this queue
+        let mut runner = unsafe { CommandQueueRunner::new((self, world), |(queue, _)| queue, 0) };
+        runner.run(|(_, world)| Some(world));
+    }
+
+    /// Take all commands from `other` and append them to `self`, leaving `other` empty
+    pub fn append(&mut self, other: &mut CommandQueue) {
+        self.bytes.append(&mut other.bytes);
+    }
+
+    /// Returns false if there are any commands in the queue
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    /// The number of bytes of commands in the queue.
+    pub(crate) fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Silences drop warning if commands are unapplied.
+    pub fn silence_drop_warning(&mut self) {
+        self.warn_on_unapplied = false;
     }
 }
 
@@ -291,8 +221,12 @@ impl Drop for CommandQueue {
                 warn!("CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply?");
             }
         }
-        // SAFETY: A reference is always a valid pointer
-        unsafe { self.get_raw().apply_or_drop_queued(None) };
+        // Dropping a `CommandQueueRunner` will drop all unapplied commands.
+        // SAFETY:
+        // * `self` is always returned
+        // * The first command always start at 0
+        // * `&mut self` prevents all other access to this queue
+        unsafe { drop(CommandQueueRunner::new(self, |queue| queue, 0)) };
     }
 }
 
@@ -312,27 +246,40 @@ impl SystemBuffer for CommandQueue {
 
 /// A RAII guard used while running commands to ensure
 /// that unapplied commands are dropped during unwind.
-struct CommandQueueRunner<'a> {
-    command_queue: &'a mut RawCommandQueue,
+pub(crate) struct CommandQueueRunner<D, F>
+where
+    F: Fn(&mut D) -> &mut CommandQueue,
+{
+    data: D,
+    command_queue: F,
     local_cursor: usize,
     start: usize,
     stop: usize,
 }
 
-impl<'a> CommandQueueRunner<'a> {
+impl<D, F> CommandQueueRunner<D, F>
+where
+    F: Fn(&mut D) -> &mut CommandQueue,
+{
+    /// Constructs a new [`CommandQueueRunner`] for the given queue.
+    ///
+    /// This runs commands from `start` to the end of the queue.
+    ///
+    /// To support running commands from the queue owned by the [`World`],
+    /// this stores references to the [`World`] and/or a [`CommandQueue`] as opaque `data`,
+    /// and uses the `command_queue` function to extract the reference to the queue.
+    ///
     /// # Safety
-    /// - `self` has not outlived the underlying queue
-    /// - there is no other unsynchonized access to the same underlying queue
-    unsafe fn new(command_queue: &'a mut RawCommandQueue) -> Self {
-        // SAFETY: Queue is life & there is no other unsynchronized access
-        let start = unsafe { command_queue.cursor.read() };
-        // SAFETY: Queue is life & there is no other unsynchronized access
-        let stop = unsafe { command_queue.bytes.as_ref().len() };
-        // SAFETY: we are setting the global cursor to the current length to prevent the executing commands from applying
-        // the remaining commands currently in this list. This is safe.
-        unsafe { command_queue.cursor.write(stop) };
-
+    ///
+    /// * `command_queue(&mut data)` must always return the same queue.
+    /// * `start` is the index of the first byte of a command in the queue,
+    ///   or the length of the queue
+    /// * Until the `CommandQueueRunner` is dropped, nothing else may
+    ///   access commands between `start` and `command_queue.len()`
+    pub unsafe fn new(mut data: D, command_queue: F, start: usize) -> Self {
+        let stop = command_queue(&mut data).len();
         Self {
+            data,
             command_queue,
             local_cursor: start,
             start,
@@ -340,21 +287,22 @@ impl<'a> CommandQueueRunner<'a> {
         }
     }
 
-    fn run(&mut self, mut world: Option<&mut World>) {
+    pub fn run(&mut self, world: impl Fn(&mut D) -> Option<&mut World>) {
         #[cfg(feature = "std")]
         {
             PANIC_ORIGINATES_FROM_ERROR_HANDLER.set(false);
         }
 
         while self.local_cursor < self.stop {
+            let command_queue = (self.command_queue)(&mut self.data);
+
             // We must re-read the pointer to the allocation before each command
             // as the previous might have cause a reallocation.
             // SAFETY: The cursor is either at the start of the buffer, or just after the previous command.
             // Since we know that the cursor is in bounds, it must point to the start of a new command.
             let meta = unsafe {
-                self.command_queue
+                command_queue
                     .bytes
-                    .as_mut()
                     .as_mut_ptr()
                     .add(self.local_cursor)
                     .cast::<CommandMeta>()
@@ -369,9 +317,8 @@ impl<'a> CommandQueueRunner<'a> {
             // `cmd` points to a valid address of a stored command, so it must be non-null.
             let cmd = unsafe {
                 OwningPtr::<Unaligned>::new(NonNull::new_unchecked(
-                    self.command_queue
+                    command_queue
                         .bytes
-                        .as_mut()
                         .as_mut_ptr()
                         .add(self.local_cursor)
                         .cast(),
@@ -386,7 +333,7 @@ impl<'a> CommandQueueRunner<'a> {
             unsafe {
                 (meta.consume_command_and_get_size)(
                     cmd,
-                    world.as_deref_mut(),
+                    world(&mut self.data),
                     &mut self.local_cursor,
                 );
             }
@@ -417,19 +364,21 @@ fn handle_panic_payload(
     world.fallback_error_handler()(error, ErrorContext::Command { name });
 }
 
-impl Drop for CommandQueueRunner<'_> {
+impl<D, F> Drop for CommandQueueRunner<D, F>
+where
+    F: Fn(&mut D) -> &mut CommandQueue,
+{
     fn drop(&mut self) {
         // Drop any unapplied commands before resetting the length.
         // If `run` completed successfully then this will do nothing.
-        self.run(None);
+        self.run(|_| None);
+
+        let command_queue = (self.command_queue)(&mut self.data);
 
         // Reset the buffer: all commands past the original `start` cursor have been applied.
         // SAFETY: we are setting the length of bytes to the original length, minus the length of the original
         // list of commands being considered. All bytes remaining in the Vec are still valid, unapplied commands.
-        unsafe {
-            self.command_queue.bytes.as_mut().set_len(self.start);
-            *self.command_queue.cursor.as_mut() = self.start;
-        }
+        unsafe { command_queue.bytes.set_len(self.start) };
     }
 }
 

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -4,7 +4,7 @@ use crate::{
     world::{DeferredWorld, World},
 };
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::vec::Vec;
 use bevy_ptr::{OwningPtr, Unaligned};
 use core::{
     fmt::Debug,
@@ -15,6 +15,8 @@ use log::warn;
 
 #[cfg(feature = "std")]
 use crate::error::{BevyError, ErrorContext, Severity, PANIC_ORIGINATES_FROM_ERROR_HANDLER};
+#[cfg(feature = "std")]
+use alloc::boxed::Box;
 #[cfg(feature = "std")]
 use bevy_utils::DebugName;
 #[cfg(feature = "std")]

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -265,7 +265,8 @@ where
 {
     /// Constructs a new [`CommandQueueRunner`] for the given queue.
     ///
-    /// This runs commands from `start` to the current end of the queue.
+    /// This applies or drops commands from `start` to the current end of the queue,
+    /// and will truncate the queue to `start` when dropped.
     ///
     /// Stores references to just the [`World`] (when running the world command queue), to just a [`CommandQueue`] (when dropping), or both (when running any other queues).
     /// In the case of the world's command queue, this allows us to fetch a new reference to the queue after every command, as the command can invalidate it due to receiving the `&mut World`.
@@ -289,6 +290,10 @@ where
         }
     }
 
+    /// Applies or drops the commands in the queue.
+    ///
+    /// If `world` returns [`Some`], this will apply the queued [commands](`Command`) to that `World`.
+    /// If `world` returns [`None`], this will drop the queued [commands](`Command`) (without applying them).
     pub fn run(&mut self, world: impl Fn(&mut D) -> Option<&mut World>) {
         #[cfg(feature = "std")]
         {

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -70,15 +70,7 @@ impl<'w> DeferredWorld<'w> {
     #[inline]
     pub fn commands(&mut self) -> Commands<'_, '_> {
         // SAFETY: &mut self ensure that there are no outstanding accesses to the queue
-        let command_queue = unsafe { self.world.get_raw_command_queue() };
-        // SAFETY: command_queue is stored on world and always valid while the world exists
-        unsafe {
-            Commands::new_raw_from_entities(
-                command_queue,
-                self.world.entity_allocator(),
-                self.world.entities(),
-            )
-        }
+        unsafe { self.world.commands() }
     }
 
     /// Retrieves a mutable reference to the given `entity`'s [`Component`] of the given type.
@@ -441,11 +433,7 @@ impl<'w> DeferredWorld<'w> {
         // SAFETY:
         // - `&mut self` gives mutable access to the entire world, and prevents simultaneous access.
         // - Command queue access does not conflict with entity access.
-        let raw_queue = unsafe { cell.get_raw_command_queue() };
-        // SAFETY: `&mut self` ensures the commands does not outlive the world.
-        let commands = unsafe {
-            Commands::new_raw_from_entities(raw_queue, cell.entity_allocator(), cell.entities())
-        };
+        let commands = unsafe { cell.commands() };
 
         (fetcher, commands)
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -57,14 +57,17 @@ use crate::{
     storage::{NonSendData, Storages},
     system::Commands,
     world::{
-        command_queue::RawCommandQueue,
+        command_queue::CommandQueueRunner,
         error::{
             EntityDespawnError, EntityMutableFetchError, TryInsertBatchError, TryRunScheduleError,
         },
     },
 };
-use alloc::{boxed::Box, vec::Vec};
-use bevy_platform::sync::atomic::{AtomicU32, Ordering};
+use alloc::vec::Vec;
+use bevy_platform::{
+    cell::SyncUnsafeCell,
+    sync::atomic::{AtomicU32, Ordering},
+};
 use bevy_ptr::{move_as_ptr, MovingPtr, OwningPtr, Ptr};
 use bevy_utils::prelude::DebugName;
 use core::{any::TypeId, fmt, mem::ManuallyDrop};
@@ -106,7 +109,19 @@ pub struct World {
     pub(crate) last_change_tick: Tick,
     pub(crate) last_check_tick: Tick,
     pub(crate) last_trigger_id: u32,
-    pub(crate) command_queue: RawCommandQueue,
+    /// The byte index in [`Self::command_queue`] at which unapplied command start.
+    ///
+    /// This is nonzero while running commands to allow the same buffer to be shared by nested commands.
+    command_queue_start: usize,
+    /// The world's command queue.
+    ///
+    /// This is stored inside a [`SyncUnsafeCell`] to allow mutable access to
+    /// commands from an [`UnsafeWorldCell`] without being invalidated by `&World`
+    /// references used for metadata.
+    ///
+    /// This must not be exposed as a `&mut` to untrusted code,
+    /// as calling `apply()` on it could execute commands before [`Self::command_queue_start`].
+    command_queue: SyncUnsafeCell<CommandQueue>,
 }
 
 impl Default for World {
@@ -128,22 +143,12 @@ impl Default for World {
             last_change_tick: Tick::new(0),
             last_check_tick: Tick::new(0),
             last_trigger_id: 0,
-            command_queue: RawCommandQueue::new(),
+            command_queue_start: 0,
+            command_queue: SyncUnsafeCell::new(CommandQueue::silent()),
             component_ids: ComponentIds::default(),
         };
         world.bootstrap();
         world
-    }
-}
-
-impl Drop for World {
-    fn drop(&mut self) {
-        // SAFETY: Not passing a pointer so the argument is always valid
-        unsafe { self.command_queue.apply_or_drop_queued(None) };
-        // SAFETY: Pointers in internal command queue are only invalidated here
-        drop(unsafe { Box::from_raw(self.command_queue.bytes.as_ptr()) });
-        // SAFETY: Pointers in internal command queue are only invalidated here
-        drop(unsafe { Box::from_raw(self.command_queue.cursor.as_ptr()) });
     }
 }
 
@@ -302,14 +307,11 @@ impl World {
     /// Use [`World::flush`] to apply all queued commands
     #[inline]
     pub fn commands(&mut self) -> Commands<'_, '_> {
-        // SAFETY: command_queue is stored on world and always valid while the world exists
-        unsafe {
-            Commands::new_raw_from_entities(
-                self.command_queue.clone(),
-                &self.entity_allocator,
-                &self.entities,
-            )
-        }
+        Commands::new_from_entities(
+            self.command_queue.get_mut(),
+            &self.entity_allocator,
+            &self.entities,
+        )
     }
 
     /// Registers a new [`Component`] type and returns the [`ComponentId`] created for it.
@@ -1036,11 +1038,7 @@ impl World {
         // SAFETY:
         // - `&mut self` gives mutable access to the entire world, and prevents simultaneous access.
         // - Command queue access does not conflict with entity access.
-        let raw_queue = unsafe { cell.get_raw_command_queue() };
-        // SAFETY: `&mut self` ensures the commands does not outlive the world.
-        let commands = unsafe {
-            Commands::new_raw_from_entities(raw_queue, cell.entity_allocator(), cell.entities())
-        };
+        let commands = unsafe { cell.commands() };
 
         (fetcher, commands)
     }
@@ -1112,8 +1110,7 @@ impl World {
 
         let mut entity_location = Some(entity_location);
 
-        // SAFETY: command_queue is not referenced anywhere else
-        if !unsafe { self.command_queue.is_empty() } {
+        if !self.command_queue_is_empty() {
             self.flush();
             entity_location = self.entities().get_spawned(entity).ok();
         }
@@ -3060,13 +3057,53 @@ impl World {
     /// This will panic if any of the queued commands are [`spawn`](Commands::spawn).
     /// If this is possible, you should instead use [`flush`](Self::flush).
     pub(crate) fn flush_commands(&mut self) {
-        // SAFETY: `self.command_queue` is only de-allocated in `World`'s `Drop`
-        if !unsafe { self.command_queue.is_empty() } {
-            // SAFETY: `self.command_queue` is only de-allocated in `World`'s `Drop`
-            unsafe {
-                self.command_queue.clone().apply_or_drop_queued(Some(self));
-            };
+        if self.command_queue_is_empty() {
+            return;
         }
+
+        // Prevent nested calls to `flush_commands()` from accessing the commands being run now.
+        // Set `command_queue_start` to the end of the buffer,
+        // and use a RAII type to set it back when done.
+        struct Guard<'a> {
+            world: &'a mut World,
+            start: usize,
+        }
+        impl Drop for Guard<'_> {
+            fn drop(&mut self) {
+                // Return `command_queue_start` to its original value.
+                // `CommandQueueRunner` will have set `len()` to `start`,
+                // so this will result in a zero-length queue.
+                debug_assert_eq!(self.world.command_queue.get_mut().len(), self.start);
+                self.world.command_queue_start = self.start;
+            }
+        }
+
+        let start = self.command_queue_start;
+        let end = self.command_queue.get_mut().len();
+        let guard = Guard { world: self, start };
+        guard.world.command_queue_start = end;
+
+        // SAFETY:
+        // * The world's command queue is always returned
+        // * `start` was set by a call to `flush_commands` to equal `end`,
+        //   so any new commands started there
+        // * `command_queue_start = end` prevents nested calls from accessing commands between `start` and `command_queue.len`
+        let mut runner = unsafe {
+            CommandQueueRunner::new(
+                &mut *guard.world,
+                |world| world.command_queue.get_mut(),
+                start,
+            )
+        };
+        runner.run(|world| Some(world));
+    }
+
+    /// Returns false if there are any commands in the queue.
+    ///
+    /// This must be used instead of [`CommandQueue::is_empty`]
+    /// to ignore any commands earlier than [`Self::command_queue_start`].
+    fn command_queue_is_empty(&mut self) -> bool {
+        self.command_queue_start >= self.command_queue.get_mut().len()
     }
 
     /// Applies any queued component registration.

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -19,7 +19,7 @@ use crate::{
     query::{DebugCheckedUnwrap, QueryAccessError, ReleaseStateQueryData, SingleEntityQueryData},
     resource::{Resource, ResourceEntities},
     storage::{ComponentSparseSet, Storages, Table},
-    world::RawCommandQueue,
+    system::Commands,
 };
 use bevy_platform::sync::atomic::Ordering;
 use bevy_ptr::{Ptr, UnsafeCellDeref};
@@ -686,17 +686,19 @@ impl<'w> UnsafeWorldCell<'w> {
             .get_with_ticks()
     }
 
-    // Returns a mutable reference to the underlying world's [`CommandQueue`].
+    /// Creates a [`Commands`] instance that pushes to the world's command queue
     /// # Safety
     /// It is the caller's responsibility to ensure that
     /// - the [`UnsafeWorldCell`] has permission to access the queue mutably
-    /// - no mutable references to the queue exist at the same time
-    pub(crate) unsafe fn get_raw_command_queue(self) -> RawCommandQueue {
+    /// - no references to the queue exist at the same time
+    pub(crate) unsafe fn commands(self) -> Commands<'w, 'w> {
         self.assert_allows_mutable_access();
         // SAFETY:
-        // - caller ensures there are no existing mutable references
+        // - caller ensures there are no existing references
         // - caller ensures that we have permission to access the queue
-        unsafe { (*self.ptr).command_queue.clone() }
+        let command_queue = unsafe { &mut *(*self.ptr).command_queue.get() };
+
+        Commands::new_from_entities(command_queue, self.entity_allocator(), self.entities())
     }
 
     /// # Safety


### PR DESCRIPTION
# Objective

Simplify the code that runs commands so that it uses less `unsafe` and is easier to understand, and save a bit of memory.  

The `World` stores a command queue that is used for commands queued by hooks and observers.  Since running commands requires `&mut World`, it's difficult to hold a reference to that command queue while running its commands!  The current solution is to have a separate `RawCommandQueue` type that holds raw pointers to the relevant parts of the `CommandQueue`.  This requires a lot of `unsafe`!  It also means that `Commands` needs to handle either `CommandQueue` or `RawCommandQueue`, preventing it from using `#[derive(SystemParam)]` and requiring a full manual implementation.  

## Solution

When running commands from the `World` queue, hold a single `&mut World` that is used both to obtain the `CommandQueue` and to pass to commands.  In order to use the same code for the world queue and other queues, make the runner generic, so that it can store either `&mut World` or `(&mut World, &mut CommandQueue)` as needed (or even just `&mut CommandQueue` during `drop`).  

Move `CommandQueue::cursor` to `World::command_queue_start`.  That field is used to separate the command queue into stack frames when pushing commands to the world's queue during application of other commands, and was always zero for all other `CommandQueue`s.  Move management of that field to a separate RAII guard that is local to `World::flush_commands`, and pass the value (or 0) to `CommandQueueRunner`.  

Store the world's command queue directly instead of through pointers.  This removes the need for a custom `impl Drop for World`, and avoids some allocation overhead.  Note that the command queue needs to be stored inside an `UnsafeCell` because it is valid to create a `&World` to read metadata even while holding a `Commands` created from the world.  

With those done, get rid of the `RawCommandQueue` and `InternalQueue` types entirely, and switch `Commands` back to using `#[derive(SystemParam)]`!  