### PR TITLE
Expose dcamera in bevy_math

### DIFF
--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -55,6 +55,7 @@ pub use compass::{CompassOctant, CompassQuadrant};
 pub use direction::*;
 pub use float_ord::*;
 pub use glam::camera::rh::proj::directx as proj;
+pub use glam::dcamera::rh::proj::directx as dproj;
 pub use isometry::{Isometry2d, Isometry3d};
 pub use mat3::*;
 pub use ops::FloatPow;


### PR DESCRIPTION
# Objective

- bevy_math re-exports `glam::camera::rh::proj::directx` as `proj` but doesn't reexport analogous f64 version `glam::dcamera::rh::proj::directx`, that I need for upstreaming #25434.

## Solution

- Re-export `glam::dcamera::rh::proj::directx` as `dproj`.

---

## Showcase

Usage:
```rust
bevy_math::dproj::perspective_infinite(vertical_fov, aspect_ratio, near)
```

