### PR TITLE
Migrate `transform_gizmo` to use `FeathersRadio` and `FeathersSlider`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4556,7 +4556,7 @@ wasm = true
 name = "transform_gizmo"
 path = "examples/gizmos/transform_gizmo.rs"
 doc-scrape-examples = true
-required-features = ["free_camera"]
+required-features = ["free_camera", "bevy_feathers"]
 
 [package.metadata.example.transform_gizmo]
 name = "Transform Gizmo"

--- a/examples/gizmos/transform_gizmo.rs
+++ b/examples/gizmos/transform_gizmo.rs
@@ -2,18 +2,26 @@
 //!
 //! Demonstrates translate, rotate, and scale gizmos with click-to-select.
 //! - Click an object to select it (primary mouse button)
-//! - **1** = Translate, **2** = Rotate, **3** = Scale
-//! - **X** = Toggle World/Local space
+//! - Radio buttons switch between Translate/Rotate/Scale modes and toggle World/Local space.
 
 use bevy::{
     camera_controller::free_camera::{FreeCamera, FreeCameraPlugin},
+    feathers::{
+        controls::FeathersSlider, dark_theme::create_dark_theme, theme::UiTheme, FeathersPlugins,
+    },
     gizmos::transform_gizmo::{
         TransformGizmoCamera, TransformGizmoFocus, TransformGizmoMode, TransformGizmoPlugin,
         TransformGizmoSettings, TransformGizmoSpace,
     },
     picking::{pointer::PointerButton, Pickable},
     prelude::*,
+    ui_widgets::{radio_self_update, SliderPrecision, SliderStep, SliderValue, ValueChange},
 };
+
+use radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptionValue};
+
+#[path = "../helpers/radio.rs"]
+mod radio;
 
 fn main() {
     App::new()
@@ -22,9 +30,13 @@ fn main() {
             FreeCameraPlugin,
             MeshPickingPlugin,
             TransformGizmoPlugin,
+            FeathersPlugins,
         ))
+        .insert_resource(UiTheme(create_dark_theme()))
         .add_systems(Startup, setup)
-        .add_systems(Update, (gizmo_mode_keys, update_instructions))
+        .add_systems(Update, toggle_scale_slider)
+        .add_observer(update_radio_button)
+        .add_observer(radio_self_update)
         .run();
 }
 
