### PR TITLE
Fix typo in AlignedVec docs

### DIFF
--- a/crates/bevy_platform/src/collections/aligned_vec.rs
+++ b/crates/bevy_platform/src/collections/aligned_vec.rs
@@ -1,4 +1,4 @@
-//! Provides [`AlignedVec`] based on [bevy_platform::collections::AlignedVec](https://github.com/rkyv/rkyv/blob/main/rkyv/src/util/alloc/aligned_vec.rs)'s implementation but the alignment can be set at runtime.
+//! Provides [`AlignedVec`] based on [rkyv::util::AlignedVec](https://github.com/rkyv/rkyv/blob/main/rkyv/src/util/alloc/aligned_vec.rs)'s implementation but the alignment can be set at runtime.
 //!
 //! The original source code, adapted here, is copyright 2021 David Koloski, used here under the MIT License.
 #![expect(unsafe_code, reason = "This struct needs to interact with raw memory")]


### PR DESCRIPTION
Link text should be referencing rkyv's AlignedVec rather than Bevy's.
