### PR TITLE
`ImageNode` border radius fix

### DIFF
--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -876,23 +876,24 @@ pub fn extract_uinode_images(
             visual_box.size()
         };
 
-        let inset = match image.visual_box {
+        let mut inset = match image.visual_box {
             VisualBox::ContentBox => uinode.content_inset(),
             VisualBox::PaddingBox => uinode.border(),
             VisualBox::BorderBox => BorderRect::ZERO,
         };
+        let image_inset = 0.5 * (visual_box.size() - size);
+        inset.min_inset += image_inset;
+        inset.max_inset += image_inset;
 
-        let mut border_radius = uinode.border_radius;
-        border_radius.top_left =
-            (border_radius.top_left - inset.min_inset).clamp(Vec2::ZERO, 0.5 * size);
-        border_radius.top_right = (border_radius.top_right
-            - Vec2::new(inset.max_inset.x, inset.min_inset.y))
-        .clamp(Vec2::ZERO, 0.5 * size);
-        border_radius.bottom_right =
-            (border_radius.bottom_right - inset.max_inset).clamp(Vec2::ZERO, 0.5 * size);
-        border_radius.bottom_left = (border_radius.bottom_left
-            - Vec2::new(inset.min_inset.x, inset.max_inset.y))
-        .clamp(Vec2::ZERO, 0.5 * size);
+        let radius = uinode.border_radius();
+        let clamped_radius = ResolvedBorderRadius {
+            top_left: (radius.top_left - inset.min_inset).clamp(Vec2::ZERO, 0.5 * size),
+            top_right: (radius.top_right - Vec2::new(inset.max_inset.x, inset.min_inset.y))
+                .clamp(Vec2::ZERO, 0.5 * size),
+            bottom_right: (radius.bottom_right - inset.max_inset).clamp(Vec2::ZERO, 0.5 * size),
+            bottom_left: (radius.bottom_left - Vec2::new(inset.min_inset.x, inset.max_inset.y))
+                .clamp(Vec2::ZERO, 0.5 * size),
+        };
 
         let atlas_rect = image
             .texture_atlas
@@ -943,7 +944,7 @@ pub fn extract_uinode_images(
                         flip_x: image.flip_x,
                         flip_y: image.flip_y,
                         border: BorderRect::ZERO,
-                        border_radius,
+                        border_radius: clamped_radius,
                         node_type: NodeType::Rect,
                     },
                 },

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -850,6 +850,7 @@ pub fn extract_uinode_images(
             VisualBox::PaddingBox => uinode.padding_box(),
             VisualBox::BorderBox => uinode.border_box(),
         };
+
         // Skip invisible images
         if !inherited_visibility.get()
             || image.color.is_fully_transparent()
@@ -874,6 +875,24 @@ pub fn extract_uinode_images(
         } else {
             visual_box.size()
         };
+
+        let inset = match image.visual_box {
+            VisualBox::ContentBox => uinode.content_inset(),
+            VisualBox::PaddingBox => uinode.border(),
+            VisualBox::BorderBox => BorderRect::ZERO,
+        };
+
+        let mut border_radius = uinode.border_radius;
+        border_radius.top_left =
+            (border_radius.top_left - inset.min_inset).clamp(Vec2::ZERO, 0.5 * size);
+        border_radius.top_right = (border_radius.top_right
+            - Vec2::new(inset.max_inset.x, inset.min_inset.y))
+        .clamp(Vec2::ZERO, 0.5 * size);
+        border_radius.bottom_right =
+            (border_radius.bottom_right - inset.max_inset).clamp(Vec2::ZERO, 0.5 * size);
+        border_radius.bottom_left = (border_radius.bottom_left
+            - Vec2::new(inset.min_inset.x, inset.max_inset.y))
+        .clamp(Vec2::ZERO, 0.5 * size);
 
         let atlas_rect = image
             .texture_atlas
@@ -924,7 +943,7 @@ pub fn extract_uinode_images(
                         flip_x: image.flip_x,
                         flip_y: image.flip_y,
                         border: BorderRect::ZERO,
-                        border_radius: uinode.border_radius,
+                        border_radius,
                         node_type: NodeType::Rect,
                     },
                 },

--- a/crates/bevy_ui_render/src/lib.rs
+++ b/crates/bevy_ui_render/src/lib.rs
@@ -876,6 +876,9 @@ pub fn extract_uinode_images(
             visual_box.size()
         };
 
+        // The node's border radius is subtracted from the visual box target's edge insets
+        // and then clamped to get the corner radius for the image. Ideally this should be handled
+        // on the GPU, but that might need changes to `ui.wesl`'s UV calculations.
         let mut inset = match image.visual_box {
             VisualBox::ContentBox => uinode.content_inset(),
             VisualBox::PaddingBox => uinode.border(),


### PR DESCRIPTION
# Objective

`ImageNode`'s border radius isn't clamped when you set `VisualBox::PaddingBox` or `VisualBox::ContentBox`.

## Solution

Clamp the border radius appropriately for image nodes in `extract_uinode_images`.

## Testing

Example for testing:

```rust
use bevy::prelude::*;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .run();
}

fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
    commands.spawn(Camera2d);
    commands.spawn((
        Node {
            flex_direction: FlexDirection::Column,
            width: percent(100),
            height: percent(100),
            align_items: AlignItems::Center,
            justify_content: JustifyContent::Center,
            row_gap: px(4),
            ..default()
        },
        children![
            (
                ImageNode {
                    image: asset_server.load("textures/fantasy_ui_borders/numbered_slices.png"),
                    visual_box: VisualBox::BorderBox,

                    ..default()
                },
                Node {
                    border: px(20).all(),
                    padding: px(20).all(),
                    border_radius: BorderRadius::all(px(30)),
                    width: px(200),
                    ..default()
                },
                Outline {
                    color: Color::WHITE,
                    ..default()
                }
            ),
            (
                ImageNode {
                    image: asset_server.load("textures/fantasy_ui_borders/numbered_slices.png"),
                    visual_box: VisualBox::PaddingBox,

                    ..default()
                },
                Node {
                    border: px(20).all(),
                    padding: px(20).all(),
                    border_radius: BorderRadius::all(px(30)),
                    width: px(200),
                    ..default()
                },
                Outline {
                    color: Color::WHITE,
                    ..default()
                }
            ),
            (
                ImageNode {
                    image: asset_server.load("textures/fantasy_ui_borders/numbered_slices.png"),
                    visual_box: VisualBox::ContentBox,

                    ..default()
                },
                Node {
                    border: px(20).all(),
                    padding: px(20).all(),
                    border_radius: BorderRadius::all(px(30)),
                    width: px(200),
                    ..default()
                },
                Outline {
                    color: Color::WHITE,
                    ..default()
                }
            )
        ],
    ));
}
```

On Main:
<img width="170" height="477" alt="rounded-bad" src="https://github.com/user-attachments/assets/c5366462-7822-4e87-962d-f06584e8c3d4" />

With this PR:
<img width="165" height="473" alt="image" src="https://github.com/user-attachments/assets/dfdcd5e6-6b81-48b2-bfa6-e505e0edd894" />


