### PR TITLE
Fix entity_pair_is_visible

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -452,10 +452,10 @@ mod tests {
         let main_b = MainEntity::from(entity_from(1, 0));
 
         let render_a = entity_from(0, 0);
-        // We fake a situation where index 0 gets reused for the render entity
+        // We need an entity with a different generation since it affects the sort order.
         // This is necessary to create a sort order that is different when sorting on the full tuple
         // compared to sorting on the main entity.
-        let render_b = entity_from(0, 1);
+        let render_b = entity_from(1, 1);
 
         let mut pairs = vec![(render_a, main_a), (render_b, main_b)];
 

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -270,6 +270,8 @@ impl RenderVisibleEntitiesClass {
     /// no-CPU-culling visible entries table.
     pub fn entity_pair_is_visible(&self, entity: Entity, main_entity: MainEntity) -> bool {
         self.entities_cpu_culling
+            // We need to search by the same key used to sort the vec
+            // in `collect_visible_cpu_culled_entities_for_subview()`
             .binary_search_by_key(&main_entity, |(_, main_entity)| *main_entity)
             .is_ok_and(|index| self.entities_cpu_culling[index].0 == entity)
             || self

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -270,8 +270,8 @@ impl RenderVisibleEntitiesClass {
     /// no-CPU-culling visible entries table.
     pub fn entity_pair_is_visible(&self, entity: Entity, main_entity: MainEntity) -> bool {
         self.entities_cpu_culling
-            .binary_search(&(entity, main_entity))
-            .is_ok()
+            .binary_search_by_key(&main_entity, |(_, main_entity)| *main_entity)
+            .is_ok_and(|index| self.entities_cpu_culling[index].0 == entity)
             || self
                 .entities_gpu_culling
                 .get(&main_entity)

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -429,3 +429,70 @@ fn collect_visible_cpu_culled_entities_for_subview(
         entities.update_cpu_culled_entities(&render_view_entities.entities);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bevy_ecs::entity::{EntityGeneration, EntityIndex};
+    use nonmax::NonMaxU32;
+
+    use super::*;
+
+    fn entity_from(index: u32, generation: u32) -> Entity {
+        Entity::from_index_and_generation(
+            EntityIndex::new(NonMaxU32::new(index).unwrap()),
+            EntityGeneration::FIRST.after_versions(generation),
+        )
+    }
+
+    #[test]
+    fn cpu_visible_entity_pair_lookup_uses_main_entity_sort_order() {
+        struct TestVisibilityClass;
+
+        let main_a = MainEntity::from(entity_from(0, 0));
+        let main_b = MainEntity::from(entity_from(1, 0));
+
+        let render_a = entity_from(0, 0);
+        // We fake a situation where index 0 gets reused for the render entity
+        // This is necessary to create a sort order that is different when sorting on the full tuple
+        // compared to sorting on the main entity.
+        let render_b = entity_from(0, 1);
+
+        let mut pairs = vec![(render_a, main_a), (render_b, main_b)];
+
+        let mut extracted = RenderExtractedVisibleEntities {
+            classes: TypeIdHashMap::from_iter([(
+                TypeId::of::<TestVisibilityClass>(),
+                RenderExtractedVisibleEntitiesClass {
+                    entities: pairs.clone(),
+                },
+            )]),
+        };
+        let mut render_visible_entities = RenderVisibleEntities::default();
+
+        collect_visible_cpu_culled_entities_for_subview(
+            &mut render_visible_entities,
+            &mut Some(&mut extracted),
+            &mut HashSet::default(),
+        );
+
+        let visible = render_visible_entities
+            .get::<TestVisibilityClass>()
+            .unwrap();
+
+        // Sort the pairs by the full tuple and confirm that the sort for visible entities is
+        // different
+        pairs.sort();
+        assert_ne!(visible.entities_cpu_culling, pairs);
+        // Sort the pairs by only the main_entity to make sure the order is as expected
+        pairs.sort_by_key(|(_, main_entity)| *main_entity);
+        assert_eq!(visible.entities_cpu_culling, pairs);
+
+        // Make sure the visibility lookup works
+        for (entity, main_entity) in &pairs {
+            assert!(
+                visible.entity_pair_is_visible(*entity, *main_entity),
+                "expected {entity:?}/{main_entity:?} to be visible"
+            );
+        }
+    }
+}

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -432,30 +432,18 @@ fn collect_visible_cpu_culled_entities_for_subview(
 
 #[cfg(test)]
 mod tests {
-    use bevy_ecs::entity::{EntityGeneration, EntityIndex};
-    use nonmax::NonMaxU32;
-
     use super::*;
-
-    fn entity_from(index: u32, generation: u32) -> Entity {
-        Entity::from_index_and_generation(
-            EntityIndex::new(NonMaxU32::new(index).unwrap()),
-            EntityGeneration::FIRST.after_versions(generation),
-        )
-    }
 
     #[test]
     fn cpu_visible_entity_pair_lookup_uses_main_entity_sort_order() {
         struct TestVisibilityClass;
 
-        let main_a = MainEntity::from(entity_from(0, 0));
-        let main_b = MainEntity::from(entity_from(1, 0));
+        let main_a = MainEntity::from(Entity::from_bits(1));
+        let main_b = MainEntity::from(Entity::from_bits(2));
 
-        let render_a = entity_from(0, 0);
-        // We need an entity with a different generation since it affects the sort order.
-        // This is necessary to create a sort order that is different when sorting on the full tuple
-        // compared to sorting on the main entity.
-        let render_b = entity_from(1, 1);
+        // We need the render entities to sort differently from the main entities
+        let render_a = Entity::from_bits(2);
+        let render_b = Entity::from_bits(1);
 
         let mut pairs = vec![(render_a, main_a), (render_b, main_b)];
 


### PR DESCRIPTION
# Objective

- `entity_pair_is_visible` would sometimes return false even if it should return true

## Solution

- The vec used for the binary search is sorted on the `main_entity` but the binary search was using the full tuple to search instead of the main_entity only. The sort in question is located here: https://github.com/bevyengine/bevy/blob/b9182578165b6a7d9a2bcf62c727d616c7ccc96a/crates/bevy_render/src/view/visibility/mod.rs#L425
- To fix it we instead search on the same `main_entity` key.

## Testing

- I discovered this bug while working on the SpriteMesh migration and I confirmed that this fixed my issue

Closes https://github.com/bevyengine/bevy/issues/25276