### PR TITLE
Add a CI screenshot run for the tonemapping example

### DIFF
--- a/.github/example-run/tonemapping.ron
+++ b/.github/example-run/tonemapping.ron
@@ -1,0 +1,8 @@
+(
+    setup: (
+        fixed_frame_time: Some(0.05),
+    ),
+    events: [
+        (300, ScreenshotAndExit),
+    ]
+)


### PR DESCRIPTION
# Objective

The `tonemapping` example never runs in CI, and it's the most direct coverage for upcoming tonemapping render-path work.

## Solution

Add the tonemapping example to the Pixel Eagle tests.

## Testing

Tested locally with lavapipe to validate the run and the screenshot.

---

This PR was built by me with the assistance of Claude Code w/ Fable 5
