### PR TITLE
Remove redundant #[cfg(debug_assertions)]

### DIFF
--- a/crates/bevy_ecs/src/storage/blob_array.rs
+++ b/crates/bevy_ecs/src/storage/blob_array.rs
@@ -106,7 +106,6 @@ impl BlobArray {
     /// [`Vec::len`]: alloc::vec::Vec::len
     #[inline]
     pub unsafe fn get_unchecked(&self, index: usize) -> Ptr<'_> {
-        #[cfg(debug_assertions)]
         debug_assert!(index < self.capacity);
         let size = self.item_layout.size();
         // SAFETY:
@@ -129,7 +128,6 @@ impl BlobArray {
     /// [`Vec::len`]: alloc::vec::Vec::len
     #[inline]
     pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> PtrMut<'_> {
-        #[cfg(debug_assertions)]
         debug_assert!(index < self.capacity);
         let size = self.item_layout.size();
         // SAFETY:
@@ -166,7 +164,6 @@ impl BlobArray {
     ///
     /// [`Vec::len`]: alloc::vec::Vec::len
     pub unsafe fn get_sub_slice<T>(&self, slice_len: usize) -> &[UnsafeCell<T>] {
-        #[cfg(debug_assertions)]
         debug_assert!(slice_len <= self.capacity);
         // SAFETY: the inner data will remain valid for as long as 'self.
         unsafe {
@@ -185,7 +182,6 @@ impl BlobArray {
     ///
     /// [`Vec::clear`]: alloc::vec::Vec::clear
     pub unsafe fn clear(&mut self, len: usize) {
-        #[cfg(debug_assertions)]
         debug_assert!(self.capacity >= len);
         if let Some(drop) = self.drop {
             // We set `self.drop` to `None` before dropping elements for unwind safety. This ensures we don't
@@ -213,7 +209,6 @@ impl BlobArray {
     /// - `cap` and `len` are indeed the capacity and length of this [`BlobArray`]
     /// - This [`BlobArray`] mustn't be used after calling this method.
     pub unsafe fn drop(&mut self, cap: usize, len: usize) {
-        #[cfg(debug_assertions)]
         debug_assert_eq!(self.capacity, cap);
         if cap != 0 {
             self.clear(len);
@@ -236,7 +231,6 @@ impl BlobArray {
     // - After this method is called, the last element must not be used
     // unless [`Self::initialize_unchecked`] is called to set the value of the last element.
     pub unsafe fn drop_last_element(&mut self, last_element_index: usize) {
-        #[cfg(debug_assertions)]
         debug_assert!(self.capacity > last_element_index);
         if let Some(drop) = self.drop {
             // We set `self.drop` to `None` before dropping elements for unwind safety. This ensures we don't
@@ -257,7 +251,6 @@ impl BlobArray {
     /// - Panics if the new capacity overflows `isize::MAX` bytes.
     /// - Panics if the allocation causes an out-of-memory error.
     pub(super) fn alloc(&mut self, capacity: NonZeroUsize) {
-        #[cfg(debug_assertions)]
         debug_assert_eq!(self.capacity, 0);
         if !self.is_zst() {
             let new_layout = self.item_layout.repeat_packed(capacity.get());
@@ -288,7 +281,6 @@ impl BlobArray {
         current_capacity: NonZeroUsize,
         new_capacity: NonZeroUsize,
     ) {
-        #[cfg(debug_assertions)]
         debug_assert_eq!(self.capacity, current_capacity.get());
         if !self.is_zst() {
             let new_layout = self.item_layout.repeat_packed(new_capacity.get());
@@ -326,7 +318,6 @@ impl BlobArray {
     /// - `value` must not point to the same value that is being initialized.
     #[inline]
     pub unsafe fn initialize_unchecked(&mut self, index: usize, value: OwningPtr<'_>) {
-        #[cfg(debug_assertions)]
         debug_assert!(self.capacity > index);
         let size = self.item_layout.size();
         let dst = self.get_unchecked_mut(index);
@@ -347,12 +338,9 @@ impl BlobArray {
         src_index: usize,
         dst_index: usize,
     ) {
-        #[cfg(debug_assertions)]
-        {
-            debug_assert!(src.capacity > src_last_element_index);
-            debug_assert!(src.capacity > src_index);
-            debug_assert!(self.capacity > dst_index);
-        }
+        debug_assert!(src.capacity > src_last_element_index);
+        debug_assert!(src.capacity > src_index);
+        debug_assert!(self.capacity > dst_index);
         // SAFETY:
         // - exclusive references guarantee disjointness
         // - in bounds per precondition
@@ -385,7 +373,6 @@ impl BlobArray {
     ///   and it must be safe to use the `drop` function of this [`BlobArray`] to drop `value`.
     /// - `value` must not point to the same value that is being replaced.
     pub unsafe fn replace_unchecked(&mut self, index: usize, value: OwningPtr<'_>) {
-        #[cfg(debug_assertions)]
         debug_assert!(self.capacity > index);
         // Pointer to the value in the vector that will get replaced.
         // SAFETY: The caller ensures that `index` fits in this vector.
@@ -452,11 +439,8 @@ impl BlobArray {
         index_to_remove: usize,
         index_to_keep: usize,
     ) -> OwningPtr<'_> {
-        #[cfg(debug_assertions)]
-        {
-            debug_assert!(self.capacity > index_to_keep);
-            debug_assert!(self.capacity > index_to_remove);
-        }
+        debug_assert!(self.capacity > index_to_keep);
+        debug_assert!(self.capacity > index_to_remove);
         if index_to_remove != index_to_keep {
             return self.swap_remove_unchecked_nonoverlapping(index_to_remove, index_to_keep);
         }
@@ -480,12 +464,9 @@ impl BlobArray {
         index_to_remove: usize,
         index_to_keep: usize,
     ) -> OwningPtr<'_> {
-        #[cfg(debug_assertions)]
-        {
-            debug_assert!(self.capacity > index_to_keep);
-            debug_assert!(self.capacity > index_to_remove);
-            debug_assert_ne!(index_to_keep, index_to_remove);
-        }
+        debug_assert!(self.capacity > index_to_keep);
+        debug_assert!(self.capacity > index_to_remove);
+        debug_assert_ne!(index_to_keep, index_to_remove);
         core::ptr::swap_nonoverlapping::<u8>(
             self.get_unchecked_mut(index_to_keep).as_ptr(),
             self.get_unchecked_mut(index_to_remove).as_ptr(),
@@ -510,11 +491,8 @@ impl BlobArray {
         index_to_remove: usize,
         index_to_keep: usize,
     ) {
-        #[cfg(debug_assertions)]
-        {
-            debug_assert!(self.capacity > index_to_keep);
-            debug_assert!(self.capacity > index_to_remove);
-        }
+        debug_assert!(self.capacity > index_to_keep);
+        debug_assert!(self.capacity > index_to_remove);
         let drop = self.drop;
         let value = self.swap_remove_unchecked(index_to_remove, index_to_keep);
         if let Some(drop) = drop {
@@ -537,12 +515,9 @@ impl BlobArray {
         index_to_remove: usize,
         index_to_keep: usize,
     ) {
-        #[cfg(debug_assertions)]
-        {
-            debug_assert!(self.capacity > index_to_keep);
-            debug_assert!(self.capacity > index_to_remove);
-            debug_assert_ne!(index_to_keep, index_to_remove);
-        }
+        debug_assert!(self.capacity > index_to_keep);
+        debug_assert!(self.capacity > index_to_remove);
+        debug_assert_ne!(index_to_keep, index_to_remove);
         let drop = self.drop;
         let value = self.swap_remove_unchecked_nonoverlapping(index_to_remove, index_to_keep);
         if let Some(drop) = drop {

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -217,8 +217,7 @@ impl ComponentSparseSet {
         caller: MaybeLocation,
     ) {
         if let Some(&dense_index) = self.sparse.get(entity.index()) {
-            #[cfg(debug_assertions)]
-            assert_eq!(entity, self.entities[dense_index.index()]);
+            debug_assert_eq!(entity, self.entities[dense_index.index()]);
             self.dense.replace(dense_index, value, change_tick, caller);
         } else {
             let dense_index = self.entities.len();
@@ -260,8 +259,7 @@ impl ComponentSparseSet {
         #[cfg(debug_assertions)]
         {
             if let Some(&dense_index) = self.sparse.get(entity.index()) {
-                #[cfg(debug_assertions)]
-                assert_eq!(entity, self.entities[dense_index.index()]);
+                debug_assert_eq!(entity, self.entities[dense_index.index()]);
                 true
             } else {
                 false
@@ -277,8 +275,7 @@ impl ComponentSparseSet {
     #[inline]
     pub fn get(&self, entity: Entity) -> Option<Ptr<'_>> {
         self.sparse.get(entity.index()).map(|&dense_index| {
-            #[cfg(debug_assertions)]
-            assert_eq!(entity, self.entities[dense_index.index()]);
+            debug_assert_eq!(entity, self.entities[dense_index.index()]);
             // SAFETY: if the sparse index points to something in the dense vec, it exists
             unsafe { self.dense.get_data_unchecked(dense_index) }
         })
@@ -290,8 +287,7 @@ impl ComponentSparseSet {
     #[inline]
     pub fn get_with_ticks(&self, entity: Entity) -> Option<(Ptr<'_>, ComponentTickCells<'_>)> {
         let dense_index = *self.sparse.get(entity.index())?;
-        #[cfg(debug_assertions)]
-        assert_eq!(entity, self.entities[dense_index.index()]);
+        debug_assert_eq!(entity, self.entities[dense_index.index()]);
         // SAFETY: if the sparse index points to something in the dense vec, it exists
         unsafe {
             Some((
@@ -312,8 +308,7 @@ impl ComponentSparseSet {
     #[inline]
     pub fn get_added_tick(&self, entity: Entity) -> Option<&UnsafeCell<Tick>> {
         let dense_index = *self.sparse.get(entity.index())?;
-        #[cfg(debug_assertions)]
-        assert_eq!(entity, self.entities[dense_index.index()]);
+        debug_assert_eq!(entity, self.entities[dense_index.index()]);
         // SAFETY: if the sparse index points to something in the dense vec, it exists
         unsafe { Some(self.dense.get_added_tick_unchecked(dense_index)) }
     }
@@ -324,8 +319,7 @@ impl ComponentSparseSet {
     #[inline]
     pub fn get_changed_tick(&self, entity: Entity) -> Option<&UnsafeCell<Tick>> {
         let dense_index = *self.sparse.get(entity.index())?;
-        #[cfg(debug_assertions)]
-        assert_eq!(entity, self.entities[dense_index.index()]);
+        debug_assert_eq!(entity, self.entities[dense_index.index()]);
         // SAFETY: if the sparse index points to something in the dense vec, it exists
         unsafe { Some(self.dense.get_changed_tick_unchecked(dense_index)) }
     }
@@ -336,8 +330,7 @@ impl ComponentSparseSet {
     #[inline]
     pub fn get_ticks(&self, entity: Entity) -> Option<ComponentTicks> {
         let dense_index = *self.sparse.get(entity.index())?;
-        #[cfg(debug_assertions)]
-        assert_eq!(entity, self.entities[dense_index.index()]);
+        debug_assert_eq!(entity, self.entities[dense_index.index()]);
         // SAFETY: if the sparse index points to something in the dense vec, it exists
         unsafe { Some(self.dense.get_ticks_unchecked(dense_index)) }
     }
@@ -352,8 +345,7 @@ impl ComponentSparseSet {
     ) -> MaybeLocation<Option<&UnsafeCell<&'static Location<'static>>>> {
         MaybeLocation::new_with_flattened(|| {
             let dense_index = *self.sparse.get(entity.index())?;
-            #[cfg(debug_assertions)]
-            assert_eq!(entity, self.entities[dense_index.index()]);
+            debug_assert_eq!(entity, self.entities[dense_index.index()]);
             // SAFETY: if the sparse index points to something in the dense vec, it exists
             unsafe { Some(self.dense.get_changed_by_unchecked(dense_index)) }
         })
@@ -371,12 +363,10 @@ impl ComponentSparseSet {
     #[must_use = "The returned pointer must be used to drop the removed component."]
     pub(crate) fn remove_and_forget(&mut self, entity: Entity) -> Option<OwningPtr<'_>> {
         self.sparse.remove(entity.index()).map(|dense_index| {
-            #[cfg(debug_assertions)]
-            assert_eq!(entity, self.entities[dense_index.index()]);
+            debug_assert_eq!(entity, self.entities[dense_index.index()]);
             let last = self.entities.len() - 1;
             if dense_index.index() >= last {
-                #[cfg(debug_assertions)]
-                assert_eq!(dense_index.index(), last);
+                debug_assert_eq!(dense_index.index(), last);
                 // SAFETY: This is strictly decreasing the length, so it cannot outgrow
                 // it also cannot underflow as an item was just removed from the sparse array.
                 unsafe { self.entities.set_len(last) };
@@ -423,12 +413,10 @@ impl ComponentSparseSet {
         self.sparse
             .remove(entity.index())
             .map(|dense_index| {
-                #[cfg(debug_assertions)]
-                assert_eq!(entity, self.entities[dense_index.index()]);
+                debug_assert_eq!(entity, self.entities[dense_index.index()]);
                 let last = self.entities.len() - 1;
                 if dense_index.index() >= last {
-                    #[cfg(debug_assertions)]
-                    assert_eq!(dense_index.index(), last);
+                    debug_assert_eq!(dense_index.index(), last);
                     // SAFETY: This is strictly decreasing the length, so it cannot outgrow
                     // it also cannot underflow as an item was just removed from the sparse array.
                     unsafe { self.entities.set_len(last) };

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -764,7 +764,6 @@ impl Tables {
         row: TableRow,
         change_tick: Tick,
     ) -> TableMoveResult<'_> {
-        #[cfg(debug_assertions)]
         debug_assert!(old_table_id != new_table_id);
         // SAFETY:
         // - The caller ensures `old_table_id` and `new_table_id` do not overlap.
@@ -774,7 +773,6 @@ impl Tables {
                 .get_disjoint_unchecked_mut([old_table_id.as_usize(), new_table_id.as_usize()])
         };
         let last_index = (src_table.entity_count() - 1) as usize;
-        #[cfg(debug_assertions)]
         debug_assert!(row.index() <= last_index);
         // SAFETY:
         // - All pre-existing columns will be written to immediately.

--- a/crates/bevy_ecs/src/storage/thin_array_ptr.rs
+++ b/crates/bevy_ecs/src/storage/thin_array_ptr.rs
@@ -85,8 +85,7 @@ impl<T> ThinArrayPtr<T> {
     /// - The current capacity is indeed greater than 0
     /// - The caller should update their saved `capacity` value to reflect the fact that it was changed
     pub unsafe fn realloc(&mut self, current_capacity: NonZeroUsize, new_capacity: NonZeroUsize) {
-        #[cfg(debug_assertions)]
-        assert_eq!(self.capacity, current_capacity.get());
+        debug_assert_eq!(self.capacity, current_capacity.get());
         self.set_capacity(new_capacity.get());
         if size_of::<T>() != 0 {
             let new_layout =
@@ -141,12 +140,9 @@ impl<T> ThinArrayPtr<T> {
         src_index: usize,
         dst_index: usize,
     ) {
-        #[cfg(debug_assertions)]
-        {
-            debug_assert!(src.capacity > src_last_element_index);
-            debug_assert!(src.capacity > src_index);
-            debug_assert!(self.capacity > dst_index);
-        }
+        debug_assert!(src.capacity > src_last_element_index);
+        debug_assert!(src.capacity > src_index);
+        debug_assert!(self.capacity > dst_index);
         // SAFETY:
         // - exclusive references guarantee disjointness
         // - in bounds per precondition
@@ -230,12 +226,9 @@ impl<T> ThinArrayPtr<T> {
         index_to_remove: usize,
         index_to_keep: usize,
     ) -> T {
-        #[cfg(debug_assertions)]
-        {
-            debug_assert!(self.capacity > index_to_keep);
-            debug_assert!(self.capacity > index_to_remove);
-            debug_assert_ne!(index_to_keep, index_to_remove);
-        }
+        debug_assert!(self.capacity > index_to_keep);
+        debug_assert!(self.capacity > index_to_remove);
+        debug_assert_ne!(index_to_keep, index_to_remove);
         let base_ptr = self.data.as_ptr();
         let value = ptr::read(base_ptr.add(index_to_remove));
         ptr::copy_nonoverlapping(
@@ -297,8 +290,7 @@ impl<T> ThinArrayPtr<T> {
     /// - `current_capacity` is indeed the capacity of the array
     /// - The caller must not use this `ThinArrayPtr` in any way after calling this function
     pub unsafe fn drop(&mut self, current_capacity: usize, current_len: usize) {
-        #[cfg(debug_assertions)]
-        assert_eq!(self.capacity, current_capacity);
+        debug_assert_eq!(self.capacity, current_capacity);
         if current_capacity != 0 {
             self.clear_elements(current_len);
             let layout = Layout::array::<T>(current_capacity).expect("layout should be valid");

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -136,7 +136,6 @@ impl<'w> UnsafeWorldCell<'w> {
         // allows_mutable_access field doesn't exist otherwise.
         // Kinda weird, since debug_assert would never be called,
         // but CI complained in https://github.com/bevyengine/bevy/pull/17393
-        #[cfg(debug_assertions)]
         debug_assert!(
             self.allows_mutable_access,
             "mutating world data via `World::as_unsafe_world_cell_readonly` is forbidden"

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -1126,8 +1126,7 @@ impl<'a, T> ThinSlicePtr<'a, T> {
     pub unsafe fn get_unchecked(&self, index: usize) -> &'a T {
         // We cannot use `debug_assert!` here because `self.len` does not exist when not in debug
         // mode.
-        #[cfg(debug_assertions)]
-        assert!(index < self.len, "tried to index out-of-bounds of a slice");
+        debug_assert!(index < self.len, "tried to index out-of-bounds of a slice");
 
         // SAFETY: The caller guarantees `index` is in-bounds so that the resulting pointer is
         // valid to dereference.
@@ -1141,8 +1140,7 @@ impl<'a, T> ThinSlicePtr<'a, T> {
     /// - There must be no mutable aliases for the lifetime `'a` to the slice. to the slice.
     /// - `len` must be less than or equal to the length of the slice.
     pub unsafe fn as_slice_unchecked(&self, len: usize) -> &'a [T] {
-        #[cfg(debug_assertions)]
-        assert!(len <= self.len, "tried to create an out-of-bounds slice");
+        debug_assert!(len <= self.len, "tried to create an out-of-bounds slice");
 
         // SAFETY:
         // - The caller guarantees `len` is not greater than the length of the slice.
@@ -1172,8 +1170,7 @@ impl<'a, T> ThinSlicePtr<'a, UnsafeCell<T>> {
     /// - There must not be any aliases for the lifetime `'a` to the slice.
     /// - `len` must be less than or equal to the length of the slice.
     pub unsafe fn as_mut_slice_unchecked(&self, len: usize) -> &'a mut [T] {
-        #[cfg(debug_assertions)]
-        assert!(len <= self.len, "tried to create an out-of-bounds slice");
+        debug_assert!(len <= self.len, "tried to create an out-of-bounds slice");
 
         // SAFETY:
         // - The caller ensures no aliases exist and `len` is in-bounds.


### PR DESCRIPTION
# Objective

`debug_assert`, `debug_assert_eq`, etc. macros already do a check internally for `#[cfg(debug_assertions)]`, so we don't need to mark them ourselves.

## Solution

Remove all of the redundant `#[cfg(debug_assertions)]`, and replace any normal `assert`, `assert_eq`, etc. that were gated with it, to be `debug_assert`, `debug_assert_eq`, etc. instead.
