### PR TITLE
Migrate `wireframe_2d` to use `FeathersRadio`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1174,6 +1174,7 @@ wasm = true
 name = "wireframe_2d"
 path = "examples/2d/wireframe_2d.rs"
 doc-scrape-examples = true
+required-features = ["bevy_feathers"]
 
 [package.metadata.example.wireframe_2d]
 name = "2D Wireframe"

--- a/examples/2d/wireframe_2d.rs
+++ b/examples/2d/wireframe_2d.rs
@@ -76,12 +76,30 @@ enum GlobalColorSetting {
     White,
 }
 
+impl From<GlobalColorSetting> for Color {
+    fn from(value: GlobalColorSetting) -> Self {
+        match value {
+            GlobalColorSetting::Red => RED.into(),
+            GlobalColorSetting::White => WHITE.into(),
+        }
+    }
+}
+
 /// Whether the color of the circle wireframe is red or green.
 #[derive(Clone, Copy, Component, Default, PartialEq, Debug)]
 enum ColorCircleWireframeSetting {
     #[default]
     Red,
     Green,
+}
+
+impl From<ColorCircleWireframeSetting> for Color {
+    fn from(value: ColorCircleWireframeSetting) -> Self {
+        match value {
+            ColorCircleWireframeSetting::Red => RED.into(),
+            ColorCircleWireframeSetting::Green => GREEN.into(),
+        }
+    }
 }
 
 /// Set up a simple 3D scene
@@ -165,19 +183,13 @@ fn update_radio_button(
 
     // Toggle the global wireframe color
     if let Ok(RadioButtonOptionValue(global_color)) = global_color_query.get(event.value) {
-        config.default_color = match global_color {
-            GlobalColorSetting::Red => RED.into(),
-            GlobalColorSetting::White => WHITE.into(),
-        };
+        config.default_color = (*global_color).into();
     }
 
     // Toggle the color of a wireframe using `Wireframe2dColor` and not the global color
     if let Ok(RadioButtonOptionValue(color_circle)) = color_circle_query.get(event.value) {
         for mut color in &mut wireframe_colors {
-            color.color = match color_circle {
-                ColorCircleWireframeSetting::Red => RED.into(),
-                ColorCircleWireframeSetting::Green => GREEN.into(),
-            };
+            color.color = (*color_circle).into();
         }
     }
 }

--- a/examples/2d/wireframe_2d.rs
+++ b/examples/2d/wireframe_2d.rs
@@ -10,12 +10,22 @@
 
 use bevy::{
     color::palettes::basic::{GREEN, RED, WHITE},
+    feathers::{theme::UiTheme, FeathersPlugins},
     prelude::*,
     render::{render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin},
     sprite_render::{
         NoWireframe2d, Wireframe2d, Wireframe2dColor, Wireframe2dConfig, Wireframe2dPlugin,
     },
+    ui_widgets::{radio_self_update, ValueChange},
 };
+
+use radio::{feathers_option_buttons, main_ui_node_scene, RadioButtonOptionValue};
+
+#[path = "../helpers/radio.rs"]
+mod radio;
+
+#[path = "../helpers/theme.rs"]
+mod theme;
 
 fn main() {
     App::new()
@@ -31,6 +41,7 @@ fn main() {
             }),
             // You need to add this plugin to enable wireframe rendering
             Wireframe2dPlugin::default(),
+            FeathersPlugins,
         ))
         // Wireframes can be configured with this resource. This can be changed at runtime.
         .insert_resource(Wireframe2dConfig {
@@ -42,9 +53,35 @@ fn main() {
             // Can be changed per mesh using the `Wireframe2dColor` component.
             default_color: WHITE.into(),
         })
+        .insert_resource(UiTheme(theme::basic_example_theme(Color::WHITE)))
         .add_systems(Startup, setup)
-        .add_systems(Update, update_colors)
+        .add_observer(update_radio_button)
+        .add_observer(radio_self_update)
         .run();
+}
+
+/// Whether the global wireframe setting is on or off.
+#[derive(Clone, Copy, Component, Default, PartialEq, Debug)]
+enum GlobalWireframeSetting {
+    #[default]
+    On,
+    Off,
+}
+
+/// Whether the global color setting is red or white.
+#[derive(Clone, Copy, Component, Default, PartialEq, Debug)]
+enum GlobalColorSetting {
+    #[default]
+    Red,
+    White,
+}
+
+/// Whether the color of the circle wireframe is red or green.
+#[derive(Clone, Copy, Component, Default, PartialEq, Debug)]
+enum ColorCircleWireframeSetting {
+    #[default]
+    Red,
+    Green,
 }
 
 /// Set up a simple 3D scene
