### PR TITLE
Add ViewportNode to testbed/ui

### DIFF
--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -2782,7 +2782,11 @@ mod viewport_node {
         commands.spawn((
             Mesh3d(meshes.add(Cuboid::new(5.0, 5.0, 5.0))),
             MeshMaterial3d(materials.add(Color::WHITE)),
-            Transform::from_xyz(0.0, 0.0, -10.0),
+            Transform {
+                translation: Vec3::new(0.0, 0.0, -10.0),
+                rotation: Quat::from_euler(EulerRot::XYZ, 0.4, 0.7, 0.1),
+                ..default()
+            },
             DespawnOnExit(super::Scene::ViewportNode),
         ));
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -2749,17 +2749,20 @@ mod viewport_coords {
 
 mod viewport_node {
     use bevy::{
-        camera::RenderTarget, prelude::*,
-        render::render_resource::TextureFormat, ui::widget::ViewportNode,
+        camera::RenderTarget, prelude::*, render::render_resource::TextureFormat,
+        ui::widget::ViewportNode,
     };
 
-    pub fn setup (
+    pub fn setup(
         mut commands: Commands,
         mut images: ResMut<Assets<Image>>,
         mut meshes: ResMut<Assets<Mesh>>,
         mut materials: ResMut<Assets<StandardMaterial>>,
     ) {
-        commands.spawn((Camera3d::default(), DespawnOnExit(super::Scene::ViewportNode)));
+        commands.spawn((
+            Camera3d::default(),
+            DespawnOnExit(super::Scene::ViewportNode),
+        ));
 
         let image = Image::new_target_texture(0, 0, TextureFormat::Bgra8UnormSrgb, None);
         let image_handle = images.add(image);
@@ -2775,30 +2778,28 @@ mod viewport_node {
                 DespawnOnExit(super::Scene::ViewportNode),
             ))
             .id();
-        
-        commands
-            .spawn((
-                Mesh3d(meshes.add(Cuboid::new(5.0, 5.0, 5.0))),
-                MeshMaterial3d(materials.add(Color::WHITE)),
-                Transform::from_xyz(0.0, 0.0, -10.0),
-                DespawnOnExit(super::Scene::ViewportNode),
-            ));
 
-        commands
-            .spawn((
-                Node {
-                    position_type: PositionType::Absolute,
-                    top: px(50),
-                    left: px(50),
-                    width: px(200),
-                    height: px(200),
-                    border: UiRect::all(px(5)),
-                    ..default()
-                },
-                BorderColor::all(Color::WHITE),
-                ViewportNode::new(camera),
-                DespawnOnExit(super::Scene::ViewportNode),
-            ));
+        commands.spawn((
+            Mesh3d(meshes.add(Cuboid::new(5.0, 5.0, 5.0))),
+            MeshMaterial3d(materials.add(Color::WHITE)),
+            Transform::from_xyz(0.0, 0.0, -10.0),
+            DespawnOnExit(super::Scene::ViewportNode),
+        ));
+
+        commands.spawn((
+            Node {
+                position_type: PositionType::Absolute,
+                top: px(50),
+                left: px(50),
+                width: px(200),
+                height: px(200),
+                border: UiRect::all(px(5)),
+                ..default()
+            },
+            BorderColor::all(Color::WHITE),
+            ViewportNode::new(camera),
+            DespawnOnExit(super::Scene::ViewportNode),
+        ));
     }
 }
 

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -2774,7 +2774,7 @@ mod viewport_node {
                     order: -1,
                     ..default()
                 },
-                RenderTarget::Image(image_handle.clone().into()),
+                RenderTarget::Image(image_handle.into()),
                 DespawnOnExit(super::Scene::ViewportNode),
             ))
             .id();

