### PR TITLE
Disable SSAO for meshes without depth writes

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -3461,10 +3461,6 @@ impl SpecializedMeshPipeline for MeshPipeline {
             self.skins_use_uniform_buffers,
         ));
 
-        if key.contains(MeshPipelineKey::SCREEN_SPACE_AMBIENT_OCCLUSION) {
-            shader_defs.push("SCREEN_SPACE_AMBIENT_OCCLUSION".into());
-        }
-
         if key.contains(MeshPipelineKey::CONTACT_SHADOWS) {
             shader_defs.push("CONTACT_SHADOWS".into());
         }
@@ -3535,6 +3531,11 @@ impl SpecializedMeshPipeline for MeshPipeline {
 
         if key.contains(MeshPipelineKey::DEPTH_PREPASS) {
             shader_defs.push("DEPTH_PREPASS".into());
+        }
+
+        // Transparent meshes don't contribute to the depth prepass, so SSAO should not be applied.
+        if key.contains(MeshPipelineKey::SCREEN_SPACE_AMBIENT_OCCLUSION) && depth_write_enabled {
+            shader_defs.push("SCREEN_SPACE_AMBIENT_OCCLUSION".into());
         }
 
         if key.contains(MeshPipelineKey::MOTION_VECTOR_PREPASS) {


### PR DESCRIPTION
# Objective

Screen-space ambient occlusion can produce artifacts for meshes that do not contribute to the depth prepass. SSAO may still be sampled for these meshes even though no corresponding depth information was written, potentially causing invalid or uninitialized depth data to affect the result.

This primarily affects transparent meshes and other cases where depth writes are disabled.

## Solution

Only enable screen-space ambient occlusion for meshes with depth writes enabled.

Since depth-write behavior depends on multiple pipeline properties, use the already resolved `depth_write_enabled` value when configuring the mesh pipeline rather than inferring it from individual material or pipeline flags.

## Testing

- Did you test these changes? If so, how?
`cargo run --features free_camera --example ssao` (modified)
`cargo run -p ci`
- Are there any parts that need more testing? I am not sure.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
`cargo run --features free_camera --example ssao` (modified)
The example uses a finite perspective projection with a large near/far range to make the artifact clearly visible. Bevy's default perspective projection uses an infinite far plane, which causes the relevant shader values to approach infinity and effectively hides this particular artifact.
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? Not relevant

---

## Showcase

Before:
<img width="1277" height="751" alt="image" src="https://github.com/user-attachments/assets/8637b312-a195-4b9a-a961-7e64d9cbe786" />

[Perspective](https://youtu.be/abpfvFBEyy4)

[Orthographic](https://youtu.be/46ZligW1ab4)

After:
<img width="1281" height="752" alt="image" src="https://github.com/user-attachments/assets/921669a5-2420-4bc0-9b2d-2c6d40634d3c" />

<details>
  <summary>Click to view example</summary>

```rust
//! A scene showcasing screen space ambient occlusion.

use bevy::{
    camera::{CameraProjection, SubCameraView},
    camera_controller::free_camera::{FreeCamera, FreeCameraPlugin},
    pbr::ScreenSpaceAmbientOcclusion,
    prelude::*,
};

fn main() {
    App::new()
        .insert_resource(GlobalAmbientLight {
            brightness: 2000.,
            ..default()
        })
        .add_plugins((DefaultPlugins, FreeCameraPlugin))
        .add_systems(Startup, setup)
        .run();
}

fn setup(
    mut commands: Commands,
    mut meshes: ResMut<Assets<Mesh>>,
    mut materials: ResMut<Assets<StandardMaterial>>,
) {
    commands.spawn((
        Camera3d::default(),
        Transform::from_xyz(2., 3., 7.).looking_at(Vec3::new(1.5, 0., 1.5), Vec3::Y),
        Msaa::Off,
        FreeCamera::default(),
        ScreenSpaceAmbientOcclusion::default(),
        // The issue is harder to reproduce with bevy's built-in perspective
        // projection because it uses an infinite far plane.
        Projection::custom(PerspectiveCustom(PerspectiveProjection {
            near: 0.01,
            far: 10000.,
            ..Default::default()
        })),
        // The artifact is easier to observe with TAA enabled and the built-in
        // orthographic projection using a large near/far range. To reproduce it,
        // uncomment both lines below and slowly resize the window with the mouse.
        // Artifacts should become visible while the aspect ratio is changing.
        // bevy::anti_alias::taa::TemporalAntiAliasing::default(),
        // Projection::Orthographic(OrthographicProjection {
        //     near: 0.01,
        //     far: 10000.,
        //     scale: 2.,
        //     scaling_mode: bevy::camera::ScalingMode::FixedVertical {
        //         viewport_height: 1.,
        //     },
        //     ..OrthographicProjection::default_3d()
        // })
    ));

    let transparent = materials.add(StandardMaterial {
        base_color: Color::srgba(0.5, 0.5, 1., 0.75),
        alpha_mode: AlphaMode::Blend,
        ..default()
    });
    let opaque = materials.add(StandardMaterial {
        base_color: Color::srgba(0.5, 1., 0.5, 1.),
        ..default()
    });

    for (xyz, mat) in [
        ([0., 0., 0.], transparent.clone()),
        ([1.5, 0., 0.], opaque.clone()),
        ([3., 0., 0.], transparent.clone()),
        ([0., 0., 1.5], opaque.clone()),
        ([1.5, 0., 1.5], transparent.clone()),
        ([3., 0., 1.5], opaque.clone()),
        ([0., 0., 3.], transparent.clone()),
        ([1.5, 0., 3.], opaque.clone()),
        ([3., 0., 3.], transparent.clone()),
    ] {
        commands.spawn((
            Mesh3d(meshes.add(Cuboid::default())),
            MeshMaterial3d(mat),
            Transform::from_xyz(xyz[0], xyz[1], xyz[2]),
        ));
    }

    commands.spawn((
        DirectionalLight {
            shadow_maps_enabled: false,
            ..default()
        },
        Transform::IDENTITY.looking_to(Dir3::NEG_X, Dir3::Y),
    ));
}

#[derive(Debug, Clone)]
struct PerspectiveCustom(PerspectiveProjection);

impl CameraProjection for PerspectiveCustom {
    fn get_clip_from_view(&self) -> Mat4 {
        let f = 1. / (self.0.fov * 0.5).tan();
        let z = self.0.near / (self.0.far - self.0.near);

        Mat4::from_cols(
            Vec4::new(f / self.0.aspect_ratio, 0., 0., 0.),
            Vec4::new(0., f, 0., 0.),
            Vec4::new(0., 0., z, -1.),
            Vec4::new(0., 0., self.0.far * z, 0.),
        )
    }

    fn get_clip_from_view_for_sub(&self, subview: &SubCameraView) -> Mat4 {
        self.0.get_clip_from_view_for_sub(subview)
    }

    fn update(&mut self, width: f32, height: f32) {
        self.0.update(width, height)
    }

    fn far(&self) -> f32 {
        self.0.far()
    }

    fn get_frustum_corners(&self, z_near: f32, z_far: f32) -> [Vec3A; 8] {
        self.0.get_frustum_corners(z_near, z_far)
    }
}

```

</details>
