### PR TITLE
Don't cluster light textures as decals in GPU clustering

### DIFF
--- a/crates/bevy_pbr/src/cluster/gpu.rs
+++ b/crates/bevy_pbr/src/cluster/gpu.rs
@@ -1675,7 +1675,8 @@ pub(crate) fn prepare_clusters_for_gpu_clustering(
             Some(view_irradiance_volumes) => view_irradiance_volumes.len() as u32,
             None => 0,
         };
-        let decal_count = render_clustered_decals.len() as u32;
+        // Light textures share the decal buffer but aren't clusterable objects.
+        let decal_count = render_clustered_decals.clusterable_decal_count() as u32;
 
         // Initialize the metadata.
         *view_gpu_clustering_buffers

--- a/crates/bevy_pbr/src/decal/clustered.rs
+++ b/crates/bevy_pbr/src/decal/clustered.rs
@@ -75,7 +75,13 @@ pub struct RenderClusteredDecals {
     /// [`Self::binding_index_to_textures`] holds the inverse mapping.
     texture_to_binding_index: HashMap<AssetId<Image>, i32>,
     /// The information concerning each decal that we provide to the shader.
+    ///
+    /// Light textures follow the true clustered decals in this list, so that
+    /// lights can reference them via their decal indices.
     decals: Vec<RenderClusteredDecal>,
+    /// The number of true clustered decals at the start of `decals`. Light
+    /// textures past this count aren't clusterable objects.
+    clusterable_decal_count: usize,
     /// Maps the [`bevy_render::sync_world::RenderEntity`] of each decal to the
     /// index of that decal in the [`Self::decals`] list.
     entity_to_decal_index: EntityHashMap<usize>,
@@ -88,9 +94,14 @@ impl RenderClusteredDecals {
         self.binding_index_to_textures.clear();
         self.texture_to_binding_index.clear();
         self.decals.clear();
+        self.clusterable_decal_count = 0;
         self.entity_to_decal_index.clear();
     }
 
+    /// Inserts a decal into the buffer, along with its associated textures.
+    ///
+    /// Decals inserted this way aren't assigned to clusters; use the
+    /// [`bevy_light::ClusteredDecal`] component for clusterable decals.
     pub fn insert_decal(
         &mut self,
         entity: Entity,
@@ -122,14 +133,20 @@ impl RenderClusteredDecals {
         self.entity_to_decal_index.get(&entity).copied()
     }
 
-    /// Returns the number of clustered decals in the scene.
+    /// Returns the number of entries in the decal buffer, light textures included.
     pub fn len(&self) -> usize {
         self.decals.len()
     }
 
-    /// Returns true if there are no clustered decals in the scene.
+    /// Returns true if there are no entries in the decal buffer.
     pub fn is_empty(&self) -> bool {
         self.decals.is_empty()
+    }
+
+    /// Returns the number of true clustered decals in the scene, excluding
+    /// light textures, which aren't clusterable objects.
+    pub(crate) fn clusterable_decal_count(&self) -> usize {
+        self.clusterable_decal_count
     }
 }
 
@@ -273,6 +290,11 @@ pub fn extract_decals(
     render_decals.clear();
 
     extract_clustered_decals(&decals, &mut render_decals);
+
+    // Light textures follow the true clustered decals in the buffer, but
+    // aren't clusterable objects. Record where they start.
+    render_decals.clusterable_decal_count = render_decals.decals.len();
+
     extract_spot_light_textures(&spot_light_textures, &mut render_decals);
     extract_point_light_textures(&point_light_textures, &mut render_decals);
     extract_directional_light_textures(&directional_light_textures, &mut render_decals);


### PR DESCRIPTION
# Objective

- Fixes #24836. Since #23036 (GPU clustering), a light texture (`SpotLightTexture`, `PointLightTexture`, `DirectionalLightTexture`) also gets projected onto nearby meshes as a clustered decal, replacing the surface's own material color.

## Solution

Light textures share the clustered decal buffer so that lights can sample them through their `decal_index`, but they aren't clusterable objects. CPU clustering only assigns `ClusteredDecal` entities to clusters, while GPU clustering used the length of the whole decal buffer — light textures included — as `ClusterMetadata.decal_count`. The light textures were therefore written into cluster lists and applied by `apply_decals` as base color decals.

`RenderClusteredDecals` now records how many of its entries are true clustered decals (they occupy the front of the buffer; light textures follow), and GPU clustering uses that count instead of the full buffer length.

One behavior note: decals injected directly into `RenderClusteredDecals` through the public `insert_decal` are no longer assigned to clusters under GPU clustering. That was already the case under CPU clustering, and `insert_decal` is now documented accordingly.

## Testing

- Reproduced with the scene from the issue (a mesh with a spot light and a `SpotLightTexture` on the same entity) on Linux/Vulkan, RTX 4070 Ti SUPER, GPU clustering enabled. Before the fix the texture is composited onto the mesh; after the fix the mesh keeps its material color and the texture only modulates the light, matching 0.18. Output without the texture is pixel-identical before and after.
- `cargo check`, `clippy`, `doc` and `fmt` pass for `bevy_pbr` with `pbr_clustered_decals,pbr_light_textures`.
