### PR TITLE
add "wayland-data-control" feature to arboard, if "wayland" feature set

### DIFF
--- a/crates/bevy_clipboard/Cargo.toml
+++ b/crates/bevy_clipboard/Cargo.toml
@@ -18,6 +18,7 @@ image = [
   "dep:wgpu-types",
   "arboard/image-data",
 ]
+wayland = ["arboard/wayland-data-control"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_clipboard/Cargo.toml
+++ b/crates/bevy_clipboard/Cargo.toml
@@ -18,7 +18,7 @@ image = [
   "dep:wgpu-types",
   "arboard/image-data",
 ]
-wayland = ["arboard/wayland-data-control"]
+wayland = ["arboard?/wayland-data-control"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -146,7 +146,7 @@ multi_threaded = [
 async-io = ["std", "bevy_tasks/async-io"]
 
 # Display server protocol support (X11 is enabled by default)
-wayland = ["bevy_winit/wayland"]
+wayland = ["bevy_winit/wayland", "bevy_clipboard/wayland"]
 x11 = ["bevy_winit/x11"]
 
 # Android activity support (choose one)

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -146,7 +146,7 @@ multi_threaded = [
 async-io = ["std", "bevy_tasks/async-io"]
 
 # Display server protocol support (X11 is enabled by default)
-wayland = ["bevy_winit/wayland", "bevy_clipboard/wayland"]
+wayland = ["bevy_winit/wayland", "bevy_clipboard?/wayland"]
 x11 = ["bevy_winit/x11"]
 
 # Android activity support (choose one)


### PR DESCRIPTION
# Objective

- Describe the objective or issue this PR addresses.

I noticed a problem using `bevy_clipboard::Clipboard` on my Wayland based Linux system. When using this crate, the `get_text` and `set_text` features, The copied/pasted text would work consistently inside the app, but wouldn't exchange the data with the desktop environment. 

In addition, I would get the following warning when the app closed:
```
2026-08-10T22:42:36.096514Z  WARN arboard::platform::linux::x11: Could not hand the clipboard contents over to the clipboard manager. The request timed out.
```

## Solution

Reading the readme for the arboard project, I saw a feature named `wayland-data-control` mentioned. See [here](https://github.com/1Password/arboard#backend-support). Enabling this feature leads to the correct behavior, and the `bevy_clipboard::Clipboard` object can correctly copy/paste from the Wayland desktop clipboard, and no warnings on the terminal.

## Testing

I wrote the following program to test the behavior: 

```rust
use bevy::input::ButtonState;
use bevy::input::keyboard::KeyboardInput;
use bevy::prelude::*;

fn keyboard_event(mut keys: MessageReader<KeyboardInput>, mut clipboard: ResMut<Clipboard>) {
    for event in keys.read() {
        if let KeyboardInput {
            key_code: KeyCode::KeyA,
            state: ButtonState::Pressed,
            ..
        } = event
        {
            const PAYLOAD: &str = "I don't know, fly casual!";
            info!("writing to clipboard: {PAYLOAD:?}");
            clipboard.set_text(PAYLOAD).expect("clipboard fail!");
        }
    }
}

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Update, keyboard_event)
        .run();
}
```

Using Bevy 0.19 from crates.io, or using the main branch, I would get the bad behavior described above. 

After applying the changes in this PR, I get the expected behavior.

I don't have the capability to test this on other systems, unfortunately. But, I'm confident that this change will only effect the specific combination of Linux with the Bevy `wayland` feature enabled.