### PR TITLE
Fix `bevy_math` not compiling on its own

### DIFF
--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -11,7 +11,9 @@ rust-version = "1.94.0"
 
 [dependencies]
 glam = { version = "0.33.2", default-features = false, features = [
-  "all-types",
+  "f64",
+  "i32",
+  "u32",
   "bytemuck",
 ] }
 thiserror = { version = "2", default-features = false }

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -10,7 +10,10 @@ keywords = ["bevy"]
 rust-version = "1.94.0"
 
 [dependencies]
-glam = { version = "0.33.2", default-features = false, features = ["bytemuck"] }
+glam = { version = "0.33.2", default-features = false, features = [
+  "all-types",
+  "bytemuck",
+] }
 thiserror = { version = "2", default-features = false }
 derive_more = { version = "2", default-features = false, features = [
   "from",


### PR DESCRIPTION
## Objective

`bevy_math` doesn't compile on its own, but works if `bevy_reflect` is also compiled. This is because `bevy_math` depends on types that are behind the `"integer-types"` and `"float-types"` features but doesn't enable those features itself, whereas `bevy_reflect` does enable the features on its version of `glam`.

## Solution

Add `"all-types"` to `glam`'s features in `bevy_math`.
