### PR TITLE
Initial Implementation of Screen Boxing.

### DIFF
--- a/crates/bevy_render/src/camera.rs
+++ b/crates/bevy_render/src/camera.rs
@@ -71,7 +71,10 @@ impl Plugin for CameraPlugin {
                 ExtractResourcePlugin::<ClearColor>::default(),
                 ExtractComponentPlugin::<CameraMainTextureUsages>::default(),
             ))
-            .add_systems(PostStartup, (camera_system, box_cameras).in_set(CameraUpdateSystems))
+            .add_systems(
+                PostStartup,
+                (camera_system, box_cameras).in_set(CameraUpdateSystems),
+            )
             .add_systems(
                 PostUpdate,
                 (camera_system, box_cameras)

--- a/crates/bevy_render/src/camera.rs
+++ b/crates/bevy_render/src/camera.rs
@@ -73,11 +73,12 @@ impl Plugin for CameraPlugin {
             ))
             .add_systems(
                 PostStartup,
-                (camera_system, box_cameras).in_set(CameraUpdateSystems),
+                (camera_system, box_cameras).chain().in_set(CameraUpdateSystems),
             )
             .add_systems(
                 PostUpdate,
                 (camera_system, box_cameras)
+                    .chain()
                     .in_set(CameraUpdateSystems)
                     .before(AssetEventSystems)
                     .before(visibility::update_frusta),

--- a/crates/bevy_render/src/camera.rs
+++ b/crates/bevy_render/src/camera.rs
@@ -71,11 +71,10 @@ impl Plugin for CameraPlugin {
                 ExtractResourcePlugin::<ClearColor>::default(),
                 ExtractComponentPlugin::<CameraMainTextureUsages>::default(),
             ))