--- a/examples/testbed/ui.rs
+++ b/examples/testbed/ui.rs
@@ -57,6 +57,7 @@ fn main() {
     .add_systems(OnEnter(Scene::RadialGradient), radial_gradient::setup)
     .add_systems(OnEnter(Scene::Transformations), transformations::setup)
     .add_systems(OnEnter(Scene::ViewportCoords), viewport_coords::setup)
+    .add_systems(OnEnter(Scene::ViewportNode), viewport_node::setup)
     .add_systems(OnEnter(Scene::OuterColor), outer_color::setup)
     .add_systems(OnEnter(Scene::BoxedContent), boxed_content::setup)
     .add_systems(OnEnter(Scene::EditableText), editable_text::setup)
@@ -103,6 +104,7 @@ enum Scene {
     #[cfg(feature = "bevy_ui_debug")]
     DebugOutlines,
     ViewportCoords,
+    ViewportNode,
     OuterColor,
     BoxedContent,
     EditableText,
@@ -130,6 +132,7 @@ impl Scene {
         #[cfg(feature = "bevy_ui_debug")]
         Scene::DebugOutlines,
         Scene::ViewportCoords,
+        Scene::ViewportNode,
         Scene::OuterColor,
         Scene::BoxedContent,
         Scene::EditableText,
@@ -2741,6 +2744,61 @@ mod viewport_coords {
                     BorderColor::all(PALETTE[8]),
                 ));
             });
+    }
+}
+
+mod viewport_node {
+    use bevy::{
+        camera::RenderTarget, prelude::*,
+        render::render_resource::TextureFormat, ui::widget::ViewportNode,
+    };
+
+    pub fn setup (
+        mut commands: Commands,
+        mut images: ResMut<Assets<Image>>,
+        mut meshes: ResMut<Assets<Mesh>>,
+        mut materials: ResMut<Assets<StandardMaterial>>,
+    ) {
+        commands.spawn((Camera3d::default(), DespawnOnExit(super::Scene::ViewportNode)));
+
+        let image = Image::new_target_texture(0, 0, TextureFormat::Bgra8UnormSrgb, None);
+        let image_handle = images.add(image);
+
+        let camera = commands
+            .spawn((
+                Camera3d::default(),
+                Camera {
+                    order: -1,
+                    ..default()
+                },
+                RenderTarget::Image(image_handle.clone().into()),
+                DespawnOnExit(super::Scene::ViewportNode),
+            ))
+            .id();
+        
+        commands
+            .spawn((
+                Mesh3d(meshes.add(Cuboid::new(5.0, 5.0, 5.0))),
+                MeshMaterial3d(materials.add(Color::WHITE)),
+                Transform::from_xyz(0.0, 0.0, -10.0),
+                DespawnOnExit(super::Scene::ViewportNode),
+            ));
+
+        commands
+            .spawn((
+                Node {
+                    position_type: PositionType::Absolute,
+                    top: px(50),
+                    left: px(50),
+                    width: px(200),
+                    height: px(200),
+                    border: UiRect::all(px(5)),
+                    ..default()
+                },
+                BorderColor::all(Color::WHITE),
+                ViewportNode::new(camera),
+                DespawnOnExit(super::Scene::ViewportNode),
+            ));
     }
 }
 


### PR DESCRIPTION
# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, say "Fixes #25347".

## Solution

- Added `ViewportNode` to `enum Scene` and `impl Scene` under `#[cfg(feature = "bevy_ui_debug")]
- Copied `test` function from `examples/ui/widgets/viewport_node.rs`.
- Removed `Shape` component from Mesh3d spawn because it's only used for `draw_mesh_intersection` in `viewport_node.rs`.
- Added `DespawnOnExit(super::Scene::ViewportNode)` to spawned entity so that the screen is cleared when switching Scene. 

## Testing

- Did you test these changes? If so, how?
     - Run test locally with the command `CI_TESTING_CONFIG=.github/example-run/testbed_ui.ron cargo run --example testbed_ui --features "bevy_ci_testing"`
     - Result: Screenshots were taken including `screenshot-ViewportNode.png`
- Are there any parts that need more testing?
    - Not sure.
- How can other people (reviewers) test your changes? Is there anything specific they need to know?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test?

---

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR adds a new feature or public API, consider adding a brief pseudo-code snippet of it in action
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - If you want, you could even include a before/after comparison!
- If the Migration Guide adequately covers the changes, you can delete this section

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view `screeshot-ViewportNode.png`</summary>


<img width="1920" height="1080" alt="screenshot-ViewportNode" src="https://github.com/user-attachments/assets/5882d12e-f670-4017-9684-bee1fa172f9e" />

</details>
