### PR TITLE
Use `f32` directly for `INFINITY`/`NEG_INFINITY` constants.

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -30,7 +30,7 @@ pub const DEPTH_PREPASS_TEXTURE_SUPPORTED: bool = false;
 #[cfg(any(feature = "webgpu", not(target_arch = "wasm32")))]
 pub const DEPTH_PREPASS_TEXTURE_SUPPORTED: bool = true;
 
-use core::{f32, ops::Range};
+use core::ops::Range;
 
 use bevy_camera::{Camera, Camera3d, Camera3dDepthLoadOp};
 use bevy_diagnostic::FrameCount;

--- a/crates/bevy_picking/src/window.rs
+++ b/crates/bevy_picking/src/window.rs
@@ -11,8 +11,6 @@
 //!
 //! - This backend does not provide `normal` in `HitData`.
 
-use core::f32;
-
 use bevy_camera::NormalizedRenderTarget;
 use bevy_ecs::prelude::*;
 

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_material.rs
@@ -1,5 +1,3 @@
-use core::f32;
-
 use bevy_app::Plugin;
 use bevy_color::{Color, ColorToComponents};
 use bevy_image::{Image, TextureAtlas, TextureAtlasLayout};

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -11,7 +11,7 @@ use bevy_reflect::prelude::*;
 use bevy_sprite::BorderRect;
 use bevy_utils::once;
 use bevy_window::{PrimaryWindow, WindowRef};
-use core::{f32, num::NonZero};
+use core::num::NonZero;
 use derive_more::derive::From;
 use smallvec::SmallVec;
 use thiserror::Error;


### PR DESCRIPTION
Recent nightly compilers are warning that these constants are deprecated from `core::f32` (or `std::f32`).

# Objective

- Fix warnings (ignore strange prefixes; `kache` does this):
```
warning: use of deprecated constant `std::f32::INFINITY`: replaced by the `INFINITY` associated constant on `f32`
   --> /proc/self/cwd/src/ui_node.rs:277:37
    |
277 |             clip_rect.min.x = -f32::INFINITY;
    |                                     ^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated constant `std::f32::INFINITY`: replaced by the `INFINITY` associated constant on `f32`
   --> /proc/self/cwd/src/ui_node.rs:278:36
    |
278 |             clip_rect.max.x = f32::INFINITY;
    |                                    ^^^^^^^^

warning: use of deprecated constant `std::f32::INFINITY`: replaced by the `INFINITY` associated constant on `f32`
   --> /proc/self/cwd/src/ui_node.rs:281:37
    |
281 |             clip_rect.min.y = -f32::INFINITY;
    |                                     ^^^^^^^^

warning: use of deprecated constant `std::f32::INFINITY`: replaced by the `INFINITY` associated constant on `f32`
   --> /proc/self/cwd/src/ui_node.rs:282:36
    |
282 |             clip_rect.max.y = f32::INFINITY;
    |                                    ^^^^^^^^

warning: use of deprecated constant `std::f32::MAX`: replaced by the `MAX` associated constant on `f32`
    --> /proc/self/cwd/src/ui_node.rs:2546:50
     |
2546 |     pub const MAX: Self = Self::all(Val::Px(f32::MAX));
     |                                                  ^^^

warning: use of deprecated constant `std::f32::NEG_INFINITY`: replaced by the `NEG_INFINITY` associated constant on `f32`
   --> /proc/self/cwd/src/core_3d/mod.rs:487:59
    |
487 |             TransparentSortingInfo3d::AlwaysOnTop => f32::NEG_INFINITY,
    |                                                           ^^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: `bevy_core_pipeline` (lib) generated 1 warning
warning: use of deprecated constant `std::f32::EPSILON`: replaced by the `EPSILON` associated constant on `f32`
   --> /proc/self/cwd/src/sprite_mesh/sprite_material.rs:272:75
    |
272 |                     let corner_scale = slicer.max_corner_scale.clamp(f32::EPSILON, 1.0);
    |                                                                           ^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default
```

## Solution

- Use `f32` directly for these. These constants have been available on `f32` since Rust 1.43.0.

## Testing

- Build, CI, ran some examples.
