### PR TITLE
Migrate `3d_shapes` to feathers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1211,6 +1211,7 @@ wasm = true
 name = "3d_shapes"
 path = "examples/3d/3d_shapes.rs"
 doc-scrape-examples = true
+required-features = ["bevy_feathers"]
 
 [package.metadata.example.3d_shapes]
 name = "3D Shapes"

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -283,7 +283,7 @@ fn spawn_buttons(commands: &mut Commands) {
             Children [
                 feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
                 feathers_option_checkbox("WIREFRAME", Some(CheckboxInput::Wireframe)),
-                feathers_button("ADVANCE ROWS", Some(ButtonInput::AdvanceRows)),
+                feathers_button("ADVANCE ROWS", None::<ButtonInput>),
             ]
         });
     } else {
@@ -291,7 +291,7 @@ fn spawn_buttons(commands: &mut Commands) {
             top_left_scene()
             Children [
                 feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
-                feathers_button("ADVANCE ROWS", Some(ButtonInput::AdvanceRows)),
+                feathers_button("ADVANCE ROWS", None::<ButtonInput>),
             ]
         });
     }

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -26,7 +26,7 @@ use bevy::{
     ui_widgets::{checkbox_self_update, Activate, ValueChange},
 };
 use button::feathers_button;
-use checkbox::feathers_option_checkbox;
+use checkbox::{feathers_option_checkbox, IsChecked};
 use scene::top_left_scene;
 
 #[path = "../helpers/button.rs"]
@@ -281,8 +281,8 @@ fn spawn_buttons(commands: &mut Commands) {
         commands.spawn_scene(bsn! {
             top_left_scene()
             Children [
-                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
-                feathers_option_checkbox("WIREFRAME", Some(CheckboxInput::Wireframe)),
+                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation), IsChecked(false)),
+                feathers_option_checkbox("WIREFRAME", Some(CheckboxInput::Wireframe), IsChecked(false)),
                 feathers_button("ADVANCE ROWS", None::<ButtonInput>),
             ]
         });
@@ -290,7 +290,7 @@ fn spawn_buttons(commands: &mut Commands) {
         commands.spawn_scene(bsn! {
             top_left_scene()
             Children [
-                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
+                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation), IsChecked(false)),
                 feathers_button("ADVANCE ROWS", None::<ButtonInput>),
             ]
         });

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -20,29 +20,63 @@ use bevy::pbr::wireframe::{WireframeConfig, WireframePlugin};
 use bevy::{
     asset::RenderAssetUsages,
     color::palettes::basic::SILVER,
-    input::common_conditions::{input_just_pressed, input_toggle_active},
+    feathers::{controls::FeathersCheckbox, theme::UiTheme, FeathersPlugins},
     prelude::*,
     render::render_resource::{Extent3d, TextureDimension, TextureFormat},
+    ui_widgets::{checkbox_self_update, Activate, ValueChange},
 };
+use button::feathers_button;
+use checkbox::feathers_option_checkbox;
+use scene::top_left_scene;
+
+#[path = "../helpers/button.rs"]
+mod button;
+
+#[path = "../helpers/checkbox.rs"]
+mod checkbox;
+
+#[path = "../helpers/theme.rs"]
+mod theme;
+
+#[path = "../helpers/scene.rs"]
+#[expect(dead_code, reason = "some scenes are not used in this example")]
+mod scene;
 
 fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins.set(ImagePlugin::default_nearest()),
+            FeathersPlugins,
             #[cfg(not(target_arch = "wasm32"))]
             WireframePlugin::default(),
         ))
+        .insert_resource(UiTheme(theme::basic_example_theme(Color::WHITE)))
+        .init_resource::<AppStatus>()
         .add_systems(Startup, setup)
