### PR TITLE
Mark all `Components` as changed when a disabling `Component` is removed

### DIFF
--- a/crates/bevy_ecs/src/component/info.rs
+++ b/crates/bevy_ecs/src/component/info.rs
@@ -33,6 +33,7 @@ pub struct ComponentInfo {
     pub(super) descriptor: ComponentDescriptor,
     pub(super) hooks: ComponentHooks,
     pub(super) required_components: RequiredComponents,
+    pub(super) is_disabling: bool,
     /// The set of components that require this components.
     /// Invariant: components in this set always appear after the components that they require.
     pub(super) required_by: IndexSet<ComponentId, FixedHasher>,
@@ -101,12 +102,17 @@ impl ComponentInfo {
         self.descriptor.is_send_and_sync
     }
 
+    pub fn is_disabling(&self) -> bool {
+        self.is_disabling
+    }
+
     /// Create a new [`ComponentInfo`].
     pub(crate) fn new(id: ComponentId, descriptor: ComponentDescriptor) -> Self {
         ComponentInfo {
             id,
             descriptor,
             hooks: Default::default(),
+            is_disabling: false,
             required_components: Default::default(),
             required_by: Default::default(),
         }
@@ -124,7 +130,7 @@ impl ComponentInfo {
         if self.hooks().on_discard.is_some() {
             flags.insert(ArchetypeFlags::ON_DISCARD_HOOK);
         }
-        if self.hooks().on_remove.is_some() {
+        if self.hooks().on_remove.is_some() || self.is_disabling {
             flags.insert(ArchetypeFlags::ON_REMOVE_HOOK);
         }
         if self.hooks().on_despawn.is_some() {

--- a/crates/bevy_ecs/src/component/info.rs
+++ b/crates/bevy_ecs/src/component/info.rs
@@ -102,6 +102,8 @@ impl ComponentInfo {
         self.descriptor.is_send_and_sync
     }
 
+    /// Returns whether this component is a "disabling" component, using [default query filters](crate::entity_disabling::DefaultQueryFilters) to exclude entities with the component from queries.
+    #[inline]
     pub fn is_disabling(&self) -> bool {
         self.is_disabling
     }

--- a/crates/bevy_ecs/src/component/info.rs
+++ b/crates/bevy_ecs/src/component/info.rs
@@ -33,7 +33,6 @@ pub struct ComponentInfo {
     pub(super) descriptor: ComponentDescriptor,
     pub(super) hooks: ComponentHooks,
     pub(super) required_components: RequiredComponents,
-    pub(super) is_disabling: bool,
     /// The set of components that require this components.
     /// Invariant: components in this set always appear after the components that they require.
     pub(super) required_by: IndexSet<ComponentId, FixedHasher>,
@@ -105,7 +104,7 @@ impl ComponentInfo {
     /// Returns whether this component is a "disabling" component, using [default query filters](crate::entity_disabling::DefaultQueryFilters) to exclude entities with the component from queries.
     #[inline]
     pub fn is_disabling(&self) -> bool {
-        self.is_disabling
+        self.descriptor.is_disabling
     }
 
     /// Create a new [`ComponentInfo`].
@@ -114,7 +113,6 @@ impl ComponentInfo {
             id,
             descriptor,
             hooks: Default::default(),
-            is_disabling: false,
             required_components: Default::default(),
             required_by: Default::default(),
         }
@@ -132,7 +130,7 @@ impl ComponentInfo {
         if self.hooks().on_discard.is_some() {
             flags.insert(ArchetypeFlags::ON_DISCARD_HOOK);
         }
-        if self.hooks().on_remove.is_some() || self.is_disabling {
+        if self.hooks().on_remove.is_some() || self.is_disabling() {
             flags.insert(ArchetypeFlags::ON_REMOVE_HOOK);
         }
         if self.hooks().on_despawn.is_some() {
@@ -235,6 +233,7 @@ pub struct ComponentDescriptor {
     // None if the underlying type doesn't need to be dropped
     drop: Option<for<'a> unsafe fn(OwningPtr<'a>)>,
     mutable: bool,
+    is_disabling: bool,
     clone_behavior: ComponentCloneBehavior,
     relationship_accessor: MaybeRelationshipAccessor,
 }
@@ -277,6 +276,7 @@ impl ComponentDescriptor {
             layout: Layout::new::<T>(),
             drop: needs_drop::<T>().then_some(Self::drop_ptr::<T> as _),
             mutable: T::Mutability::MUTABLE,
+            is_disabling: false,
             clone_behavior: T::clone_behavior(),
             relationship_accessor: T::relationship_accessor().map(|v| v.initializer).into(),
         }
@@ -314,8 +314,25 @@ impl ComponentDescriptor {
             layout,
             drop,
             mutable,
+            is_disabling: false,
             clone_behavior,
             relationship_accessor: relationship_accessor.into(),
+        }
+    }
+
+    pub(super) fn new_disabling<T: Component>() -> Self {
+        Self {
+            name: DebugName::type_name::<T>(),
+            storage_type: T::STORAGE_TYPE,
+            is_send_and_sync: true,
+            type_id: Some(TypeId::of::<T>()),
+            // `T` is a rust type, so the layout will have `size()` as a multiple of `align()`
+            layout: Layout::new::<T>(),
+            drop: needs_drop::<T>().then_some(Self::drop_ptr::<T> as _),
+            mutable: T::Mutability::MUTABLE,
+            is_disabling: true,
+            clone_behavior: T::clone_behavior(),
+            relationship_accessor: T::relationship_accessor().map(|v| v.initializer).into(),
         }
     }
 
@@ -329,6 +346,7 @@ impl ComponentDescriptor {
             layout: Layout::new::<T>(),
             drop: needs_drop::<T>().then_some(Self::drop_ptr::<T> as _),
             mutable: true,
+            is_disabling: false,
             clone_behavior: ComponentCloneBehavior::Default,
             relationship_accessor: None.into(),
         }

--- a/crates/bevy_ecs/src/component/register.rs
+++ b/crates/bevy_ecs/src/component/register.rs
@@ -166,7 +166,6 @@ impl<'w> ComponentsRegistrator<'w> {
             ComponentDescriptor::new::<T>,
             T::register_required_components,
             ComponentHooks::update_from_component::<T>,
-            false,
         )
     }
 
@@ -177,7 +176,6 @@ impl<'w> ComponentsRegistrator<'w> {
         descriptor: fn() -> ComponentDescriptor,
         register_required_components: fn(ComponentId, &mut RequiredComponentsRegistrator),
         update_from_component: fn(&mut ComponentHooks) -> &mut ComponentHooks,
-        is_disabling: bool,
     ) -> ComponentId {
         if let Some(&id) = self.indices.get(&type_id) {
             enforce_no_required_components_recursion(self, &self.recursion_check_stack, id);
@@ -206,7 +204,6 @@ impl<'w> ComponentsRegistrator<'w> {
                 descriptor(),
                 register_required_components,
                 update_from_component,
-                is_disabling,
             );
         }
         id
@@ -223,7 +220,6 @@ impl<'w> ComponentsRegistrator<'w> {
         descriptor: ComponentDescriptor,
         register_required_components: fn(ComponentId, &mut RequiredComponentsRegistrator),
         update_from_component: fn(&mut ComponentHooks) -> &mut ComponentHooks,
-        is_disabling: bool,
     ) {
         // SAFETY: ensured by caller.
         unsafe {
@@ -261,7 +257,6 @@ impl<'w> ComponentsRegistrator<'w> {
 
         update_from_component(&mut info.hooks);
 
-        info.is_disabling = is_disabling;
         info.required_components = required_components;
     }
 
@@ -304,10 +299,9 @@ impl<'w> ComponentsRegistrator<'w> {
     pub fn register_disabling_component<T: Component>(&mut self) -> ComponentId {
         self.register_component_checked(
             TypeId::of::<T>(),
-            ComponentDescriptor::new::<T>,
+            ComponentDescriptor::new_disabling::<T>,
             T::register_required_components,
             ComponentHooks::update_from_component::<T>,
-            true,
         )
     }
 
@@ -543,7 +537,6 @@ impl<'w> ComponentsQueuedRegistrator<'w> {
                                 descriptor,
                                 T::register_required_components,
                                 ComponentHooks::update_from_component::<T>,
-                                false,
                             );
                         }
                     },

--- a/crates/bevy_ecs/src/component/register.rs
+++ b/crates/bevy_ecs/src/component/register.rs
@@ -166,6 +166,7 @@ impl<'w> ComponentsRegistrator<'w> {
             ComponentDescriptor::new::<T>,
             T::register_required_components,
             ComponentHooks::update_from_component::<T>,
+            false,
         )
     }
 
@@ -176,6 +177,7 @@ impl<'w> ComponentsRegistrator<'w> {
         descriptor: fn() -> ComponentDescriptor,
         register_required_components: fn(ComponentId, &mut RequiredComponentsRegistrator),
         update_from_component: fn(&mut ComponentHooks) -> &mut ComponentHooks,
+        is_disabling: bool,
     ) -> ComponentId {
         if let Some(&id) = self.indices.get(&type_id) {
             enforce_no_required_components_recursion(self, &self.recursion_check_stack, id);
@@ -204,6 +206,7 @@ impl<'w> ComponentsRegistrator<'w> {
                 descriptor(),
                 register_required_components,
                 update_from_component,
+                is_disabling,
             );
         }
         id
@@ -220,6 +223,7 @@ impl<'w> ComponentsRegistrator<'w> {
         descriptor: ComponentDescriptor,
         register_required_components: fn(ComponentId, &mut RequiredComponentsRegistrator),
         update_from_component: fn(&mut ComponentHooks) -> &mut ComponentHooks,
+        is_disabling: bool,
     ) {
         // SAFETY: ensured by caller.
         unsafe {
@@ -257,6 +261,7 @@ impl<'w> ComponentsRegistrator<'w> {
 
         update_from_component(&mut info.hooks);
 
+        info.is_disabling = is_disabling;
         info.required_components = required_components;
     }
 
@@ -288,6 +293,16 @@ impl<'w> ComponentsRegistrator<'w> {
             self.components.register_component_inner(id, descriptor);
         }
         id
+    }
+
+    pub fn register_disabling_component<T: Component>(&mut self) -> ComponentId {
+        self.register_component_checked(
+            TypeId::of::<T>(),
+            ComponentDescriptor::new::<T>,
+            T::register_required_components,
+            ComponentHooks::update_from_component::<T>,
+            true,
+        )
     }
 
     /// Registers a [non-send resource](crate::system::NonSend) of type `T` with this instance.
@@ -522,6 +537,7 @@ impl<'w> ComponentsQueuedRegistrator<'w> {
                                 descriptor,
                                 T::register_required_components,
                                 ComponentHooks::update_from_component::<T>,
+                                false,
                             );
                         }
                     },

--- a/crates/bevy_ecs/src/component/register.rs
+++ b/crates/bevy_ecs/src/component/register.rs
@@ -295,6 +295,12 @@ impl<'w> ComponentsRegistrator<'w> {
         id
     }
 
+    /// Registers a "disabling" component of type `T` with this instance.
+    /// If a component of this type has already been registered, this will return
+    /// the ID of the pre-existing component.
+    ///
+    /// Disabling components use [default query filters](crate::entity_disabling::DefaultQueryFilters) to exclude entities with the component from queries.
+    #[inline]
     pub fn register_disabling_component<T: Component>(&mut self) -> ComponentId {
         self.register_component_checked(
             TypeId::of::<T>(),

--- a/crates/bevy_ecs/src/entity_disabling.rs
+++ b/crates/bevy_ecs/src/entity_disabling.rs
@@ -181,7 +181,10 @@ pub struct DefaultQueryFilters {
 impl FromWorld for DefaultQueryFilters {
     fn from_world(world: &mut World) -> Self {
         let mut filters = DefaultQueryFilters::empty();
-        let disabled_component_id = world.register_component::<Disabled>();
+        let disabled_component_id = world
+            .components_registrator()
+            .register_disabling_component::<Disabled>();
+
         filters.register_disabling_component(disabled_component_id);
         filters
     }

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -4,7 +4,7 @@ use bevy_utils::prelude::DebugName;
 
 use crate::{
     archetype::Archetype,
-    change_detection::{MaybeLocation, MutUntyped, Tick},
+    change_detection::{DetectChangesMut, MaybeLocation, MutUntyped, Tick},
     component::{ComponentId, Mutable},
     entity::Entity,
     event::{EntityComponentsTrigger, Event, EventKey, Trigger},
@@ -713,8 +713,9 @@ impl<'w> DeferredWorld<'w> {
         if archetype.has_remove_hook() {
             for component_id in targets {
                 // SAFETY: Caller ensures that these components exist
-                let hooks = unsafe { self.components().get_info_unchecked(component_id) }.hooks();
-                if let Some(hook) = hooks.on_remove {
+                let info = unsafe { self.components().get_info_unchecked(component_id) };
+
+                if let Some(hook) = info.hooks().on_remove {
                     hook(
                         DeferredWorld { world: self.world },
                         HookContext {
@@ -724,6 +725,12 @@ impl<'w> DeferredWorld<'w> {
                             relationship_hook_mode: RelationshipHookMode::Run,
                         },
                     );
+                }
+
+                if info.is_disabling() {
+                    for mut component in self.entity_mut(entity).get_mut_by_id(archetype.components()).expect("Archetype::components are guaranteed to be unique and are not missing.") {
+                        component.set_changed();
+                    }
                 }
             }
         }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -4603,6 +4603,29 @@ mod tests {
     }
 
     #[test]
+    fn removing_disabling_marks_components_changed() {
+        let mut world = World::new();
+        world.register_disabling_component::<Foo>();
+
+        let with_disabled = world.spawn((Bar, Disabled)).id();
+        let with_custom = world.spawn((Bar, Foo)).id();
+
+        world.increment_change_tick();
+
+        world.entity_mut(with_disabled).remove::<Disabled>();
+        world.entity_mut(with_custom).remove::<Foo>();
+
+        assert!(world
+            .entity_mut(with_disabled)
+            .get_change_ticks::<Bar>()
+            .is_some_and(|ticks| ticks.changed.get() == 2));
+        assert!(world
+            .entity_mut(with_custom)
+            .get_change_ticks::<Bar>()
+            .is_some_and(|ticks| ticks.changed.get() == 2));
+    }
+
+    #[test]
     fn entities_and_commands() {
         #[derive(Component, PartialEq, Debug)]
         struct Foo(u32);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -328,7 +328,9 @@ impl World {
     /// Registers a component type as "disabling",
     /// using [default query filters](DefaultQueryFilters) to exclude entities with the component from queries.
     pub fn register_disabling_component<C: Component>(&mut self) {
-        let component_id = self.register_component::<C>();
+        let component_id = self
+            .components_registrator()
+            .register_disabling_component::<C>();
         let mut dqf = self.resource_mut::<DefaultQueryFilters>();
         dqf.register_disabling_component(component_id);
     }


### PR DESCRIPTION
# Objective
Fixes #18981
Replaces #18992, #23224 

Could be used as a base to implement #22627 

## Solution

- Added `is_disabling` field to `ComponentInfo`
- Updated functions for registering disabling components to use it
- Updated `DeferredWorld::trigger_on_remove` to mark all components of an `Entity` as changed if the removed component is a disabling component.

<sub>(( thanks to @urben1680 for the idea :) ))</sub>

## Testing

Ran following example, which doesn't render anything before the change, and works for both `Disabled` and `MyDisablingComponent` after:

<details>
  <summary>See code</summary>

```rust
use bevy::{
    ecs::entity_disabling::Disabled, input::common_conditions::input_just_pressed, prelude::*,
};

fn main() {
    let mut app = App::new();
    app.add_plugins(DefaultPlugins)
        .insert_resource(ClearColor(Color::hsv(0., 0., 0.3)))
        .add_systems(Startup, setup)
        .add_systems(
            Update,
            (
                toggle_disabling::<Disabled>.run_if(input_just_pressed(KeyCode::Space)),
                toggle_disabling::<MyDisablingComponent>.run_if(input_just_pressed(KeyCode::Enter)),
            ),
        )
        .register_disabling_component::<MyDisablingComponent>();
    app.run();
}

#[derive(Component, Default)]
struct MyDisablingComponent;

fn setup(
    mut commands: Commands,
    mut materials: ResMut<Assets<ColorMaterial>>,
    mut meshes: ResMut<Assets<Mesh>>,
) {
    commands.spawn(Camera2d);
    commands.spawn((
        Mesh2d(meshes.add(Rectangle::new(100., 100.))),
        MeshMaterial2d(materials.add(Color::srgb(1., 0., 0.))),
        Transform::from_translation(Vec3::new(-100., 0., 0.)),
        Disabled,
    ));
    commands.spawn((
        Mesh2d(meshes.add(Rectangle::new(100., 100.))),
        MeshMaterial2d(materials.add(Color::srgb(0., 0., 1.))),
        Transform::from_translation(Vec3::new(100., 0., 0.)),
        MyDisablingComponent,
    ));
}

fn toggle_disabling<D: Component + Default>(
    mut commands: Commands,
    mesh_query: Query<(Entity, Has<D>), With<Mesh2d>>,
) {
    for (entity, has_comp) in mesh_query {
        if has_comp {
            info!("Removing disabling component for {entity}");
            commands.entity(entity).remove::<D>();
        } else {
            info!("Adding disabling component for {entity}");
            commands.entity(entity).insert(D::default());
        }
    }
}
```

</details> 

---

## Questions
1. I don't really like how the setting the components as changed runs *after* the `on_remove` hook (`crates/bevy_ecs/src/world/deferred_world.rs`). It was done like this because since `info` borrows `self` immutably, I couldn`t call `self.entity_mut` without getting a new info for the hooks, or setting the changes after. I worry this might cause problems if the hook inserts/removes components...
2. I marked this as a draft because I didn't want to write documentation for something that had no chance of being accepted, so if this seems like a reasonable approach, I will write up the docs for it :)
