### PR TITLE
Fix normalization in SSAO calculation

### DIFF
--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -508,7 +508,7 @@ fn extract_ssao_settings(
                 "SSAO is being used which requires Msaa::Off, but Msaa is currently set to Msaa::{:?}",
                 *msaa
             );
-            return;
+            continue;
         }
         let mut entity_commands = commands
             .get_entity(entity)

--- a/crates/bevy_pbr/src/ssao/preprocess_depth.wesl
+++ b/crates/bevy_pbr/src/ssao/preprocess_depth.wesl
@@ -26,6 +26,10 @@ import bevy_render::view::View;
 @group(1) @binding(1) var linear_clamp_sampler: sampler;
 @group(1) @binding(2) var<uniform> view: View;
 
+fn linearize_depth(ndc_depth: f32) -> f32 {
+    let near = view.clip_from_view[3][2];
+    return near / max(ndc_depth, 0.000001);
+}
 
 // Using 4 depths from the previous MIP, compute a weighted average for the depth of the current MIP
 fn weighted_average(depth0: f32, depth1: f32, depth2: f32, depth3: f32) -> f32 {
@@ -36,11 +40,16 @@ fn weighted_average(depth0: f32, depth1: f32, depth2: f32, depth3: f32) -> f32 {
     let falloff_mul = -1.0 / falloff_range;
     let falloff_add = falloff_from / falloff_range + 1.0;
 
-    let min_depth = min(min(depth0, depth1), min(depth2, depth3));
-    let weight0 = saturate((depth0 - min_depth) * falloff_mul + falloff_add);
-    let weight1 = saturate((depth1 - min_depth) * falloff_mul + falloff_add);
-    let weight2 = saturate((depth2 - min_depth) * falloff_mul + falloff_add);
-    let weight3 = saturate((depth3 - min_depth) * falloff_mul + falloff_add);
+    let linear_depth0 = linearize_depth(depth0);
+    let linear_depth1 = linearize_depth(depth1);
+    let linear_depth2 = linearize_depth(depth2);
+    let linear_depth3 = linearize_depth(depth3);
+
+    let min_depth = min(min(linear_depth0, linear_depth1), min(linear_depth2, linear_depth3));
+    let weight0 = saturate((linear_depth0 - min_depth) * falloff_mul + falloff_add);
+    let weight1 = saturate((linear_depth1 - min_depth) * falloff_mul + falloff_add);
+    let weight2 = saturate((linear_depth2 - min_depth) * falloff_mul + falloff_add);
+    let weight3 = saturate((linear_depth3 - min_depth) * falloff_mul + falloff_add);
     let weight_total = weight0 + weight1 + weight2 + weight3;
 
     return ((weight0 * depth0) + (weight1 * depth1) + (weight2 * depth2) + (weight3 * depth3)) / weight_total;

--- a/crates/bevy_pbr/src/ssao/preprocess_depth.wesl
+++ b/crates/bevy_pbr/src/ssao/preprocess_depth.wesl
@@ -26,11 +26,6 @@ import bevy_render::view::View;
 @group(1) @binding(1) var linear_clamp_sampler: sampler;
 @group(1) @binding(2) var<uniform> view: View;
 
-fn linearize_depth(ndc_depth: f32) -> f32 {
-    let near = view.clip_from_view[3][2];
-    return near / max(ndc_depth, 0.000001);
-}
-
 // Using 4 depths from the previous MIP, compute a weighted average for the depth of the current MIP
 fn weighted_average(depth0: f32, depth1: f32, depth2: f32, depth3: f32) -> f32 {
     let depth_range_scale_factor = 0.75;
@@ -40,16 +35,11 @@ fn weighted_average(depth0: f32, depth1: f32, depth2: f32, depth3: f32) -> f32 {
     let falloff_mul = -1.0 / falloff_range;
     let falloff_add = falloff_from / falloff_range + 1.0;
 
-    let linear_depth0 = linearize_depth(depth0);
-    let linear_depth1 = linearize_depth(depth1);
-    let linear_depth2 = linearize_depth(depth2);
-    let linear_depth3 = linearize_depth(depth3);
-
-    let min_depth = min(min(linear_depth0, linear_depth1), min(linear_depth2, linear_depth3));
-    let weight0 = saturate((linear_depth0 - min_depth) * falloff_mul + falloff_add);
-    let weight1 = saturate((linear_depth1 - min_depth) * falloff_mul + falloff_add);
-    let weight2 = saturate((linear_depth2 - min_depth) * falloff_mul + falloff_add);
-    let weight3 = saturate((linear_depth3 - min_depth) * falloff_mul + falloff_add);
+    let min_depth = min(min(depth0, depth1), min(depth2, depth3));
+    let weight0 = saturate((depth0 - min_depth) * falloff_mul + falloff_add);
+    let weight1 = saturate((depth1 - min_depth) * falloff_mul + falloff_add);
+    let weight2 = saturate((depth2 - min_depth) * falloff_mul + falloff_add);
+    let weight3 = saturate((depth3 - min_depth) * falloff_mul + falloff_add);
     let weight_total = weight0 + weight1 + weight2 + weight3;
 
     return ((weight0 * depth0) + (weight1 * depth1) + (weight2 * depth2) + (weight3 * depth3)) / weight_total;

--- a/crates/bevy_pbr/src/ssao/spatial_denoise.wesl
+++ b/crates/bevy_pbr/src/ssao/spatial_denoise.wesl
@@ -54,15 +54,15 @@ fn spatial_denoise(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
     let center_visibility = visibility0.y;
     let left_visibility = visibility0.x;
-    let right_visibility = visibility0.z;
-    let top_visibility = visibility1.x;
+    let right_visibility = visibility1.x;
+    let top_visibility = visibility0.z;
     let bottom_visibility = visibility2.z;
     let top_left_visibility = visibility0.w;
     let top_right_visibility = visibility1.w;
     let bottom_left_visibility = visibility2.w;
     let bottom_right_visibility = visibility3.w;
 
-    var sum = center_visibility;
+    var sum = center_visibility * center_weight;
     sum += left_visibility * left_weight;
     sum += right_visibility * right_weight;
     sum += top_visibility * top_weight;

--- a/crates/bevy_pbr/src/ssao/ssao.wesl
+++ b/crates/bevy_pbr/src/ssao/ssao.wesl
@@ -125,7 +125,7 @@ fn processSample(
         fast_acos(dot(normalize(delta_position_back_face), view_vec)),
     );
 
-    front_back_horizon = saturate(fma(vec2(sampling_direction), -front_back_horizon, n));
+    front_back_horizon = saturate(fma(vec2(sampling_direction), -front_back_horizon * (1.0 / PI), n));
     front_back_horizon = select(front_back_horizon.xy, front_back_horizon.yx, sampling_direction >= 0.0);
 
     *bitmask = updateSectors(front_back_horizon.x, front_back_horizon.y, samples_per_slice, *bitmask);


### PR DESCRIPTION
# Objective

- Fix a math issue with the SSAO shader.
  - processSample() mixes together `n` which is normalized to [0..1] with `front_back_horizon` which comes from `fast_acos()` and is in radians.

From the cited webpage in `ssao.wesl`: (https://cdrinmatane.github.io/posts/ssaovb-code/)
```
    // Shift sample from V to normal, clamp in [0..1]
    frontBackHorizon = saturate(((samplingDirection * -frontBackHorizon) - N + HALF_PI) / PI);
```
Both `front_back_horizon` and `n` should be divided by PI.

## Solution

- Normalize `front_back_horizon` as well by dividing it by PI.

## Testing

- I found this issue while debugging the ambient occlusion in my hobby project.
- The patch was tested in my game and I also tested on the SSAO example from this repo, but the geometry in the SSAO demo is very simple so the bug is not so apparent there.

---

## Showcase

With upstream SSAO shader:
<img width="434" height="194" alt="upstream" src="https://github.com/user-attachments/assets/a9922313-d6ce-4d9a-8d0d-444e297dc8f9" />


With this patch:
<img width="467" height="176" alt="patched" src="https://github.com/user-attachments/assets/189a037a-f2a8-4f15-9c90-2bf0d5396d91" />