-        .add_systems(
-            Update,
-            (
-                rotate.run_if(input_toggle_active(true, KeyCode::KeyR)),
-                advance_rows.run_if(input_just_pressed(KeyCode::Tab)),
-                #[cfg(not(target_arch = "wasm32"))]
-                toggle_wireframe,
-            ),
-        )
+        .add_systems(Update, (rotate.run_if(rotate_checkbox_checked),))
+        .add_observer(handle_value_change_checkbox)
+        .add_observer(handle_button_press)
+        .add_observer(checkbox_self_update)
         .run();
+}
+
+/// Settings for the example.
+#[derive(Resource, Default)]
+struct AppStatus {
+    rotation: bool,
+}
+
+#[derive(Clone, Copy, Component, Debug, Default, PartialEq)]
+enum CheckboxInput {
+    #[default]
+    Rotation,
+    Wireframe,
+}
+
+#[derive(Clone, Copy, Component, Debug, Default, PartialEq)]
+enum ButtonInput {
+    #[default]
+    AdvanceRows,
 }
 
 /// A marker component for our shapes so we can query them separately from the ground plane
@@ -203,23 +237,7 @@ fn setup(
         Camera3d::default(),
         Transform::from_xyz(0.0, 7., 14.0).looking_at(Vec3::new(0., 1., 0.), Vec3::Y),
     ));
