### PR TITLE
Expose multiview_mask on RenderPipelineDescriptor

### DIFF
--- a/crates/bevy_dev_tools/src/render_debug.rs
+++ b/crates/bevy_dev_tools/src/render_debug.rs
@@ -551,6 +551,7 @@ impl SpecializedRenderPipeline for RenderDebugOverlayPipeline {
             primitive: bevy_render::render_resource::PrimitiveState::default(),
             depth_stencil: None,
             multisample: bevy_render::render_resource::MultisampleState::default(),
+            multiview_mask: None,
             immediate_size: 0,
             zero_initialize_workgroup_memory: false,
         }

--- a/crates/bevy_material/src/descriptor.rs
+++ b/crates/bevy_material/src/descriptor.rs
@@ -3,7 +3,7 @@ use bevy_asset::Handle;
 use bevy_derive::Deref;
 use bevy_mesh::VertexBufferLayout;
 use bevy_shader::{CachedPipelineId, Shader, ShaderDefVal};
-use core::iter;
+use core::{iter, num::NonZeroU32};
 use thiserror::Error;
 use wgpu_types::{
     BindGroupLayoutEntry, ColorTargetState, DepthStencilState, MultisampleState, PrimitiveState,
@@ -43,6 +43,14 @@ pub struct RenderPipelineDescriptor {
     pub depth_stencil: Option<DepthStencilState>,
     /// The multi-sampling properties of the pipeline.
     pub multisample: MultisampleState,
+    /// The view mask for multiview rendering, if any.
+    ///
+    /// When `Some`, the pipeline renders to multiple view layers in a single
+    /// pass; each bit of the mask selects a layer of the render target's
+    /// texture array. Shaders can read the current view via
+    /// `@builtin(view_index)`. The render pass that uses this pipeline must
+    /// be configured with a matching multiview mask.
+    pub multiview_mask: Option<NonZeroU32>,
     /// The compiled fragment stage, its entry point, and the color targets.
     pub fragment: Option<FragmentState>,
     /// Whether to zero-initialize workgroup memory by default. If you're not sure, set this to true.

--- a/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
+++ b/crates/bevy_pbr/src/meshlet/material_pipeline_prepare.rs
@@ -234,6 +234,7 @@ pub fn prepare_material_meshlet_meshes_main_opaque_pass(
                         bias: DepthBiasState::default(),
                     }),
                     multisample: MultisampleState::default(),
+                    multiview_mask: None,
                     fragment: Some(FragmentState {
                         shader: match material.properties.get_shader(MeshletFragmentShader) {
                             Some(shader) => shader.clone(),

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -558,7 +558,7 @@ impl PipelineCache {
                     .collect();
 
                 let descriptor = RawRenderPipelineDescriptor {
-                    multiview_mask: None,
+                    multiview_mask: descriptor.multiview_mask,
                     depth_stencil: descriptor.depth_stencil.clone(),
                     label: descriptor.label.as_deref(),
                     layout: layout.as_ref().map(|layout| -> &PipelineLayout { layout }),


### PR DESCRIPTION
wgpu's render pipeline descriptor carries a multiview_mask, but Bevy's
pipeline cache hard-coded it to None when lowering to the raw
descriptor. There was no way to build a multiview pipeline through
Bevy's normal pipeline machinery, even though the backend supports it.

Adds the field to RenderPipelineDescriptor and passes it through.
Nothing in the tree sets it, so there is no behavior change: every
pipeline still gets None.

Multiview renders N view layers in a single pass, with the GPU
broadcasting each draw to every layer of an array render target and the
shader selecting per-view data via @builtin(view_index). It is the
standard way to render stereo for VR. This is the smallest piece of the
foundation for that; see #15864 and the earlier effort in #16059.

Of the 90 RenderPipelineDescriptor construction sites in the tree, only
three build the struct exhaustively rather than through Default, so the
change to callers is three lines. One of them is behind the `meshlet`
feature and is not covered by a default `cargo check`.
