### PR TITLE
Fix incorrect `textureGather` argument in SSAO

### DIFF
--- a/crates/bevy_pbr/src/ssao/preprocess_depth.wesl
+++ b/crates/bevy_pbr/src/ssao/preprocess_depth.wesl
@@ -60,7 +60,7 @@ fn preprocess_depth(@builtin(global_invocation_id) global_id: vec3<u32>, @builti
     let pixel_coordinates2 = pixel_coordinates0 + vec2<i32>(0i, 1i);
     let pixel_coordinates3 = pixel_coordinates0 + vec2<i32>(1i, 1i);
     let depths_uv = vec2<f32>(pixel_coordinates0) / view.viewport.zw;
-    let depths = textureGather(0, input_depth, point_clamp_sampler, depths_uv, vec2<i32>(1i, 1i));
+    let depths = textureGather(input_depth, point_clamp_sampler, depths_uv, vec2<i32>(1i, 1i));
     textureStore(preprocessed_depth_mip0, pixel_coordinates0, vec4<f32>(depths.w, 0.0, 0.0, 0.0));
     textureStore(preprocessed_depth_mip0, pixel_coordinates1, vec4<f32>(depths.z, 0.0, 0.0, 0.0));
     textureStore(preprocessed_depth_mip0, pixel_coordinates2, vec4<f32>(depths.x, 0.0, 0.0, 0.0));


### PR DESCRIPTION
# Objective

For `texture_depth_2d`, the first argument of [`textureGather`](https://www.w3.org/TR/WGSL/#texturegather) is not an integer, which causes `createShaderModule` error on chrome.

```
ERROR crates/bevy_render/src/error_handler.rs:132 Caught rendering error: [Invalid ShaderModule (unlabeled)] is invalid due to a     
previous error. - While validating compute stage ([Invalid ShaderModule (unlabeled)], entryPoint: [undefined]). - While calling [Device].CreateComputePipeline([ComputePipelineDescriptor                          
""ssao_preprocess_depth_pipeline""]).                                                                                                                                                                              
index.html:1 [Invalid ShaderModule (unlabeled)] is invalid due to a previous error.                                                                                                                                
 - While validating compute stage ([Invalid ShaderModule (unlabeled)], entryPoint: [undefined]).                                                                                                                   
 - While calling [Device].CreateComputePipeline([ComputePipelineDescriptor ""ssao_preprocess_depth_pipeline""]).                                                                                                   
                                                                                                                                                                                                                   
wasm_example.js:1359 ERROR crates/bevy_render/src/error_handler.rs:79 Quitting the application due to Validation RenderError      
```

<details>

```
Error while parsing WGSL: :51:18 error: no matching call to 'textureGather(abstract-int, texture_depth_2d, sampler, vec2<f32>, vec2<i32>)'

12 candidate functions:
 • 'textureGather(component: C  ✓ , texture: texture_2d<T>  ✗ , sampler: sampler  ✓ , coords: vec2<f32>  ✓ , offset: vec2<i32>  ✓ ) -> vec4<T>' where:
      ✗  'T' is 'f32', 'i32' or 'u32'
      ✓  'C' is 'i32' or 'u32'
 • 'textureGather(component: C  ✓ , texture: texture_2d_array<T>  ✗ , sampler: sampler  ✓ , coords: vec2<f32>  ✓ , array_index: A  ✗ ) -> vec4<T>' where:
      ✗  'T' is 'f32', 'i32' or 'u32'
      ✓  'C' is 'i32' or 'u32'
      ✗  'A' is 'i32' or 'u32'
 • 'textureGather(component: C  ✓ , texture: texture_2d<T>  ✗ , sampler: sampler  ✓ , coords: vec2<f32>  ✓ ) -> vec4<T>' where:
      ✗  'T' is 'f32', 'i32' or 'u32'
      ✓  'C' is 'i32' or 'u32'
 • 'textureGather(component: C  ✓ , texture: texture_cube_array<T>  ✗ , sampler: sampler  ✓ , coords: vec3<f32>  ✗ , array_index: A  ✗ ) -> vec4<T>' where:
      ✗  'T' is 'f32', 'i32' or 'u32'
      ✓  'C' is 'i32' or 'u32'
      ✗  'A' is 'i32' or 'u32'
 • 'textureGather(component: C  ✓ , texture: texture_2d_array<T>  ✗ , sampler: sampler  ✓ , coords: vec2<f32>  ✓ , array_index: A  ✗ , offset: vec2<i32>  ✗ ) -> vec4<T>' where:
      ✗  'T' is 'f32', 'i32' or 'u32'
      ✓  'C' is 'i32' or 'u32'
      ✗  'A' is 'i32' or 'u32'
 • 'textureGather(texture: texture_depth_2d_array  ✗ , sampler: sampler  ✗ , coords: vec2<f32>  ✗ , array_index: A  ✗ , offset: vec2<i32>  ✓ ) -> vec4<f32>' where:
      ✗  'A' is 'i32' or 'u32'
 • 'textureGather(component: C  ✓ , texture: texture_cube<T>  ✗ , sampler: sampler  ✓ , coords: vec3<f32>  ✗ ) -> vec4<T>' where:
      ✗  'T' is 'f32', 'i32' or 'u32'
      ✓  'C' is 'i32' or 'u32'
 • 'textureGather(texture: texture_depth_2d_array  ✗ , sampler: sampler  ✗ , coords: vec2<f32>  ✗ , array_index: A  ✗ ) -> vec4<f32>' where:
      ✗  'A' is 'i32' or 'u32'
 • 'textureGather(texture: texture_depth_cube_array  ✗ , sampler: sampler  ✗ , coords: vec3<f32>  ✗ , array_index: A  ✗ ) -> vec4<f32>' where:
      ✗  'A' is 'i32' or 'u32'
 • 'textureGather(texture: texture_depth_2d  ✗ , sampler: sampler  ✗ , coords: vec2<f32>  ✗ , offset: vec2<i32>  ✗ ) -> vec4<f32>'
 • 'textureGather(texture: texture_depth_2d  ✗ , sampler: sampler  ✗ , coords: vec2<f32>  ✗ ) -> vec4<f32>'
 • 'textureGather(texture: texture_depth_cube  ✗ , sampler: sampler  ✗ , coords: vec3<f32>  ✗ ) -> vec4<f32>'

    let depths = textureGather(0, input_depth, point_clamp_sampler, depths_uv, vec2<i32>(1i, 1i));
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


 - While calling [Device].CreateShaderModule([ShaderModuleDescriptor]).
```
</details>

wgpu does not validate it yet (https://github.com/gfx-rs/wgpu/issues/9087) so there is no error on native and firefox.

## Solution

Fix it

## Testing

Run any 3d webgpu example on chrome.