-
-    let mut text = "\
-        Press 'R' to pause/resume rotation\n\
-        Press 'Tab' to cycle through rows"
-        .to_string();
-    #[cfg(not(target_arch = "wasm32"))]
-    text.push_str("\nPress 'Space' to toggle wireframes");
-
-    commands.spawn((
-        Text::new(text),
-        Node {
-            position_type: PositionType::Absolute,
-            top: px(12),
-            left: px(12),
-            ..default()
-        },
-    ));
+    spawn_buttons(&mut commands);
 }
 
 fn rotate(mut query: Query<&mut Transform, With<Shape>>, time: Res<Time>) {
@@ -257,14 +275,58 @@ fn uv_debug_texture() -> Image {
     )
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-fn toggle_wireframe(
-    mut wireframe_config: ResMut<WireframeConfig>,
-    keyboard: Res<ButtonInput<KeyCode>>,
-) {
-    if keyboard.just_pressed(KeyCode::Space) {
-        wireframe_config.global = !wireframe_config.global;
+/// Spawns the control widgets in the top left corner of the screen.
+fn spawn_buttons(commands: &mut Commands) {
+    if !cfg!(target_arch = "wasm32") {
+        commands.spawn_scene(bsn! {
+            top_left_scene()
+            Children [
+                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
+                feathers_option_checkbox("WIREFRAME", Some(CheckboxInput::Wireframe)),
+                feathers_button("ADVANCE ROWS", Some(ButtonInput::AdvanceRows)),
+            ]
+        });
+    } else {
+        commands.spawn_scene(bsn! {
+            top_left_scene()
+            Children [
+                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
+                feathers_button("ADVANCE ROWS", Some(ButtonInput::AdvanceRows)),
+            ]
+        });
     }
+}
+
+fn rotate_checkbox_checked(app_status: Res<AppStatus>) -> bool {
+    app_status.rotation
+}
+
+fn handle_value_change_checkbox(
+    event: On<ValueChange<bool>>,
+    #[cfg(not(target_arch = "wasm32"))] mut wireframe_config: ResMut<WireframeConfig>,
+    mut app_status: ResMut<AppStatus>,
+    checkbox_input_q: Query<&CheckboxInput, With<FeathersCheckbox>>,
+) {
+    if let Ok(checkbox_input) = checkbox_input_q.get(event.source) {
+        match checkbox_input {
+            CheckboxInput::Rotation => {
+                app_status.rotation = event.value;
+            }
+            #[cfg(target_arch = "wasm32")]
+            CheckboxInput::Wireframe => {}
+            #[cfg(not(target_arch = "wasm32"))]
+            CheckboxInput::Wireframe => {
+                wireframe_config.global = event.value;
+            }
+        }
+    }
+}
+
+fn handle_button_press(
+    _activate: On<Activate>,
+    shapes: Query<(&mut Row, &mut Transform), With<Shape>>,
+) {
+    advance_rows(shapes);
 }
 
 #[derive(Component, Clone, Copy)]

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -10,7 +10,7 @@
 //!
 //! The mesh and material are [`Handle<Mesh>`] and [`Handle<StandardMaterial>`] at the moment, neither of which implement `Component` on their own. Handles are put behind "newtypes" to prevent ambiguity, as some entities might want to have handles to meshes (or images, or materials etc.) for different purposes! All we need to do to make them rendering-relevant components is wrap the mesh handle and the material handle in [`Mesh3d`] and [`MeshMaterial3d`] respectively.
 //!
-//! You can toggle wireframes with the space bar except on wasm. Wasm does not support
+//! You can toggle wireframes via checkbox except on wasm. Wasm does not support
 //! `POLYGON_MODE_LINE` on the gpu.
 
 use std::f32::consts::PI;

--- a/examples/helpers/button.rs
+++ b/examples/helpers/button.rs
@@ -1,0 +1,46 @@
+/// Helpers to create an action button using `FeathersButtons`.
+/// Using these helpers requires the `bevy_feathers` feature to be enabled.
+use bevy::{
+    feathers::{controls::FeathersButton, display::caption},
+    picking::hover::Hovered,
+    prelude::*,
+};
+
+/// Creates a single feathers button that allows activation of a setting.  
+///
+/// Examples that use this to create a button should handle its `On<Activate>` trigger.
+/// If there is a need to identify the button that originated the activation trigger,
+/// query which `button_identifier` with the `FeathersButton` is the trigger's source entity.
+pub fn feathers_button<T>(option_name: &str, button_identifier: Option<T>) -> Box<dyn Scene>
+where
+    T: Template<Output: Component> + Clone + Default + Send + Sync + Unpin + 'static,
+{
+    if let Some(identifier) = button_identifier {
+        Box::new(bsn! {
+            Node {
+                align_items: AlignItems::Center,
+                column_gap: px(5),
+            }
+            Children [
+                @FeathersButton {
+                    @caption: bsn! { caption(option_name) }
+                }
+                Hovered::default()
+                template_value(identifier)
+            ]
+        })
+    } else {
+        Box::new(bsn! {
+            Node {
+                align_items: AlignItems::Center,
+                column_gap: px(5),
+            }
+            Children [
+                @FeathersButton {
+                    @caption: bsn! { caption(option_name) }
+                }
+                Hovered::default()
+            ]
+        })
+    }
+}

--- a/examples/helpers/theme.rs
+++ b/examples/helpers/theme.rs
@@ -114,15 +114,15 @@ pub fn basic_example_theme(text_color: Color) -> ThemeProps {
     // Feathers Button / Select
     color.insert(
         bevy::feathers::tokens::BUTTON_BG,
-        bevy::feathers::palette::TRANSPARENT,
+        bevy::feathers::palette::BLACK,
     );
     color.insert(
         bevy::feathers::tokens::BUTTON_BG_HOVER,
-        bevy::feathers::palette::TRANSPARENT,
+        bevy::feathers::palette::GRAY_0,
     );
     color.insert(
         bevy::feathers::tokens::BUTTON_BG_PRESSED,
-        bevy::feathers::palette::TRANSPARENT,
+        bevy::feathers::palette::GRAY_1,
     );
     color.insert(
         bevy::feathers::tokens::MENU_BG,


### PR DESCRIPTION
# Objective
Part of #25032

## Solution
Added a button helper (just used existing themes); migrated to use feathers checkboxes and buttons. 

## Testing
`cargo run --example 3d_shapes --features="bevy_feathers"`

On Wasm: 
```
cargo build --release --example 3d_shapes --features="bevy_feathers" --target wasm32-unknown-unknown 
wasm-bindgen --out-name wasm_example \ 
  --out-dir examples/wasm/target \ 
  --target web target/wasm32-unknown-unknown/release/examples/3d_shapes.wasm 

python3 -m http.server --directory examples/wasm 
```
https://github.com/user-attachments/assets/8cbd670d-7108-4ba0-99b7-5e2b0a5ff5d5

