### PR TITLE
Support Bundles in BundleScratch. Combined Bundle Templates in Scenes

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -165,7 +165,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             #[inline]
             unsafe fn get_components(
                 ptr: #ecs_path::ptr::MovingPtr<'_, Self>,
-                func: &mut impl ::core::ops::FnMut(#ecs_path::component::StorageType, #ecs_path::ptr::OwningPtr<'_>)
+                func: &mut impl ::core::ops::FnMut(#ecs_path::component::StorageType, #ecs_path::ptr::OwningPtr<'_>, Option<::core::alloc::Layout>)
             ) {
                 use #ecs_path::__macro_exports::DebugCheckedUnwrap;
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -165,7 +165,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
             #[inline]
             unsafe fn get_components(
                 ptr: #ecs_path::ptr::MovingPtr<'_, Self>,
-                func: &mut impl ::core::ops::FnMut(#ecs_path::component::StorageType, #ecs_path::ptr::OwningPtr<'_>, Option<::core::alloc::Layout>)
+                func: &mut impl ::core::ops::FnMut(#ecs_path::component::StorageType, #ecs_path::ptr::OwningPtr<'_>, #FQOption<::core::alloc::Layout>)
             ) {
                 use #ecs_path::__macro_exports::DebugCheckedUnwrap;
 

--- a/crates/bevy_ecs/src/bundle/impls.rs
+++ b/crates/bevy_ecs/src/bundle/impls.rs
@@ -1,4 +1,4 @@
-use core::{any::TypeId, iter};
+use core::{alloc::Layout, any::TypeId, iter};
 
 use bevy_ptr::{MovingPtr, OwningPtr};
 use core::mem::MaybeUninit;
@@ -45,9 +45,13 @@ impl<C: Component> DynamicBundle for C {
     #[inline]
     unsafe fn get_components(
         ptr: MovingPtr<'_, Self>,
-        func: &mut impl FnMut(StorageType, OwningPtr<'_>),
+        func: &mut impl FnMut(StorageType, OwningPtr<'_>, Option<Layout>),
     ) -> Self::Effect {
-        func(C::STORAGE_TYPE, OwningPtr::from(ptr));
+        func(
+            C::STORAGE_TYPE,
+            OwningPtr::from(ptr),
+            Some(Layout::new::<C>()),
+        );
     }
 
     #[inline]
@@ -134,7 +138,7 @@ macro_rules! tuple_impl {
                 reason = "Zero-length tuples will generate a function body equivalent to `()`; however, this macro is meant for all applicable tuples, and as such it makes no sense to rewrite it just for that case."
             )]
             #[inline(always)]
-            unsafe fn get_components(ptr: MovingPtr<'_, Self>, func: &mut impl FnMut(StorageType, OwningPtr<'_>)) {
+            unsafe fn get_components(ptr: MovingPtr<'_, Self>, func: &mut impl FnMut(StorageType, OwningPtr<'_>, Option<Layout>)) {
                 bevy_ptr::deconstruct_moving_ptr!({
                     let tuple { $($index: $alias,)* } = ptr;
                 });

--- a/crates/bevy_ecs/src/bundle/info.rs
+++ b/crates/bevy_ecs/src/bundle/info.rs
@@ -5,7 +5,7 @@ use bevy_platform::{
 };
 use bevy_ptr::{MovingPtr, OwningPtr};
 use bevy_utils::TypeIdHashMap;
-use core::{any::TypeId, ptr::NonNull};
+use core::{alloc::Layout, any::TypeId, ptr::NonNull};
 use indexmap::{IndexMap, IndexSet};
 
 use crate::{
@@ -252,7 +252,7 @@ impl BundleInfo {
         // NOTE: get_components calls `write_component` on each component in "bundle order".
         // bundle_info.component_ids are also in "bundle order"
         let mut bundle_component = 0;
-        let mut write_component = bind_lifetime(|storage_type, component_ptr| {
+        let mut write_component = bind_lifetime(|storage_type, component_ptr, _layout| {
             // SAFETY: bundle_component is a valid index per unsafe bundle impl
             let component_id = *unsafe {
                 self.contributed_component_ids
@@ -310,7 +310,7 @@ impl BundleInfo {
             bundle_component += 1;
         });
         // Remove this once closure_lifetime_binder is stable
-        fn bind_lifetime<F: FnMut(StorageType, OwningPtr<'_>)>(func: F) -> F {
+        fn bind_lifetime<F: FnMut(StorageType, OwningPtr<'_>, Option<Layout>)>(func: F) -> F {
             func
         }
         // SAFETY:

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use remove::BundleRemover;
 pub(crate) use spawner::BundleSpawner;
 
 use bevy_ptr::MovingPtr;
-use core::mem::MaybeUninit;
+use core::{alloc::Layout, mem::MaybeUninit};
 pub use info::*;
 pub use writer::*;
 
@@ -266,7 +266,7 @@ pub trait DynamicBundle: Sized {
     // information.
     unsafe fn get_components(
         ptr: MovingPtr<'_, Self>,
-        func: &mut impl FnMut(StorageType, OwningPtr<'_>),
+        func: &mut impl FnMut(StorageType, OwningPtr<'_>, Option<Layout>),
     );
 
     /// Applies the after-effects of spawning this bundle.

--- a/crates/bevy_ecs/src/bundle/writer.rs
+++ b/crates/bevy_ecs/src/bundle/writer.rs
@@ -1,10 +1,11 @@
 use crate::{
+    bundle::{Bundle, DynamicBundle, NoBundleEffect},
     component::{Component, ComponentId, Components, ComponentsRegistrator},
     relationship::RelationshipHookMode,
     world::EntityWorldMut,
 };
 use alloc::vec::Vec;
-use bevy_ptr::OwningPtr;
+use bevy_ptr::{move_as_ptr, OwningPtr};
 use bumpalo::Bump;
 use core::{alloc::Layout, ptr::NonNull};
 
@@ -124,6 +125,39 @@ impl<'a> BundleWriter<'a> {
         self.0.component_ptrs.push(ptr);
     }
 
+    /// Pushes the bundle onto the dynamic bundle
+    ///
+    /// # Safety
+    ///
+    /// `components` must be from the same world that all previous [`Self::push_component`] or [`Self::push_component_by_id`] calls were called with,
+    /// and the _next_ [`Self::write`] or [`Self::write_with_relationship_hook_insert_mode`] call.
+    // Note: Bundle::Effect must be `NoBundleEffect` here, as we discard it.
+    pub unsafe fn push_bundle<B: Bundle<Effect: NoBundleEffect>>(
+        &mut self,
+        components: &mut ComponentsRegistrator,
+        bundle: B,
+    ) {
+        self.0.component_ids.extend(B::component_ids(components));
+        move_as_ptr!(bundle);
+        // SAFETY: called exactly once, and this bundle has no effect
+        unsafe {
+            <B as DynamicBundle>::get_components(bundle, &mut |_storage, component_ptr, layout| {
+                let layout =
+                    layout.expect("Layout should be present because this is not a dynamic Bundle");
+                let target_ptr = self.0.alloc.alloc_layout(layout);
+                // SAFETY:
+                // - `component_ptr` points to a valid value with this layout per precondition
+                // - `target_ptr` was just allocated (so cannot overlap) and has the same layout
+                core::ptr::copy_nonoverlapping(
+                    component_ptr.as_ptr(),
+                    target_ptr.as_ptr(),
+                    layout.size(),
+                );
+                self.0.component_ptrs.push(target_ptr);
+            });
+        }
+    }
+
     /// Writes the current contents of the bundle to the given `entity` and clears the scratch space.
     ///
     /// Runs with [`RelationshipHookMode::Run`] by default.
@@ -183,9 +217,15 @@ mod tests {
     use crate::{bundle::BundleScratch, component::Component, name::Name, world::World};
 
     #[test]
-    fn write_component() {
+    fn write_bundle_scratch() {
         #[derive(Component)]
         struct X;
+
+        #[derive(Component)]
+        struct Y(usize);
+
+        #[derive(Component)]
+        struct Z(usize);
 
         let mut world = World::new();
         let mut bundle_scratch = BundleScratch::default();
@@ -195,11 +235,14 @@ mod tests {
             let mut components = world.components_registrator();
             bundle_writer.push_component(&mut components, X);
             bundle_writer.push_component(&mut components, Name::new("Hi"));
+            bundle_writer.push_bundle(&mut components, (Y(1), Z(2)));
             let mut entity = world.spawn_empty();
             bundle_writer.write(&mut entity);
 
             assert_eq!(entity.get::<Name>().unwrap().as_str(), "Hi");
             assert!(entity.contains::<X>());
+            assert_eq!(entity.get::<Y>().unwrap().0, 1);
+            assert_eq!(entity.get::<Z>().unwrap().0, 2);
         }
     }
 }

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -11,6 +11,7 @@ use crate::{
 use alloc::vec::Vec;
 use bevy_ptr::{move_as_ptr, MovingPtr};
 use core::{
+    alloc::Layout,
     marker::PhantomData,
     mem::{self, MaybeUninit},
 };
@@ -316,7 +317,7 @@ impl<R: Relationship, L: SpawnableList<R>> DynamicBundle for SpawnRelatedBundle<
 
     unsafe fn get_components(
         ptr: MovingPtr<'_, Self>,
-        func: &mut impl FnMut(crate::component::StorageType, bevy_ptr::OwningPtr<'_>),
+        func: &mut impl FnMut(crate::component::StorageType, bevy_ptr::OwningPtr<'_>, Option<Layout>),
     ) {
         let target =
             <R::RelationshipTarget as RelationshipTarget>::with_capacity(ptr.list.size_hint());
@@ -366,7 +367,7 @@ impl<R: Relationship, B: Bundle> DynamicBundle for SpawnOneRelated<R, B> {
 
     unsafe fn get_components(
         ptr: MovingPtr<'_, Self>,
-        func: &mut impl FnMut(crate::component::StorageType, bevy_ptr::OwningPtr<'_>),
+        func: &mut impl FnMut(crate::component::StorageType, bevy_ptr::OwningPtr<'_>, Option<Layout>),
     ) {
         let target = <R::RelationshipTarget as RelationshipTarget>::with_capacity(1);
         move_as_ptr!(target);

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -27,7 +27,7 @@ use crate::{
 
 use alloc::vec::Vec;
 use bevy_ptr::{move_as_ptr, MovingPtr, OwningPtr};
-use core::{any::TypeId, marker::PhantomData, mem::MaybeUninit};
+use core::{alloc::Layout, any::TypeId, marker::PhantomData, mem::MaybeUninit};
 
 /// A mutable reference to a particular [`Entity`], and the entire world.
 ///
@@ -2419,9 +2419,9 @@ unsafe fn insert_dynamic_bundle<
         type Effect = ();
         unsafe fn get_components(
             mut ptr: MovingPtr<'_, Self>,
-            func: &mut impl FnMut(StorageType, OwningPtr<'_>),
+            func: &mut impl FnMut(StorageType, OwningPtr<'_>, Option<Layout>),
         ) {
-            (&mut ptr.components).for_each(|(t, ptr)| func(t, ptr));
+            (&mut ptr.components).for_each(|(t, ptr)| func(t, ptr, None));
         }
 
         unsafe fn apply_effect(

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -1,7 +1,7 @@
 use crate::{Ready, ResolveContext, ResolveSceneError, Scene, SceneList, ScenePatch};
 use bevy_asset::{AssetId, AssetPath, AssetServer, Assets, Handle, UntypedAssetId};
 use bevy_ecs::{
-    bundle::{Bundle, BundleScratch, BundleWriter},
+    bundle::{Bundle, BundleScratch, BundleWriter, NoBundleEffect},
     component::{Component, ComponentsRegistrator},
     entity::Entity,
     error::{BevyError, Result},
@@ -163,10 +163,12 @@ impl ResolvedSceneListRoot {
 /// [`Children`]: bevy_ecs::hierarchy::Children
 #[derive(Default)]
 pub struct ResolvedScene {
-    /// The collection of component [`Template`]s to apply to a spawned [`Entity`]. This can have multiple copies of the same [`Template`].
-    component_templates: Vec<Box<dyn ErasedComponentTemplate>>,
-    /// The collection of Bundle templates to apply to a spawned [`Entity`].
-    bundle_templates: Vec<Box<dyn ErasedBundleTemplate>>,
+    /// The collection of [`Template`]s to apply to a spawned [`Entity`]. This can have multiple copies of the same [`Template`].
+    /// The results of these templates will be inserted together as a single bundle.
+    templates: Vec<Box<dyn ErasedTemplate>>,
+    /// The collection of Bundle templates with effects to apply to a spawned [`Entity`]. These will be inserted one-by-ne, separately
+    /// from `templates`.
+    effect_bundle_templates: Vec<Box<dyn ErasedEffectBundleTemplate>>,
     /// The collection of [`RelatedResolvedScenes`], which will be spawned as "related" entities (ex: [`Children`] entities).
     ///
     /// [`Children`]: bevy_ecs::hierarchy::Children
@@ -326,7 +328,7 @@ impl ResolvedScene {
         bundle_writer: &mut BundleWriter,
         skip_templates: impl SkipTemplate,
     ) -> Result<(), ApplySceneError> {
-        for template in &self.component_templates {
+        for template in &self.templates {
             if skip_templates.should_skip((**template).type_id()) {
                 continue;
             }
@@ -339,7 +341,7 @@ impl ResolvedScene {
             }
         }
 
-        for template in &self.bundle_templates {
+        for template in &self.effect_bundle_templates {
             // SAFETY: bundle_writer is used with the same World across all template.apply calls,
             // and the next bundle_writer.write call
             unsafe {
@@ -427,7 +429,9 @@ impl ResolvedScene {
     }
 
     /// Inserts the given [`Template`]. This will overwrite the existing [`Template`] of that type if it already exists.
-    pub fn insert_template<T: Template<Output: Component> + Send + Sync + 'static>(
+    pub fn insert_template<
+        T: Template<Output: Bundle<Effect: NoBundleEffect>> + Send + Sync + 'static,
+    >(
         &mut self,
         template: T,
     ) {
@@ -435,21 +439,17 @@ impl ResolvedScene {
     }
 
     /// Inserts the given [`Template`] with the given `type_id`. This will overwrite the existing [`Template`] of that type if it already exists.
-    pub fn insert_erased_template(
-        &mut self,
-        type_id: TypeId,
-        template: Box<dyn ErasedComponentTemplate>,
-    ) {
+    pub fn insert_erased_template(&mut self, type_id: TypeId, template: Box<dyn ErasedTemplate>) {
         match self.template_indices.entry(type_id) {
             bevy_utils::TypeIdHashMapEntry::Occupied(occupied_entry) => {
                 let index = *occupied_entry.get();
                 // SAFETY: just looked up a valid index
-                let stored_template = unsafe { self.component_templates.get_unchecked_mut(index) };
+                let stored_template = unsafe { self.templates.get_unchecked_mut(index) };
                 *stored_template = template;
             }
             bevy_utils::TypeIdHashMapEntry::Vacant(vacant_entry) => {
-                vacant_entry.insert(self.component_templates.len());
-                self.component_templates.push(template);
+                vacant_entry.insert(self.templates.len());
+                self.templates.push(template);
             }
         }
     }
@@ -467,11 +467,11 @@ impl ResolvedScene {
         &'a mut self,
         context: &mut ResolveContext,
         type_id: TypeId,
-        default: fn() -> Box<dyn ErasedComponentTemplate>,
-    ) -> &'a mut dyn ErasedComponentTemplate {
+        default: fn() -> Box<dyn ErasedTemplate>,
+    ) -> &'a mut dyn ErasedTemplate {
         let mut is_cached = false;
         let index = self.template_indices.entry(type_id).or_insert_with(|| {
-            let index = self.component_templates.len();
+            let index = self.templates.len();
             let value = if let Some(cached_patch) = &mut context.cached
                 && let Some(resolved_cached) = &cached_patch.resolved
                 && let Some(cached_template) =
@@ -482,11 +482,11 @@ impl ResolvedScene {
             } else {
                 default()
             };
-            self.component_templates.push(value);
+            self.templates.push(value);
             index
         });
         let template = self
-            .component_templates
+            .templates
             .get_mut(*index)
             .map(|value| &mut **value)
             .unwrap();
@@ -503,16 +503,15 @@ impl ResolvedScene {
     }
 
     /// Returns the [`ErasedComponentTemplate`] for the given `type_id`, if it exists in this [`ResolvedScene`]. This ignores cached scenes.
-    pub fn get_direct_erased_template(
-        &self,
-        type_id: TypeId,
-    ) -> Option<&dyn ErasedComponentTemplate> {
+    pub fn get_direct_erased_template(&self, type_id: TypeId) -> Option<&dyn ErasedTemplate> {
         let index = self.template_indices.get(&type_id)?;
-        Some(&*self.component_templates[*index])
+        Some(&*self.templates[*index])
     }
 
     /// Adds the `template` to the "back" of the [`ResolvedScene`] (it will applied later than earlier [`Template`]s).
-    pub fn push_template<T: Template<Output: Component> + Send + Sync + 'static>(
+    pub fn push_template<
+        T: Template<Output: Bundle<Effect: NoBundleEffect>> + Send + Sync + 'static,
+    >(
         &mut self,
         template: T,
     ) {
@@ -520,22 +519,25 @@ impl ResolvedScene {
     }
 
     /// Adds the `template` to the "back" of the [`ResolvedScene`] (it will applied later than earlier [`Template`]s).
-    pub fn push_template_erased(&mut self, template: Box<dyn ErasedComponentTemplate>) {
-        self.component_templates.push(template);
+    pub fn push_template_erased(&mut self, template: Box<dyn ErasedTemplate>) {
+        self.templates.push(template);
     }
-
-    /// Adds the `template` to the "back" of the [`ResolvedScene`] (it will applied later than earlier [`Template`]s).
-    pub fn push_bundle_template<T: Template<Output: Bundle> + Send + Sync + 'static>(
+    /// Adds the "effect bundle" `template` to the "back" of the [`ResolvedScene`] (it will applied later than earlier [`Template`]s).
+    pub fn push_effect_bundle_template<T: Template<Output: Bundle> + Send + Sync + 'static>(
         &mut self,
         template: T,
     ) {
-        self.push_bundle_template_erased(Box::new(template));
+        self.push_effect_bundle_template_erased(Box::new(template));
     }
 
-    /// Adds the `template` to the "back" of the [`ResolvedScene`] (it will applied later than earlier [`Template`]s).
-    pub fn push_bundle_template_erased(&mut self, template: Box<dyn ErasedBundleTemplate>) {
-        self.bundle_templates.push(template);
+    /// Adds the erased "effect bundle" `template` to the "back" of the [`ResolvedScene`] (it will applied later than earlier [`Template`]s).
+    pub fn push_effect_bundle_template_erased(
+        &mut self,
+        template: Box<dyn ErasedEffectBundleTemplate>,
+    ) {
+        self.effect_bundle_templates.push(template);
     }
+
     /// This will return the existing [`RelatedResolvedScenes`], if it exists. If not, a new empty [`RelatedResolvedScenes`] will be inserted and returned.
     ///
     /// This is used to add new related scenes and read existing related scenes.
@@ -558,7 +560,7 @@ impl ResolvedScene {
                 path: cached.handle.path().cloned(),
             });
         }
-        if !(self.component_templates.is_empty() && self.related.is_empty()) {
+        if !(self.templates.is_empty() && self.related.is_empty()) {
             return Err(CachedSceneError::LateCached {
                 id: handle.id().untyped(),
                 path: handle.path().cloned(),
@@ -696,9 +698,9 @@ impl RelatedResolvedScenes {
     }
 }
 
-/// A type-erased, object-safe, downcastable version of [`Template`] that produces a [`Component`], which will be added to the
+/// A type-erased, object-safe, downcastable version of [`Template`] that produces a [`Bundle`], which will be added to the
 /// given [`BundleWriter`].
-pub trait ErasedComponentTemplate: Any + Send + Sync {
+pub trait ErasedTemplate: Any + Send + Sync {
     /// Applies this template to the given `entity`.
     ///
     /// # Safety
@@ -713,32 +715,36 @@ pub trait ErasedComponentTemplate: Any + Send + Sync {
     ) -> Result<(), BevyError>;
 
     /// Clones this template. See [`Clone`].
-    fn clone_template(&self) -> Box<dyn ErasedComponentTemplate>;
+    fn clone_template(&self) -> Box<dyn ErasedTemplate>;
 }
 
-impl<T: Template<Output: Component> + Send + Sync + 'static> ErasedComponentTemplate for T {
+impl<T: Template<Output: Bundle<Effect: NoBundleEffect>> + Send + Sync + 'static> ErasedTemplate
+    for T
+{
     unsafe fn apply(
         &self,
         context: &mut TemplateContext,
         bundle_writer: &mut BundleWriter,
     ) -> Result<(), BevyError> {
-        let component = self.build_template(context)?;
+        let bundle = self.build_template(context)?;
         // SAFETY: world_mut is only used to register components, which does not affect entity location
         let mut components = unsafe { context.entity.world_mut().components_registrator() };
         // SAFETY: The caller verifies that `bundle_writer` is always used with the same World.
-        unsafe { bundle_writer.push_component(&mut components, component) };
+        unsafe { bundle_writer.push_bundle(&mut components, bundle) };
 
         Ok(())
     }
 
-    fn clone_template(&self) -> Box<dyn ErasedComponentTemplate> {
+    fn clone_template(&self) -> Box<dyn ErasedTemplate> {
         Box::new(Template::clone_template(self))
     }
 }
 
-/// A type-erased, object-safe, downcastable version of [`Template`] that produces a [`Bundle`], which will be added
-/// immediately to a given `entity`.
-pub trait ErasedBundleTemplate: Any + Send + Sync {
+/// A type-erased, object-safe, downcastable version of [`Template`] that produces a [`Bundle`], which can have an effect,
+/// which will be added immediately to a given `entity`.
+///
+/// In general, [`ErasedTemplate`] should be preferred for efficiency, for [`Bundle`]s that do not have an effect.
+pub trait ErasedEffectBundleTemplate: Any + Send + Sync {
     /// Applies this template to the given `entity`.
     ///
     /// # Safety
@@ -749,17 +755,17 @@ pub trait ErasedBundleTemplate: Any + Send + Sync {
     unsafe fn apply(&self, context: &mut TemplateContext) -> Result<(), BevyError>;
 
     /// Clones this template. See [`Clone`].
-    fn clone_template(&self) -> Box<dyn ErasedBundleTemplate>;
+    fn clone_template(&self) -> Box<dyn ErasedEffectBundleTemplate>;
 }
 
-impl<T: Template<Output: Bundle> + Send + Sync + 'static> ErasedBundleTemplate for T {
+impl<T: Template<Output: Bundle> + Send + Sync + 'static> ErasedEffectBundleTemplate for T {
     unsafe fn apply(&self, context: &mut TemplateContext) -> Result<(), BevyError> {
         let bundle = self.build_template(context)?;
         context.entity.insert(bundle);
         Ok(())
     }
 
-    fn clone_template(&self) -> Box<dyn ErasedBundleTemplate> {
+    fn clone_template(&self) -> Box<dyn ErasedEffectBundleTemplate> {
         Box::new(Template::clone_template(self))
     }
 }

--- a/crates/bevy_scene/src/resolved_scene.rs
+++ b/crates/bevy_scene/src/resolved_scene.rs
@@ -149,7 +149,7 @@ impl ResolvedSceneListRoot {
 }
 
 /// A final resolved scene (usually produced by calling [`Scene::resolve`]). This consists of:
-/// 1. A collection of [`Template`]s to apply to a spawned [`Entity`], which are stored as [`ErasedComponentTemplate`]s and [`ErasedBundleTemplate`]s.
+/// 1. A collection of [`Template`]s to apply to a spawned [`Entity`], which are stored as [`ErasedTemplate`]s and [`ErasedEffectBundleTemplate`]s.
 /// 2. A collection of [`RelatedResolvedScenes`], which will be spawned as "related" entities (ex: [`Children`] entities).
 /// 3. An optional cached [`ScenePatch`].
 ///
@@ -454,8 +454,8 @@ impl ResolvedScene {
         }
     }
 
-    /// This will get the [`ErasedComponentTemplate`] for the given [`TypeId`], if it already exists in this [`ResolvedScene`]. If it doesn't exist,
-    /// it will use the `default` function to create a new [`ErasedComponentTemplate`]. _For correctness, the [`TypeId`] of the [`Template`] returned
+    /// This will get the [`ErasedTemplate`] for the given [`TypeId`], if it already exists in this [`ResolvedScene`]. If it doesn't exist,
+    /// it will use the `default` function to create a new [`ErasedTemplate`]. _For correctness, the [`TypeId`] of the [`Template`] returned
     /// by `default` should match the passed in `type_id`_.
     ///
     /// This uses "copy-on-write" behavior for cached scenes. If a [`Template`] is requested which the cached scene has as well,
@@ -502,7 +502,7 @@ impl ResolvedScene {
         template
     }
 
-    /// Returns the [`ErasedComponentTemplate`] for the given `type_id`, if it exists in this [`ResolvedScene`]. This ignores cached scenes.
+    /// Returns the [`ErasedTemplate`] for the given `type_id`, if it exists in this [`ResolvedScene`]. This ignores cached scenes.
     pub fn get_direct_erased_template(&self, type_id: TypeId) -> Option<&dyn ErasedTemplate> {
         let index = self.template_indices.get(&type_id)?;
         Some(&*self.templates[*index])

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,4 +1,4 @@
-use crate::{CachedSceneError, ErasedComponentTemplate, ResolvedScene, SceneList, ScenePatch};
+use crate::{CachedSceneError, ErasedTemplate, ResolvedScene, SceneList, ScenePatch};
 use bevy_asset::{Asset, AssetPath, AssetServer, Assets};
 use bevy_ecs::{
     bundle::Bundle,
@@ -351,7 +351,7 @@ pub struct InsertTemplate {
     /// The type id of the [`Template`] in `template`.
     pub type_id: TypeId,
     /// The template to insert.
-    pub template: Box<dyn ErasedComponentTemplate>,
+    pub template: Box<dyn ErasedTemplate>,
 }
 impl Scene for InsertTemplate {
     fn resolve(
@@ -559,7 +559,7 @@ impl<
         _context: &mut ResolveContext,
         scene: &mut ResolvedScene,
     ) -> Result<(), ResolveSceneError> {
-        scene.push_bundle_template(OnTemplate(self.0, PhantomData));
+        scene.push_template(OnTemplate(self.0, PhantomData));
         Ok(())
     }
 }

--- a/crates/bevy_ui_widgets/src/observe.rs
+++ b/crates/bevy_ui_widgets/src/observe.rs
@@ -2,7 +2,7 @@
 // It is certainly a useful thing to have.
 #![expect(unsafe_code, reason = "Unsafe code is used to improve performance.")]
 
-use core::{marker::PhantomData, mem};
+use core::{alloc::Layout, marker::PhantomData, mem};
 
 use bevy_ecs::{
     bundle::{Bundle, DynamicBundle},
@@ -49,7 +49,11 @@ impl<E: EntityEvent, B: Bundle, M, I: IntoObserverSystem<E, B, M>> DynamicBundle
     #[inline]
     unsafe fn get_components(
         ptr: bevy_ecs::ptr::MovingPtr<'_, Self>,
-        _func: &mut impl FnMut(bevy_ecs::component::StorageType, bevy_ecs::ptr::OwningPtr<'_>),
+        _func: &mut impl FnMut(
+            bevy_ecs::component::StorageType,
+            bevy_ecs::ptr::OwningPtr<'_>,
+            Option<Layout>,
+        ),
     ) {
         // SAFETY: We must not drop the pointer here, or it will be uninitialized in `apply_effect`
         // below.


### PR DESCRIPTION
# Objective

`BundleScratch` currently only supports adding individual components. This is overly limiting / prevents a number of important use cases. This limitation extends into BSN's `ResolvedScene`, which currently requires inserting bundles separately one-by-one, rather in the combined `BundleScratch` insertion.

This relates to my current work on making some BSN syntax / semantics improvements as they rely on supporting arbitrary bundles in "template" position.


## Solution

- Add `Option<Layout>` to our bundle insertion logic, exposing the necessary information to allocate memory and insert bundle contents. Layout is `Some` for non-dynamic bundle contents.
- Use this capability to implement `BundleWriter::push_bundle`. This is constrained to `NoBundleEffect`, as effects are not (easily or efficiently) possible in the context of BundleScratch.
- Adapt the BSN implementation to take advantage of this.
- Reframe the old "separate bundle insert" ResolvedScene API to "effect bundles", to retain support for those (relatively niche in the context of BSN)  use cases.
- Extend the BundleScratch test to include `push_bundle`.

I ran the relevant World spawn / insertion / entity cloning benchmarks and detected no performance changes.