### PR TITLE
Make `Column` fields fully private and remove `use super::*`

### DIFF
--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -23,11 +23,11 @@ use core::{mem::needs_drop, panic::Location};
 /// [`ComponentSparseSet`]: crate::storage::ComponentSparseSet
 #[derive(Debug)]
 pub struct Column {
-    pub(super) data: BlobArray,
-    pub(super) added_ticks: ThinArrayPtr<UnsafeCell<Tick>>,
-    pub(super) changed_ticks: ThinArrayPtr<UnsafeCell<Tick>>,
-    pub(super) changed_by: MaybeLocation<ThinArrayPtr<UnsafeCell<&'static Location<'static>>>>,
-    pub(super) summary_tick: Option<AtomicTick>,
+    data: BlobArray,
+    added_ticks: ThinArrayPtr<UnsafeCell<Tick>>,
+    changed_ticks: ThinArrayPtr<UnsafeCell<Tick>>,
+    changed_by: MaybeLocation<ThinArrayPtr<UnsafeCell<&'static Location<'static>>>>,
+    summary_tick: Option<AtomicTick>,
 }
 
 impl Column {

--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -21,6 +21,7 @@ use core::{cell::UnsafeCell, mem::needs_drop, num::NonZeroUsize, panic::Location
 /// This type is used by [`Table`] and [`ComponentSparseSet`], where the corresponding capacity
 /// and length can be found.
 ///
+/// [`Table`]: crate::storage::Table
 /// [`ComponentSparseSet`]: crate::storage::ComponentSparseSet
 #[derive(Debug)]
 pub struct Column {

--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -1,9 +1,10 @@
-use super::*;
 use crate::{
-    change_detection::{AtomicTick, MaybeLocation},
-    storage::{blob_array::BlobArray, thin_array_ptr::ThinArrayPtr},
+    change_detection::{AtomicTick, CheckChangeTicks, ComponentTicks, MaybeLocation, Tick},
+    component::ComponentInfo,
+    storage::{blob_array::BlobArray, thin_array_ptr::ThinArrayPtr, TableRow},
 };
-use core::{mem::needs_drop, panic::Location};
+use bevy_ptr::{OwningPtr, Ptr, UnsafeCellDeref};
+use core::{cell::UnsafeCell, mem::needs_drop, num::NonZeroUsize, panic::Location};
 
 /// A type-erased contiguous container for data of a homogeneous type.
 ///

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -316,7 +316,7 @@ impl Table {
 
         // SAFETY: `row.index()` < `len`
         self.get_column(component_id)
-            .map(|col| unsafe { col.changed_ticks.get_unchecked(row.index()) })
+            .map(|col| unsafe { col.get_changed_tick_unchecked(row) })
     }
 
     /// Get the specific [`added tick`](Tick) of the component matching `component_id` in `row`.
@@ -331,7 +331,7 @@ impl Table {
 
         // SAFETY: `row.index()` < `len`
         self.get_column(component_id)
-            .map(|col| unsafe { col.added_ticks.get_unchecked(row.index()) })
+            .map(|col| unsafe { col.get_added_tick_unchecked(row) })
     }
 
     /// Get the specific calling location that changed the component matching `component_id` in `row`
@@ -345,12 +345,9 @@ impl Table {
                 return None;
             }
 
-            self.get_column(component_id).map(|col| {
-                // SAFETY: `row.index()` < `len`
-                col.changed_by
-                    .as_ref()
-                    .map(|changed_by| unsafe { changed_by.get_unchecked(row.index()) })
-            })
+            // SAFETY: `row.index()` < `len`
+            self.get_column(component_id)
+                .map(|col| unsafe { col.get_changed_by_unchecked(row) })
         })
     }
 
@@ -363,10 +360,8 @@ impl Table {
         component_id: ComponentId,
         row: TableRow,
     ) -> Option<ComponentTicks> {
-        self.get_column(component_id).map(|col| ComponentTicks {
-            added: col.added_ticks.get_unchecked(row.index()).read(),
-            changed: col.changed_ticks.get_unchecked(row.index()).read(),
-        })
+        self.get_column(component_id)
+            .map(|col| col.get_ticks_unchecked(row))
     }
 
     /// Fetches a read-only reference to the [`Column`] for a given [`Component`] within the table.
@@ -509,7 +504,7 @@ impl Table {
     /// Get the drop function for some component that is stored in this table.
     #[inline]
     pub fn get_drop_for(&self, component_id: ComponentId) -> Option<unsafe fn(OwningPtr<'_>)> {
-        self.get_column(component_id)?.data.drop
+        self.get_column(component_id)?.get_drop()
     }
 
     /// Gets the number of components being stored in the table.
@@ -579,8 +574,8 @@ impl Table {
     ) -> OwningPtr<'_> {
         self.get_column_mut(component_id)
             .debug_checked_unwrap()
-            .data
-            .get_unchecked_mut(row.index())
+            .get_data_unchecked(row)
+            .assert_unique()
             .promote()
     }
 
@@ -594,7 +589,7 @@ impl Table {
         row: TableRow,
     ) -> Option<Ptr<'_>> {
         self.get_column(component_id)
-            .map(|col| col.data.get_unchecked(row.index()))
+            .map(|col| col.get_data_unchecked(row))
     }
 
     /// Returns a reference to this table's summary tick for the given

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -1,3 +1,7 @@
+mod column;
+
+pub use column::Column;
+
 use crate::{
     change_detection::{AtomicTick, CheckChangeTicks, ComponentTicks, MaybeLocation, Tick},
     component::{ComponentId, ComponentInfo, Components},
@@ -7,8 +11,7 @@ use crate::{
 };
 use alloc::{boxed::Box, vec, vec::Vec};
 use bevy_platform::collections::HashMap;
-use bevy_ptr::{OwningPtr, Ptr, UnsafeCellDeref};
-pub use column::*;
+use bevy_ptr::{OwningPtr, Ptr};
 use core::{
     cell::UnsafeCell,
     num::NonZeroUsize,
@@ -16,7 +19,6 @@ use core::{
     panic::Location,
 };
 use nonmax::NonMaxU32;
-mod column;
 
 /// An opaque unique ID for a [`Table`] within a [`World`].
 ///


### PR DESCRIPTION
## Objective

`Column`'s fields are currently all `pub(super)` so they can be used in `Table` methods. All of these external usages of the fields can be replaced by existing equivalent methods, allowing the fields to be private.

More generally, it's preferable for fields to be as private as possible so that internals can be changed with less churn.

Also, the column file has the glob import `use super::*`, but (at least in Bevy) glob imports aren't typically used besides preludes and re-exports.

## Solution

Make fields private and use equivalent methods. Remove `use super::*`  and use specific imports.