### PR TITLE
Fix spot light degenerate outer angle

### DIFF
--- a/_release-content/migration-guides/spot_light_outer_angle_clamping.md
+++ b/_release-content/migration-guides/spot_light_outer_angle_clamping.md
@@ -1,0 +1,17 @@
+---
+title: "`SpotLight::outer_angle` is clamped to a narrower range"
+pull_requests: []
+---
+
+`SpotLight::outer_angle` is now clamped to `SpotLight::MIN_OUTER_ANGLE`(0.001 radians)..=`SpotLight::MAX_OUTER_ANGLE` (1.5 radians, ~85.9°). Previously only the upper bound was enforced, at just below `PI / 2.0`.
+
+Both old bounds produced a broken cone, because `tan(outer_angle)` is the scale of the perspective projection the cone is rendered with:
+
+- An `outer_angle` of `0.0` made that scale zero, so the shadow map projection and the shadow lookup in the shader divided by zero and rendered garbage.
+- An `outer_angle` at the old clamp of `PI / 2.0 - 1e-4` made it ~10000, collapsing the whole cone into the few shadow map texels around its axis, so the nearest occluder shadowed everything and the light appeared to vanish.
+
+The clamp is also now applied consistently: cluster assignment and the shadow map frustum previously used the unclamped angle, so they disagreed with the angle the shadow map was actually rendered with.
+
+If you set `outer_angle` between 1.5 and `PI / 2.0`, your cone will be narrower than before. Those values did not render correctly, so this is a fix rather than a restriction; if you need a wider cone, use a `PointLight`, which uses a cubemap and has no such limit.
+
+Clamping is silent. `SpotLight::clamped_angles` returns the `(inner_angle, outer_angle)` pair actually used for rendering, so compare against it to check whether a light's configured angles are the ones being rendered.

