### PR TITLE
Fix wireframe specialization

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -98,7 +98,9 @@ use crate::{
 use bevy_core_pipeline::oit::OrderIndependentTransparencySettings;
 use bevy_core_pipeline::prepass::{DeferredPrepass, DepthPrepass, NormalPrepass};
 use bevy_core_pipeline::tonemapping::{DebandDither, Tonemapping};
-use bevy_render::camera::{DirtySpecializations, ExtractedCamera, TemporalJitter};
+use bevy_render::camera::{
+    DirtySpecializations, DirtyWireframeSpecializations, ExtractedCamera, TemporalJitter,
+};
 use bevy_render::prelude::Msaa;
 use bevy_render::sync_world::{MainEntity, MainEntityHashMap};
 use bevy_render::view::{
@@ -360,6 +362,7 @@ pub struct ViewKeyCache(HashMap<RetainedViewEntity, MeshPipelineKey>);
 pub fn check_views_need_specialization(
     mut view_key_cache: ResMut<ViewKeyCache>,
     mut dirty_specializations: ResMut<DirtySpecializations>,
+    mut dirty_wireframe_specializations: ResMut<DirtyWireframeSpecializations>,
     mut views: Query<(
         &ExtractedView,
         Option<&ExtractedCamera>,
@@ -500,6 +503,9 @@ pub fn check_views_need_specialization(
         {
             view_key_cache.insert(view.retained_view_entity, view_key);
             dirty_specializations
+                .views
+                .insert(view.retained_view_entity);
+            dirty_wireframe_specializations
                 .views
                 .insert(view.retained_view_entity);
         }

--- a/crates/bevy_sprite_render/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh.rs
@@ -5,7 +5,7 @@ use bevy_asset::{embedded_asset, load_embedded_asset, AssetId, AssetServer, Hand
 use bevy_camera::{visibility::ViewVisibility, Camera2d, CompositingSpace};
 use bevy_platform::collections::HashMap;
 use bevy_render::{
-    camera::{DirtySpecializations, ExtractedCamera},
+    camera::{DirtySpecializations, DirtyWireframeSpecializations, ExtractedCamera},
     material_bind_groups::{
         MaterialBindGroupIndex, MaterialBindGroupSlot, MaterialBindingId, RenderMaterialBindings,
     },
@@ -136,6 +136,7 @@ pub struct ViewKeyCache(MainEntityHashMap<Mesh2dPipelineKey>);
 pub fn check_views_need_specialization(
     mut view_key_cache: ResMut<ViewKeyCache>,
     mut dirty_specializations: ResMut<DirtySpecializations>,
+    mut dirty_wireframe_specializations: ResMut<DirtyWireframeSpecializations>,
     cameras: Query<(
         &MainEntity,
         &ExtractedView,
@@ -178,6 +179,9 @@ pub fn check_views_need_specialization(
         {
             view_key_cache.insert(*view_entity, view_key);
             dirty_specializations
+                .views
+                .insert(view.retained_view_entity);
+            dirty_wireframe_specializations
                 .views
                 .insert(view.retained_view_entity);
         }


### PR DESCRIPTION
# Objective

Fixes #25375 

## Solution

When msaa changes, bevy detects the view key as changed. Existing code sets only `DirtySpecializations` as dirty, but leaves `DirtyWireframeSpecializations` untouched. This patch adds the dirty flag to the latter as well.

## Testing

To test the before-after behavior, please apply the patch at #25375 to the bevy wireframe example.

Before this patch: error logs + crash

After this patch: continues working

Tested both 3d & 2d.

<details>
<summary>2D repro</summary>

```diff
diff --git a/examples/2d/wireframe_2d.rs b/examples/2d/wireframe_2d.rs
index 9b3e16a39..6d5a3a9c6 100644
--- a/examples/2d/wireframe_2d.rs
+++ b/examples/2d/wireframe_2d.rs
@@ -55,6 +55,7 @@ fn main() {
         })
         .insert_resource(UiTheme(theme::basic_example_theme(Color::WHITE)))
         .add_systems(Startup, setup)
+        .add_systems(Update, toggle_msaa)
         .add_observer(update_radio_button)
         .add_observer(radio_self_update)
         .run();
@@ -164,7 +165,19 @@ fn setup(
         },
     ));

-    commands.spawn(Camera2d);
+    commands.spawn((Camera2d, Msaa::Sample4));
+}
+
+fn toggle_msaa(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut camera_msaa: Single<&mut Msaa, With<Camera2d>>,
+) {
+    if keyboard_input.just_pressed(KeyCode::Space) {
+        **camera_msaa = match **camera_msaa {
+            Msaa::Off => Msaa::Sample4,
+            _ => Msaa::Off,
+        };
+    }
 }

 /// This system lets you toggle various wireframe settings
```

</details>

AI disclosure: the root cause analysis, patch & test code for 2D was written by AI.