@@ -33,19 +45,55 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // Instructions
-    commands.spawn((
-        Text::new(
-            "Click an object to select it\n1: Translate | 2: Rotate | 3: Scale | X: World/Local space",
-        ),
-        Node {
-            position_type: PositionType::Absolute,
-            top: px(12),
-            left: px(12),
-            ..default()
-        },
-        InstructionsText,
-    ));
+    commands.spawn_scene(bsn! {
+        main_ui_node_scene()
+        Children [
+            (
+                Text::new("Click an object to select it")
+            ),
+            (
+                feathers_option_buttons("",
+                &[
+                    (TransformGizmoMode::Translate, "Translate"),
+                    (TransformGizmoMode::Rotate, "Rotate"),
+                    (TransformGizmoMode::Scale, "Scale"),
+                ], 0)
+            ),
+            (
+                feathers_option_buttons("",
+                &[
+                    (TransformGizmoSpace::World, "World"),
+                    (TransformGizmoSpace::Local, "Local"),
+                ], 0)
+            ),
+            (
+                Node {
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    column_gap: px(4)
+                }
+                ScaleSensitivitySlider
+                Children [
+                    (
+                        Text::new("Sensitivity ")
+                        TextFont{
+                            font_size: 14.0_f32,
+                        }
+                    ),
+                    (
+                        @FeathersSlider{
+                            @max: 2.0,
+                            @min: 0.1,
+                        }
+                        SliderValue(1.0)
+                        SliderPrecision(2)
+                        SliderStep(0.1)
+                        on(slider_update)
+                    )
+                ]
+            )
+        ]
+    });
 
     // Ground plane (not pickable)
     commands.spawn((
@@ -135,62 +183,41 @@ fn on_click_select(
     commands.entity(click.entity).insert(TransformGizmoFocus);
 }
 
-// Note: Using 1/2/3 instead of Blender's G/R/S because S conflicts with
-// the FreeCameraPlugin's WASD movement controls.
-fn gizmo_mode_keys(
-    keyboard: Res<ButtonInput<KeyCode>>,
+fn update_radio_button(
+    event: On<ValueChange<Entity>>,
+    mode_value_query: Query<&RadioButtonOptionValue<TransformGizmoMode>>,
+    space_value_query: Query<&RadioButtonOptionValue<TransformGizmoSpace>>,
     mut settings: ResMut<TransformGizmoSettings>,
 ) {
-    if keyboard.just_pressed(KeyCode::Digit1) {
-        settings.mode = TransformGizmoMode::Translate;
-    }
-    if keyboard.just_pressed(KeyCode::Digit2) {
-        settings.mode = TransformGizmoMode::Rotate;
-    }
-    if keyboard.just_pressed(KeyCode::Digit3) {
-        settings.mode = TransformGizmoMode::Scale;
-    }
-    if keyboard.just_pressed(KeyCode::KeyX) {
-        settings.space = match settings.space {
-            TransformGizmoSpace::World => TransformGizmoSpace::Local,
-            TransformGizmoSpace::Local => TransformGizmoSpace::World,
-        };
-    }
-    if settings.mode == TransformGizmoMode::Scale {
-        if keyboard.just_pressed(KeyCode::ArrowUp) {
-            settings.scale_sensitivity = (settings.scale_sensitivity + 0.1).min(2.0);
-        }
-        if keyboard.just_pressed(KeyCode::ArrowDown) {
-            settings.scale_sensitivity = (settings.scale_sensitivity - 0.1).max(0.1);
-        }
-    }
+    if let Ok(RadioButtonOptionValue(mode)) = mode_value_query.get(event.value) {
+        settings.mode = *mode;
+    } else if let Ok(RadioButtonOptionValue(space)) = space_value_query.get(event.value) {
+        settings.space = *space;
+    };
 }
 
-#[derive(Component)]
-struct InstructionsText;
-
-fn update_instructions(
-    settings: Res<TransformGizmoSettings>,
-    mut text: Single<&mut Text, With<InstructionsText>>,
+fn slider_update(
+    value_change: On<ValueChange<f32>>,
+    mut commands: Commands,
+    mut settings: ResMut<TransformGizmoSettings>,
 ) {
-    let mode_str = match settings.mode {
-        TransformGizmoMode::Translate => "Translate",
-        TransformGizmoMode::Rotate => "Rotate",
-        TransformGizmoMode::Scale => "Scale",
-    };
-    let space_str = match settings.space {
-        TransformGizmoSpace::World => "World",
-        TransformGizmoSpace::Local => "Local",
-    };
-    let base = format!(
-        "Click an object to select it\n1: Translate | 2: Rotate | 3: Scale | X: World/Local space\nMode: {mode_str} | Space: {space_str}"
-    );
-    text.0 = if settings.mode == TransformGizmoMode::Scale {
-        format!(
-            "{base}\nArrowUp or ArrowDown: Scale sensitivity {:.2}",
-            settings.scale_sensitivity
-        )
+    commands
+        .entity(value_change.source)
+        .insert(SliderValue(value_change.value));
+
+    settings.scale_sensitivity = value_change.value;
+}
+
+#[derive(Component, Clone, Default)]
+struct ScaleSensitivitySlider;
+
+fn toggle_scale_slider(
+    settings: Res<TransformGizmoSettings>,
+    mut slider_node: Single<&mut Node, With<ScaleSensitivitySlider>>,
+) {
+    slider_node.display = if settings.mode == TransformGizmoMode::Scale {
+        Display::Flex
     } else {
-        base
+        Display::None
     };
 }

--- a/examples/gizmos/transform_gizmo.rs
+++ b/examples/gizmos/transform_gizmo.rs
@@ -6,9 +6,7 @@
 
 use bevy::{
     camera_controller::free_camera::{FreeCamera, FreeCameraPlugin},
-    feathers::{
-        controls::FeathersSlider, dark_theme::create_dark_theme, theme::UiTheme, FeathersPlugins,
-    },
+    feathers::{controls::FeathersSlider, display::label, theme::UiTheme, FeathersPlugins},
     gizmos::transform_gizmo::{
         TransformGizmoCamera, TransformGizmoFocus, TransformGizmoMode, TransformGizmoPlugin,
         TransformGizmoSettings, TransformGizmoSpace,
@@ -23,6 +21,9 @@ use radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptionValue}
 #[path = "../helpers/radio.rs"]
 mod radio;
 
+#[path = "../helpers/theme.rs"]
+mod theme;
+
 fn main() {
     App::new()
         .add_plugins((
@@ -32,7 +33,7 @@ fn main() {
             TransformGizmoPlugin,
             FeathersPlugins,
         ))
-        .insert_resource(UiTheme(create_dark_theme()))
+        .insert_resource(UiTheme(theme::basic_example_theme(Color::WHITE)))
         .add_systems(Startup, setup)
         .add_systems(Update, toggle_scale_slider)
         .add_observer(update_radio_button)
@@ -49,7 +50,7 @@ fn setup(
         main_ui_node_scene()
         Children [
             (
-                Text::new("Click an object to select it")
+                label("Click an object to select it")
             ),
             (
                 feathers_option_buttons("",
@@ -68,17 +69,13 @@ fn setup(
             ),
             (
                 Node {
-                    flex_direction: FlexDirection::Row,
                     align_items: AlignItems::Center,
                     column_gap: px(4)
                 }
                 ScaleSensitivitySlider
                 Children [
                     (
-                        Text::new("Sensitivity ")
-                        TextFont{
-                            font_size: 14.0_f32,
-                        }
+                        label("Sensitivity")
                     ),
                     (
                         @FeathersSlider{

--- a/examples/helpers/theme.rs
+++ b/examples/helpers/theme.rs
@@ -159,6 +159,33 @@ pub fn basic_example_theme(text_color: Color) -> ThemeProps {
     color.insert(bevy::feathers::tokens::BUTTON_TEXT, text_color);
     color.insert(bevy::feathers::tokens::LISTROW_TEXT, text_color);
 
+    // Slider tokens
+    color.insert(
+        bevy::feathers::tokens::SLIDER_BG,
+        bevy::feathers::palette::BLACK,
+    );
+    color.insert(
+        bevy::feathers::tokens::SLIDER_BG_HOVER,
+        bevy::feathers::palette::GRAY_0,
+    );
+    color.insert(
+        bevy::feathers::tokens::SLIDER_BG_PRESSED,
+        bevy::feathers::palette::GRAY_1,
+    );
+    color.insert(
+        bevy::feathers::tokens::SLIDER_BAR,
+        bevy::feathers::palette::ACCENT,
+    );
+    color.insert(
+        bevy::feathers::tokens::SLIDER_BAR_HOVER,
+        bevy::feathers::palette::ACCENT.lighter(0.05),
+    );
+    color.insert(
+        bevy::feathers::tokens::SLIDER_BAR_PRESSED,
+        bevy::feathers::palette::ACCENT.lighter(0.1),
+    );
+    color.insert(bevy::feathers::tokens::SLIDER_TEXT, text_color);
+
     // Main text color
     color.insert(bevy::feathers::tokens::TEXT_MAIN, text_color);
     ThemeProps::new_non_contextual(color)


### PR DESCRIPTION
# Objective

- Addresses one item in https://github.com/bevyengine/bevy/issues/25032

## Solution

- Replaced key inputs with `FeathersRadio` buttons and `FeathersSlider`.
- Used the helpers in `examples/helpers/radio.rs`.

## Testing

- Tested manually using `cargo run --example transform_gizmo --features="free_camera bevy_feathers"`.

---

## Showcase

https://github.com/user-attachments/assets/db985363-2150-4170-afdc-179900742a7c

## Remarks

- ~~Setting this to draft as I plan to refactor the slider logic using helper functions.~~
- I considered refactoring the slider logic into a helper function, but gave up as abstracting `on(slider_update)` was difficult.