### PR TITLE
text input: retry the font family resolve when the font asset lands

### DIFF
--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -206,7 +206,11 @@ pub fn update_editable_text_styles(
                 ));
         }
 
-        if text_font.is_changed()
+        // `fonts.is_changed()` is a retry, not redundancy: a `FontSource::Handle`
+        // is usually still loading on the frame its field spawns, so the resolve
+        // fails, and `text_font` is only `is_changed()` that once -- without it
+        // the editor keeps parley's default family for the field's whole life.
+        if (text_font.is_changed() || fonts.is_changed())
             && let Ok(resolved_family) = text_font.font.resolve_font_family(fonts.as_ref())
         {
             let family = resolved_family.into_owned();

--- a/crates/bevy_ui/src/widget/text_input_layout.rs
+++ b/crates/bevy_ui/src/widget/text_input_layout.rs
@@ -206,10 +206,11 @@ pub fn update_editable_text_styles(
                 ));
         }
 
-        // `fonts.is_changed()` is a retry, not redundancy: a `FontSource::Handle`
-        // is usually still loading on the frame its field spawns, so the resolve
-        // fails, and `text_font` is only `is_changed()` that once -- without it
-        // the editor keeps parley's default family for the field's whole life.
+        // A `FontSource::Handle` is usually still loading on the frame its field
+        // spawns and `text_font.is_changed()` will only be true after another
+        // change, so to guarantee the editor gets the correct family,
+        // `resolve_font_family()` is retried on `fonts.is_changed()` after the
+        // load completes.
         if (text_font.is_changed() || fonts.is_changed())
             && let Ok(resolved_family) = text_font.font.resolve_font_family(fonts.as_ref())
         {


### PR DESCRIPTION
# Objective

An `EditableText` field whose `TextFont` names a `FontSource::Handle` can end up
rendering in parley's default family for the rest of its life.

`update_editable_text_styles` pushes the resolved family only when
`text_font.is_changed()`:

```rust
if text_font.is_changed()
    && let Ok(resolved_family) = text_font.font.resolve_font_family(fonts.as_ref())
```

On the frame a field spawns, its handle is usually still loading, so
`resolve_font_family` fails. `TextFont` is not `is_changed()` again after that
frame, so nothing ever retries: the font asset finishes loading, gets registered
into the `FontContext`, and the editor is never told to use it.

The field is left with whatever family parley defaults to, while an equivalent
non-editable `Text` node picks the font up correctly.

## Solution

Also attempt the resolve when `Assets<Font>` changes, which is exactly when a
late handle becomes resolvable. One extra `insert(FontFamily)` per editable
field per font-asset change; it is skipped entirely once the resolve succeeds
and no further font assets arrive.

A narrower alternative would be to read `AssetEvent<Font>` and match the
`Added`/`Modified` ids against each field's handle. That is more code for a
system that already runs every frame and whose body is a handful of style
inserts, so this takes the simpler condition.

## Testing

Found while chasing a related bug in a fork of 0.19, where the same skip also
swallowed `LineHeight` and `TextLayout` syncing (that code used `continue`
rather than a let-chain, so an unresolved font skipped the rest of the loop
body; main's let-chain refactor already fixed that half). With the retry, a
field whose font handle resolves a frame or two after spawn renders in the
requested family; without it, it never does.

