### PR TITLE
Derive Default for `FloatOrd`

### DIFF
--- a/crates/bevy_math/src/float_ord.rs
+++ b/crates/bevy_math/src/float_ord.rs
@@ -16,7 +16,7 @@ use bevy_reflect::Reflect;
 ///
 /// Wrapping a float with `FloatOrd` breaks conformance with the standard
 /// by sorting `NaN` as less than all other numbers and equal to any other `NaN`.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),


### PR DESCRIPTION
# Objective

Not much to say about this. While using `bevy_math::FloatOrd`, I noticed that unlike `f32`, `FloatOrd` doesn't implement `Default`. And I don't really see a reason, why it shouldn't.

## Solution

- derive `Default` for `FloatOrd`

## Testing

- nothing to test really, ran `cargo test` once, no issues.