### PR TITLE
Use `import package` in wesl files

### DIFF
--- a/crates/bevy_core_pipeline/src/blit/blit.wesl
+++ b/crates/bevy_core_pipeline/src/blit/blit.wesl
@@ -1,4 +1,4 @@
-import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
+import package::fullscreen_vertex_shader::FullscreenVertexOutput;
 @if(SRGB_TO_LINEAR) import bevy_render::color_operations::srgb_to_linear;
 @if(OKLAB_TO_LINEAR) import bevy_render::color_operations::oklab_to_linear_rgb;
 

--- a/crates/bevy_core_pipeline/src/deferred/copy_deferred_lighting_id.wesl
+++ b/crates/bevy_core_pipeline/src/deferred/copy_deferred_lighting_id.wesl
@@ -1,4 +1,4 @@
-import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
+import package::fullscreen_vertex_shader::FullscreenVertexOutput;
 
 @group(0) @binding(0)
 var material_id_texture: texture_2d<u32>;

--- a/crates/bevy_core_pipeline/src/oit/resolve/oit_resolve.wesl
+++ b/crates/bevy_core_pipeline/src/oit/resolve/oit_resolve.wesl
@@ -60,7 +60,7 @@ fn resolve(head: u32, opaque_depth: f32) -> vec4<f32> {
     var fragment_list: array<OitFragment, SORTED_FRAGMENT_MAX_COUNT>;
     var final_color = vec4<f32>(0.0);
 
-    var packed_opaque_depth = bevy_core_pipeline::oit::draw::pack_24bit_depth_8bit_alpha(opaque_depth, 1.0);
+    var packed_opaque_depth = package::oit::draw::pack_24bit_depth_8bit_alpha(opaque_depth, 1.0);
 
     // fill list
     var current_node = head;
@@ -132,5 +132,5 @@ fn blend(color_a: vec4<f32>, color_b: vec4<f32>) -> vec4<f32> {
 }
 
 fn packed_depth_alpha_get_alpha(packed: u32) -> f32 {
-    return bevy_core_pipeline::oit::draw::unpack_24bit_depth_8bit_alpha(packed).y;
+    return package::oit::draw::unpack_24bit_depth_8bit_alpha(packed).y;
 }

--- a/crates/bevy_core_pipeline/src/prepass/background_motion_vectors.wesl
+++ b/crates/bevy_core_pipeline/src/prepass/background_motion_vectors.wesl
@@ -1,5 +1,5 @@
 import bevy_render::view::View;
-import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
+import package::fullscreen_vertex_shader::FullscreenVertexOutput;
 import bevy_pbr::render::view_transformations::uv_to_ndc;
 
 struct PreviousViewUniforms {

--- a/crates/bevy_core_pipeline/src/tonemapping.wesl
+++ b/crates/bevy_core_pipeline/src/tonemapping.wesl
@@ -4,7 +4,7 @@ import bevy_render::{
     maths::{PI_2, powsafe},
 };
 
-import bevy_core_pipeline::tonemapping::lut_bindings::{
+import package::tonemapping::lut_bindings::{
     dt_lut_texture,
     dt_lut_sampler,
 };

--- a/crates/bevy_core_pipeline/src/tonemapping/tonemapping_frag.wesl
+++ b/crates/bevy_core_pipeline/src/tonemapping/tonemapping_frag.wesl
@@ -2,7 +2,7 @@ import bevy_render::{
     view::View,
     maths::powsafe,
 };
-import bevy_core_pipeline::{
+import package::{
     fullscreen_vertex_shader::FullscreenVertexOutput,
     tonemapping::{tone_mapping, screen_space_dither},
 };

--- a/crates/bevy_pbr/src/atmosphere/aerial_view_lut.wesl
+++ b/crates/bevy_pbr/src/atmosphere/aerial_view_lut.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     atmosphere::{
         bindings::settings,
         functions::{

--- a/crates/bevy_pbr/src/atmosphere/bindings.wesl
+++ b/crates/bevy_pbr/src/atmosphere/bindings.wesl
@@ -1,6 +1,6 @@
 import bevy_render::view::View;
 
-import bevy_pbr::{
+import package::{
     render::mesh_view_types::Lights,
     atmosphere::types::{Atmosphere, AtmosphereSettings, AtmosphereTransforms}
 };

--- a/crates/bevy_pbr/src/atmosphere/bruneton_functions.wesl
+++ b/crates/bevy_pbr/src/atmosphere/bruneton_functions.wesl
@@ -53,7 +53,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-import bevy_pbr::atmosphere::{
+import package::atmosphere::{
     types::Atmosphere,
     bindings::atmosphere,
     functions::{get_local_r, sample_transmittance_lut},

--- a/crates/bevy_pbr/src/atmosphere/environment.wesl
+++ b/crates/bevy_pbr/src/atmosphere/environment.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     atmosphere::{
         functions::{direction_world_to_atmosphere, sample_sky_view_lut, get_view_position},
     },

--- a/crates/bevy_pbr/src/atmosphere/functions.wesl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wesl
@@ -1,6 +1,6 @@
 import bevy_render::maths::{PI, HALF_PI, PI_2, fast_acos, fast_acos_4, fast_atan2, ray_sphere_intersect};
 
-import bevy_pbr::atmosphere::{
+import package::atmosphere::{
     types::Atmosphere,
     bindings::{
         atmosphere, settings, view, lights, transmittance_lut, atmosphere_lut_sampler,

--- a/crates/bevy_pbr/src/atmosphere/multiscattering_lut.wesl
+++ b/crates/bevy_pbr/src/atmosphere/multiscattering_lut.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     atmosphere::{
         bindings::{atmosphere, settings},
         functions::{

--- a/crates/bevy_pbr/src/atmosphere/render_sky.wesl
+++ b/crates/bevy_pbr/src/atmosphere/render_sky.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::atmosphere::{
+import package::atmosphere::{
     bindings::{view, settings},
     bruneton_functions::sample_transmittance_lut_segment,
     functions::{

--- a/crates/bevy_pbr/src/atmosphere/sky_view_lut.wesl
+++ b/crates/bevy_pbr/src/atmosphere/sky_view_lut.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     atmosphere::{
         bindings::settings,
         functions::{

--- a/crates/bevy_pbr/src/atmosphere/transmittance_lut.wesl
+++ b/crates/bevy_pbr/src/atmosphere/transmittance_lut.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::atmosphere::{
+import package::atmosphere::{
     bindings::settings,
     functions::{
         sample_density_lut, get_local_r, max_atmosphere_distance,

--- a/crates/bevy_pbr/src/cluster.wesl
+++ b/crates/bevy_pbr/src/cluster.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::clustered_forward::view_z_to_z_slice;
+import package::render::clustered_forward::view_z_to_z_slice;
 
 // Valid values for the `object_type` field.
 const CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT: u32 = 0u;

--- a/crates/bevy_pbr/src/cluster/cluster_allocate.wesl
+++ b/crates/bevy_pbr/src/cluster/cluster_allocate.wesl
@@ -1,5 +1,5 @@
-import bevy_pbr::cluster::ClusterMetadata;
-import bevy_pbr::render::mesh_view_types::{ClusterOffsetsAndCounts, Lights};
+import package::cluster::ClusterMetadata;
+import package::render::mesh_view_types::{ClusterOffsetsAndCounts, Lights};
 
 // The shader that allocates the clustered object ID buffer.
 //

--- a/crates/bevy_pbr/src/cluster/cluster_raster.wesl
+++ b/crates/bevy_pbr/src/cluster/cluster_raster.wesl
@@ -1,12 +1,12 @@
-import bevy_pbr::cluster::{
+import package::cluster::{
     Aabb, CLUSTERABLE_OBJECT_TYPE_DECAL, CLUSTERABLE_OBJECT_TYPE_IRRADIANCE_VOLUME,
     CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT, CLUSTERABLE_OBJECT_TYPE_REFLECTION_PROBE,
     CLUSTERABLE_OBJECT_TYPE_SPOT_LIGHT, ClusterableObjectZSlice,
     calculate_sphere_cluster_bounds, compute_view_from_world_scale
 };
-import bevy_pbr::render::clustered_forward;
-import bevy_pbr::light_probe::transpose_affine_matrix;
-import bevy_pbr::render::mesh_view_types::{
+import package::render::clustered_forward;
+import package::light_probe::transpose_affine_matrix;
+import package::render::mesh_view_types::{
     ClusterOffsetsAndCounts, ClusterableObjectIndexLists, ClusteredDecals, ClusteredLights,
     LightProbes, Lights, POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE
 };

--- a/crates/bevy_pbr/src/cluster/cluster_z_slice.wesl
+++ b/crates/bevy_pbr/src/cluster/cluster_z_slice.wesl
@@ -1,10 +1,10 @@
-import bevy_pbr::cluster::{
+import package::cluster::{
     CLUSTERABLE_OBJECT_TYPE_DECAL, CLUSTERABLE_OBJECT_TYPE_IRRADIANCE_VOLUME,
     CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT, CLUSTERABLE_OBJECT_TYPE_REFLECTION_PROBE,
     CLUSTERABLE_OBJECT_TYPE_SPOT_LIGHT, ClusterMetadata, ClusterableObjectZSlice,
     calculate_sphere_cluster_bounds, compute_view_from_world_scale
 };
-import bevy_pbr::render::mesh_view_types::{
+import package::render::mesh_view_types::{
     ClusteredDecals, ClusteredLights, LightProbes, Lights, POINT_LIGHT_FLAGS_SPOT_LIGHT_BIT
 };
 import bevy_render::view::View;

--- a/crates/bevy_pbr/src/decal/clustered.wesl
+++ b/crates/bevy_pbr/src/decal/clustered.wesl
@@ -26,17 +26,17 @@
 // Note that the order in which decals are returned is currently unpredictable,
 // though generally stable from frame to frame.
 
-import bevy_pbr::render::clustered_forward;
-import bevy_pbr::render::clustered_forward::ClusterableObjectIndexRanges;
-import bevy_pbr::render::mesh_view_bindings;
-import bevy_pbr::render::pbr_functions;
-import bevy_pbr::render::pbr_types::PbrInput;
-import bevy_pbr::render::utils::porter_duff_over;
+import package::render::clustered_forward;
+import package::render::clustered_forward::ClusterableObjectIndexRanges;
+import package::render::mesh_view_bindings;
+import package::render::pbr_functions;
+import package::render::pbr_types::PbrInput;
+import package::render::utils::porter_duff_over;
 import bevy_render::maths;
 
-@if(MESHLET_MESH_MATERIAL_PASS) import bevy_pbr::meshlet::visibility_buffer_resolve::VertexOutput;
-@elif(PREPASS_PIPELINE) import bevy_pbr::prepass::io::VertexOutput;
-@else import bevy_pbr::render::forward_io::VertexOutput;
+@if(MESHLET_MESH_MATERIAL_PASS) import package::meshlet::visibility_buffer_resolve::VertexOutput;
+@elif(PREPASS_PIPELINE) import package::prepass::io::VertexOutput;
+@else import package::render::forward_io::VertexOutput;
 
 // An object that allows stepping through all clustered decals that affect a
 // single fragment.

--- a/crates/bevy_pbr/src/decal/forward.wesl
+++ b/crates/bevy_pbr/src/decal/forward.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::{
         forward_io::VertexOutput,
         mesh_functions::get_world_from_local,

--- a/crates/bevy_pbr/src/deferred/deferred_lighting.wesl
+++ b/crates/bevy_pbr/src/deferred/deferred_lighting.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     prepass::utils as prepass_utils,
     render::{
         pbr_types::STANDARD_MATERIAL_FLAGS_UNLIT_BIT,
@@ -12,8 +12,8 @@ import bevy_pbr::{
     },
 };
 
-@if(SCREEN_SPACE_AMBIENT_OCCLUSION) import bevy_pbr::render::mesh_view_bindings::screen_space_ambient_occlusion_texture;
-@if(SCREEN_SPACE_AMBIENT_OCCLUSION) import bevy_pbr::ssao::utils::ssao_multibounce;
+@if(SCREEN_SPACE_AMBIENT_OCCLUSION) import package::render::mesh_view_bindings::screen_space_ambient_occlusion_texture;
+@if(SCREEN_SPACE_AMBIENT_OCCLUSION) import package::ssao::utils::ssao_multibounce;
 
 struct FullscreenVertexOutput {
     @builtin(position)

--- a/crates/bevy_pbr/src/deferred/functions.wesl
+++ b/crates/bevy_pbr/src/deferred/functions.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::{
         pbr_types::{PbrInput, pbr_input_new, STANDARD_MATERIAL_FLAGS_UNLIT_BIT},
         pbr_functions,
@@ -11,11 +11,11 @@ import bevy_pbr::{
 };
 import bevy_render::utils::{octahedral_encode, octahedral_decode};
 
-@if(MESHLET_MESH_MATERIAL_PASS) import bevy_pbr::meshlet::visibility_buffer_resolve::VertexOutput;
-@else import bevy_pbr::prepass::io::VertexOutput;
+@if(MESHLET_MESH_MATERIAL_PASS) import package::meshlet::visibility_buffer_resolve::VertexOutput;
+@else import package::prepass::io::VertexOutput;
 
 @if(MOTION_VECTOR_PREPASS)
-    import bevy_pbr::render::pbr_prepass_functions::calculate_motion_vector;
+    import package::render::pbr_prepass_functions::calculate_motion_vector;
 
 // Creates the deferred gbuffer from a PbrInput.
 fn deferred_gbuffer_from_pbr_input(in: PbrInput) -> vec4<u32> {

--- a/crates/bevy_pbr/src/deferred/types.wesl
+++ b/crates/bevy_pbr/src/deferred/types.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_types::MESH_FLAGS_SHADOW_RECEIVER_BIT,
     pbr_types::{STANDARD_MATERIAL_FLAGS_FOG_ENABLED_BIT, STANDARD_MATERIAL_FLAGS_UNLIT_BIT},
 };

--- a/crates/bevy_pbr/src/light_probe.wesl
+++ b/crates/bevy_pbr/src/light_probe.wesl
@@ -1,7 +1,7 @@
-import bevy_pbr::render::clustered_forward;
-import bevy_pbr::render::clustered_forward::ClusterableObjectIndexRanges;
-import bevy_pbr::render::mesh_view_bindings::light_probes;
-import bevy_pbr::render::mesh_view_types::{
+import package::render::clustered_forward;
+import package::render::clustered_forward::ClusterableObjectIndexRanges;
+import package::render::mesh_view_bindings::light_probes;
+import package::render::mesh_view_types::{
     LightProbe, LIGHT_PROBE_FLAG_AFFECTS_LIGHTMAPPED_MESH_DIFFUSE,
     LIGHT_PROBE_FLAG_PARALLAX_CORRECT
 };

--- a/crates/bevy_pbr/src/light_probe/environment_filter.wesl
+++ b/crates/bevy_pbr/src/light_probe/environment_filter.wesl
@@ -1,5 +1,5 @@
 import bevy_render::maths::PI;
-import bevy_pbr::render::{
+import package::render::{
     pbr_lighting as lighting,
     utils::{sample_cosine_hemisphere, dir_to_cube_uv, sample_cube_dir, hammersley_2d, rand_vec2f}
 };

--- a/crates/bevy_pbr/src/light_probe/environment_map.wesl
+++ b/crates/bevy_pbr/src/light_probe/environment_map.wesl
@@ -1,11 +1,11 @@
-import bevy_pbr::light_probe::{light_probe_iterator_new, light_probe_iterator_next};
-import bevy_pbr::render::mesh_view_bindings as bindings;
-import bevy_pbr::render::mesh_view_bindings::light_probes;
-import bevy_pbr::render::mesh_view_types::{
+import package::light_probe::{light_probe_iterator_new, light_probe_iterator_next};
+import package::render::mesh_view_bindings as bindings;
+import package::render::mesh_view_bindings::light_probes;
+import package::render::mesh_view_types::{
     LIGHT_PROBE_FLAG_AFFECTS_LIGHTMAPPED_MESH_DIFFUSE, LIGHT_PROBE_FLAG_PARALLAX_CORRECT
 };
-import bevy_pbr::render::pbr_lighting::{F_Schlick_vec, LightingInput, LayerLightingInput, LAYER_BASE, LAYER_CLEARCOAT};
-import bevy_pbr::render::clustered_forward::ClusterableObjectIndexRanges;
+import package::render::pbr_lighting::{F_Schlick_vec, LightingInput, LayerLightingInput, LAYER_BASE, LAYER_CLEARCOAT};
+import package::render::clustered_forward::ClusterableObjectIndexRanges;
 
 // The maximum representable value in a 32-bit floating point number.
 const FLOAT_MAX: f32 = 3.40282347e+38;

--- a/crates/bevy_pbr/src/light_probe/irradiance_volume.wesl
+++ b/crates/bevy_pbr/src/light_probe/irradiance_volume.wesl
@@ -1,13 +1,13 @@
-import bevy_pbr::light_probe::{light_probe_iterator_new, light_probe_iterator_next};
-import bevy_pbr::render::mesh_view_bindings::{
+import package::light_probe::{light_probe_iterator_new, light_probe_iterator_next};
+import package::render::mesh_view_bindings::{
     irradiance_volumes,
     irradiance_volume,
     irradiance_volume_sampler,
     light_probes,
 };
-import bevy_pbr::render::clustered_forward::ClusterableObjectIndexRanges;
+import package::render::clustered_forward::ClusterableObjectIndexRanges;
 
-@if(LIGHTMAP) import bevy_pbr::render::mesh_view_types::LIGHT_PROBE_FLAG_AFFECTS_LIGHTMAPPED_MESH_DIFFUSE;
+@if(LIGHTMAP) import package::render::mesh_view_types::LIGHT_PROBE_FLAG_AFFECTS_LIGHTMAPPED_MESH_DIFFUSE;
 
 @if(IRRADIANCE_VOLUMES_ARE_USABLE)
 

--- a/crates/bevy_pbr/src/lightmap.wesl
+++ b/crates/bevy_pbr/src/lightmap.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::mesh_bindings::mesh;
+import package::render::mesh_bindings::mesh;
 
 @if(MULTIPLE_LIGHTMAPS_IN_ARRAY)
 enable wgpu_binding_array;

--- a/crates/bevy_pbr/src/meshlet/bindings.wesl
+++ b/crates/bevy_pbr/src/meshlet/bindings.wesl
@@ -1,6 +1,6 @@
-import bevy_pbr::render::mesh_types::Mesh;
+import package::render::mesh_types::Mesh;
 import bevy_render::view::View;
-import bevy_pbr::prepass::bindings::PreviousViewUniforms;
+import package::prepass::bindings::PreviousViewUniforms;
 import bevy_render::utils::octahedral_decode_signed;
 
 struct BvhNode {

--- a/crates/bevy_pbr/src/meshlet/cull_bvh.wesl
+++ b/crates/bevy_pbr/src/meshlet/cull_bvh.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::meshlet::bindings::{
+import package::meshlet::bindings::{
     InstancedOffset,
     get_aabb,
     get_aabb_error,
@@ -18,7 +18,7 @@ import bevy_pbr::meshlet::bindings::{
     meshlet_second_pass_bvh_dispatch,
     meshlet_second_pass_bvh_queue,
 };
-import bevy_pbr::meshlet::cull_shared::{
+import package::meshlet::cull_shared::{
     lod_error_is_imperceptible,
     aabb_in_frustum,
     should_occlusion_cull_aabb,

--- a/crates/bevy_pbr/src/meshlet/cull_clusters.wesl
+++ b/crates/bevy_pbr/src/meshlet/cull_clusters.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::meshlet::bindings::{
+import package::meshlet::bindings::{
     InstancedOffset,
     get_aabb,
     get_aabb_error,
@@ -15,7 +15,7 @@ import bevy_pbr::meshlet::bindings::{
     meshlet_meshlet_cull_dispatch,
     meshlet_meshlet_cull_queue,
 };
-import bevy_pbr::meshlet::cull_shared::{
+import package::meshlet::cull_shared::{
     ScreenAabb,
     project_aabb,
     lod_error_is_imperceptible,

--- a/crates/bevy_pbr/src/meshlet/cull_instances.wesl
+++ b/crates/bevy_pbr/src/meshlet/cull_instances.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::meshlet::bindings::{
+import package::meshlet::bindings::{
     InstancedOffset,
     constants,
     meshlet_view_instance_visibility,
@@ -11,7 +11,7 @@ import bevy_pbr::meshlet::bindings::{
     meshlet_second_pass_instance_dispatch,
     meshlet_second_pass_instance_candidates,
 };
-import bevy_pbr::meshlet::cull_shared::{
+import package::meshlet::cull_shared::{
     aabb_in_frustum,
     should_occlusion_cull_aabb,
 };

--- a/crates/bevy_pbr/src/meshlet/cull_shared.wesl
+++ b/crates/bevy_pbr/src/meshlet/cull_shared.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::meshlet::bindings::{
+import package::meshlet::bindings::{
     MeshletAabb,
     DispatchIndirectArgs,
     InstancedOffset,

--- a/crates/bevy_pbr/src/meshlet/meshlet_mesh_material.wesl
+++ b/crates/bevy_pbr/src/meshlet/meshlet_mesh_material.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     meshlet::visibility_buffer_resolve::resolve_vertex_output,
     prepass::io as prepass_io,
     render::{
@@ -43,7 +43,7 @@ fn prepass_fragment(@builtin(position) frag_coord: vec4<f32>) -> prepass_io::Fra
     // emissive magenta out to the deferred gbuffer to be rendered by the first deferred lighting pass layer.
     // This is here so if the default prepass fragment is used for deferred magenta will be rendered, and also
     // as an example to show that a user could write to the deferred gbuffer if they were to start from this shader.
-    out.deferred = vec4(0u, bevy_pbr::render::rgb9e5::vec3_to_rgb9e5_(vec3(1.0, 0.0, 1.0)), 0u, 0u);
+    out.deferred = vec4(0u, package::render::rgb9e5::vec3_to_rgb9e5_(vec3(1.0, 0.0, 1.0)), 0u, 0u);
     @if(DEFERRED_PREPASS)
     out.deferred_lighting_pass_id = 1u;
 

--- a/crates/bevy_pbr/src/meshlet/resolve_render_targets.wesl
+++ b/crates/bevy_pbr/src/meshlet/resolve_render_targets.wesl
@@ -1,5 +1,5 @@
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
-import bevy_pbr::meshlet::bindings::InstancedOffset;
+import package::meshlet::bindings::InstancedOffset;
 
 @if(MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT)
 @group(0) @binding(0) var meshlet_visibility_buffer: texture_storage_2d<r64uint, read>;

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_hardware_raster.wesl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_hardware_raster.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     meshlet::bindings::{
         meshlet_cluster_meshlet_ids,
         meshlets,

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_resolve.wesl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_resolve.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     meshlet::bindings::{
         Meshlet,
         meshlet_visibility_buffer,
@@ -20,7 +20,7 @@ import bevy_pbr::{
 import bevy_render::maths::{affine3_to_square, mat2x4_f32_to_mat3x3_unpack};
 
 @if(PREPASS_FRAGMENT && MOTION_VECTOR_PREPASS)
-import bevy_pbr::{
+import package::{
     prepass::bindings::previous_view_uniforms,
     render::pbr_prepass_functions::calculate_motion_vector,
 };

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_software_raster.wesl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_software_raster.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     meshlet::bindings::{
         meshlet_cluster_meshlet_ids,
         meshlets,

--- a/crates/bevy_pbr/src/prepass/io.wesl
+++ b/crates/bevy_pbr/src/prepass/io.wesl
@@ -66,7 +66,7 @@ struct Vertex {
 // The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
 // See https://github.com/gfx-rs/naga/issues/2416
 fn decompress_vertex(vertex_in: Vertex, instance_index: u32) -> UncompressedVertex {
-    let mesh_metadata = bevy_pbr::render::mesh_functions::get_metadata(instance_index);
+    let mesh_metadata = package::render::mesh_functions::get_metadata(instance_index);
     var uncompressed_vertex: UncompressedVertex;
     uncompressed_vertex.instance_index = instance_index;
 @if(VERTEX_POSITIONS_COMPRESSED)

--- a/crates/bevy_pbr/src/prepass/prepass.wesl
+++ b/crates/bevy_pbr/src/prepass/prepass.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     prepass::{
         bindings as prepass_bindings,
         io::{Vertex, UncompressedVertex, VertexOutput, FragmentOutput, decompress_vertex},
@@ -15,7 +15,7 @@ import bevy_pbr::{
 };
 
 @if(DEFERRED_PREPASS)
-import bevy_pbr::render::rgb9e5;
+import package::render::rgb9e5;
 
 @if(MORPH_TARGETS)
 // The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
@@ -202,7 +202,7 @@ fn fragment(in: VertexOutput) -> FragmentOutput {
     // emissive magenta out to the deferred gbuffer to be rendered by the first deferred lighting pass layer.
     // This is here so if the default prepass fragment is used for deferred magenta will be rendered, and also
     // as an example to show that a user could write to the deferred gbuffer if they were to start from this shader.
-    out.deferred = vec4(0u, bevy_pbr::render::rgb9e5::vec3_to_rgb9e5_(vec3(1.0, 0.0, 1.0)), 0u, 0u);
+    out.deferred = vec4(0u, package::render::rgb9e5::vec3_to_rgb9e5_(vec3(1.0, 0.0, 1.0)), 0u, 0u);
     out.deferred_lighting_pass_id = 1u;
 }
 

--- a/crates/bevy_pbr/src/prepass/utils.wesl
+++ b/crates/bevy_pbr/src/prepass/utils.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::mesh_view_bindings as view_bindings;
+import package::render::mesh_view_bindings as view_bindings;
 
 @if(DEPTH_PREPASS)
 fn prepass_depth(frag_coord: vec4<f32>, sample_index: u32) -> f32 {

--- a/crates/bevy_pbr/src/render/clustered_forward.wesl
+++ b/crates/bevy_pbr/src/render/clustered_forward.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_view_bindings as bindings,
     utils::rand_f,
 };

--- a/crates/bevy_pbr/src/render/fog.wesl
+++ b/crates/bevy_pbr/src/render/fog.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_view_bindings::fog,
     mesh_view_types::Fog,
 };

--- a/crates/bevy_pbr/src/render/forward_io.wesl
+++ b/crates/bevy_pbr/src/render/forward_io.wesl
@@ -57,7 +57,7 @@ struct Vertex {
 // The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
 // See https://github.com/gfx-rs/naga/issues/2416
 fn decompress_vertex(vertex_in: Vertex, instance_index: u32) -> UncompressedVertex {
-    let mesh_metadata = bevy_pbr::render::mesh_functions::get_metadata(instance_index);
+    let mesh_metadata = package::render::mesh_functions::get_metadata(instance_index);
     var uncompressed_vertex: UncompressedVertex;
     uncompressed_vertex.instance_index = instance_index;
 @if(VERTEX_POSITIONS && VERTEX_POSITIONS_COMPRESSED)

--- a/crates/bevy_pbr/src/render/mesh.wesl
+++ b/crates/bevy_pbr/src/render/mesh.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_bindings::mesh,
     mesh_functions,
     skinning,
@@ -16,9 +16,9 @@ fn morph_vertex(vertex_in: UncompressedVertex, instance_index: u32) -> Uncompres
     let vertex_index = vertex.index - first_vertex;
     let morph_descriptor_index = mesh[instance_index].morph_descriptor_index;
 
-    let weight_count = bevy_pbr::render::morph::layer_count(morph_descriptor_index);
+    let weight_count = package::render::morph::layer_count(morph_descriptor_index);
     for (var i: u32 = 0u; i < weight_count; i ++) {
-        let weight = bevy_pbr::render::morph::weight_at(i, morph_descriptor_index);
+        let weight = package::render::morph::weight_at(i, morph_descriptor_index);
         if weight == 0.0 {
             continue;
         }

--- a/crates/bevy_pbr/src/render/mesh_bindings.wesl
+++ b/crates/bevy_pbr/src/render/mesh_bindings.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::mesh_types::Mesh;
+import package::render::mesh_types::Mesh;
 import bevy_render::mesh::metadata_types::MeshMetadata;
 
 @if(!MESHLET_MESH_MATERIAL_PASS && PER_OBJECT_BUFFER_BATCH_SIZE)

--- a/crates/bevy_pbr/src/render/mesh_functions.wesl
+++ b/crates/bevy_pbr/src/render/mesh_functions.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_view_bindings::{
         view,
         visibility_ranges,

--- a/crates/bevy_pbr/src/render/mesh_preprocess.wesl
+++ b/crates/bevy_pbr/src/render/mesh_preprocess.wesl
@@ -17,14 +17,14 @@
 import bevy_render::occlusion_culling::mesh_preprocess_types::{
     IndirectParametersMetadata, MeshInput, PreviousMeshInput, PreprocessWorkItem
 };
-import bevy_pbr::render::mesh_types::{
+import package::render::mesh_types::{
     Mesh, MESH_FLAGS_AABB_BASED_VISIBILITY_RANGE_BIT, MESH_FLAGS_NO_FRUSTUM_CULLING_BIT,
     MESH_FLAGS_VISIBILITY_RANGE_INDEX_BITS
 };
-import bevy_pbr::render::mesh_view_bindings::view;
-import bevy_pbr::render::occlusion_culling;
-import bevy_pbr::prepass::bindings::previous_view_uniforms;
-import bevy_pbr::render::view_transformations::{
+import package::render::mesh_view_bindings::view;
+import package::render::occlusion_culling;
+import package::prepass::bindings::previous_view_uniforms;
+import package::render::view_transformations::{
     position_world_to_ndc, position_world_to_view, ndc_to_uv, view_z_to_depth_ndc,
     position_world_to_prev_ndc, position_world_to_prev_view, prev_view_z_to_depth_ndc
 };

--- a/crates/bevy_pbr/src/render/mesh_types.wesl
+++ b/crates/bevy_pbr/src/render/mesh_types.wesl
@@ -7,7 +7,7 @@ struct Mesh {
     // [0].xyz, [1].x,
     // [1].yz, [2].xy
     // [2].z
-    // Use bevy_pbr::render::mesh_functions::mat2x4_f32_to_mat3x3_unpack to unpack
+    // Use package::render::mesh_functions::mat2x4_f32_to_mat3x3_unpack to unpack
     local_from_world_transpose_a: mat2x4<f32>,
     local_from_world_transpose_b: f32,
     // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wesl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wesl
@@ -1,5 +1,5 @@
-import bevy_pbr::render::mesh_view_types as types;
-import bevy_pbr::atmosphere::types as atmosphere_types;
+import package::render::mesh_view_types as types;
+import package::atmosphere::types as atmosphere_types;
 import bevy_render::{
     view::View,
     globals::Globals,

--- a/crates/bevy_pbr/src/render/mesh_view_types.wesl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wesl
@@ -185,7 +185,7 @@ struct LightProbes {
 // Settings for screen space reflections.
 //
 // For more information on these settings, see the documentation for
-// `bevy_pbr::ssr::ScreenSpaceReflections`.
+// `package::ssr::ScreenSpaceReflections`.
 struct ScreenSpaceReflectionsSettings {
     min_perceptual_roughness: f32,
     min_perceptual_roughness_fully_active: f32,

--- a/crates/bevy_pbr/src/render/morph.wesl
+++ b/crates/bevy_pbr/src/render/morph.wesl
@@ -1,4 +1,4 @@
-@if(MORPH_TARGETS) import bevy_pbr::render::mesh_types::{MorphAttributes, MorphDescriptor, MorphWeights};
+@if(MORPH_TARGETS) import package::render::mesh_types::{MorphAttributes, MorphDescriptor, MorphWeights};
 
 @if(MORPH_TARGETS && SKINS_USE_UNIFORM_BUFFERS) {
 @group(2) @binding(2) var<uniform> morph_weights: MorphWeights;

--- a/crates/bevy_pbr/src/render/parallax_mapping.wesl
+++ b/crates/bevy_pbr/src/render/parallax_mapping.wesl
@@ -1,12 +1,12 @@
 import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d};
 
-import bevy_pbr::render::{
+import package::render::{
     pbr_bindings::{depth_map_texture, depth_map_sampler},
     mesh_bindings::mesh
 };
 
 @if(BINDLESS)
-import bevy_pbr::render::pbr_bindings::material_indices;
+import package::render::pbr_bindings::material_indices;
 
 fn sample_depth_map(uv: vec2<f32>, material_bind_group_slot: u32) -> f32 {
     // We use `textureSampleLevel` over `textureSample` because the wgpu DX12

--- a/crates/bevy_pbr/src/render/pbr.wesl
+++ b/crates/bevy_pbr/src/render/pbr.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::{
         pbr_types,
         pbr_functions::alpha_discard,
@@ -8,28 +8,28 @@ import bevy_pbr::{
 };
 
 @if(PREPASS_PIPELINE)
-import bevy_pbr::{
+import package::{
     prepass::io::{VertexOutput, FragmentOutput},
     deferred::functions::deferred_output,
 };
 @else
-import bevy_pbr::render::{
+import package::render::{
     forward_io::{VertexOutput, FragmentOutput},
     pbr_functions::{apply_pbr_lighting, main_pass_post_lighting_processing},
     pbr_types::STANDARD_MATERIAL_FLAGS_UNLIT_BIT,
 };
 
 @if(VISIBILITY_RANGE_DITHER)
-import bevy_pbr::render::pbr_functions::visibility_range_dither;
+import package::render::pbr_functions::visibility_range_dither;
 
 @if(MESHLET_MESH_MATERIAL_PASS)
-import bevy_pbr::meshlet::visibility_buffer_resolve::resolve_vertex_output;
+import package::meshlet::visibility_buffer_resolve::resolve_vertex_output;
 
 @if(MATERIAL_OIT_ENABLED)
 import bevy_core_pipeline::oit::draw::oit_draw;
 
 @if(FORWARD_DECAL)
-import bevy_pbr::decal::forward::get_forward_decal_info;
+import package::decal::forward::get_forward_decal_info;
 
 @fragment
 fn fragment(

--- a/crates/bevy_pbr/src/render/pbr_ambient.wesl
+++ b/crates/bevy_pbr/src/render/pbr_ambient.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     pbr_lighting::{EnvBRDFApprox, F_AB},
     mesh_view_bindings::lights,
 };

--- a/crates/bevy_pbr/src/render/pbr_bindings.wesl
+++ b/crates/bevy_pbr/src/render/pbr_bindings.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::pbr_types::StandardMaterial;
+import package::render::pbr_types::StandardMaterial;
 
 @if(BINDLESS) {
 struct StandardMaterialBindings {

--- a/crates/bevy_pbr/src/render/pbr_fragment.wesl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wesl
@@ -1,6 +1,6 @@
 import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d};
 
-import bevy_pbr::{
+import package::{
     render::{
         pbr_functions,
         pbr_functions::SampleBias,
@@ -16,19 +16,19 @@ import bevy_pbr::{
 };
 
 @if(SCREEN_SPACE_AMBIENT_OCCLUSION)
-import bevy_pbr::render::mesh_view_bindings::screen_space_ambient_occlusion_texture;
+import package::render::mesh_view_bindings::screen_space_ambient_occlusion_texture;
 @if(SCREEN_SPACE_AMBIENT_OCCLUSION)
-import bevy_pbr::ssao::utils::ssao_multibounce;
+import package::ssao::utils::ssao_multibounce;
 
 @if(MESHLET_MESH_MATERIAL_PASS)
-import bevy_pbr::meshlet::visibility_buffer_resolve::VertexOutput;
+import package::meshlet::visibility_buffer_resolve::VertexOutput;
 @elif(PREPASS_PIPELINE)
-import bevy_pbr::prepass::io::VertexOutput;
+import package::prepass::io::VertexOutput;
 @else
-import bevy_pbr::render::forward_io::VertexOutput;
+import package::render::forward_io::VertexOutput;
 
 @if(BINDLESS)
-import bevy_pbr::render::pbr_bindings::material_indices;
+import package::render::pbr_bindings::material_indices;
 
 // prepare a basic PbrInput from the vertex stage output, mesh binding and view binding
 fn pbr_input_from_vertex_output(

--- a/crates/bevy_pbr/src/render/pbr_functions.wesl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::{
         pbr_types,
         pbr_bindings,
@@ -19,19 +19,19 @@ import bevy_pbr::{
     },
     ssr::raymarch,
 };
-import bevy_pbr::render::mesh_view_bindings::globals;
-import bevy_pbr::render::view_transformations::{position_world_to_ndc};
+import package::render::mesh_view_bindings::globals;
+import package::render::view_transformations::{position_world_to_ndc};
 import bevy_render::maths::{E, powsafe};
 
-@if(STANDARD_MATERIAL_SPECULAR_TRANSMISSION) import bevy_pbr::transmission;
+@if(STANDARD_MATERIAL_SPECULAR_TRANSMISSION) import package::transmission;
 
-@if(IRRADIANCE_VOLUME) import bevy_pbr::light_probe::irradiance_volume;
+@if(IRRADIANCE_VOLUME) import package::light_probe::irradiance_volume;
 
-@if(MESHLET_MESH_MATERIAL_PASS) import bevy_pbr::meshlet::visibility_buffer_resolve::VertexOutput;
-@elif(PREPASS_PIPELINE) import bevy_pbr::prepass::io::VertexOutput;
-@else import bevy_pbr::render::forward_io::VertexOutput;
+@if(MESHLET_MESH_MATERIAL_PASS) import package::meshlet::visibility_buffer_resolve::VertexOutput;
+@elif(PREPASS_PIPELINE) import package::prepass::io::VertexOutput;
+@else import package::render::forward_io::VertexOutput;
 
-@if(ENVIRONMENT_MAP) import bevy_pbr::light_probe::environment_map;
+@if(ENVIRONMENT_MAP) import package::light_probe::environment_map;
 
 @if(TONEMAP_IN_SHADER) import bevy_core_pipeline::tonemapping::{tone_mapping, screen_space_dither};
 
@@ -897,13 +897,13 @@ fn apply_fog(
     }
 
     if fog_params.mode == mesh_view_types::FOG_MODE_LINEAR {
-        return bevy_pbr::render::fog::linear_fog(fog_params, input_color, distance, scattering);
+        return package::render::fog::linear_fog(fog_params, input_color, distance, scattering);
     } else if fog_params.mode == mesh_view_types::FOG_MODE_EXPONENTIAL {
-        return bevy_pbr::render::fog::exponential_fog(fog_params, input_color, distance, scattering);
+        return package::render::fog::exponential_fog(fog_params, input_color, distance, scattering);
     } else if fog_params.mode == mesh_view_types::FOG_MODE_EXPONENTIAL_SQUARED {
-        return bevy_pbr::render::fog::exponential_squared_fog(fog_params, input_color, distance, scattering);
+        return package::render::fog::exponential_squared_fog(fog_params, input_color, distance, scattering);
     } else if fog_params.mode == mesh_view_types::FOG_MODE_ATMOSPHERIC {
-        return bevy_pbr::render::fog::atmospheric_fog(fog_params, input_color, distance, scattering);
+        return package::render::fog::atmospheric_fog(fog_params, input_color, distance, scattering);
     } else {
         return input_color;
     }

--- a/crates/bevy_pbr/src/render/pbr_lighting.wesl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::mesh_view_types::POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE,
     render::mesh_view_bindings as view_bindings,
     atmosphere::functions::{calculate_visible_sun_ratio, clamp_to_surface},

--- a/crates/bevy_pbr/src/render/pbr_prepass.wesl
+++ b/crates/bevy_pbr/src/render/pbr_prepass.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::{
         pbr_prepass_functions,
         pbr_bindings,
@@ -15,10 +15,10 @@ import bevy_pbr::{
 import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d};
 
 @if(MESHLET_MESH_MATERIAL_PASS)
-import bevy_pbr::meshlet::visibility_buffer_resolve::resolve_vertex_output;
+import package::meshlet::visibility_buffer_resolve::resolve_vertex_output;
 
 @if(BINDLESS)
-import bevy_pbr::render::pbr_bindings::material_indices;
+import package::render::pbr_bindings::material_indices;
 
 @if(PREPASS_FRAGMENT)
 @fragment

--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wesl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wesl
@@ -1,6 +1,6 @@
 import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d};
 
-import bevy_pbr::{
+import package::{
     prepass::io::VertexOutput,
     prepass::bindings::previous_view_uniforms,
     render::{
@@ -12,7 +12,7 @@ import bevy_pbr::{
 };
 
 @if(BINDLESS)
-import bevy_pbr::render::pbr_bindings::material_indices;
+import package::render::pbr_bindings::material_indices;
 
 // Cutoff used for the premultiplied alpha modes BLEND, ADD, and ALPHA_TO_COVERAGE.
 const PREMULTIPLIED_ALPHA_CUTOFF = 0.05;

--- a/crates/bevy_pbr/src/render/shadow_sampling.wesl
+++ b/crates/bevy_pbr/src/render/shadow_sampling.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_view_bindings as view_bindings,
     utils::interleaved_gradient_noise,
     utils,

--- a/crates/bevy_pbr/src/render/shadows.wesl
+++ b/crates/bevy_pbr/src/render/shadows.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::{
+import package::render::{
     mesh_view_types::POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE,
     mesh_view_bindings as view_bindings,
     shadow_sampling::{

--- a/crates/bevy_pbr/src/render/skinning.wesl
+++ b/crates/bevy_pbr/src/render/skinning.wesl
@@ -1,5 +1,5 @@
-import bevy_pbr::render::mesh_types::SkinnedMesh;
-import bevy_pbr::render::mesh_bindings::mesh;
+import package::render::mesh_types::SkinnedMesh;
+import package::render::mesh_bindings::mesh;
 
 @if(SKINNED && SKINS_USE_UNIFORM_BUFFERS)
 @group(2) @binding(1) var<uniform> joint_matrices: SkinnedMesh;

--- a/crates/bevy_pbr/src/render/utils.wesl
+++ b/crates/bevy_pbr/src/render/utils.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::render::rgb9e5;
+import package::render::rgb9e5;
 import bevy_render::maths::{PI, PI_2, orthonormalize};
 
 // Generates a random u32 in range [0, u32::MAX].

--- a/crates/bevy_pbr/src/render/view_transformations.wesl
+++ b/crates/bevy_pbr/src/render/view_transformations.wesl
@@ -1,5 +1,5 @@
-import bevy_pbr::render::mesh_view_bindings as view_bindings;
-import bevy_pbr::prepass::bindings as prepass_bindings;
+import package::render::mesh_view_bindings as view_bindings;
+import package::prepass::bindings as prepass_bindings;
 
 /// World space:
 /// +y is up

--- a/crates/bevy_pbr/src/render/wireframe.wesl
+++ b/crates/bevy_pbr/src/render/wireframe.wesl
@@ -1,10 +1,10 @@
-@if(WIREFRAME_WIDE) import bevy_pbr::render::{
+@if(WIREFRAME_WIDE) import package::render::{
     mesh_bindings::mesh,
     mesh_view_bindings::view,
     view_transformations::position_world_to_clip,
 };
 @if(WIREFRAME_WIDE) import bevy_render::maths::affine3_to_square;
-@if(!WIREFRAME_WIDE) import bevy_pbr::render::forward_io::VertexOutput;
+@if(!WIREFRAME_WIDE) import package::render::forward_io::VertexOutput;
 
 @if(WIREFRAME_WIDE) {
 struct Immediates {

--- a/crates/bevy_pbr/src/ssr.wesl
+++ b/crates/bevy_pbr/src/ssr.wesl
@@ -1,7 +1,7 @@
 // A postprocessing pass that performs screen-space reflections.
 
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
-import bevy_pbr::{
+import package::{
     render::{
         clustered_forward,
         pbr_lighting as lighting,
@@ -42,7 +42,7 @@ import bevy_render::{
     maths::orthonormalize,
 };
 
-@if(ENVIRONMENT_MAP) import bevy_pbr::light_probe::environment_map;
+@if(ENVIRONMENT_MAP) import package::light_probe::environment_map;
 
 // The texture representing the color framebuffer.
 @group(2) @binding(0) var color_texture: texture_2d<f32>;

--- a/crates/bevy_pbr/src/ssr/raymarch.wesl
+++ b/crates/bevy_pbr/src/ssr/raymarch.wesl
@@ -14,8 +14,8 @@
 // [`raymarch.hlsl`]:
 // https://gist.github.com/h3r2tic/9c8356bdaefbe80b1a22ae0aaee192db
 
-import bevy_pbr::render::mesh_view_bindings::depth_prepass_texture;
-import bevy_pbr::render::view_transformations::{
+import package::render::mesh_view_bindings::depth_prepass_texture;
+import package::render::view_transformations::{
     direction_world_to_clip,
     ndc_to_uv,
     perspective_camera_near,

--- a/crates/bevy_pbr/src/transmission.wesl
+++ b/crates/bevy_pbr/src/transmission.wesl
@@ -1,4 +1,4 @@
-import bevy_pbr::{
+import package::{
     render::{
         pbr_lighting as lighting,
         utils::interleaved_gradient_noise,

--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wesl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wesl
@@ -14,30 +14,30 @@
 // [2]: http://www.alexandre-pestana.com/volumetric-lights/
 
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
-import bevy_pbr::atmosphere::{
+import package::atmosphere::{
     functions::{calculate_visible_sun_ratio, clamp_to_surface},
     bruneton_functions::transmittance_lut_r_mu_to_uv,
 };
-import bevy_pbr::render::mesh_functions::{get_world_from_local, mesh_position_local_to_clip};
-import bevy_pbr::render::mesh_view_bindings::{
+import package::render::mesh_functions::{get_world_from_local, mesh_position_local_to_clip};
+import package::render::mesh_view_bindings::{
     globals, lights, view, clustered_lights,
     atmosphere, atmosphere_transmittance_texture, atmosphere_transmittance_sampler
 };
-import bevy_pbr::render::mesh_view_types::{
+import package::render::mesh_view_types::{
     DIRECTIONAL_LIGHT_FLAGS_VOLUMETRIC_BIT,
     POINT_LIGHT_FLAGS_SHADOWS_ENABLED_BIT,
     POINT_LIGHT_FLAGS_VOLUMETRIC_BIT,
     POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE,
 };
-import bevy_pbr::render::shadow_sampling::{
+import package::render::shadow_sampling::{
     sample_shadow_map_hardware,
     sample_shadow_cubemap,
     sample_shadow_map,
     SPOT_SHADOW_TEXEL_SIZE
 };
-import bevy_pbr::render::shadows::{get_cascade_index, world_to_directional_light_local};
-import bevy_pbr::render::utils::interleaved_gradient_noise;
-import bevy_pbr::render::view_transformations::{
+import package::render::shadows::{get_cascade_index, world_to_directional_light_local};
+import package::render::utils::interleaved_gradient_noise;
+import package::render::view_transformations::{
     depth_ndc_to_view_z,
     frag_coord_to_ndc,
     position_ndc_to_view,
@@ -45,8 +45,8 @@ import bevy_pbr::render::view_transformations::{
     position_view_to_world
 };
 import bevy_render::maths::orthonormalize;
-import bevy_pbr::render::clustered_forward as clustering;
-import bevy_pbr::render::pbr_lighting::getDistanceAttenuation;
+import package::render::clustered_forward as clustering;
+import package::render::pbr_lighting::getDistanceAttenuation;
 
 // The GPU version of [`VolumetricFog`]. See the comments in
 // `volumetric_fog/mod.rs` for descriptions of the fields here.

--- a/crates/bevy_post_process/src/dof/dof.wesl
+++ b/crates/bevy_post_process/src/dof/dof.wesl
@@ -18,7 +18,7 @@
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
 import bevy_pbr::render::mesh_view_bindings::view;
 import bevy_pbr::render::view_transformations::depth_ndc_to_view_z;
-import bevy_post_process::gaussian_blur::gaussian_blur;
+import package::gaussian_blur::gaussian_blur;
 import bevy_render::view::View;
 
 // Parameters that control the depth of field effect. See

--- a/crates/bevy_post_process/src/effect_stack/chromatic_aberration.wesl
+++ b/crates/bevy_post_process/src/effect_stack/chromatic_aberration.wesl
@@ -2,7 +2,7 @@
 //
 // This makes edges of objects turn into multicolored streaks.
 
-// See `bevy_post_process::effect_stack::ChromaticAberration` for more
+// See `package::effect_stack::ChromaticAberration` for more
 // information on these fields.
 struct ChromaticAberrationSettings {
     intensity: f32,

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.wesl
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.wesl
@@ -1,6 +1,6 @@
 // The lens distortion postprocessing effect.
 
-// See `bevy_post_process::effect_stack::LensDistortion` for more
+// See `package::effect_stack::LensDistortion` for more
 // information on these fields.
 struct LensDistortionSettings {
     intensity: f32,

--- a/crates/bevy_post_process/src/effect_stack/post_process.wesl
+++ b/crates/bevy_post_process/src/effect_stack/post_process.wesl
@@ -1,9 +1,9 @@
 // Miscellaneous postprocessing effects, currently just chromatic aberration.
 
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
-import bevy_post_process::effect_stack::chromatic_aberration::chromatic_aberration;
-import bevy_post_process::effect_stack::lens_distortion::lens_distortion;
-import bevy_post_process::effect_stack::vignette::vignette;
+import package::effect_stack::chromatic_aberration::chromatic_aberration;
+import package::effect_stack::lens_distortion::lens_distortion;
+import package::effect_stack::vignette::vignette;
 
 @fragment
 fn fragment_main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {

--- a/crates/bevy_post_process/src/effect_stack/vignette.wesl
+++ b/crates/bevy_post_process/src/effect_stack/vignette.wesl
@@ -1,8 +1,8 @@
 // The vignette postprocessing effect.
 
-import bevy_post_process::effect_stack::chromatic_aberration::source_texture;
+import package::effect_stack::chromatic_aberration::source_texture;
 
-// See `bevy_post_process::effect_stack::Vignette` for more
+// See `package::effect_stack::Vignette` for more
 // information on these fields.
 struct VignetteSettings {
     intensity: f32,

--- a/crates/bevy_render/src/color_operations.wesl
+++ b/crates/bevy_render/src/color_operations.wesl
@@ -1,4 +1,4 @@
-import bevy_render::maths::{PI_2,PI,FRAC_PI_3};
+import package::maths::{PI_2,PI,FRAC_PI_3};
 
 const HUE_GUARD: f32 = 0.0001;
 

--- a/crates/bevy_solari/src/pathtracer/pathtracer.wesl
+++ b/crates/bevy_solari/src/pathtracer/pathtracer.wesl
@@ -1,9 +1,9 @@
 import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance;
 import bevy_pbr::render::utils::{rand_f, rand_vec2f};
 import bevy_render::view::View;
-import bevy_solari::scene::brdf::{evaluate_brdf, evaluate_and_sample_brdf, brdf_pdf, F_AB};
-import bevy_solari::scene::sampling::{sample_random_light, random_emissive_light_pdf, power_heuristic};
-import bevy_solari::scene::bindings::{trace_ray, resolve_ray_hit_full, RAY_T_MIN, RAY_T_MAX, MIRROR_ROUGHNESS_THRESHOLD};
+import package::scene::brdf::{evaluate_brdf, evaluate_and_sample_brdf, brdf_pdf, F_AB};
+import package::scene::sampling::{sample_random_light, random_emissive_light_pdf, power_heuristic};
+import package::scene::bindings::{trace_ray, resolve_ray_hit_full, RAY_T_MIN, RAY_T_MAX, MIRROR_ROUGHNESS_THRESHOLD};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/realtime/bindings.wesl
+++ b/crates/bevy_solari/src/realtime/bindings.wesl
@@ -1,6 +1,6 @@
 import bevy_render::view::View;
 import bevy_pbr::prepass::bindings::PreviousViewUniforms;
-import bevy_solari::scene::sampling::{LightSample, NULL_LIGHT_ID};
+import package::scene::sampling::{LightSample, NULL_LIGHT_ID};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/realtime/gbuffer_utils.wesl
+++ b/crates/bevy_solari/src/realtime/gbuffer_utils.wesl
@@ -2,7 +2,7 @@ import bevy_pbr::deferred::types::unpack_24bit_normal;
 import bevy_pbr::render::rgb9e5::rgb9e5_to_vec3_;
 import bevy_render::utils::octahedral_decode;
 import bevy_render::view::{View, depth_ndc_to_view_z};
-import bevy_solari::scene::bindings::ResolvedMaterial;
+import package::scene::bindings::ResolvedMaterial;
 
 struct ResolvedGPixel {
     world_position: vec3<f32>,

--- a/crates/bevy_solari/src/realtime/initial_path.wesl
+++ b/crates/bevy_solari/src/realtime/initial_path.wesl
@@ -2,18 +2,18 @@ import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance;
 import bevy_pbr::render::utils::{rand_f, rand_range_u};
 import bevy_render::maths::PI;
 import bevy_render::utils::octahedral_encode;
-import bevy_solari::scene::brdf::{brdf_pdf, evaluate_and_sample_brdf, evaluate_brdf, F_AB};
-import bevy_solari::realtime::presample_light_tiles::unpack_resolved_light_sample;
-import bevy_solari::realtime::bindings::{empty_reservoir, light_tile_resolved_samples, light_tile_samples, Reservoir, constants, view};
-import bevy_solari::scene::sampling::{calculate_resolved_light_contribution, isinf, LightSample, NULL_LIGHT_ID, power_heuristic, trace_visibility};
-import bevy_solari::scene::bindings::{light_sources, MIRROR_ROUGHNESS_THRESHOLD, RAY_T_MAX, RAY_T_MIN, resolve_ray_hit_full, ResolvedMaterial, ResolvedRayHitFull, trace_ray};
-import bevy_solari::realtime::world_cache_query::{get_cell_size, query_world_cache, WORLD_CACHE_CELL_LIFETIME};
+import package::scene::brdf::{brdf_pdf, evaluate_and_sample_brdf, evaluate_brdf, F_AB};
+import package::realtime::presample_light_tiles::unpack_resolved_light_sample;
+import package::realtime::bindings::{empty_reservoir, light_tile_resolved_samples, light_tile_samples, Reservoir, constants, view};
+import package::scene::sampling::{calculate_resolved_light_contribution, isinf, LightSample, NULL_LIGHT_ID, power_heuristic, trace_visibility};
+import package::scene::bindings::{light_sources, MIRROR_ROUGHNESS_THRESHOLD, RAY_T_MAX, RAY_T_MIN, resolve_ray_hit_full, ResolvedMaterial, ResolvedRayHitFull, trace_ray};
+import package::realtime::world_cache_query::{get_cell_size, query_world_cache, WORLD_CACHE_CELL_LIFETIME};
 @if(DLSS_RR_GUIDE_BUFFERS)
 import bevy_pbr::render::pbr_functions::{calculate_diffuse_color, calculate_F0};
 @if(DLSS_RR_GUIDE_BUFFERS)
-import bevy_solari::realtime::bindings::{diffuse_albedo, normal_roughness, previous_view, specular_albedo, specular_motion_vectors};
+import package::realtime::bindings::{diffuse_albedo, normal_roughness, previous_view, specular_albedo, specular_motion_vectors};
 @if(DLSS_RR_GUIDE_BUFFERS)
-import bevy_solari::realtime::resolve_dlss_rr_textures::env_brdf_approx2;
+import package::realtime::resolve_dlss_rr_textures::env_brdf_approx2;
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/realtime/presample_light_tiles.wesl
+++ b/crates/bevy_solari/src/realtime/presample_light_tiles.wesl
@@ -2,8 +2,8 @@
 
 import bevy_pbr::render::rgb9e5::{vec3_to_rgb9e5_, rgb9e5_to_vec3_};
 import bevy_render::utils::{octahedral_encode, octahedral_decode};
-import bevy_solari::scene::sampling::{generate_random_light_sample, ResolvedLightSample};
-import bevy_solari::realtime::bindings::{light_tile_samples, light_tile_resolved_samples, view, constants, ResolvedLightSamplePacked};
+import package::scene::sampling::{generate_random_light_sample, ResolvedLightSample};
+import package::realtime::bindings::{light_tile_samples, light_tile_resolved_samples, view, constants, ResolvedLightSamplePacked};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/realtime/resolve_dlss_rr_textures.wesl
+++ b/crates/bevy_solari/src/realtime/resolve_dlss_rr_textures.wesl
@@ -1,6 +1,6 @@
 import bevy_pbr::render::pbr_functions::{calculate_diffuse_color, calculate_F0};
-import bevy_solari::realtime::gbuffer_utils::gpixel_resolve;
-import bevy_solari::realtime::bindings::{gbuffer, depth_buffer, motion_vectors, view, diffuse_albedo, specular_albedo, normal_roughness, specular_motion_vectors};
+import package::realtime::gbuffer_utils::gpixel_resolve;
+import package::realtime::bindings::{gbuffer, depth_buffer, motion_vectors, view, diffuse_albedo, specular_albedo, normal_roughness, specular_motion_vectors};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/realtime/restir.wesl
+++ b/crates/bevy_solari/src/realtime/restir.wesl
@@ -3,13 +3,13 @@
 import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance;
 import bevy_pbr::render::utils::{rand_f, rand_u, sample_disk};
 import bevy_render::utils::octahedral_decode;
-import bevy_solari::scene::brdf::{brdf_pdf, evaluate_brdf, F_AB};
-import bevy_solari::realtime::gbuffer_utils::{gpixel_resolve, permute_pixel, pixel_dissimilar};
-import bevy_solari::realtime::initial_path::{generate_initial_reservoir, InitialSamplingResult};
-import bevy_solari::realtime::bindings::{depth_buffer, empty_reservoir, gbuffer, motion_vectors, previous_depth_buffer, previous_gbuffer, previous_view, reservoirs_a, reservoirs_b, Reservoir, constants, view, view_output};
-import bevy_solari::scene::sampling::{balance_heuristic, calculate_resolved_light_contribution, isinf, isnan, LightSample, NULL_LIGHT_ID, power_heuristic, resolve_light_sample, ResolvedLightSample, trace_visibility, trace_visibility_previous_frame};
-import bevy_solari::scene::bindings::{light_sources, LIGHT_NOT_PRESENT_THIS_FRAME, previous_frame_light_id_translations, RAY_T_MAX, RAY_T_MIN, ResolvedMaterial};
-import bevy_solari::realtime::world_cache_query::{query_world_cache, WORLD_CACHE_CELL_LIFETIME};
+import package::scene::brdf::{brdf_pdf, evaluate_brdf, F_AB};
+import package::realtime::gbuffer_utils::{gpixel_resolve, permute_pixel, pixel_dissimilar};
+import package::realtime::initial_path::{generate_initial_reservoir, InitialSamplingResult};
+import package::realtime::bindings::{depth_buffer, empty_reservoir, gbuffer, motion_vectors, previous_depth_buffer, previous_gbuffer, previous_view, reservoirs_a, reservoirs_b, Reservoir, constants, view, view_output};
+import package::scene::sampling::{balance_heuristic, calculate_resolved_light_contribution, isinf, isnan, LightSample, NULL_LIGHT_ID, power_heuristic, resolve_light_sample, ResolvedLightSample, trace_visibility, trace_visibility_previous_frame};
+import package::scene::bindings::{light_sources, LIGHT_NOT_PRESENT_THIS_FRAME, previous_frame_light_id_translations, RAY_T_MAX, RAY_T_MIN, ResolvedMaterial};
+import package::realtime::world_cache_query::{query_world_cache, WORLD_CACHE_CELL_LIFETIME};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/realtime/world_cache_compact.wesl
+++ b/crates/bevy_solari/src/realtime/world_cache_compact.wesl
@@ -1,5 +1,5 @@
-import bevy_solari::realtime::world_cache_query::WORLD_CACHE_EMPTY_CELL;
-import bevy_solari::realtime::bindings::{
+import package::realtime::world_cache_query::WORLD_CACHE_EMPTY_CELL;
+import package::realtime::bindings::{
     world_cache,
 };
 

--- a/crates/bevy_solari/src/realtime/world_cache_query.wesl
+++ b/crates/bevy_solari/src/realtime/world_cache_query.wesl
@@ -1,7 +1,7 @@
 import constants::WORLD_CACHE_SIZE;
 import bevy_pbr::render::utils::{rand_f, rand_vec2f};
 import bevy_render::maths::orthonormalize;
-import bevy_solari::realtime::bindings::{
+import package::realtime::bindings::{
     world_cache,
     constants,
 };

--- a/crates/bevy_solari/src/realtime/world_cache_update.wesl
+++ b/crates/bevy_solari/src/realtime/world_cache_update.wesl
@@ -1,10 +1,10 @@
 import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance;
 import bevy_pbr::render::utils::{rand_f, rand_range_u, sample_cosine_hemisphere};
-import bevy_solari::realtime::presample_light_tiles::unpack_resolved_light_sample;
-import bevy_solari::scene::sampling::{calculate_resolved_light_contribution, trace_visibility};
-import bevy_solari::scene::bindings::{trace_ray, resolve_ray_hit_full, RAY_T_MIN};
-import bevy_solari::realtime::world_cache_query::query_world_cache;
-import bevy_solari::realtime::bindings::{
+import package::realtime::presample_light_tiles::unpack_resolved_light_sample;
+import package::scene::sampling::{calculate_resolved_light_contribution, trace_visibility};
+import package::scene::bindings::{trace_ray, resolve_ray_hit_full, RAY_T_MIN};
+import package::realtime::world_cache_query::query_world_cache;
+import package::realtime::bindings::{
     light_tile_resolved_samples,
     view,
     constants,

--- a/crates/bevy_solari/src/scene/brdf.wesl
+++ b/crates/bevy_solari/src/scene/brdf.wesl
@@ -3,8 +3,8 @@ import bevy_pbr::render::pbr_lighting::{D_GGX, V_SmithGGXCorrelated, specular_mu
 import bevy_pbr::render::pbr_functions::calculate_F0_dielectric;
 import bevy_pbr::render::utils::{rand_f, sample_cosine_hemisphere};
 import bevy_render::maths::{PI, orthonormalize};
-import bevy_solari::scene::sampling::{sample_ggx_vndf, ggx_vndf_pdf, ggx_vndf_sample_invalid};
-import bevy_solari::scene::bindings::{ResolvedMaterial, MIRROR_ROUGHNESS_THRESHOLD, brdf_dfg_lut, brdf_dfg_lut_sampler};
+import package::scene::sampling::{sample_ggx_vndf, ggx_vndf_pdf, ggx_vndf_sample_invalid};
+import package::scene::bindings::{ResolvedMaterial, MIRROR_ROUGHNESS_THRESHOLD, brdf_dfg_lut, brdf_dfg_lut_sampler};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_solari/src/scene/sampling.wesl
+++ b/crates/bevy_solari/src/scene/sampling.wesl
@@ -1,7 +1,7 @@
 import bevy_pbr::render::pbr_lighting::D_GGX;
 import bevy_pbr::render::utils::{rand_vec2f, rand_u, rand_range_u};
 import bevy_render::maths::{PI_2, orthonormalize};
-import bevy_solari::scene::bindings::{trace_ray, trace_ray_previous_frame, RAY_T_MIN, RAY_T_MAX, light_sources, directional_lights, LightSource, LIGHT_SOURCE_KIND_DIRECTIONAL, resolve_triangle_data_full, ResolvedRayHitFull, MIRROR_ROUGHNESS_THRESHOLD};
+import package::scene::bindings::{trace_ray, trace_ray_previous_frame, RAY_T_MIN, RAY_T_MAX, light_sources, directional_lights, LightSource, LIGHT_SOURCE_KIND_DIRECTIONAL, resolve_triangle_data_full, ResolvedRayHitFull, MIRROR_ROUGHNESS_THRESHOLD};
 
 enable wgpu_ray_query;
 

--- a/crates/bevy_sprite_render/src/mesh2d/bindings.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/bindings.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::types::Mesh2d;
+import package::mesh2d::types::Mesh2d;
 import bevy_render::mesh::metadata_types::MeshMetadata;
 
 @if(PER_OBJECT_BUFFER_BATCH_SIZE)

--- a/crates/bevy_sprite_render/src/mesh2d/color_material.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/color_material.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::{
+import package::mesh2d::{
     vertex_output::VertexOutput,
     view_bindings::view,
     bindings::mesh,

--- a/crates/bevy_sprite_render/src/mesh2d/functions.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/functions.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::{
+import package::mesh2d::{
     view_bindings::view,
     bindings::{mesh, metadata},
 };

--- a/crates/bevy_sprite_render/src/mesh2d/mesh2d.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh2d.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::{
+import package::mesh2d::{
     functions as mesh_functions,
     vertex_output::VertexOutput,
     view_bindings::view,

--- a/crates/bevy_sprite_render/src/mesh2d/vertex_input.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/vertex_input.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::functions as mesh_functions;
+import package::mesh2d::functions as mesh_functions;
 
 struct UncompressedVertex {
     @builtin(instance_index) instance_index: u32,

--- a/crates/bevy_sprite_render/src/mesh2d/wireframe2d.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/wireframe2d.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::vertex_output::VertexOutput;
+import package::mesh2d::vertex_output::VertexOutput;
 
 struct PushConstants {
     color: vec4<f32>

--- a/crates/bevy_sprite_render/src/render/sprite.wesl
+++ b/crates/bevy_sprite_render/src/render/sprite.wesl
@@ -10,7 +10,7 @@ import bevy_render::{
     view::View,
 };
 
-import bevy_sprite_render::render::sprite_view_bindings::view;
+import package::render::sprite_view_bindings::view;
 
 struct VertexInput {
     @builtin(vertex_index) index: u32,

--- a/crates/bevy_sprite_render/src/sprite_mesh/bindings.wesl
+++ b/crates/bevy_sprite_render/src/sprite_mesh/bindings.wesl
@@ -1,6 +1,6 @@
-import bevy_sprite_render::sprite_mesh::types::SpriteMaterial;
+import package::sprite_mesh::types::SpriteMaterial;
 @if(BINDLESS)
-import bevy_sprite_render::sprite_mesh::types::SpriteMaterialBindings;
+import package::sprite_mesh::types::SpriteMaterialBindings;
 
 @if(BINDLESS) {
 @group(constants::MATERIAL_BIND_GROUP) @binding(0) var<storage> material_indices:

--- a/crates/bevy_sprite_render/src/sprite_mesh/functions.wesl
+++ b/crates/bevy_sprite_render/src/sprite_mesh/functions.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::sprite_mesh::{
+import package::sprite_mesh::{
     types::{
         SPRITE_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS,
         SPRITE_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE,
@@ -11,10 +11,10 @@ import bevy_sprite_render::sprite_mesh::{
     bindings::material,
 };
 @if(BINDLESS)
-import bevy_sprite_render::sprite_mesh::bindings::material_indices;
+import package::sprite_mesh::bindings::material_indices;
 @if(!BINDLESS)
-import bevy_sprite_render::sprite_mesh::bindings::{texture, texture_sampler};
-import bevy_sprite_render::mesh2d::bindings::mesh;
+import package::sprite_mesh::bindings::{texture, texture_sampler};
+import package::mesh2d::bindings::mesh;
 import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d};
 
 // Applies all the transformations to the UV and samples the sprite's final color.

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.wesl
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::{
+import package::{
     mesh2d::functions as mesh_functions,
     mesh2d::vertex_output::VertexOutput,
     mesh2d::view_bindings::view,
@@ -8,7 +8,7 @@ import bevy_sprite_render::{
     sprite_mesh::functions as sprite_functions,
 };
 @if(BINDLESS)
-import bevy_sprite_render::sprite_mesh::bindings::material_indices;
+import package::sprite_mesh::bindings::material_indices;
 
 @if(TONEMAP_IN_SHADER)
 import bevy_core_pipeline::tonemapping;

--- a/crates/bevy_sprite_render/src/tilemap_chunk/tilemap_chunk_material.wesl
+++ b/crates/bevy_sprite_render/src/tilemap_chunk/tilemap_chunk_material.wesl
@@ -1,4 +1,4 @@
-import bevy_sprite_render::mesh2d::{
+import package::mesh2d::{
     functions as mesh_functions,
     view_bindings::view,
     vertex_output::VertexOutput,

--- a/crates/bevy_ui_render/src/box_shadow.wesl
+++ b/crates/bevy_ui_render/src/box_shadow.wesl
@@ -1,6 +1,6 @@
 import bevy_render::view::View;
 import bevy_render::globals::Globals;
-import bevy_ui_render::ui::{
+import package::ui::{
     select_corner_radius
 };
 

--- a/crates/bevy_ui_render/src/gradient.wesl
+++ b/crates/bevy_ui_render/src/gradient.wesl
@@ -1,5 +1,5 @@
 import bevy_render::view::View;
-import bevy_ui_render::ui::{
+import package::ui::{
     draw_uinode_background,
     draw_uinode_border,
 };

--- a/crates/bevy_ui_render/src/ui_material.wesl
+++ b/crates/bevy_ui_render/src/ui_material.wesl
@@ -2,7 +2,7 @@ import bevy_render::{
     view::View,
     globals::Globals,
 };
-import bevy_ui_render::ui_vertex_output::UiVertexOutput;
+import package::ui_vertex_output::UiVertexOutput;
 
 @group(0) @binding(0)
 var<uniform> view: View;


### PR DESCRIPTION
# Objective

Use `import package::` instead of `import "this_package_name"::` to conform to WESL.

## Solution

Executed the script below to make the changes.

```bash
#!/usr/bin/env bash

cd crates

for dir in */; do
  dirname="${dir%/}"
  echo "Processing ${dirname}"
  
  # $dirname:: -> package::
  find "$dirname" -type f -name "*.wesl" -exec sed -i "s/${dirname}::/package::/g" {} +
done
```

## Testing

- I did run a few examples.
- Looked at the diff.
