### PR TITLE
Add perp method to Dir2

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -434,7 +434,7 @@ macro_rules! load_internal_binary_asset {
 
 #[cfg(test)]
 mod tests {
-    use super::{EmbeddedAssetRegistry, _embedded_asset_path};
+    use super::{_embedded_asset_path, EmbeddedAssetRegistry};
     use std::path::Path;
 
     // Relative paths show up if this macro is being invoked by a local crate.

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -434,7 +434,7 @@ macro_rules! load_internal_binary_asset {
 
 #[cfg(test)]
 mod tests {
-    use super::{_embedded_asset_path, EmbeddedAssetRegistry};
+    use super::{EmbeddedAssetRegistry, _embedded_asset_path};
     use std::path::Path;
 
     // Relative paths show up if this macro is being invoked by a local crate.

--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -550,7 +550,7 @@ where
         .draw_arrow(true);
 
         // draw the plane line
-        let direction = -normal.perp();
+        let direction = -normal.perpendicular();
 
         self.primitive_2d(&Line2d { direction }, isometry, polymorphic_color)
             .draw_arrow(false);

--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -551,7 +551,7 @@ where
 
         // draw the plane line
         let direction = -normal.perp();
-        
+
         self.primitive_2d(&Line2d { direction }, isometry, polymorphic_color)
             .draw_arrow(false);
 

--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -550,7 +550,8 @@ where
         .draw_arrow(true);
 
         // draw the plane line
-        let direction = Dir2::new_unchecked(-normal.perp());
+        let direction = -normal.perp();
+        
         self.primitive_2d(&Line2d { direction }, isometry, polymorphic_color)
             .draw_arrow(false);
 

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -292,6 +292,11 @@ impl Dir2 {
         // Based on a Taylor approximation of the inverse square root, see [`Dir3::fast_renormalize`] for more details.
         Self(self * (0.5 * (3.0 - length_squared)))
     }
+    /// Returns the perpendicular vector rotated to 90 degrees counterclockwise.
+    #[inline]
+    pub fn perp(self) -> Self {
+        Self::new_unchecked(self.as_vec2().perp())
+    }
 }
 
 impl TryFrom<Vec2> for Dir2 {
@@ -1321,6 +1326,21 @@ mod tests {
             "Denormalization doesn't work, test is faulty"
         );
         assert!(dir_b.is_normalized(), "Renormalisation did not work.");
+    }
+
+    #[test]
+    fn dir2_perp() {
+        // (1, 0) rotated 90 deg counterclockwise becomes (0, 1)
+        assert_eq!(Dir2::X.perp(), Dir2::Y);
+
+        // (0, 1) rotated 90 deg counter-lockwise becomes (-1, 0)
+        assert_eq!(Dir2::Y.perp(), Dir2::NEG_X);
+
+        // (-1, 0) rotated 90 deg counterclockwise becomes (0, -1)
+        assert_eq!(Dir2::NEG_X.perp(), Dir2::NEG_Y);
+
+        // (0, -1) rotated 90 deg counterclockwise becomes (1, 0)
+        assert_eq!(Dir2::NEG_Y.perp(), Dir2::X);
     }
 
     #[test]

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -292,7 +292,7 @@ impl Dir2 {
         // Based on a Taylor approximation of the inverse square root, see [`Dir3::fast_renormalize`] for more details.
         Self(self * (0.5 * (3.0 - length_squared)))
     }
-    
+
     /// Returns the perpendicular vector rotated to 90 degrees counterclockwise.
     #[inline]
     pub fn perpendicular(self) -> Self {

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -292,9 +292,10 @@ impl Dir2 {
         // Based on a Taylor approximation of the inverse square root, see [`Dir3::fast_renormalize`] for more details.
         Self(self * (0.5 * (3.0 - length_squared)))
     }
+    
     /// Returns the perpendicular vector rotated to 90 degrees counterclockwise.
     #[inline]
-    pub fn perp(self) -> Self {
+    pub fn perpendicular(self) -> Self {
         Self::new_unchecked(self.as_vec2().perp())
     }
 }
@@ -1331,16 +1332,16 @@ mod tests {
     #[test]
     fn dir2_perp() {
         // (1, 0) rotated 90 deg counterclockwise becomes (0, 1)
-        assert_eq!(Dir2::X.perp(), Dir2::Y);
+        assert_eq!(Dir2::X.perpendicular(), Dir2::Y);
 
-        // (0, 1) rotated 90 deg counter-lockwise becomes (-1, 0)
-        assert_eq!(Dir2::Y.perp(), Dir2::NEG_X);
+        // (0, 1) rotated 90 deg counterclockwise becomes (-1, 0)
+        assert_eq!(Dir2::Y.perpendicular(), Dir2::NEG_X);
 
         // (-1, 0) rotated 90 deg counterclockwise becomes (0, -1)
-        assert_eq!(Dir2::NEG_X.perp(), Dir2::NEG_Y);
+        assert_eq!(Dir2::NEG_X.perpendicular(), Dir2::NEG_Y);
 
         // (0, -1) rotated 90 deg counterclockwise becomes (1, 0)
-        assert_eq!(Dir2::NEG_Y.perp(), Dir2::X);
+        assert_eq!(Dir2::NEG_Y.perpendicular(), Dir2::X);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #25418

This PR adds a `perp` method to `Dir2` inline with how `glam` implements it for `Vec2`. It utilizes`Self::new_unchecked` since rotating a normalized 2D unit vector by 90 degrees inherently preserves its unit length. 

Unit tests have been added to verify correct rotation and length preservation.