### PR TITLE
Don't panic when a nested load rejects an unapproved path

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -739,7 +739,8 @@ mod tests {
         loader::{AssetLoader, LoadContext},
         Asset, AssetApp, AssetEvent, AssetId, AssetLoadError, AssetLoadFailedEvent, AssetPath,
         AssetPlugin, AssetServer, Assets, InvalidGenerationError, LoadState, LoadedAsset,
-        UnapprovedPathMode, UntypedHandle, VisitAssetDependencies, WriteDefaultMetaError,
+        LoadedUntypedAsset, UnapprovedPathMode, UntypedHandle, VisitAssetDependencies,
+        WriteDefaultMetaError,
     };
     use alloc::{
         boxed::Box,
@@ -783,6 +784,42 @@ mod tests {
     #[derive(Asset, TypePath, Debug)]
     pub struct SubText {
         pub text: String,
+    }
+
+    /// An asset whose loader performs a nested *untyped* load, to exercise
+    /// [`NestedLoadBuilder::load_untyped`](crate::NestedLoadBuilder::load_untyped).
+    #[derive(Asset, TypePath, Debug)]
+    pub struct UntypedDependent {
+        #[dependency]
+        pub dependency: Handle<LoadedUntypedAsset>,
+    }
+
+    #[derive(Default, TypePath)]
+    pub struct UntypedDependentLoader;
+
+    impl AssetLoader for UntypedDependentLoader {
+        type Asset = UntypedDependent;
+
+        type Settings = ();
+
+        type Error = std::io::Error;
+
+        async fn load(
+            &self,
+            reader: &mut dyn Reader,
+            _settings: &Self::Settings,
+            load_context: &mut LoadContext<'_>,
+        ) -> Result<Self::Asset, Self::Error> {
+            let mut bytes = Vec::new();
+            reader.read_to_end(&mut bytes).await?;
+            Ok(UntypedDependent {
+                dependency: load_context.load_builder().load_untyped("../a.cool.ron"),
+            })
+        }
+
+        fn extensions(&self) -> &[&str] {
+            &["untyped_dependent"]
+        }
     }
 
     #[derive(Serialize, Deserialize, Default)]
@@ -2131,6 +2168,22 @@ mod tests {
 
         dir.insert_asset_text(Path::new(a_path), a_ron);
 
+        // An approved asset that declares the unapproved asset above as a dependency, so that the
+        // unapproved path is reached through a nested load from inside an `AssetLoader`.
+        let dependent_path = "dependent.cool.ron";
+        let dependent_ron = r#"
+(
+    text: "dependent",
+    dependencies: ["../a.cool.ron"],
+    embedded_dependencies: [],
+    sub_texts: [],
+)"#;
+
+        dir.insert_asset_text(Path::new(dependent_path), dependent_ron);
+
+        // Reached through a nested *untyped* load; the contents are unused.
+        dir.insert_asset_text(Path::new("dependent.untyped_dependent"), "");
+
         let mut app = App::new();
         let memory_reader = MemoryAssetReader { root: dir };
         app.register_asset_source(
@@ -2190,6 +2243,68 @@ mod tests {
 
         // Make sure this asset actually loads.
         run_app_until(&mut app, |_| asset_server.is_loaded(&handle).then_some(()));
+    }
+
+    /// Regression test for [#21584](https://github.com/bevyengine/bevy/issues/21584).
+    ///
+    /// Rejecting an unapproved path yields a default (`Uuid`) handle, but nested loads assumed
+    /// they always received a `Strong` handle and unwrapped the conversion, panicking inside the
+    /// asset loader. The nested load should instead be skipped, matching the behavior of a
+    /// top-level [`AssetServer::load`] of an unapproved path.
+    #[test]
+    fn unapproved_path_deny_does_not_panic_in_nested_load() {
+        let mut app = unapproved_path_setup(UnapprovedPathMode::Deny);
+
+        let asset_server = app.world().resource::<AssetServer>().clone();
+        let handle = asset_server.load::<CoolText>("dependent.cool.ron");
+
+        run_app_until(&mut app, |_| {
+            matches!(
+                asset_server.load_state(&handle),
+                LoadState::Loaded | LoadState::Failed(_)
+            )
+            .then_some(())
+        });
+
+        assert!(
+            matches!(asset_server.load_state(&handle), LoadState::Loaded),
+            "an unapproved dependency should be rejected without failing the whole load, but got {:?}",
+            asset_server.load_state(&handle)
+        );
+
+        let cool_text = get::<CoolText>(app.world(), handle.id()).unwrap();
+        assert_eq!(cool_text.text, "dependent");
+        // The rejected dependency resolves to a default handle rather than panicking.
+        assert_eq!(cool_text.dependencies, vec![Handle::default()]);
+    }
+
+    /// Regression test for [#21584](https://github.com/bevyengine/bevy/issues/21584), covering the
+    /// untyped nested load path, which rejects unapproved paths the same way.
+    #[test]
+    fn unapproved_path_deny_does_not_panic_in_nested_untyped_load() {
+        let mut app = unapproved_path_setup(UnapprovedPathMode::Deny);
+        app.init_asset::<UntypedDependent>()
+            .register_asset_loader(UntypedDependentLoader);
+
+        let asset_server = app.world().resource::<AssetServer>().clone();
+        let handle = asset_server.load::<UntypedDependent>("dependent.untyped_dependent");
+
+        run_app_until(&mut app, |_| {
+            matches!(
+                asset_server.load_state(&handle),
+                LoadState::Loaded | LoadState::Failed(_)
+            )
+            .then_some(())
+        });
+
+        assert!(
+            matches!(asset_server.load_state(&handle), LoadState::Loaded),
+            "an unapproved untyped dependency should be rejected without failing the whole load, but got {:?}",
+            asset_server.load_state(&handle)
+        );
+
+        let dependent = get::<UntypedDependent>(app.world(), handle.id()).unwrap();
+        assert_eq!(dependent.dependency, Handle::default());
     }
 
     #[test]

--- a/crates/bevy_asset/src/loader_builders.rs
+++ b/crates/bevy_asset/src/loader_builders.rs
@@ -4,8 +4,9 @@
 use crate::{
     io::Reader,
     meta::{loader_settings_meta_transform, MetaTransform, Settings},
-    Asset, AssetPath, ErasedAssetLoader, ErasedLoadedAsset, Handle, LoadContext, LoadDirectError,
-    LoadedAsset, LoadedUntypedAsset, RequestedHandleTypeMismatchError, UntypedHandle,
+    Asset, AssetPath, ErasedAssetIndex, ErasedAssetLoader, ErasedLoadedAsset, Handle, LoadContext,
+    LoadDirectError, LoadedAsset, LoadedUntypedAsset, RequestedHandleTypeMismatchError,
+    UntypedHandle,
 };
 use alloc::{borrow::ToOwned, boxed::Box, sync::Arc};
 use core::any::{type_name, TypeId};
@@ -129,10 +130,12 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
                 .asset_server
                 .get_or_create_path_handle(path, self.meta_transform)
         };
-        // `load_unknown_type_with_meta_transform` and `get_or_create_path_handle` always returns a
-        // Strong variant, so we are safe to unwrap.
-        let index = (&handle).try_into().unwrap();
-        self.load_context.dependencies.insert(index);
+        // `load_unknown_type_with_meta_transform` returns a default `Uuid` handle when it refuses
+        // to start the load, for example because the path is unapproved. There is no load to
+        // track as a dependency in that case, and the reason has already been logged.
+        if let Ok(index) = ErasedAssetIndex::try_from(&handle) {
+            self.load_context.dependencies.insert(index);
+        }
         handle
     }
 
@@ -246,10 +249,12 @@ impl<'ctx, 'builder> NestedLoadBuilder<'ctx, 'builder> {
                 .asset_server
                 .get_or_create_path_handle_erased(path, type_id, type_name, self.meta_transform)
         };
-        // `load_with_meta_transform` and `get_or_create_path_handle` always returns a Strong
-        // variant, so we are safe to unwrap.
-        let index = (&handle).try_into().unwrap();
-        self.load_context.dependencies.insert(index);
+        // `load_with_meta_transform` returns a default `Uuid` handle when it refuses to start the
+        // load, for example because the path is unapproved. There is no load to track as a
+        // dependency in that case, and the reason has already been logged.
+        if let Ok(index) = ErasedAssetIndex::try_from(&handle) {
+            self.load_context.dependencies.insert(index);
+        }
         handle
     }
 


### PR DESCRIPTION
# Objective

- When an asset loader loads a dependency whose path is unapproved, the nested load panics inside the loader rather than being rejected cleanly. The panic is caught and surfaced as `AssetLoaderPanic`, so the outer asset fails to load as well.
- This affects the default configuration: `UnapprovedPathMode` defaults to `Forbid`. It also occurs under `Deny` without an override.
- A top-level `AssetServer::load` of the same path already returns a default handle without panicking, so the direct and nested paths currently disagree.
- Fixes #21584

## Solution

- Rather than unwrapping the handle-to-index conversion, only register the dependency when the handle actually has an index:

  ```rust
  if let Ok(index) = ErasedAssetIndex::try_from(&handle) {
      self.load_context.dependencies.insert(index);
  }

## Testing

- **Did you test these changes? If so, how?**
Two regression tests were added, one covering `load` and one covering `load_untyped`. Both were written before the fix and confirmed to fail against the unfixed code with the panic from the issue (`called Result::unwrap() on an Err value: UuidNotSupportedError`). For the `load_untyped` fix I re-introduced just that one line to check its test failed independently, then restored it. The full crate suite passes: 108 unit tests and 15 doc-tests. `cargo fmt` and `cargo clippy --all-targets --all-features -- -Dwarnings` are clean, and `cargo check -p bevy` still builds.

- **Are there any parts that need more testing?**
Both new tests use `UnapprovedPathMode::Deny`. `Forbid` is the default and reaches the same branch, but is not separately exercised for the nested case, so that may be worth adding. `load_erased` shares `load_internal` with `load`, so it is covered by the same code path but not through its own entry point.

- **How can other people (reviewers) test your changes?**
`cargo test -p bevy_asset --lib unapproved_path` runs all six unapproved-path tests in well under a second. To see the original failure, change the `if let Ok(index) = ...` block in `NestedLoadBuilder::load_internal` back to `.try_into().unwrap()` and re-run.

- **What platforms did you test on?**
Windows 11, `x86_64-pc-windows-msvc`, rustc 1.97.1. The change is platform-independent (no `cfg` branches, no platform APIs), but I have not run it on Linux, macOS or wasm.