--- a/crates/bevy_light/src/cluster/assign.rs
+++ b/crates/bevy_light/src/cluster/assign.rs
@@ -205,7 +205,7 @@ pub(crate) fn assign_objects_to_clusters(
                         transform: *transform,
                         range: spot_light.range,
                         object_type: ClusterableObjectType::SpotLight {
-                            outer_angle: spot_light.outer_angle,
+                            outer_angle: spot_light.clamped_angles().1,
                             shadow_maps_enabled: spot_light.shadow_maps_enabled,
                             volumetric: volumetric.is_some(),
                         },

--- a/crates/bevy_light/src/spot_light.rs
+++ b/crates/bevy_light/src/spot_light.rs
@@ -124,13 +124,13 @@ pub struct SpotLight {
 
     /// Angle defining the distance from the spot light direction to the outer limit
     /// of the light's cone of effect.
-    /// `outer_angle` must be < `PI / 2.0`.
+    /// Clamped to [`SpotLight::MIN_OUTER_ANGLE`]..=[`SpotLight::MAX_OUTER_ANGLE`].
     pub outer_angle: f32,
 
     /// Angle defining the distance from the spot light direction to the inner limit
     /// of the light's cone of effect.
     /// Light is attenuated from `inner_angle` to `outer_angle` to give a smooth falloff.
-    /// `inner_angle` should be <= `outer_angle`
+    /// Values greater than `outer_angle` are clamped to it.
     pub inner_angle: f32,
 }
 
@@ -141,6 +141,27 @@ impl SpotLight {
     pub const DEFAULT_SHADOW_NORMAL_BIAS: f32 = 1.8;
     /// The default value of [`SpotLight::shadow_map_near_z`].
     pub const DEFAULT_SHADOW_MAP_NEAR_Z: f32 = 0.1;
+
+    /// The smallest supported [`SpotLight::outer_angle`], in radians.
+    ///
+    /// Zero would make the cone's `tan(outer_angle)` projection scale divide by zero.
+    pub const MIN_OUTER_ANGLE: f32 = 1.0e-3;
+
+    /// The largest supported [`SpotLight::outer_angle`], in radians (~85.9°).
+    ///
+    /// Closer to `PI / 2.0`, the shadow map collapses into the texels around the cone axis.
+    pub const MAX_OUTER_ANGLE: f32 = 1.5;
+
+    /// Returns `(inner_angle, outer_angle)` clamped to what rendering supports, with
+    /// `inner_angle <= outer_angle`.
+    #[expect(clippy::manual_clamp, reason = "`clamp` would propagate a NaN angle")]
+    pub fn clamped_angles(&self) -> (f32, f32) {
+        let outer_angle = self
+            .outer_angle
+            .max(Self::MIN_OUTER_ANGLE)
+            .min(Self::MAX_OUTER_ANGLE);
+        (self.inner_angle.max(0.0).min(outer_angle), outer_angle)
+    }
 }
 
 impl Default for SpotLight {
@@ -259,8 +280,10 @@ pub fn update_spot_light_frusta(
         let view_backward = transform.back();
 
         let spot_world_from_view = spot_light_world_from_view(transform);
+        // Must match the angle the shadow map is rendered with.
+        let (_, outer_angle) = spot_light.clamped_angles();
         let spot_clip_from_view =
-            spot_light_clip_from_view(spot_light.outer_angle, spot_light.shadow_map_near_z);
+            spot_light_clip_from_view(outer_angle, spot_light.shadow_map_near_z);
         let clip_from_world = spot_clip_from_view * spot_world_from_view.inverse();
 
         *frustum = Frustum(ViewFrustum::from_clip_from_world_custom_far(
@@ -269,5 +292,26 @@ pub fn update_spot_light_frusta(
             &view_backward,
             spot_light.range,
         ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamped_angles_keep_the_cone_projection_finite() {
+        for outer_angle in [0.0, -1.0, f32::NAN, core::f32::consts::FRAC_PI_2, 100.0] {
+            let light = SpotLight {
+                outer_angle,
+                inner_angle: outer_angle,
+                ..SpotLight::default()
+            };
+            let (inner, outer) = light.clamped_angles();
+
+            assert!((SpotLight::MIN_OUTER_ANGLE..=SpotLight::MAX_OUTER_ANGLE).contains(&outer));
+            assert!((0.0..=outer).contains(&inner));
+            assert!(spot_light_clip_from_view(outer, light.shadow_map_near_z).is_finite());
+        }
     }
 }

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -26,7 +26,6 @@ use bevy_light::{
     Cascades, DirectionalLight, DirectionalLightShadowMap, GlobalAmbientLight, PointLight,
     PointLightShadowMap, RectLight, ShadowFilteringMethod, SpotLight, VolumetricLight,
 };
-use bevy_log::warn_once;
 use bevy_material::{
     key::{ErasedMaterialPipelineKey, ErasedMeshPipelineKey},
     MaterialProperties,
@@ -678,20 +677,7 @@ pub fn extract_lights(
             ));
         }
 
-        // `outer_angle` must be <π/2.
-        let (inner_angle, outer_angle) = {
-            let mut outer_angle = spot_light.outer_angle;
-            if outer_angle >= core::f32::consts::FRAC_PI_2 {
-                warn_once!(
-                    "A `SpotLight` has `outer_angle` {} >= π/2 (~1.57079), clamping it to just below π/2. \
-                     Spot lights require `outer_angle < π/2`",
-                    outer_angle
-                );
-                outer_angle = core::f32::consts::FRAC_PI_2 - 1e-4;
-            }
-            // Keep inner_angle <= outer_angle after clamping.
-            (spot_light.inner_angle.min(outer_angle), outer_angle)
-        };
+        let (inner_angle, outer_angle) = spot_light.clamped_angles();
 
         let texel_size = 2.0 * ops::tan(outer_angle) / directional_light_shadow_map.size as f32;
 


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/25360
- A `SpotLight` with `outer_angle` of `0.0` renders garbage when `shadow_maps_enabled` is set, and a `SpotLight` with `outer_angle` at or near `PI / 2.0` disappears entirely, even though it logs that it is being clamped.

## Solution

`tan(outer_angle)` is the scale of the cone's perspective projection, and both ends of the old range broke it:

- `0.0` → scale 0, so the shadow map projection and the shader's shadow lookup divide by zero.
- Old clamp `PI / 2.0 - 1e-4` → scale ~10000, collapsing the cone into a few texels at the shadow map centre, so the nearest occluder shadows everything.
- Exactly `PI / 2.0` → `f32(PI / 2.0)` rounds above true π/2, so `tan` is `-2.3e7` and the projection inverts.

Adds `SpotLight::MIN_OUTER_ANGLE` (1e-3), `MAX_OUTER_ANGLE` (1.5 rad, ~85.9°, still ~1 shadow texel per degree at 2048), and `clamped_angles()`, which clamps both angles, keeps `inner <= outer`, and maps NaN to the minimum. Cluster assignment and the shadow map frustum used the raw angle before, so they disagreed with what the shadow map was rendered with.

Drops the `warn_once!` in `extract_lights`: it fired once per process and named a clamp target that didn't work. Clamping is silent; `clamped_angles()` reports what's rendered. The warning was also logically inconsistent if the spotlight goes from invalid to valid to invalid again. 

## Testing

- Unit test: clamped angles stay in range and keep the projection finite for `0.0`, `-1.0`, `NaN`, `PI / 2.0`, `100.0`.
- Behaves correctly in minimal reproduction at both pi/2 and 0. 

https://github.com/user-attachments/assets/7e07de4c-6f7e-426f-a49b-d5f2898f3b23

