### PR TITLE
Fix caching of TilemapChunk Meshes

### DIFF
--- a/crates/bevy_sprite_render/src/tilemap_chunk/mod.rs
+++ b/crates/bevy_sprite_render/src/tilemap_chunk/mod.rs
@@ -165,15 +165,18 @@ fn on_insert_tilemap_chunk(mut world: DeferredWorld, HookContext { entity, .. }:
 
     let tile_data_image = make_chunk_tile_data_image(&chunk_size, &packed_tile_data);
 
-    let tilemap_chunk_mesh_cache = world.resource::<TilemapChunkMeshCache>();
-
     let mesh_size = chunk_size * tilemap_chunk.tile_display_size;
 
-    let mesh = if let Some(mesh) = tilemap_chunk_mesh_cache.get(&mesh_size) {
+    let mesh = if let Some(mesh) = world.resource::<TilemapChunkMeshCache>().get(&mesh_size) {
         mesh.clone()
     } else {
-        let mut meshes = world.resource_mut::<Assets<Mesh>>();
-        meshes.add(Rectangle::from_size(mesh_size.as_vec2()))
+        let mesh = world
+            .resource_mut::<Assets<Mesh>>()
+            .add(Rectangle::from_size(mesh_size.as_vec2()));
+        world
+            .resource_mut::<TilemapChunkMeshCache>()
+            .insert(mesh_size, mesh.clone());
+        mesh
     };
 
     let mut images = world.resource_mut::<Assets<Image>>();


### PR DESCRIPTION
# Objective

Reading through the source code, I noticed the cache was read from but never written to.

## Solution

Writing to the cache should have been simple. However, since the caching occurred in a on_insert hook, only a DeferredWorld was available. DeferredWorld does not support .resource_scope or SystemState. The change therefore juggles between TilemapChunkMeshCache and Assets<Mesh> to satisfy the borrow checker.

## Testing

Manually modified tilemap_chunk example to have two tilemaps and printed the Mesh2d component. Before the fix there were two different meshes, after the fix they were deduped.