### PR TITLE
`ImageNode::with_visual_box` builder method

### DIFF
--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -186,6 +186,13 @@ impl ImageNode {
         self.image_mode = mode;
         self
     }
+
+    /// Set the region within the UI node where the image should be drawn.
+    #[must_use]
+    pub const fn with_visual_box(mut self, visual_box: VisualBox) -> Self {
+        self.visual_box = visual_box;
+        self
+    }
 }
 
 impl From<Handle<Image>> for ImageNode {


### PR DESCRIPTION
# Objective

`ImageNode` has builder methods for the all its fields except `visual_box`. Add one.

## Solution

Add a `with_visual_box` method.