### PR TITLE
Fix documented despawn lifecycle event order

### DIFF
--- a/crates/bevy_ecs/src/lifecycle.rs
+++ b/crates/bevy_ecs/src/lifecycle.rs
@@ -27,7 +27,8 @@
 //! - [`Remove`]: Triggered when a component is removed from an entity and not replaced, before the component is removed.
 //! - [`Despawn`]: Triggered for each component on an entity when it is despawned.
 //!
-//! [`Discard`] hooks are evaluated before [`Remove`], then finally [`Despawn`] hooks are evaluated.
+//! [`Discard`] hooks are evaluated before [`Remove`] hooks. When an entity is despawned,
+//! [`Despawn`] hooks are evaluated first, followed by [`Discard`] and then [`Remove`] hooks.
 //!
 //! [`Add`] and [`Remove`] are counterparts: they are only triggered when a component is added or removed
 //! from an entity in such a way as to cause a change in the component's presence on that entity.


### PR DESCRIPTION
# Objective

The lifecycle documentation states that despawning triggers hooks in the order
`Discard` → `Remove` → `Despawn`, while the implementation and existing tests
use `Despawn` → `Discard` → `Remove`.

Fixes #24217.

## Solution

Update the lifecycle documentation to match the established runtime behavior:

`Despawn` → `Discard` → `Remove`

This avoids changing observable lifecycle behavior for existing users.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p bevy_ecs observer_new_old_archetypes --lib`
- `cargo test -p bevy_ecs --doc`
