### PR TITLE
Don't skip layout and lineheight updates in `update_editable_text_styles` on unresolved fonts

### DIFF
--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -206,14 +206,16 @@ pub fn update_editable_text_styles(
                 ));
         }
 
-        if text_font.is_changed() {
-            let Ok(resolved_family) = text_font.font.resolve_font_family(fonts.as_ref()) else {
-                continue;
-            };
-
+        if text_font.is_changed()
+            && let Ok(resolved_family) = text_font.font.resolve_font_family(fonts.as_ref())
+        {
             let family = resolved_family.into_owned();
             let style_set = editable_text.editor.edit_styles();
             style_set.insert(StyleProperty::FontFamily(family));
+        }
+
+        if text_font.is_changed() {
+            let style_set = editable_text.editor.edit_styles();
             style_set.insert(StyleProperty::FontWeight(text_font.weight.into()));
             style_set.insert(StyleProperty::FontWidth(text_font.width.into()));
             style_set.insert(StyleProperty::FontStyle(text_font.style.into()));


### PR DESCRIPTION
# Objective

In `update_editable_text_styles` if the font family can't be resolved, it continues to the next `EditableText` entity, skipping the `LineHeight` and `TextLayout` updates. In following frames, even if the font is now resolved correctly, the `LineHeight` and `TextLayout` components are no longer marked changed so the `PlainEditor`'s state will remain stale.

Reported by @gagnus in a comment on #24362.

## Solution

Split off the family style update into a separate block and remove the continue.