### PR TITLE
Update spin requirement from 0.10.0 to 0.12.2

### DIFF
--- a/crates/bevy_platform/Cargo.toml
+++ b/crates/bevy_platform/Cargo.toml
@@ -64,7 +64,7 @@ bytemuck = ["dep:bytemuck"]
 
 [dependencies]
 critical-section = { version = "1.2.0", default-features = false, optional = true }
-spin = { version = "0.10.0", default-features = false, features = [
+spin = { version = "0.12.2", default-features = false, features = [
   "mutex",
   "spin_mutex",
   "rwlock",
@@ -94,7 +94,7 @@ wasm-bindgen = { version = "0.2", default-features = false, optional = true }
 portable-atomic = { version = "1", default-features = false, features = [
   "fallback",
 ] }
-spin = { version = "0.10.0", default-features = false, features = [
+spin = { version = "0.12.2", default-features = false, features = [
   "portable-atomic",
 ] }
 

--- a/crates/bevy_platform/src/sync/lazy_lock.rs
+++ b/crates/bevy_platform/src/sync/lazy_lock.rs
@@ -7,5 +7,5 @@ use std::sync as implementation;
 
 #[cfg(not(feature = "std"))]
 mod implementation {
-    pub use spin::Lazy as LazyLock;
+    pub use spin::LazyLock;
 }


### PR DESCRIPTION
# Objective

- Fixes #25324

## Solution

- Replaced a deprecated type alias (`spin::Lazy` -> `spin::LazyLock`).

## Testing

- CI checks