### PR TITLE
Add a static hint of whether the summary tick is present or not

### DIFF
--- a/_release-content/release-notes/per_column_change_ticks.md
+++ b/_release-content/release-notes/per_column_change_ticks.md
@@ -1,7 +1,7 @@
 ---
 title: Per-column change ticks
-authors: ["@pcwalton"]
-pull_requests: [25157]
+authors: ["@pcwalton", "@SkiFire13"]
+pull_requests: [25157, 25429]
 ---
 
-TODO
+A new summary change tick is now stored per-column, representing the last time any component in that column was changed. This allows skipping the whole column in case no component was changed, as opposed to going through each component checking them individually.

--- a/crates/bevy_ecs/macro_logic/src/component.rs
+++ b/crates/bevy_ecs/macro_logic/src/component.rs
@@ -229,9 +229,7 @@ impl DeriveComponent {
         // If this component has a summary tick, define the appropriate method.
         let has_summary_tick = if self.summary_tick {
             quote! {
-                fn has_summary_tick() -> bool {
-                    true
-                }
+                const HAS_SUMMARY_TICK: bool = true;
             }
         } else {
             quote! {}

--- a/crates/bevy_ecs/src/component/info.rs
+++ b/crates/bevy_ecs/src/component/info.rs
@@ -270,7 +270,7 @@ impl ComponentDescriptor {
 
     /// Create a new `ComponentDescriptor` for the type `T`.
     pub fn new<T: Component>() -> Self {
-        let summary_tick = T::has_summary_tick();
+        let summary_tick = T::HAS_SUMMARY_TICK;
         assert!(
             !summary_tick || matches!(T::STORAGE_TYPE, StorageType::Table),
             "Summary ticks are only supported for table components"

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -674,7 +674,7 @@ pub trait Component: Send + Sync + 'static {
         None
     }
 
-    /// Return true from this method if the component should track a summary
+    /// Set true to this constant if the component should track a summary
     /// tick.
     ///
     /// Summary ticks allow users of contiguous iteration queries to skip
@@ -687,11 +687,8 @@ pub trait Component: Send + Sync + 'static {
     /// Summary ticks are only valid for table components. If the component is a
     /// sparse set component, this method must return false.
     ///
-    /// By default, this method returns false.
-    #[inline]
-    fn has_summary_tick() -> bool {
-        false
-    }
+    /// By default, this constant is set to false.
+    const HAS_SUMMARY_TICK: bool = false;
 }
 
 mod private {

--- a/crates/bevy_ecs/src/component/mod.rs
+++ b/crates/bevy_ecs/src/component/mod.rs
@@ -674,7 +674,7 @@ pub trait Component: Send + Sync + 'static {
         None
     }
 
-    /// Set true to this constant if the component should track a summary
+    /// Set this constant to true if the component should track a summary
     /// tick.
     ///
     /// Summary ticks allow users of contiguous iteration queries to skip

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -2529,8 +2529,8 @@ unsafe impl<'__w, T: Component<Mutability = Mutable>> QueryData for &'__w mut T 
                 let caller =
                     callers.map(|callers| unsafe { callers.get_unchecked(table_row.index()) });
                 // Make it statically known whether the atomic tick is present or not.
-                let summary_tick = if T::has_summary_tick() {
-                    // SAFETY: Summary tick presence always matches `T::has_summary_tick()`.
+                let summary_tick = if T::HAS_SUMMARY_TICK {
+                    // SAFETY: Summary tick presence always matches `T::HAS_SUMMARY_TICK`.
                     Some(unsafe { summary_tick.debug_checked_unwrap() })
                 } else {
                     None

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -2528,6 +2528,13 @@ unsafe impl<'__w, T: Component<Mutability = Mutable>> QueryData for &'__w mut T 
                 // SAFETY: The caller ensures `table_row` is in range.
                 let caller =
                     callers.map(|callers| unsafe { callers.get_unchecked(table_row.index()) });
+                // Make it statically known whether the atomic tick is present or not.
+                let summary_tick = if T::has_summary_tick() {
+                    // SAFETY: Summary tick presence always matches `T::has_summary_tick()`.
+                    Some(unsafe { summary_tick.debug_checked_unwrap() })
+                } else {
+                    None
+                };
 
                 Mut {
                     value: component.deref_mut(),


### PR DESCRIPTION
# Objective

- #25157 made some benchmarks worse. Let's try to recover some of the performance.

## Solution

- This RP adds a static hint for whether the summary tick is present or not. This is done in the `QueryData::fetch` implementation, where `T` is known to implement `Component` and thus we can statically get whether it enables the summary tick or not.
- Here are some results for the `iter` benchmarks on my Macbook M4 Pro:

```
group                                              after                                  before
-----                                              -----                                  ------
iter_fragmented(4096)_empty/foreach_sparse         1.01      6.4±0.12µs        ? ?/sec    1.00      6.3±0.11µs        ? ?/sec
iter_fragmented(4096)_empty/foreach_table          1.00  1908.5±62.72ns        ? ?/sec    1.01  1921.3±80.69ns        ? ?/sec
iter_fragmented/base                               1.00    204.5±4.92ns        ? ?/sec    1.38   281.8±37.62ns        ? ?/sec
iter_fragmented/foreach                            1.00     65.3±0.41ns        ? ?/sec    3.57    233.3±3.12ns        ? ?/sec
iter_fragmented/foreach_wide                       1.00     11.0±0.16µs        ? ?/sec    1.08     11.9±0.50µs        ? ?/sec
iter_fragmented/wide                               1.00      2.2±0.11µs        ? ?/sec    2.21      5.0±0.04µs        ? ?/sec
iter_fragmented_sparse/base                        1.00      4.5±0.16ns        ? ?/sec    1.23      5.6±0.24ns        ? ?/sec
iter_fragmented_sparse/foreach                     1.00      3.7±0.03ns        ? ?/sec    1.48      5.5±0.05ns        ? ?/sec
iter_fragmented_sparse/foreach_wide                1.00    127.4±2.10ns        ? ?/sec    1.03    131.9±1.38ns        ? ?/sec
iter_fragmented_sparse/wide                        1.00     35.7±1.24ns        ? ?/sec    1.48     52.8±0.96ns        ? ?/sec
iter_simple/base                                   1.00      5.4±0.04µs        ? ?/sec    1.01      5.5±0.12µs        ? ?/sec
iter_simple/base_contiguous                        1.00      2.8±0.07µs        ? ?/sec    1.00      2.8±0.03µs        ? ?/sec
iter_simple/base_no_detection                      1.00      4.6±0.02µs        ? ?/sec    1.00      4.6±0.02µs        ? ?/sec
iter_simple/base_no_detection_contiguous           1.00      2.5±0.10µs        ? ?/sec    1.00      2.5±0.05µs        ? ?/sec
iter_simple/foreach                                1.00      3.0±0.06µs        ? ?/sec    1.00      3.0±0.05µs        ? ?/sec
iter_simple/foreach_hybrid                         1.00      6.8±0.06µs        ? ?/sec    1.00      6.9±0.27µs        ? ?/sec
iter_simple/foreach_sparse_set                     1.01     14.5±0.63µs        ? ?/sec    1.00     14.4±0.10µs        ? ?/sec
iter_simple/foreach_wide                           1.00    112.0±2.31µs        ? ?/sec    1.01    112.9±2.35µs        ? ?/sec
iter_simple/foreach_wide_sparse_set                1.02    271.3±4.60µs        ? ?/sec    1.00    265.1±4.70µs        ? ?/sec
iter_simple/sparse_set                             1.00     13.7±0.07µs        ? ?/sec    1.00     13.7±0.09µs        ? ?/sec
iter_simple/summary_tick                           1.00     10.0±0.13µs        ? ?/sec    1.24     12.3±0.15µs        ? ?/sec
iter_simple/system                                 1.00      5.4±0.03µs        ? ?/sec    1.00      5.5±0.05µs        ? ?/sec
iter_simple/wide                                   1.00     32.8±0.64µs        ? ?/sec    1.81     59.3±1.06µs        ? ?/sec
iter_simple/wide_sparse_set                        1.00    117.3±1.60µs        ? ?/sec    1.00    117.0±1.41µs        ? ?/sec
par_iter_simple/hybrid                             1.07    49.4±12.13µs        ? ?/sec    1.00     46.2±1.08µs        ? ?/sec
par_iter_simple/summary_tick_with_0_fragment       1.00     48.2±1.83µs        ? ?/sec    1.01     48.5±0.51µs        ? ?/sec
par_iter_simple/summary_tick_with_1000_fragment    1.00     54.6±5.25µs        ? ?/sec    1.00     54.5±0.85µs        ? ?/sec
par_iter_simple/summary_tick_with_100_fragment     1.00     48.6±0.62µs        ? ?/sec    1.01     49.0±0.59µs        ? ?/sec
par_iter_simple/summary_tick_with_10_fragment      1.00     48.5±0.82µs        ? ?/sec    1.01     49.2±2.18µs        ? ?/sec
par_iter_simple/with_0_fragment                    1.00     29.0±0.30µs        ? ?/sec    1.01     29.3±0.47µs        ? ?/sec
par_iter_simple/with_1000_fragment                 1.00     34.8±0.67µs        ? ?/sec    1.03     35.7±1.41µs        ? ?/sec
par_iter_simple/with_100_fragment                  1.00     28.8±0.60µs        ? ?/sec    1.00     28.9±0.45µs        ? ?/sec
par_iter_simple/with_10_fragment                   1.00     28.8±0.79µs        ? ?/sec    1.03     29.7±3.10µs        ? ?/sec
```

## Testing

- Existing tests pass, no new tests needed.