### PR TITLE
Fix SSAO depth sampling for cameras with Some(Viewport)

### DIFF
--- a/crates/bevy_pbr/src/deferred/deferred_lighting.wesl
+++ b/crates/bevy_pbr/src/deferred/deferred_lighting.wesl
@@ -63,7 +63,8 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     if ((pbr_input.material.flags & STANDARD_MATERIAL_FLAGS_UNLIT_BIT) == 0u) {
 
 @if(SCREEN_SPACE_AMBIENT_OCCLUSION) {
-        let ssao = textureLoad(screen_space_ambient_occlusion_texture, vec2<i32>(in.position.xy), 0i).r;
+        let ssao_tex_pos = vec2<i32>(in.position.xy - view.viewport.xy);
+        let ssao = textureLoad(screen_space_ambient_occlusion_texture, ssao_tex_pos, 0i).r;
         let ssao_multibounce = ssao_multibounce(ssao, pbr_input.material.base_color.rgb);
         pbr_input.diffuse_occlusion = min(pbr_input.diffuse_occlusion, ssao_multibounce);
 

--- a/crates/bevy_pbr/src/render/pbr_fragment.wesl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wesl
@@ -528,7 +528,8 @@ pbr_input.material.uv_transform = uv_transform;
             diffuse_occlusion *= textureSampleBias(texture, sampler_, coords, bias.mip_bias).r;
         }
 @if(SCREEN_SPACE_AMBIENT_OCCLUSION) {
-        let ssao = textureLoad(screen_space_ambient_occlusion_texture, vec2<i32>(in.position.xy), 0i).r;
+        let ssao_tex_pos = vec2<i32>(in.position.xy - view.viewport.xy);
+        let ssao = textureLoad(screen_space_ambient_occlusion_texture, ssao_tex_pos, 0i).r;
         let ssao_multibounce = ssao_multibounce(ssao, pbr_input.material.base_color.rgb);
         diffuse_occlusion = min(diffuse_occlusion, ssao_multibounce);
         // Use SSAO to estimate the specular occlusion.

--- a/crates/bevy_pbr/src/ssao/preprocess_depth.wesl
+++ b/crates/bevy_pbr/src/ssao/preprocess_depth.wesl
@@ -58,7 +58,8 @@ fn preprocess_depth(@builtin(global_invocation_id) global_id: vec3<u32>, @builti
     let pixel_coordinates1 = pixel_coordinates0 + vec2<i32>(1i, 0i);
     let pixel_coordinates2 = pixel_coordinates0 + vec2<i32>(0i, 1i);
     let pixel_coordinates3 = pixel_coordinates0 + vec2<i32>(1i, 1i);
-    let depths_uv = vec2<f32>(pixel_coordinates0) / view.viewport.zw;
+    let input_depth_size = vec2<f32>(textureDimensions(input_depth));
+    let depths_uv = (vec2<f32>(pixel_coordinates0) + view.viewport.xy) / input_depth_size;
     let depths = textureGather(input_depth, point_clamp_sampler, depths_uv, vec2<i32>(1i, 1i));
     textureStore(preprocessed_depth_mip0, pixel_coordinates0, vec4<f32>(depths.w, 0.0, 0.0, 0.0));
     textureStore(preprocessed_depth_mip0, pixel_coordinates1, vec4<f32>(depths.z, 0.0, 0.0, 0.0));

--- a/crates/bevy_pbr/src/ssao/ssao.wesl
+++ b/crates/bevy_pbr/src/ssao/ssao.wesl
@@ -75,8 +75,8 @@ fn calculate_neighboring_depth_differences(pixel_coordinates: vec2<i32>) -> f32 
     return depth_center;
 }
 
-fn load_normal_view_space(uv: vec2<f32>) -> vec3<f32> {
-    var world_normal = textureSampleLevel(normals, point_clamp_sampler, uv, 0.0).xyz;
+fn load_normal_view_space(uv_normals: vec2<f32>) -> vec3<f32> {
+    var world_normal = textureSampleLevel(normals, point_clamp_sampler, uv_normals, 0.0).xyz;
     world_normal = (world_normal * 2.0) - 1.0;
     let view_from_world = mat3x3<f32>(
         view.view_from_world[0].xyz,
@@ -144,6 +144,8 @@ fn ssao(@builtin(global_invocation_id) global_id: vec3<u32>) {
     pixel_depth += 0.00001; // Avoid depth precision issues
 
     let pixel_position = reconstruct_view_space_position(pixel_depth, uv);
+    let normals_size = vec2<f32>(textureDimensions(normals));
+    let uv_normals = (vec2<f32>(pixel_coordinates) + 0.5 + view.viewport.xy) / normals_size;
     let pixel_normal = load_normal_view_space(uv);
     let view_vec = normalize(-pixel_position);
 

--- a/crates/bevy_pbr/src/ssao/ssao.wesl
+++ b/crates/bevy_pbr/src/ssao/ssao.wesl
@@ -146,7 +146,7 @@ fn ssao(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let pixel_position = reconstruct_view_space_position(pixel_depth, uv);
     let normals_size = vec2<f32>(textureDimensions(normals));
     let uv_normals = (vec2<f32>(pixel_coordinates) + 0.5 + view.viewport.xy) / normals_size;
-    let pixel_normal = load_normal_view_space(uv);
+    let pixel_normal = load_normal_view_space(uv_normals);
     let view_vec = normalize(-pixel_position);
 
     let noise = load_noise(pixel_coordinates);


### PR DESCRIPTION
# Objective

Fixes SSAO rendering for cameras using `Some(Viewport)` by sampling the correct region of the depth prepass texture instead of assuming the viewport starts at the render target origin.

## Solution

Account for the camera viewport when addressing SSAO-related textures:
- Offset depth prepass sampling in the SSAO compute pass so it reads from the correct viewport region of the full render target.
- Convert render-target fragment coordinates to viewport-local coordinates when sampling the viewport-sized SSAO texture in deferred lighting and PBR materials.

## Testing

- Did you test these changes? If so, how?
`cargo run --example ssao` (modified)
`cargo run -p ci`
- Are there any parts that need more testing? I do not think so.
- How can other people (reviewers) test your changes? Is there anything specific they need to know? Run modified `ssao` example (attached)
`cargo run --example ssao` (modified)
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? Not relevant

---

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

Before:
<img width="2560" height="1322" alt="image" src="https://github.com/user-attachments/assets/8b4b8338-b4c5-4f42-a2ad-ccba8fc7059f" />

After:
<img width="2558" height="1320" alt="image" src="https://github.com/user-attachments/assets/4d1efb31-73d3-44ac-944b-fd65d70fb508" />


<details>
  <summary>Click to view example</summary>

```rust
//! A scene showcasing screen space ambient occlusion.

use bevy::{
    anti_alias::taa::TemporalAntiAliasing,
    camera::{Hdr, Viewport},
    math::ops,
    pbr::{ScreenSpaceAmbientOcclusion, ScreenSpaceAmbientOcclusionQualityLevel},
    prelude::*,
    render::camera::TemporalJitter,
};
use std::f32::consts::PI;

fn main() {
    App::new()
        .insert_resource(GlobalAmbientLight {
            brightness: 1000.,
            ..default()
        })
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .add_systems(Update, update)
        .run();
}

fn setup(
    mut commands: Commands,
    mut meshes: ResMut<Assets<Mesh>>,
    mut materials: ResMut<Assets<StandardMaterial>>,
) {
    commands.spawn((
        Camera3d::default(),
        Transform::from_xyz(-2.0, 2.0, -2.0).looking_at(Vec3::ZERO, Vec3::Y),
        Hdr,
        Msaa::Off,
        ScreenSpaceAmbientOcclusion::default(),
        TemporalAntiAliasing::default(),
    ));

    let material = materials.add(StandardMaterial {
        base_color: Color::srgb(0.5, 0.5, 0.5),
        perceptual_roughness: 1.0,
        reflectance: 0.0,
        ..default()
    });
    commands.spawn((
        Mesh3d(meshes.add(Cuboid::default())),
        MeshMaterial3d(material.clone()),
        Transform::from_xyz(0.0, 0.0, 1.0),
    ));
    commands.spawn((
        Mesh3d(meshes.add(Cuboid::default())),
        MeshMaterial3d(material.clone()),
        Transform::from_xyz(0.0, -1.0, 0.0),
    ));
    commands.spawn((
        Mesh3d(meshes.add(Cuboid::default())),
        MeshMaterial3d(material),
        Transform::from_xyz(1.0, 0.0, 0.0),
    ));
    commands.spawn((
        Mesh3d(meshes.add(Sphere::new(0.4).mesh().uv(72, 36))),
        MeshMaterial3d(materials.add(StandardMaterial {
            base_color: Color::srgb(0.4, 0.4, 0.4),
            perceptual_roughness: 1.0,
            reflectance: 0.0,
            ..default()
        })),
        SphereMarker,
    ));

    commands.spawn((
        DirectionalLight {
            shadow_maps_enabled: true,
            ..default()
        },
        Transform::from_rotation(Quat::from_euler(EulerRot::ZYX, 0.0, PI * -0.15, PI * -0.15)),
    ));

    commands.spawn((
        Text::default(),
        Node {
            position_type: PositionType::Absolute,
            bottom: px(12),
            left: px(12),
            ..default()
        },
    ));
}

fn update(
    camera: Single<(
        Entity,
        &mut Camera,
        Option<&ScreenSpaceAmbientOcclusion>,
        Option<&TemporalJitter>,
    )>,
    window: Single<&Window>,
    mut text: Single<&mut Text>,
    mut sphere: Single<&mut Transform, With<SphereMarker>>,
    mut commands: Commands,
    keycode: Res<ButtonInput<KeyCode>>,
    time: Res<Time>,
) {
    sphere.translation.y = ops::sin(time.elapsed_secs() / 1.7) * 0.7;

    let (camera_entity, mut camera, ssao, temporal_jitter) = camera.into_inner();
    let window = window.into_inner();
    let window_phys_size = window.physical_size();

    camera.viewport = Some(Viewport {
        physical_position: [window_phys_size.x / 2, 0].into(),
        physical_size: [window_phys_size.x / 2, window_phys_size.y / 2].into(),
        ..Default::default()
    });

    let current_ssao = ssao.cloned().unwrap_or_default();

    let mut commands = commands.entity(camera_entity);
    commands
        .insert_if(
            ScreenSpaceAmbientOcclusion {
                quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Low,
                ..current_ssao
            },
            || keycode.just_pressed(KeyCode::Digit2),
        )
        .insert_if(
            ScreenSpaceAmbientOcclusion {
                quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Medium,
                ..current_ssao
            },
            || keycode.just_pressed(KeyCode::Digit3),
        )
        .insert_if(
            ScreenSpaceAmbientOcclusion {
                quality_level: ScreenSpaceAmbientOcclusionQualityLevel::High,
                ..current_ssao
            },
            || keycode.just_pressed(KeyCode::Digit4),
        )
        .insert_if(
            ScreenSpaceAmbientOcclusion {
                quality_level: ScreenSpaceAmbientOcclusionQualityLevel::Ultra,
                ..current_ssao
            },
            || keycode.just_pressed(KeyCode::Digit5),
        )
        .insert_if(
            ScreenSpaceAmbientOcclusion {
                constant_object_thickness: (current_ssao.constant_object_thickness * 2.0).min(4.0),
                ..current_ssao
            },
            || keycode.just_pressed(KeyCode::ArrowUp),
        )
        .insert_if(
            ScreenSpaceAmbientOcclusion {
                constant_object_thickness: (current_ssao.constant_object_thickness * 0.5)
                    .max(0.0625),
                ..current_ssao
            },
            || keycode.just_pressed(KeyCode::ArrowDown),
        )
        .insert_if(
            ScreenSpaceAmbientOcclusion {
                radius: (current_ssao.radius * 1.25).min(8.0),
                ..current_ssao
            },
            || keycode.just_pressed(KeyCode::ArrowRight),
        )
        .insert_if(
            ScreenSpaceAmbientOcclusion {
                radius: (current_ssao.radius * 0.8).max(0.1),
                ..current_ssao
            },
            || keycode.just_pressed(KeyCode::ArrowLeft),
        );
    if keycode.just_pressed(KeyCode::Digit1) {
        commands.remove::<ScreenSpaceAmbientOcclusion>();
    }
    if keycode.just_pressed(KeyCode::Space) {
        if temporal_jitter.is_some() {
            commands.remove::<TemporalJitter>();
        } else {
            commands.insert(TemporalJitter::default());
        }
    }

    text.clear();

    let (o, l, m, h, u) = match ssao.map(|s| s.quality_level) {
        None => ("*", "", "", "", ""),
        Some(ScreenSpaceAmbientOcclusionQualityLevel::Low) => ("", "*", "", "", ""),
        Some(ScreenSpaceAmbientOcclusionQualityLevel::Medium) => ("", "", "*", "", ""),
        Some(ScreenSpaceAmbientOcclusionQualityLevel::High) => ("", "", "", "*", ""),
        Some(ScreenSpaceAmbientOcclusionQualityLevel::Ultra) => ("", "", "", "", "*"),
        _ => unreachable!(),
    };

    if let Some(radius) = ssao.map(|s| s.radius) {
        text.push_str(&format!("Radius: {radius} (Left/Right)\n"));
    }

    if let Some(thickness) = ssao.map(|s| s.constant_object_thickness) {
        text.push_str(&format!(
            "Constant object thickness: {thickness} (Up/Down)\n\n"
        ));
    }

    text.push_str("SSAO Quality:\n");
    text.push_str(&format!("(1) {o}Off{o}\n"));
    text.push_str(&format!("(2) {l}Low{l}\n"));
    text.push_str(&format!("(3) {m}Medium{m}\n"));
    text.push_str(&format!("(4) {h}High{h}\n"));
    text.push_str(&format!("(5) {u}Ultra{u}\n\n"));

    text.push_str("Temporal Antialiasing:\n");
    text.push_str(match temporal_jitter {
        Some(_) => "(Space) Enabled",
        None => "(Space) Disabled",
    });
}

#[derive(Component)]
struct SphereMarker;
```

</details>
