### PR TITLE
Allow `PanCamera` to be used inside `bsn!` macros

### DIFF
--- a/crates/bevy_camera_controller/src/pan_camera.rs
+++ b/crates/bevy_camera_controller/src/pan_camera.rs
@@ -94,7 +94,7 @@ pub struct MousePanSettings {
     pub button: PointerButton,
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 /// Target focal point for zooming using the [`PanCamera`] controller
 pub enum ZoomTarget {
     /// Zoom to / from the center of the window

--- a/crates/bevy_camera_controller/src/pan_camera.rs
+++ b/crates/bevy_camera_controller/src/pan_camera.rs
@@ -47,7 +47,7 @@ impl Plugin for PanCameraPlugin {
 ///
 /// Add this component to a [`Camera`] entity to enable keyboard and mouse controls
 /// for panning, zooming, and optional rotation. Requires the [`PanCameraPlugin`].
-#[derive(Component)]
+#[derive(Component, Clone)]
 pub struct PanCamera {
     /// Enables this [`PanCamera`] when `true`.
     pub enabled: bool,
@@ -86,6 +86,7 @@ pub struct PanCamera {
 }
 
 /// Settings for mouse panning for the [`PanCamera`] controller.
+#[derive(Clone)]
 pub struct MousePanSettings {
     /// Whether the mouse panning is enabled.
     pub enabled: bool,


### PR DESCRIPTION
# Objective

Allow scenes with a `PanCamera` component from the `bevy_camera_controller` crate to be created through a `bsn!` macro.

## Solution

I compared the implementation of `PanCamera` with `FreeCamera` (which belongs to the same crate and can be used inside bsn macros) and saw that it just needed to derive the `Copy` trait.

## Testing

Spawned a simple scene together with:

```rust
bsn! {
  Camera2d
  PanCamera
}
```

This works as expected and the pan camera has full functionality.
