### PR TITLE
Update to Taffy 13

### DIFF
--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -37,7 +37,7 @@ bevy_platform = { path = "../bevy_platform", version = "0.20.0-dev", default-fea
 ] }
 
 # other
-taffy = { version = "0.10", default-features = false, features = [
+taffy = { version = "0.13", default-features = false, features = [
   "std",
   "block_layout",
   "flexbox",

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -148,13 +148,13 @@ impl From<AlignItems> for Option<taffy::style::AlignItems> {
     fn from(value: AlignItems) -> Self {
         match value {
             AlignItems::Default => None,
-            AlignItems::Start => taffy::style::AlignItems::Start.into(),
-            AlignItems::End => taffy::style::AlignItems::End.into(),
-            AlignItems::FlexStart => taffy::style::AlignItems::FlexStart.into(),
-            AlignItems::FlexEnd => taffy::style::AlignItems::FlexEnd.into(),
-            AlignItems::Center => taffy::style::AlignItems::Center.into(),
-            AlignItems::Baseline => taffy::style::AlignItems::Baseline.into(),
-            AlignItems::Stretch => taffy::style::AlignItems::Stretch.into(),
+            AlignItems::Start => taffy::style::AlignItems::START.into(),
+            AlignItems::End => taffy::style::AlignItems::END.into(),
+            AlignItems::FlexStart => taffy::style::AlignItems::FLEX_START.into(),
+            AlignItems::FlexEnd => taffy::style::AlignItems::FLEX_END.into(),
+            AlignItems::Center => taffy::style::AlignItems::CENTER.into(),
+            AlignItems::Baseline => taffy::style::AlignItems::BASELINE.into(),
+            AlignItems::Stretch => taffy::style::AlignItems::STRETCH.into(),
         }
     }
 }
@@ -163,11 +163,11 @@ impl From<JustifyItems> for Option<taffy::style::JustifyItems> {
     fn from(value: JustifyItems) -> Self {
         match value {
             JustifyItems::Default => None,
-            JustifyItems::Start => taffy::style::JustifyItems::Start.into(),
-            JustifyItems::End => taffy::style::JustifyItems::End.into(),
-            JustifyItems::Center => taffy::style::JustifyItems::Center.into(),
-            JustifyItems::Baseline => taffy::style::JustifyItems::Baseline.into(),
-            JustifyItems::Stretch => taffy::style::JustifyItems::Stretch.into(),
+            JustifyItems::Start => taffy::style::JustifyItems::START.into(),
+            JustifyItems::End => taffy::style::JustifyItems::END.into(),
+            JustifyItems::Center => taffy::style::JustifyItems::CENTER.into(),
+            JustifyItems::Baseline => taffy::style::JustifyItems::BASELINE.into(),
+            JustifyItems::Stretch => taffy::style::JustifyItems::STRETCH.into(),
         }
     }
 }
@@ -176,13 +176,13 @@ impl From<AlignSelf> for Option<taffy::style::AlignSelf> {
     fn from(value: AlignSelf) -> Self {
         match value {
             AlignSelf::Auto => None,
-            AlignSelf::Start => taffy::style::AlignSelf::Start.into(),
-            AlignSelf::End => taffy::style::AlignSelf::End.into(),
-            AlignSelf::FlexStart => taffy::style::AlignSelf::FlexStart.into(),
-            AlignSelf::FlexEnd => taffy::style::AlignSelf::FlexEnd.into(),
-            AlignSelf::Center => taffy::style::AlignSelf::Center.into(),
-            AlignSelf::Baseline => taffy::style::AlignSelf::Baseline.into(),
-            AlignSelf::Stretch => taffy::style::AlignSelf::Stretch.into(),
+            AlignSelf::Start => taffy::style::AlignSelf::START.into(),
+            AlignSelf::End => taffy::style::AlignSelf::END.into(),
+            AlignSelf::FlexStart => taffy::style::AlignSelf::FLEX_START.into(),
+            AlignSelf::FlexEnd => taffy::style::AlignSelf::FLEX_END.into(),
+            AlignSelf::Center => taffy::style::AlignSelf::CENTER.into(),
+            AlignSelf::Baseline => taffy::style::AlignSelf::BASELINE.into(),
+            AlignSelf::Stretch => taffy::style::AlignSelf::STRETCH.into(),
         }
     }
 }
@@ -191,11 +191,11 @@ impl From<JustifySelf> for Option<taffy::style::JustifySelf> {
     fn from(value: JustifySelf) -> Self {
         match value {
             JustifySelf::Auto => None,
-            JustifySelf::Start => taffy::style::JustifySelf::Start.into(),
-            JustifySelf::End => taffy::style::JustifySelf::End.into(),
-            JustifySelf::Center => taffy::style::JustifySelf::Center.into(),
-            JustifySelf::Baseline => taffy::style::JustifySelf::Baseline.into(),
-            JustifySelf::Stretch => taffy::style::JustifySelf::Stretch.into(),
+            JustifySelf::Start => taffy::style::JustifySelf::START.into(),
+            JustifySelf::End => taffy::style::JustifySelf::END.into(),
+            JustifySelf::Center => taffy::style::JustifySelf::CENTER.into(),
+            JustifySelf::Baseline => taffy::style::JustifySelf::BASELINE.into(),
+            JustifySelf::Stretch => taffy::style::JustifySelf::STRETCH.into(),
         }
     }
 }
@@ -204,15 +204,15 @@ impl From<AlignContent> for Option<taffy::style::AlignContent> {
     fn from(value: AlignContent) -> Self {
         match value {
             AlignContent::Default => None,
-            AlignContent::Start => taffy::style::AlignContent::Start.into(),
-            AlignContent::End => taffy::style::AlignContent::End.into(),
-            AlignContent::FlexStart => taffy::style::AlignContent::FlexStart.into(),
-            AlignContent::FlexEnd => taffy::style::AlignContent::FlexEnd.into(),
-            AlignContent::Center => taffy::style::AlignContent::Center.into(),
-            AlignContent::Stretch => taffy::style::AlignContent::Stretch.into(),
-            AlignContent::SpaceBetween => taffy::style::AlignContent::SpaceBetween.into(),
-            AlignContent::SpaceAround => taffy::style::AlignContent::SpaceAround.into(),
-            AlignContent::SpaceEvenly => taffy::style::AlignContent::SpaceEvenly.into(),
+            AlignContent::Start => taffy::style::AlignContent::START.into(),
+            AlignContent::End => taffy::style::AlignContent::END.into(),
+            AlignContent::FlexStart => taffy::style::AlignContent::FLEX_START.into(),
+            AlignContent::FlexEnd => taffy::style::AlignContent::FLEX_END.into(),
+            AlignContent::Center => taffy::style::AlignContent::CENTER.into(),
+            AlignContent::Stretch => taffy::style::AlignContent::STRETCH.into(),
+            AlignContent::SpaceBetween => taffy::style::AlignContent::SPACE_BETWEEN.into(),
+            AlignContent::SpaceAround => taffy::style::AlignContent::SPACE_AROUND.into(),
+            AlignContent::SpaceEvenly => taffy::style::AlignContent::SPACE_EVENLY.into(),
         }
     }
 }
@@ -221,15 +221,15 @@ impl From<JustifyContent> for Option<taffy::style::JustifyContent> {
     fn from(value: JustifyContent) -> Self {
         match value {
             JustifyContent::Default => None,
-            JustifyContent::Start => taffy::style::JustifyContent::Start.into(),
-            JustifyContent::End => taffy::style::JustifyContent::End.into(),
-            JustifyContent::FlexStart => taffy::style::JustifyContent::FlexStart.into(),
-            JustifyContent::FlexEnd => taffy::style::JustifyContent::FlexEnd.into(),
-            JustifyContent::Center => taffy::style::JustifyContent::Center.into(),
-            JustifyContent::Stretch => taffy::style::JustifyContent::Stretch.into(),
-            JustifyContent::SpaceBetween => taffy::style::JustifyContent::SpaceBetween.into(),
-            JustifyContent::SpaceAround => taffy::style::JustifyContent::SpaceAround.into(),
-            JustifyContent::SpaceEvenly => taffy::style::JustifyContent::SpaceEvenly.into(),
+            JustifyContent::Start => taffy::style::JustifyContent::START.into(),
+            JustifyContent::End => taffy::style::JustifyContent::END.into(),
+            JustifyContent::FlexStart => taffy::style::JustifyContent::FLEX_START.into(),
+            JustifyContent::FlexEnd => taffy::style::JustifyContent::FLEX_END.into(),
+            JustifyContent::Center => taffy::style::JustifyContent::CENTER.into(),
+            JustifyContent::Stretch => taffy::style::JustifyContent::STRETCH.into(),
+            JustifyContent::SpaceBetween => taffy::style::JustifyContent::SPACE_BETWEEN.into(),
+            JustifyContent::SpaceAround => taffy::style::JustifyContent::SPACE_AROUND.into(),
+            JustifyContent::SpaceEvenly => taffy::style::JustifyContent::SPACE_EVENLY.into(),
         }
     }
 }
@@ -562,21 +562,21 @@ mod tests {
         assert_eq!(taffy_style.flex_wrap, taffy::style::FlexWrap::WrapReverse);
         assert_eq!(
             taffy_style.align_items,
-            Some(taffy::style::AlignItems::Baseline)
+            Some(taffy::style::AlignItems::BASELINE)
         );
-        assert_eq!(taffy_style.align_self, Some(taffy::style::AlignSelf::Start));
+        assert_eq!(taffy_style.align_self, Some(taffy::style::AlignSelf::START));
         assert_eq!(
             taffy_style.align_content,
-            Some(taffy::style::AlignContent::SpaceAround)
+            Some(taffy::style::AlignContent::SPACE_AROUND)
         );
         assert_eq!(
             taffy_style.justify_content,
-            Some(taffy::style::JustifyContent::SpaceEvenly)
+            Some(taffy::style::JustifyContent::SPACE_EVENLY)
         );
         assert_eq!(taffy_style.justify_items, None);
         assert_eq!(
             taffy_style.justify_self,
-            Some(taffy::style::JustifySelf::Center)
+            Some(taffy::style::JustifySelf::CENTER)
         );
         assert_eq!(
             taffy_style.margin.left,

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -52,6 +52,7 @@ fn print_node(
         (_, taffy::style::Display::Flex) => "FLEX",
         (_, taffy::style::Display::Grid) => "GRID",
         (_, taffy::style::Display::Block) => "BLOCK",
+        (_, taffy::style::Display::FlowRoot) => "FLOWROOT",
     };
 
     let fork_string = if has_sibling {

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -205,8 +205,8 @@ impl UiSurface {
                             width: taffy::style_helpers::percent(1.0_f32),
                             height: taffy::style_helpers::percent(1.0_f32),
                         },
-                        align_items: Some(taffy::style::AlignItems::Start),
-                        justify_items: Some(taffy::style::JustifyItems::Start),
+                        align_items: Some(taffy::style::AlignItems::START),
+                        justify_items: Some(taffy::style::JustifyItems::START),
                         ..default()
                     })
                     .unwrap();


### PR DESCRIPTION
# Objective

Update to Taffy 0.13.

We haven't updated our Taffy dependency since its 0.10 release, missing out on many bug fixes:

https://github.com/DioxusLabs/taffy/blob/main/CHANGELOG.md

## Solution

No user-facing changes. 

Taffy 11 introduced safe alignment, the alignment enums on `Node` are mapped in `convert` to their corresponding Taffy variants with `AlignmentSafety::Unsafe` set for now.

---

I didn't try to add support for any of the new features here. Full support for alignment safety could be a 3000+ line change by itself.

## Testing

Everything should be fine if the `testbed_ui` screenshot CI passes, 🤞