### PR TITLE
Label component uniform buffers with their component type name

### DIFF
--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -209,9 +209,7 @@ impl<T: ShaderType> DynamicUniformBuffer<T> {
     pub fn get_label(&self) -> Option<&str> {
         self.label.as_deref()
     }
-}
 
-impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
     pub fn new_with_alignment(alignment: u64) -> Self {
         Self {
             scratch: DynamicUniformBufferWrapper::new_with_alignment(Vec::new(), alignment),
@@ -240,12 +238,6 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.scratch.as_ref().is_empty()
-    }
-
-    /// Push data into the `DynamicUniformBuffer`'s internal vector (residing on system RAM).
-    #[inline]
-    pub fn push(&mut self, value: &T) -> u32 {
-        self.scratch.write(value).unwrap() as u32
     }
 
     /// Add more [`BufferUsages`] to the buffer.
@@ -352,6 +344,14 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
     pub fn clear(&mut self) {
         self.scratch.as_mut().clear();
         self.scratch.set_offset(0);
+    }
+}
+
+impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
+    /// Push data into the `DynamicUniformBuffer`'s internal vector (residing on system RAM).
+    #[inline]
+    pub fn push(&mut self, value: &T) -> u32 {
+        self.scratch.write(value).unwrap() as u32
     }
 }
 

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -195,6 +195,22 @@ impl<T: ShaderType> Default for DynamicUniformBuffer<T> {
     }
 }
 
+impl<T: ShaderType> DynamicUniformBuffer<T> {
+    pub fn set_label(&mut self, label: Option<&str>) {
+        let label = label.map(str::to_string);
+
+        if label != self.label {
+            self.changed = true;
+        }
+
+        self.label = label;
+    }
+
+    pub fn get_label(&self) -> Option<&str> {
+        self.label.as_deref()
+    }
+}
+
 impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
     pub fn new_with_alignment(alignment: u64) -> Self {
         Self {
@@ -230,20 +246,6 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
     #[inline]
     pub fn push(&mut self, value: &T) -> u32 {
         self.scratch.write(value).unwrap() as u32
-    }
-
-    pub fn set_label(&mut self, label: Option<&str>) {
-        let label = label.map(str::to_string);
-
-        if label != self.label {
-            self.changed = true;
-        }
-
-        self.label = label;
-    }
-
-    pub fn get_label(&self) -> Option<&str> {
-        self.label.as_deref()
     }
 
     /// Add more [`BufferUsages`] to the buffer.

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -196,20 +196,6 @@ impl<T: ShaderType> Default for DynamicUniformBuffer<T> {
 }
 
 impl<T: ShaderType> DynamicUniformBuffer<T> {
-    pub fn set_label(&mut self, label: Option<&str>) {
-        let label = label.map(str::to_string);
-
-        if label != self.label {
-            self.changed = true;
-        }
-
-        self.label = label;
-    }
-
-    pub fn get_label(&self) -> Option<&str> {
-        self.label.as_deref()
-    }
-
     pub fn new_with_alignment(alignment: u64) -> Self {
         Self {
             scratch: DynamicUniformBufferWrapper::new_with_alignment(Vec::new(), alignment),
@@ -238,6 +224,20 @@ impl<T: ShaderType> DynamicUniformBuffer<T> {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.scratch.as_ref().is_empty()
+    }
+
+    pub fn set_label(&mut self, label: Option<&str>) {
+        let label = label.map(str::to_string);
+
+        if label != self.label {
+            self.changed = true;
+        }
+
+        self.label = label;
+    }
+
+    pub fn get_label(&self) -> Option<&str> {
+        self.label.as_deref()
     }
 
     /// Add more [`BufferUsages`] to the buffer.

--- a/crates/bevy_render/src/uniform.rs
+++ b/crates/bevy_render/src/uniform.rs
@@ -75,9 +75,12 @@ impl<C: Component + ShaderType> ComponentUniforms<C> {
 
 impl<C: Component + ShaderType> Default for ComponentUniforms<C> {
     fn default() -> Self {
-        Self {
-            uniforms: Default::default(),
-        }
+        let mut uniforms = DynamicUniformBuffer::default();
+        uniforms.set_label(Some(&format!(
+            "{} uniforms buffer",
+            core::any::type_name::<C>()
+        )));
+        Self { uniforms }
     }
 }
 

--- a/crates/bevy_render/src/uniform.rs
+++ b/crates/bevy_render/src/uniform.rs
@@ -77,7 +77,7 @@ impl<C: Component + ShaderType> Default for ComponentUniforms<C> {
     fn default() -> Self {
         let mut uniforms = DynamicUniformBuffer::default();
         uniforms.set_label(Some(&format!(
-            "{} uniforms buffer",
+            "{} ComponentUniforms buffer",
             core::any::type_name::<C>()
         )));
         Self { uniforms }


### PR DESCRIPTION
# Objective

`ComponentUniforms<C>` creates its uniform buffer without a label. wgpu-core identifies each resource in a validation error as `Buffer with '<label>' label`. An empty label makes the error show `Buffer with '' label`. It is not possible to find the uniform buffer that caused the error.

The `type_label_buffers` feature writes a type name into the label when the code creates the buffer. This feature is off in a default build.

## Solution

- Set the buffer label to the type name of `C` in `Default for ComponentUniforms<C>`.
- Move the functions of `DynamicUniformBuffer<T>` that do not need `WriteInto` into the `impl<T: ShaderType>` block. Only `push` needs `WriteInto`, so only `push` stays in the `impl<T: ShaderType + WriteInto>` block. The other functions do not write values of type `T`, so their `WriteInto` bound was not necessary.
- The relaxed bounds keep `Default for ComponentUniforms<C>` at `C: Component + ShaderType`. The change does not break existing code, and a migration guide is not necessary.

#22698 removed the label from the constructors because `type_name()` returns a `&'static str`, the `label` field is an `Option<String>`, and `.to_string()` is not const. This is a problem only for const constructors. This constructor is not const.

## Testing

- `cargo check -p bevy`, with and without the `bevy_render/debug` feature.

---

This PR was built by me with the assistance of Claude Code w/ Fable 5
