### PR TITLE
impl EntityCommand for Arc<dyn Fn(EntityWorldMut) ...>

### DIFF
--- a/crates/bevy_ecs/src/system/commands/entity_command.rs
+++ b/crates/bevy_ecs/src/system/commands/entity_command.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use bevy_ptr::{move_as_ptr, OwningPtr};
 
-use alloc::sync::Arc;
+use bevy_platform::sync::Arc;
 
 /// A command which gets executed for a given [`Entity`].
 ///

--- a/crates/bevy_ecs/src/system/commands/entity_command.rs
+++ b/crates/bevy_ecs/src/system/commands/entity_command.rs
@@ -24,6 +24,8 @@ use crate::{
 };
 use bevy_ptr::{move_as_ptr, OwningPtr};
 
+use alloc::sync::Arc;
+
 /// A command which gets executed for a given [`Entity`].
 ///
 /// Should be used with [`EntityCommands::queue`](crate::system::EntityCommands::queue).
@@ -119,6 +121,17 @@ impl<Out, F> EntityCommand for F
 where
     F: FnOnce(EntityWorldMut) -> Out + Send + 'static,
     Out: EntityCommandOutput,
+{
+    type Out = Out;
+
+    fn apply(self, entity: EntityWorldMut) -> Self::Out {
+        self(entity)
+    }
+}
+
+impl<Out> EntityCommand for Arc<dyn Fn(EntityWorldMut) -> Out + Send + Sync + 'static>
+where
+    Out: EntityCommandOutput + 'static,
 {
     type Out = Out;
 

--- a/crates/bevy_ecs/src/system/commands/entity_command.rs
+++ b/crates/bevy_ecs/src/system/commands/entity_command.rs
@@ -129,8 +129,9 @@ where
     }
 }
 
-impl<Out> EntityCommand for Arc<dyn Fn(EntityWorldMut) -> Out + Send + Sync + 'static>
+impl<Out, F> EntityCommand for Arc<F>
 where
+    F: Fn(EntityWorldMut) -> Out + Send + Sync + ?Sized + 'static,
     Out: EntityCommandOutput + 'static,
 {
     type Out = Out;


### PR DESCRIPTION
# Objective

A `Box<dyn Fn(EntityWorldMut) -> Out + Send +  'static>` can already be used as an `EntityCommand`, but an `Arc` can't.

## Solution

Add an implementation for `Arc`.

## Testing

None