@@ -53,6 +90,32 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
+    commands.spawn_scene(bsn! {
+        main_ui_node_scene()
+        Children [
+            (
+                feathers_option_buttons("Toggle global",
+                    &[
+                        (GlobalWireframeSetting::On, "ON"),
+                        (GlobalWireframeSetting::Off, "OFF"),
+                    ], 0)
+            ),
+            (
+                feathers_option_buttons("Change global color",
+                    &[
+                        (GlobalColorSetting::Red, "RED"),
+                        (GlobalColorSetting::White, "WHITE"),
+                    ], 1)
+            ),
+            (
+                feathers_option_buttons("Change color of the circle wireframe",
+                    &[
+                        (ColorCircleWireframeSetting::Red, "RED"),
+                        (ColorCircleWireframeSetting::Green, "GREEN"),
+                    ], 1)
+            ),
+        ]
+    });
     // Triangle: Never renders a wireframe
     commands.spawn((
         Mesh2d(meshes.add(Triangle2d::new(
@@ -84,62 +147,36 @@ fn setup(
     ));
 
     commands.spawn(Camera2d);
-
-    // Text used to show controls
-    commands.spawn((
-        Text::default(),
-        Node {
-            position_type: PositionType::Absolute,
-            top: px(12),
-            left: px(12),
-            ..default()
-        },
-    ));
 }
 
 /// This system lets you toggle various wireframe settings
-fn update_colors(
-    keyboard_input: Res<ButtonInput<KeyCode>>,
+fn update_radio_button(
+    event: On<ValueChange<Entity>>,
+    toggle_global_query: Query<&RadioButtonOptionValue<GlobalWireframeSetting>>,
+    global_color_query: Query<&RadioButtonOptionValue<GlobalColorSetting>>,
+    color_circle_query: Query<&RadioButtonOptionValue<ColorCircleWireframeSetting>>,
     mut config: ResMut<Wireframe2dConfig>,
     mut wireframe_colors: Query<&mut Wireframe2dColor>,
-    mut text: Single<&mut Text>,
 ) {
-    text.0 = format!(
-        "Controls
----------------
-Z - Toggle global
-X - Change global color
-C - Change color of the circle wireframe
-
-Wireframe2dConfig
--------------
-Global: {}
-Color: {:?}",
-        config.global,
-        config.default_color.to_srgba(),
-    );
-
     // Toggle showing a wireframe on all meshes
-    if keyboard_input.just_pressed(KeyCode::KeyZ) {
-        config.global = !config.global;
+    if let Ok(RadioButtonOptionValue(toggle_global)) = toggle_global_query.get(event.value) {
+        config.global = matches!(toggle_global, GlobalWireframeSetting::On);
     }
 
     // Toggle the global wireframe color
-    if keyboard_input.just_pressed(KeyCode::KeyX) {
-        config.default_color = if config.default_color == WHITE.into() {
-            RED.into()
-        } else {
-            WHITE.into()
+    if let Ok(RadioButtonOptionValue(global_color)) = global_color_query.get(event.value) {
+        config.default_color = match global_color {
+            GlobalColorSetting::Red => RED.into(),
+            GlobalColorSetting::White => WHITE.into(),
         };
     }
 
     // Toggle the color of a wireframe using `Wireframe2dColor` and not the global color
-    if keyboard_input.just_pressed(KeyCode::KeyC) {
+    if let Ok(RadioButtonOptionValue(color_circle)) = color_circle_query.get(event.value) {
         for mut color in &mut wireframe_colors {
-            color.color = if color.color == GREEN.into() {
-                RED.into()
-            } else {
-                GREEN.into()
+            color.color = match color_circle {
+                ColorCircleWireframeSetting::Red => RED.into(),
+                ColorCircleWireframeSetting::Green => GREEN.into(),
             };
         }
     }


### PR DESCRIPTION
# Objective

- Addresses one item in https://github.com/bevyengine/bevy/issues/25032

## Solution

- Replaced key inputs with FeathersRadio buttons.
- Used the helpers in examples/helpers/radio.rs.

## Testing

- Tested manually using `cargo run --example wireframe_2d --features="bevy_feathers"`.

---

## Showcase

https://github.com/user-attachments/assets/7043c314-7cb3-4775-88c8-e4db86507593