### PR TITLE
Use buckets for SpriteMesh add_material cache and fix memory leak

### DIFF
--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -5,11 +5,10 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{component::Component, reflect::ReflectComponent, template::FromTemplate};
 use bevy_image::{Image, TextureAtlas, TextureAtlasLayout};
 use bevy_math::{Rect, UVec2, Vec2};
-use bevy_reflect::{std_traits::ReflectDefault, PartialReflect, Reflect};
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_transform::components::Transform;
 
 use crate::TextureSlicer;
-use core::hash::Hash;
 
 /// Describes a sprite to be rendered to a 2D camera
 #[derive(Component, Debug, Default, Clone, Reflect, FromTemplate)]

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -163,7 +163,7 @@ impl AsAssetId for Sprite {
 }
 
 /// Controls how the image is altered when scaled.
-#[derive(Default, Debug, Clone, Reflect, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Reflect, PartialEq)]
 #[reflect(Debug, Default, Clone)]
 pub enum SpriteImageMode {
     /// The sprite will take on the size of the image by default, and will be stretched or shrunk if [`Sprite::custom_size`] is set.
@@ -255,13 +255,6 @@ pub enum SpriteScalingMode {
 #[reflect(Component, Default, Debug, PartialEq, Clone)]
 #[doc(alias = "pivot")]
 pub struct Anchor(pub Vec2);
-
-impl Eq for Anchor {}
-impl Hash for Anchor {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.0.reflect_hash().hash(state);
-    }
-}
 
 #[expect(missing_docs, reason = "the associated constants are self-documenting")]
 impl Anchor {

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -162,7 +162,7 @@ impl AsAssetId for Sprite {
 }
 
 /// Controls how the image is altered when scaled.
-#[derive(Default, Debug, Clone, Copy, Reflect, PartialEq)]
+#[derive(Default, Debug, Clone, Reflect, PartialEq)]
 #[reflect(Debug, Default, Clone)]
 pub enum SpriteImageMode {
     /// The sprite will take on the size of the image by default, and will be stretched or shrunk if [`Sprite::custom_size`] is set.

--- a/crates/bevy_sprite/src/sprite_mesh.rs
+++ b/crates/bevy_sprite/src/sprite_mesh.rs
@@ -4,7 +4,7 @@ use bevy_color::Color;
 use bevy_ecs::{component::Component, reflect::ReflectComponent, template::FromTemplate};
 use bevy_image::{Image, TextureAtlas, TextureAtlasLayout};
 use bevy_math::{Rect, UVec2, Vec2};
-use bevy_reflect::{std_traits::ReflectDefault, PartialReflect, Reflect};
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_transform::components::Transform;
 
 use crate::{Anchor, SpriteImageMode};
@@ -44,19 +44,6 @@ pub struct SpriteMesh {
     /// set it to `Blend` instead (significantly worse for performance).
     pub alpha_mode: SpriteAlphaMode,
 }
-
-impl core::hash::Hash for SpriteMesh {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.image.hash(state);
-        self.texture_atlas.hash(state);
-        self.color.reflect_hash().hash(state);
-        self.custom_size.reflect_hash().hash(state);
-        self.flip_x.hash(state);
-        self.flip_y.hash(state);
-    }
-}
-
-impl Eq for SpriteMesh {}
 
 // NOTE: The SpriteImageMode, SpriteScalingMode and Anchor are imported from the sprite module.
 

--- a/crates/bevy_sprite/src/texture_slice/slicer.rs
+++ b/crates/bevy_sprite/src/texture_slice/slicer.rs
@@ -10,7 +10,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 /// sections will be scaled or tiled.
 ///
 /// See [9-sliced](https://en.wikipedia.org/wiki/9-slice_scaling) textures.
-#[derive(Debug, Clone, Copy, Reflect, PartialEq)]
+#[derive(Debug, Clone, Reflect, PartialEq)]
 #[reflect(Clone, PartialEq)]
 pub struct TextureSlicer {
     /// Inset values in pixels that define the four slicing lines dividing the texture into nine sections.

--- a/crates/bevy_sprite/src/texture_slice/slicer.rs
+++ b/crates/bevy_sprite/src/texture_slice/slicer.rs
@@ -10,7 +10,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 /// sections will be scaled or tiled.
 ///
 /// See [9-sliced](https://en.wikipedia.org/wiki/9-slice_scaling) textures.
-#[derive(Debug, Clone, Reflect, PartialEq)]
+#[derive(Debug, Clone, Copy, Reflect, PartialEq)]
 #[reflect(Clone, PartialEq)]
 pub struct TextureSlicer {
     /// Inset values in pixels that define the four slicing lines dividing the texture into nine sections.

--- a/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
@@ -1,15 +1,17 @@
 use bevy_app::{Plugin, PostUpdate};
+use bevy_color::ColorToComponents;
 use bevy_ecs::{
     entity::Entity,
+    message::MessageReader,
     query::{Added, Changed, Or},
     schedule::IntoScheduleConfigs,
     system::{Commands, Local, Query, Res, ResMut},
 };
 
-use bevy_asset::{Assets, Handle};
+use bevy_asset::{AssetEvent, AssetId, Assets, Handle};
 
-use bevy_image::TextureAtlasLayout;
-use bevy_math::{primitives::Rectangle, vec2};
+use bevy_image::{Image, TextureAtlasLayout};
+use bevy_math::{primitives::Rectangle, vec2, FloatOrd};
 use bevy_mesh::{
     mark_2d_meshes_as_changed_if_their_assets_changed, Mesh, Mesh2d, MeshAttributeCompressionFlags,
     MeshBuilder, Meshable,
@@ -17,7 +19,7 @@ use bevy_mesh::{
 
 use bevy_platform::collections::HashMap;
 use bevy_shader::load_shader_library;
-use bevy_sprite::{prelude::SpriteMesh, Anchor};
+use bevy_sprite::{prelude::SpriteMesh, Anchor, SpriteAlphaMode};
 
 mod sprite_material;
 pub use sprite_material::*;
@@ -70,44 +72,121 @@ fn add_mesh(
     }
 }
 
-// Change the material when SpriteMesh is added / changed.
-//
-// NOTE: This also adds the SpriteAtlasLayout into the SpriteMaterial,
-// but this should instead be read later, similar to the images, allowing
-// for hot reload.
+/// Key used to determine in which bucket to cache the material for a [`SpriteMesh`]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct SpriteMaterialBucketKey {
+    image: AssetId<Image>,
+    texture_atlas_layout: Option<AssetId<TextureAtlasLayout>>,
+    color: [FloatOrd; 4],
+    flip_x: bool,
+    flip_y: bool,
+    custom_size: Option<[FloatOrd; 2]>,
+    rect: Option<([FloatOrd; 2], [FloatOrd; 2])>,
+    alpha_mode: SpriteAlphaModeKey,
+    anchor: [FloatOrd; 2],
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum SpriteAlphaModeKey {
+    Opaque,
+    Mask(FloatOrd),
+    Blend,
+}
+
+impl SpriteMaterialBucketKey {
+    fn new(sprite: &SpriteMesh, anchor: &Anchor) -> Self {
+        Self {
+            image: sprite.image.id(),
+            texture_atlas_layout: sprite.texture_atlas.as_ref().map(|a| a.layout.id()),
+            color: sprite.color.to_linear().to_f32_array().map(FloatOrd),
+            flip_x: sprite.flip_x,
+            flip_y: sprite.flip_y,
+            custom_size: sprite.custom_size.map(|v| v.to_array().map(FloatOrd)),
+            rect: sprite.rect.map(|r| {
+                (
+                    r.min.to_array().map(FloatOrd),
+                    r.max.to_array().map(FloatOrd),
+                )
+            }),
+            alpha_mode: match sprite.alpha_mode {
+                SpriteAlphaMode::Opaque => SpriteAlphaModeKey::Opaque,
+                SpriteAlphaMode::Mask(mask) => SpriteAlphaModeKey::Mask(FloatOrd(mask)),
+                SpriteAlphaMode::Blend => SpriteAlphaModeKey::Blend,
+            },
+            anchor: anchor.0.to_array().map(FloatOrd),
+        }
+    }
+}
+
+/// Change the material when [`SpriteMesh`] is added / changed.
+///
+/// The materials are cached based on their [`SpriteMesh`] and [`Anchor`].
+///
+/// Since not all fields of the [`SpriteMesh`] are easy to hash, we keep multiple "buckets" keyed on
+/// parts of the struct that are easy to hash.
+///
+/// NOTE: This also adds the [`TextureAtlasLayout`] into the [`SpriteMaterial`],
+/// but this should instead be read later, similar to the images, allowing
+/// for hot reload.
 fn add_material(
+    mut commands: Commands,
     sprites: Query<
         (Entity, &SpriteMesh, &Anchor),
         Or<(Changed<SpriteMesh>, Changed<Anchor>, Added<Mesh2d>)>,
     >,
     texture_atlas_layouts: Res<Assets<TextureAtlasLayout>>,
-    mut cached_materials: Local<HashMap<(SpriteMesh, Anchor), Handle<SpriteMaterial>>>,
+    mut cached_materials: Local<
+        HashMap<SpriteMaterialBucketKey, Vec<(SpriteMesh, AssetId<SpriteMaterial>)>>,
+    >,
+    mut reversed_cached_materials: Local<HashMap<AssetId<SpriteMaterial>, SpriteMaterialBucketKey>>,
     mut materials: ResMut<Assets<SpriteMaterial>>,
-    mut commands: Commands,
+    mut material_events: MessageReader<AssetEvent<SpriteMaterial>>,
 ) {
-    for (entity, sprite, anchor) in sprites {
-        if let Some(handle) = cached_materials.get(&(sprite.clone(), *anchor)) {
-            commands
-                .entity(entity)
-                .insert(MeshMaterial2d(handle.clone()));
-        } else {
-            let mut material = SpriteMaterial::from_sprite_mesh(sprite.clone());
-            material.anchor = **anchor;
-
-            if let Some(texture_atlas) = &sprite.texture_atlas
-                && let Some(texture_atlas_layout) =
-                    texture_atlas_layouts.get(texture_atlas.layout.id())
-            {
-                material.texture_atlas_layout = Some(texture_atlas_layout.clone());
-                material.texture_atlas_index = texture_atlas.index;
+    // Remove materials from the cache
+    for event in material_events.read() {
+        if let AssetEvent::Removed { id } = event
+            && let Some(key) = reversed_cached_materials.remove(id)
+            && let Some(bucket) = cached_materials.get_mut(&key)
+        {
+            bucket.retain(|(_, cached_material_id)| cached_material_id != id);
+            if bucket.is_empty() {
+                cached_materials.remove(&key);
             }
-
-            let handle = materials.add(material);
-            cached_materials.insert((sprite.clone(), *anchor), handle.clone());
-
-            commands
-                .entity(entity)
-                .insert(MeshMaterial2d(handle.clone()));
         }
+    }
+
+    for (entity, sprite, anchor) in sprites {
+        // Get the bucket for the sprite and anchor
+        let bucket_key = SpriteMaterialBucketKey::new(sprite, anchor);
+        let bucket = cached_materials.entry(bucket_key).or_default();
+
+        let maybe_handle = bucket
+            .iter()
+            .find(|(cached_sprite, _)| cached_sprite == sprite)
+            .and_then(|(_, id)| materials.get_strong_handle(*id));
+
+        let handle = match maybe_handle {
+            Some(handle) => handle,
+            None => {
+                let mut material = SpriteMaterial::from_sprite_mesh(sprite.clone());
+                material.anchor = **anchor;
+
+                if let Some(texture_atlas) = &sprite.texture_atlas
+                    && let Some(texture_atlas_layout) =
+                        texture_atlas_layouts.get(texture_atlas.layout.id())
+                {
+                    material.texture_atlas_layout = Some(texture_atlas_layout.clone());
+                    material.texture_atlas_index = texture_atlas.index;
+                }
+
+                let handle = materials.add(material);
+                bucket.push((sprite.clone(), handle.id()));
+                handle
+            }
+        };
+
+        commands
+            .entity(entity)
+            .insert(MeshMaterial2d(handle.clone()));
     }
 }

--- a/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     system::{Commands, Local, Query, Res, ResMut},
 };
 
-use bevy_asset::{AssetEvent, AssetId, Assets, Handle};
+use bevy_asset::{AssetEvent, AssetEventSystems, AssetId, Assets, Handle};
 
 use bevy_image::{Image, TextureAtlasLayout};
 use bevy_math::{primitives::Rectangle, vec2, FloatOrd};
@@ -41,7 +41,8 @@ impl Plugin for SpriteMeshPlugin {
             (add_mesh, add_material)
                 .chain()
                 .before(check_entities_needing_specialization::<SpriteMaterial>)
-                .before(mark_2d_meshes_as_changed_if_their_assets_changed),
+                .before(mark_2d_meshes_as_changed_if_their_assets_changed)
+                .after(AssetEventSystems),
         );
     }
 }

--- a/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
@@ -17,7 +17,7 @@ use bevy_mesh::{
     MeshBuilder, Meshable,
 };
 
-use bevy_platform::collections::HashMap;
+use bevy_platform::collections::{hash_map::Entry, HashMap};
 use bevy_shader::load_shader_library;
 use bevy_sprite::{prelude::SpriteMesh, Anchor, SpriteAlphaMode};
 
@@ -146,11 +146,13 @@ fn add_material(
     for event in material_events.read() {
         if let AssetEvent::Removed { id } = event
             && let Some(key) = reversed_cached_materials.remove(id)
-            && let Some(bucket) = cached_materials.get_mut(&key)
+            && let Entry::Occupied(mut bucket) = cached_materials.entry(key)
         {
-            bucket.retain(|(_, cached_material_id)| cached_material_id != id);
-            if bucket.is_empty() {
-                cached_materials.remove(&key);
+            bucket
+                .get_mut()
+                .retain(|(_, cached_material_id)| cached_material_id != id);
+            if bucket.get().is_empty() {
+                bucket.remove();
             }
         }
     }


### PR DESCRIPTION
# Objective

- Fix memory leak in `add_material`
- Fix performance issue when spawning new SpriteMesh entities
	- The `SpriteMesh` and `Anchor` Hash implementation is very flawed and resulted in a lot of hash collision which made spawning new sprites extremely slow
	- The current hash implementation relies on `reflect_hash` which returns None on types that can't be hashed which is most of them

## Solution

- Clear the cache when sprite materials are removed
- Store the cache materials in buckets based on a key derived from a `SpriteMesh`
- Introduce a new `SpriteMaterialBucketKey` which is built from a subset of `SpriteMesh` and uses `FloatOrd` to hash floats

## Testing

- I tested bevymark with --vary-per-instance

red is main, yellow is this PR

<img width="988" height="627" alt="image" src="https://github.com/user-attachments/assets/5a77358b-9a55-4137-97d5-97e4bcb8f643" />

This was measured with `cargo run --release --example bevymark --features trace_tracy -- --per-wave 1000 --waves 100 --alpha-mode alpha_mask --mode sprite_mesh --vary-per-instance` and the trace was only taken while the waves were still spawning

When spawning new sprites on main, it would become slower with each new wave while with this fix each new wave was roughly the same cost.