-            .add_systems(PostStartup, camera_system.in_set(CameraUpdateSystems))
-            .add_systems(PostUpdate, box_cameras.in_set(CameraUpdateSystems))
+            .add_systems(PostStartup, (camera_system, box_cameras).in_set(CameraUpdateSystems))
             .add_systems(
                 PostUpdate,
-                camera_system
+                (camera_system, box_cameras)
                     .in_set(CameraUpdateSystems)
                     .before(AssetEventSystems)
                     .before(visibility::update_frusta),

--- a/crates/bevy_render/src/camera.rs
+++ b/crates/bevy_render/src/camera.rs
@@ -17,6 +17,7 @@ use crate::{
     Extract, ExtractSchedule, Render, RenderApp, RenderSystems,
 };
 
+use crate::screen_boxing::box_cameras;
 use bevy_app::{App, Plugin, PostStartup, PostUpdate};
 use bevy_asset::{AssetEvent, AssetEventSystems, AssetId, Assets};
 use bevy_camera::{
@@ -71,6 +72,7 @@ impl Plugin for CameraPlugin {
                 ExtractComponentPlugin::<CameraMainTextureUsages>::default(),
             ))
             .add_systems(PostStartup, camera_system.in_set(CameraUpdateSystems))
+            .add_systems(PostUpdate, box_cameras.in_set(CameraUpdateSystems))
             .add_systems(
                 PostUpdate,
                 camera_system

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -58,6 +58,7 @@ pub mod render_asset;
 pub mod render_phase;
 pub mod render_resource;
 pub mod renderer;
+pub mod screen_boxing;
 pub mod settings;
 pub mod slab_allocator;
 pub mod storage;

--- a/crates/bevy_render/src/screen_boxing.rs
+++ b/crates/bevy_render/src/screen_boxing.rs
@@ -203,3 +203,396 @@ fn is_within_rect(rect: &UVec2, position: &UVec2, size: &UVec2) -> bool {
     let actual_bounds = position + size;
     rect.x >= actual_bounds.x && rect.y >= actual_bounds.y
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    mod systems {
+        use bevy_app::{App, First};
+        use super::*;
+        use bevy_camera::RenderTarget;
+        use bevy_window::{WindowRef, WindowResolution};
+        use crate::camera::CameraPlugin;
+
+        const W360P: UVec2 = UVec2::new(640, 360);
+        const W720P: UVec2 = UVec2::new(1280, 720);
+        const W180P: UVec2 = UVec2::new(320, 180);
+
+        fn setup_app(camerabox: CameraBox, window_resolution: WindowResolution) -> (App, Entity) {
+            let mut app = App::new();
+
+            app.init_resource::<ManualTextureViews>();
+            app.init_resource::<Assets<Image>>();
+            app.add_systems(First, box_cameras);
+            app.world_mut().spawn((
+                Window {
+                    resolution: window_resolution,
+                    ..Window::default()
+                },
+                PrimaryWindow,
+            ));
+            let camera_id = app
+                .world_mut()
+                .spawn((
+                    Camera {
+                        viewport: None,
+                        is_active: true,
+                        ..Camera::default()
+                    },
+                    RenderTarget::Window(WindowRef::Primary),
+                    camerabox,
+                ))
+                .id();
+            (app, camera_id)
+        }
+
+        #[test]
+        fn test_basic_windowboxing() {
+            let (mut app, camera_id) = setup_app(
+                CameraBox::WindowBox {
+                    left: 10,
+                    right: 10,
+                    top: 10,
+                    bottom: 10,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(10, 10));
+            assert_eq!(viewport.physical_size, UVec2::new(620, 340));
+
+            let (mut app, camera_id) = setup_app(
+                CameraBox::WindowBox {
+                    left: 650,
+                    right: 0,
+                    top: 370,
+                    bottom: 0,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport;
+            assert!(viewport.is_none());
+        }
+
+        #[test]
+        fn test_basic_pillarboxing() {
+            let (mut app, camera_id) = setup_app(
+                CameraBox::PillarBox {
+                    left: 2,
+                    right: 2,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(2, 0));
+            assert_eq!(viewport.physical_size, UVec2::new(636, 360));
+
+            let (mut app, camera_id) = setup_app(
+                CameraBox::PillarBox {
+                    left: 5,
+                    right: 0,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(5, 0));
+            assert_eq!(viewport.physical_size, UVec2::new(635, 360));
+
+            let (mut app, camera_id) = setup_app(
+                CameraBox::PillarBox {
+                    left: 0,
+                    right: 5,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(0, 0));
+            assert_eq!(viewport.physical_size, UVec2::new(635, 360));
+
+            let (mut app, camera_id) = setup_app(
+                CameraBox::PillarBox {
+                    left: 5,
+                    right: 10,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(5, 0));
+            assert_eq!(viewport.physical_size, UVec2::new(625, 360));
+
+            let (mut app, camera_id) = setup_app(
+                CameraBox::PillarBox {
+                    left: 10,
+                    right: 5,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(10, 0));
+            assert_eq!(viewport.physical_size, UVec2::new(625, 360));
+
+            let (mut app, camera_id) = setup_app(
+                CameraBox::PillarBox {
+                    left: 640,
+                    right: 0,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport;
+            assert!(viewport.is_none());
+        }
+
+        #[test]
+        fn test_basic_letterboxing() {
+            let (mut app, camera_id) = setup_app(
+                CameraBox::LetterBox {
+                    top: 2,
+                    bottom: 2,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(0, 2));
+            assert_eq!(viewport.physical_size, UVec2::new(640, 356));
+
+            let (mut app, camera_id) = setup_app(
+                CameraBox::LetterBox {
+                    top: 5,
+                    bottom: 0,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(0, 5));
+            assert_eq!(viewport.physical_size, UVec2::new(640, 355));
+
+            let (mut app, camera_id) = setup_app(
+                CameraBox::LetterBox {
+                    top: 0,
+                    bottom: 5,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(0, 0));
+            assert_eq!(viewport.physical_size, UVec2::new(640, 355));
+
+            let (mut app, camera_id) = setup_app(
+                CameraBox::LetterBox {
+                    top: 10,
+                    bottom: 5,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(0, 10));
+            assert_eq!(viewport.physical_size, UVec2::new(640, 345));
+
+            let (mut app, camera_id) = setup_app(
+                CameraBox::LetterBox {
+                    top: 5,
+                    bottom: 10,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(0, 5));
+            assert_eq!(viewport.physical_size, UVec2::new(640, 345));
+
+            let (mut app, camera_id) = setup_app(
+                CameraBox::LetterBox {
+                    top: 360,
+                    bottom: 0,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport;
+            assert!(viewport.is_none());
+
+        }
+
+        #[test]
+        fn test_basic_resolution() {
+            let (mut app, camera_id) = setup_app(
+                CameraBox::StaticResolution {
+                    resolution: W360P.into(),
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport;
+            assert!(viewport.is_none());
+            let (mut app, camera_id) = setup_app(
+                CameraBox::StaticResolution {
+                    resolution: W360P.into(),
+                },
+                W720P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(320, 180));
+            assert_eq!(viewport.physical_size, W360P);
+
+            let (mut app, camera_id) = setup_app(
+                CameraBox::StaticResolution {
+                    resolution: W360P.into(),
+                },
+                W180P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(0, 0));
+            assert_eq!(viewport.physical_size, W180P);
+        }
+
+        #[test]
+        fn test_basic_aspect_ratio() {
+            let desired_aspect_ratio = AspectRatio::try_from(W720P.as_vec2()).unwrap();
+            let (mut app, camera_id) = setup_app(
+                CameraBox::StaticAspectRatio {
+                    aspect_ratio: desired_aspect_ratio,
+                },
+                W360P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport;
+            assert!(viewport.is_none());
+
+            let desired_aspect_ratio = AspectRatio::try_new(640., 480.).unwrap();
+            let (mut app, camera_id) = setup_app(
+                CameraBox::StaticAspectRatio {
+                    aspect_ratio: desired_aspect_ratio,
+                },
+                W720P.into(),
+            );
+            app.update();
+            let viewport = app
+                .world()
+                .get::<Camera>(camera_id)
+                .unwrap()
+                .to_owned()
+                .viewport
+                .unwrap();
+            assert_eq!(viewport.physical_position, UVec2::new(160, 0));
+            assert_eq!(viewport.physical_size, UVec2::new(960, 720));
+        }
+    }
+}

--- a/crates/bevy_render/src/screen_boxing.rs
+++ b/crates/bevy_render/src/screen_boxing.rs
@@ -1,0 +1,205 @@
+use crate::camera::NormalizedRenderTargetExt;
+use crate::texture::ManualTextureViews;
+use bevy_asset::Assets;
+use bevy_camera::{Camera, RenderTarget, Viewport};
+use bevy_ecs::component::Component;
+use bevy_ecs::entity::Entity;
+use bevy_ecs::query::With;
+use bevy_ecs::system::{Query, Res, Single};
+use bevy_image::Image;
+use bevy_log::warn_once;
+use bevy_math::AspectRatio;
+use bevy_window::{PrimaryWindow, Window};
+use glam::UVec2;
+use tracing::warn;
+
+#[derive(Component, Clone, Debug)]
+/// Configures how to box the camera output, if at all.
+pub enum CameraBox {
+    /// Keep the output at a static resolution, and box only if the actual resolution would be larger.
+    /// If the output resolution is smaller than the desired output, it will output at the
+    /// smaller resolution.
+    StaticResolution { resolution: UVec2 },
+
+    /// Keep the output at a specific Aspect Ratio. If the output resolution would not fit within
+    /// the desired Aspect Ratio, box the resolution to force it to fit.
+    StaticAspectRatio { aspect_ratio: AspectRatio },
+
+    /// Static Letterboxing with a specific size for each of the bars.
+    /// If the boxes are larger than the output, then letterboxing will be disabled.
+    LetterBox { top: u32, bottom: u32 },
+
+    /// Static Pillarboxing with a specific size for each of the bars.
+    /// If the boxes are larger than the output, then pillarboxing will be disabled.
+    PillarBox { left: u32, right: u32 },
+
+    /// Static Window-boxing, with a specific size for bars on all sizes of the output.
+    /// If the boxes are larger than the output, then window-boxing will be disabled.
+    WindowBox {
+        top: u32,
+        bottom: u32,
+        left: u32,
+        right: u32,
+    },
+}
+
+pub fn box_cameras(
+    mut boxed_cameras: Query<(&mut Camera, &mut RenderTarget, &CameraBox)>,
+    primary_window: Option<Single<Entity, With<PrimaryWindow>>>,
+    windows: Query<(Entity, &Window)>,
+    texture_views: Res<ManualTextureViews>,
+    images: Res<Assets<Image>>,
+) {
+    let primary_window = primary_window.map(Single::into_inner);
+    for (mut camera, target, camera_box) in boxed_cameras.iter_mut() {
+        let target = match target
+            .normalize(primary_window)
+            .map(|t| t.get_render_target_info(windows, &images, &texture_views))
+        {
+            // As a note this failure case should be rare, such as render target being primary window
+            // but no primary window exists.
+            None => continue,
+            Some(Err(e)) => {
+                warn_once!("Missing Render Target Info: {:#?}", e);
+                continue;
+            }
+            Some(Ok(target)) => target,
+        };
+
+        let mut viewport = match &mut camera.viewport {
+            None => Viewport::default(),
+            Some(vp) => vp.to_owned(),
+        };
+
+        let physical_size = &target.physical_size;
+        match camera_box {
+            CameraBox::StaticResolution { resolution } => {
+                if &target.physical_size == resolution {
+                    camera.viewport = None;
+                    continue;
+                }
+
+                let clamped_resolution = if &viewport.physical_size != resolution {
+                    resolution.clamp(UVec2::ONE, target.physical_size)
+                } else {
+                    *resolution
+                };
+
+                let render_placement = (target.physical_size
+                    - resolution.clamp(UVec2::ZERO, target.physical_size))
+                    / 2;
+
+                viewport.physical_size = clamped_resolution;
+                viewport.physical_position = render_placement;
+                camera.viewport = Some(viewport);
+            }
+            CameraBox::StaticAspectRatio { aspect_ratio } => {
+                let physical_aspect_ratio = match AspectRatio::try_from(physical_size.as_vec2()) {
+                    Ok(ar) if ar.ratio() == aspect_ratio.ratio() => {
+                        camera.viewport = None;
+                        continue;
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Error occurred in aspect ratio scaling calculation: {:?}",
+                            e
+                        );
+                        continue;
+                    }
+                    Ok(ar) => ar,
+                };
+                let (render_resolution, render_position) = if physical_aspect_ratio.ratio()
+                    > aspect_ratio.ratio()
+                {
+                    let render_height = physical_size.y;
+                    let render_width = (render_height as f32 * aspect_ratio.ratio()).round() as u32;
+
+                    (
+                        UVec2::new(physical_size.x / 2 - render_width / 2, 0),
+                        UVec2::new(render_width, render_height),
+                    )
+                } else {
+                    let render_width = physical_size.x;
+                    let render_height = (render_width as f32 / aspect_ratio.ratio()).round() as u32;
+                    (
+                        UVec2::new(0, physical_size.y / 2 - render_height / 2),
+                        UVec2::new(render_width, render_height),
+                    )
+                };
+
+                viewport.physical_size = render_resolution;
+                viewport.physical_position = render_position;
+                camera.viewport = Some(viewport);
+            }
+            CameraBox::LetterBox { top, bottom } => {
+                let letterbox_height = top + bottom;
+
+                let render_resolution =
+                    UVec2::new(physical_size.x, physical_size.y - letterbox_height);
+
+                let render_position = UVec2::new(0, *top);
+
+                if render_resolution.y == 0
+                    || !is_within_rect(physical_size, &render_position, &render_resolution)
+                {
+                    camera.viewport = None;
+                    continue;
+                }
+
+                viewport.physical_size = render_resolution;
+                viewport.physical_position = render_position;
+                camera.viewport = Some(viewport);
+            }
+            CameraBox::PillarBox { left, right } => {
+                let pillarbox_width = left + right;
+                let render_resolution =
+                    UVec2::new(physical_size.x - pillarbox_width, physical_size.y);
+
+                let render_position = UVec2::new(*left, 0);
+                if render_resolution.x == 0
+                    || !is_within_rect(physical_size, &render_position, &render_resolution)
+                {
+                    camera.viewport = None;
+                    continue;
+                }
+
+                viewport.physical_size = render_resolution; //output resolution
+                viewport.physical_position = render_position; // resolution offset;
+                camera.viewport = Some(viewport);
+            }
+            CameraBox::WindowBox {
+                top,
+                bottom,
+                left,
+                right,
+            } => {
+                let letterbox_height = top + bottom;
+                let pillarbox_width = left + right;
+
+                let render_resolution = UVec2::new(
+                    physical_size.y - letterbox_height,
+                    physical_size.x - pillarbox_width,
+                );
+
+                let render_position = UVec2::new(*left, *top);
+
+                if render_resolution.x == 0
+                    || !is_within_rect(physical_size, &render_position, &render_resolution)
+                {
+                    // No boxing
+                    camera.viewport = None;
+                    continue;
+                }
+
+                viewport.physical_size = render_resolution; //output resolution
+                viewport.physical_position = render_position; // resolution offset;
+                camera.viewport = Some(viewport);
+            }
+        }
+    }
+}
+
+fn is_within_rect(rect: &UVec2, position: &UVec2, size: &UVec2) -> bool {
+    let actual_bounds = position + size;
+    rect.x >= actual_bounds.x && rect.y >= actual_bounds.y
+}

--- a/crates/bevy_render/src/screen_boxing.rs
+++ b/crates/bevy_render/src/screen_boxing.rs
@@ -223,7 +223,6 @@ mod tests {
 
     mod systems {
         use super::*;
-        use crate::camera::CameraPlugin;
         use bevy_app::{App, First};
         use bevy_camera::RenderTarget;
         use bevy_window::{WindowRef, WindowResolution};
@@ -272,13 +271,9 @@ mod tests {
                 W360P.into(),
             );
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(10, 10));
             assert_eq!(viewport.physical_size, UVec2::new(620, 340));
 
@@ -292,12 +287,9 @@ mod tests {
                 W360P.into(),
             );
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport;
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport;
             assert!(viewport.is_none());
         }
 
@@ -306,65 +298,45 @@ mod tests {
             let (mut app, camera_id) =
                 setup_app(CameraBox::PillarBox { left: 2, right: 2 }, W360P.into());
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(2, 0));
             assert_eq!(viewport.physical_size, UVec2::new(636, 360));
 
             let (mut app, camera_id) =
                 setup_app(CameraBox::PillarBox { left: 5, right: 0 }, W360P.into());
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(5, 0));
             assert_eq!(viewport.physical_size, UVec2::new(635, 360));
 
             let (mut app, camera_id) =
                 setup_app(CameraBox::PillarBox { left: 0, right: 5 }, W360P.into());
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(0, 0));
             assert_eq!(viewport.physical_size, UVec2::new(635, 360));
 
             let (mut app, camera_id) =
                 setup_app(CameraBox::PillarBox { left: 5, right: 10 }, W360P.into());
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(5, 0));
             assert_eq!(viewport.physical_size, UVec2::new(625, 360));
 
             let (mut app, camera_id) =
                 setup_app(CameraBox::PillarBox { left: 10, right: 5 }, W360P.into());
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(10, 0));
             assert_eq!(viewport.physical_size, UVec2::new(625, 360));
 
@@ -376,12 +348,9 @@ mod tests {
                 W360P.into(),
             );
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport;
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport;
             assert!(viewport.is_none());
         }
 
@@ -390,65 +359,45 @@ mod tests {
             let (mut app, camera_id) =
                 setup_app(CameraBox::LetterBox { top: 2, bottom: 2 }, W360P.into());
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(0, 2));
             assert_eq!(viewport.physical_size, UVec2::new(640, 356));
 
             let (mut app, camera_id) =
                 setup_app(CameraBox::LetterBox { top: 5, bottom: 0 }, W360P.into());
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(0, 5));
             assert_eq!(viewport.physical_size, UVec2::new(640, 355));
 
             let (mut app, camera_id) =
                 setup_app(CameraBox::LetterBox { top: 0, bottom: 5 }, W360P.into());
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(0, 0));
             assert_eq!(viewport.physical_size, UVec2::new(640, 355));
 
             let (mut app, camera_id) =
                 setup_app(CameraBox::LetterBox { top: 10, bottom: 5 }, W360P.into());
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(0, 10));
             assert_eq!(viewport.physical_size, UVec2::new(640, 345));
 
             let (mut app, camera_id) =
                 setup_app(CameraBox::LetterBox { top: 5, bottom: 10 }, W360P.into());
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(0, 5));
             assert_eq!(viewport.physical_size, UVec2::new(640, 345));
 
@@ -460,12 +409,9 @@ mod tests {
                 W360P.into(),
             );
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport;
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport;
             assert!(viewport.is_none());
         }
 
@@ -478,12 +424,9 @@ mod tests {
                 W360P.into(),
             );
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport;
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport;
             assert!(viewport.is_none());
             let (mut app, camera_id) = setup_app(
                 CameraBox::StaticResolution {
@@ -492,13 +435,9 @@ mod tests {
                 W720P.into(),
             );
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(320, 180));
             assert_eq!(viewport.physical_size, W360P);
 
@@ -508,14 +447,9 @@ mod tests {
                 },
                 W180P.into(),
             );
-            app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(0, 0));
             assert_eq!(viewport.physical_size, W180P);
         }
@@ -530,12 +464,9 @@ mod tests {
                 W360P.into(),
             );
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport;
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport;
             assert!(viewport.is_none());
 
             let desired_aspect_ratio = AspectRatio::try_new(640., 480.).unwrap();
@@ -546,13 +477,9 @@ mod tests {
                 W720P.into(),
             );
             app.update();
-            let viewport = app
-                .world()
-                .get::<Camera>(camera_id)
-                .unwrap()
-                .to_owned()
-                .viewport
-                .unwrap();
+            let world = app.world();
+            let camera = world.get::<Camera>(camera_id).unwrap().to_owned();
+            let viewport = camera.viewport.unwrap();
             assert_eq!(viewport.physical_position, UVec2::new(160, 0));
             assert_eq!(viewport.physical_size, UVec2::new(960, 720));
         }

--- a/crates/bevy_render/src/screen_boxing.rs
+++ b/crates/bevy_render/src/screen_boxing.rs
@@ -115,15 +115,15 @@ pub fn box_cameras(
                     let render_width = (render_height as f32 * aspect_ratio.ratio()).round() as u32;
 
                     (
-                        UVec2::new(physical_size.x / 2 - render_width / 2, 0),
                         UVec2::new(render_width, render_height),
+                        UVec2::new(physical_size.x / 2 - render_width / 2, 0),
                     )
                 } else {
                     let render_width = physical_size.x;
                     let render_height = (render_width as f32 / aspect_ratio.ratio()).round() as u32;
                     (
-                        UVec2::new(0, physical_size.y / 2 - render_height / 2),
                         UVec2::new(render_width, render_height),
+                        UVec2::new(0, physical_size.y / 2 - render_height / 2),
                     )
                 };
 
@@ -133,6 +133,10 @@ pub fn box_cameras(
             }
             CameraBox::LetterBox { top, bottom } => {
                 let letterbox_height = top + bottom;
+                if physical_size.y <= letterbox_height {
+                    camera.viewport = None;
+                    continue;
+                }
 
                 let render_resolution =
                     UVec2::new(physical_size.x, physical_size.y - letterbox_height);
@@ -152,6 +156,11 @@ pub fn box_cameras(
             }
             CameraBox::PillarBox { left, right } => {
                 let pillarbox_width = left + right;
+                if physical_size.x <= pillarbox_width {
+                    camera.viewport = None;
+                    continue;
+                }
+
                 let render_resolution =
                     UVec2::new(physical_size.x - pillarbox_width, physical_size.y);
 
@@ -175,10 +184,14 @@ pub fn box_cameras(
             } => {
                 let letterbox_height = top + bottom;
                 let pillarbox_width = left + right;
+                if physical_size.x <= letterbox_height || physical_size.y <= pillarbox_width {
+                    camera.viewport = None;
+                    continue;
+                }
 
                 let render_resolution = UVec2::new(
-                    physical_size.y - letterbox_height,
                     physical_size.x - pillarbox_width,
+                    physical_size.y - letterbox_height,
                 );
 
                 let render_position = UVec2::new(*left, *top);
@@ -207,13 +220,13 @@ fn is_within_rect(rect: &UVec2, position: &UVec2, size: &UVec2) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     mod systems {
-        use bevy_app::{App, First};
         use super::*;
+        use crate::camera::CameraPlugin;
+        use bevy_app::{App, First};
         use bevy_camera::RenderTarget;
         use bevy_window::{WindowRef, WindowResolution};
-        use crate::camera::CameraPlugin;
 
         const W360P: UVec2 = UVec2::new(640, 360);
         const W720P: UVec2 = UVec2::new(1280, 720);
@@ -290,13 +303,8 @@ mod tests {
 
         #[test]
         fn test_basic_pillarboxing() {
-            let (mut app, camera_id) = setup_app(
-                CameraBox::PillarBox {
-                    left: 2,
-                    right: 2,
-                },
-                W360P.into(),
-            );
+            let (mut app, camera_id) =
+                setup_app(CameraBox::PillarBox { left: 2, right: 2 }, W360P.into());
             app.update();
             let viewport = app
                 .world()
@@ -308,13 +316,8 @@ mod tests {
             assert_eq!(viewport.physical_position, UVec2::new(2, 0));
             assert_eq!(viewport.physical_size, UVec2::new(636, 360));
 
-            let (mut app, camera_id) = setup_app(
-                CameraBox::PillarBox {
-                    left: 5,
-                    right: 0,
-                },
-                W360P.into(),
-            );
+            let (mut app, camera_id) =
+                setup_app(CameraBox::PillarBox { left: 5, right: 0 }, W360P.into());
             app.update();
             let viewport = app
                 .world()
@@ -326,13 +329,8 @@ mod tests {
             assert_eq!(viewport.physical_position, UVec2::new(5, 0));
             assert_eq!(viewport.physical_size, UVec2::new(635, 360));
 
-            let (mut app, camera_id) = setup_app(
-                CameraBox::PillarBox {
-                    left: 0,
-                    right: 5,
-                },
-                W360P.into(),
-            );
+            let (mut app, camera_id) =
+                setup_app(CameraBox::PillarBox { left: 0, right: 5 }, W360P.into());
             app.update();
             let viewport = app
                 .world()
@@ -344,13 +342,8 @@ mod tests {
             assert_eq!(viewport.physical_position, UVec2::new(0, 0));
             assert_eq!(viewport.physical_size, UVec2::new(635, 360));
 
-            let (mut app, camera_id) = setup_app(
-                CameraBox::PillarBox {
-                    left: 5,
-                    right: 10,
-                },
-                W360P.into(),
-            );
+            let (mut app, camera_id) =
+                setup_app(CameraBox::PillarBox { left: 5, right: 10 }, W360P.into());
             app.update();
             let viewport = app
                 .world()
@@ -362,13 +355,8 @@ mod tests {
             assert_eq!(viewport.physical_position, UVec2::new(5, 0));
             assert_eq!(viewport.physical_size, UVec2::new(625, 360));
 
-            let (mut app, camera_id) = setup_app(
-                CameraBox::PillarBox {
-                    left: 10,
-                    right: 5,
-                },
-                W360P.into(),
-            );
+            let (mut app, camera_id) =
+                setup_app(CameraBox::PillarBox { left: 10, right: 5 }, W360P.into());
             app.update();
             let viewport = app
                 .world()
@@ -399,13 +387,8 @@ mod tests {
 
         #[test]
         fn test_basic_letterboxing() {
-            let (mut app, camera_id) = setup_app(
-                CameraBox::LetterBox {
-                    top: 2,
-                    bottom: 2,
-                },
-                W360P.into(),
-            );
+            let (mut app, camera_id) =
+                setup_app(CameraBox::LetterBox { top: 2, bottom: 2 }, W360P.into());
             app.update();
             let viewport = app
                 .world()
@@ -417,13 +400,8 @@ mod tests {
             assert_eq!(viewport.physical_position, UVec2::new(0, 2));
             assert_eq!(viewport.physical_size, UVec2::new(640, 356));
 
-            let (mut app, camera_id) = setup_app(
-                CameraBox::LetterBox {
-                    top: 5,
-                    bottom: 0,
-                },
-                W360P.into(),
-            );
+            let (mut app, camera_id) =
+                setup_app(CameraBox::LetterBox { top: 5, bottom: 0 }, W360P.into());
             app.update();
             let viewport = app
                 .world()
@@ -435,13 +413,8 @@ mod tests {
             assert_eq!(viewport.physical_position, UVec2::new(0, 5));
             assert_eq!(viewport.physical_size, UVec2::new(640, 355));
 
-            let (mut app, camera_id) = setup_app(
-                CameraBox::LetterBox {
-                    top: 0,
-                    bottom: 5,
-                },
-                W360P.into(),
-            );
+            let (mut app, camera_id) =
+                setup_app(CameraBox::LetterBox { top: 0, bottom: 5 }, W360P.into());
             app.update();
             let viewport = app
                 .world()
@@ -453,13 +426,8 @@ mod tests {
             assert_eq!(viewport.physical_position, UVec2::new(0, 0));
             assert_eq!(viewport.physical_size, UVec2::new(640, 355));
 
-            let (mut app, camera_id) = setup_app(
-                CameraBox::LetterBox {
-                    top: 10,
-                    bottom: 5,
-                },
-                W360P.into(),
-            );
+            let (mut app, camera_id) =
+                setup_app(CameraBox::LetterBox { top: 10, bottom: 5 }, W360P.into());
             app.update();
             let viewport = app
                 .world()
@@ -471,13 +439,8 @@ mod tests {
             assert_eq!(viewport.physical_position, UVec2::new(0, 10));
             assert_eq!(viewport.physical_size, UVec2::new(640, 345));
 
-            let (mut app, camera_id) = setup_app(
-                CameraBox::LetterBox {
-                    top: 5,
-                    bottom: 10,
-                },
-                W360P.into(),
-            );
+            let (mut app, camera_id) =
+                setup_app(CameraBox::LetterBox { top: 5, bottom: 10 }, W360P.into());
             app.update();
             let viewport = app
                 .world()
@@ -504,7 +467,6 @@ mod tests {
                 .to_owned()
                 .viewport;
             assert!(viewport.is_none());
-
         }
 
         #[test]


### PR DESCRIPTION
# Objective
This PR provides a very basic initial implementation of Screen Boxing (Aspect Ratio Masking) for Cameras in Bevy. 

While not directly relevant I would like to ask anyone reviewing this to note I do not want AI Output sent to me in any way, nor do I want any AI-based reviews on my PR.

This should close #15130 

## Solution
This PR uses the API and design from `bevy_simple_screen_boxing` by exposing an enum component that is meant to be attached onto Cameras, to aspect ratio mask them or not. 

As a note this is missing the integer scaling code, arbitrary placement of window position, and removes some features that exist in the crate for backwards compatibility reasons. It also only supports pillar/letter/windowboxing without scaling the boxing itself.

## Testing

- I ran my provided unit tests and they passed (after fixing them).
---

## Showcase
> This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR adds a new feature or public API, consider adding a brief pseudo-code snippet of it in action
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - If you want, you could even include a before/after comparison!
- If the Migration Guide adequately covers the changes, you can delete this section

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

```rust
println!("My super cool code.");
```

</details>
