### PR TITLE
Move Tonemapping and DebandDither to bevy_render::view

### DIFF
--- a/_release-content/migration-guides/tonemapping_moved_to_bevy_render.md
+++ b/_release-content/migration-guides/tonemapping_moved_to_bevy_render.md
@@ -1,0 +1,11 @@
+---
+title: "`Tonemapping` and `DebandDither` moved to `bevy_render::view`"
+pull_requests: [25480]
+---
+
+`Tonemapping` and `DebandDither` moved from `bevy_core_pipeline::tonemapping` to
+`bevy_render::view`. Rust imports still work through re-exports, but the reflected type
+paths changed: update scene files and Bevy Remote Protocol component keys that name them.
+
+- `bevy_core_pipeline::tonemapping::Tonemapping` is now `bevy_render::view::Tonemapping`
+- `bevy_core_pipeline::tonemapping::DebandDither` is now `bevy_render::view::DebandDither`

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -2,14 +2,12 @@ use bevy_app::prelude::*;
 use bevy_asset::{
     embedded_asset, load_embedded_asset, AssetServer, Assets, Handle, RenderAssetUsages,
 };
-use bevy_camera::Camera;
 use bevy_ecs::prelude::*;
 use bevy_image::{CompressedImageFormats, Image, ImageSampler, ImageType};
 #[cfg(not(feature = "tonemapping_luts"))]
 use bevy_log::error;
-use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
-    extract_component::{ExtractComponent, ExtractComponentPlugin},
+    extract_component::ExtractComponentPlugin,
     extract_resource::{ExtractResource, ExtractResourcePlugin},
     render_asset::RenderAssets,
     render_resource::{
@@ -26,6 +24,7 @@ use bitflags::bitflags;
 
 mod node;
 
+pub use bevy_render::view::{DebandDither, Tonemapping};
 use bevy_utils::default;
 pub use node::tonemapping;
 
@@ -108,71 +107,6 @@ pub struct TonemappingPipeline {
     sampler: Sampler,
     fullscreen_shader: FullscreenShader,
     fragment_shader: Handle<Shader>,
-}
-
-/// Optionally enables a tonemapping shader that attempts to map linear input stimulus into a perceptually uniform image for a given [`Camera`] entity.
-#[derive(
-    Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
-)]
-#[extract_component_filter(With<Camera>)]
-#[reflect(Component, Debug, Hash, Default, PartialEq)]
-#[extract_app(RenderApp)]
-pub enum Tonemapping {
-    /// Bypass tonemapping.
-    None,
-    /// Suffers from lots hue shifting, brights don't desaturate naturally.
-    /// Bright primaries and secondaries don't desaturate at all.
-    Reinhard,
-    /// Suffers from hue shifting. Brights don't desaturate much at all across the spectrum.
-    ReinhardLuminance,
-    /// Same base implementation that Godot 4.0 uses for Tonemap ACES.
-    /// <https://github.com/TheRealMJP/BakingLab/blob/master/BakingLab/ACES.hlsl>
-    /// Not neutral, has a very specific aesthetic, intentional and dramatic hue shifting.
-    /// Bright greens and reds turn orange. Bright blues turn magenta.
-    /// Significantly increased contrast. Brights desaturate across the spectrum.
-    AcesFitted,
-    /// By Troy Sobotka
-    /// <https://github.com/sobotka/AgX>
-    /// Very neutral. Image is somewhat desaturated when compared to other tonemappers.
-    /// Little to no hue shifting. Subtle [Abney shifting](https://en.wikipedia.org/wiki/Abney_effect).
-    /// NOTE: Requires the `tonemapping_luts` cargo feature.
-    AgX,
-    /// By Tomasz Stachowiak
-    /// Has little hue shifting in the darks and mids, but lots in the brights. Brights desaturate across the spectrum.
-    /// Is sort of between Reinhard and `ReinhardLuminance`. Conceptually similar to reinhard-jodie.
-    /// Designed as a compromise if you want e.g. decent skin tones in low light, but can't afford to re-do your
-    /// VFX to look good without hue shifting.
-    SomewhatBoringDisplayTransform,
-    /// Current Bevy default.
-    /// By Tomasz Stachowiak
-    /// <https://github.com/h3r2tic/tony-mc-mapface>
-    /// Very neutral. Subtle but intentional hue shifting. Brights desaturate across the spectrum.
-    /// Comment from author:
-    /// Tony is a display transform intended for real-time applications such as games.
-    /// It is intentionally boring, does not increase contrast or saturation, and stays close to the
-    /// input stimulus where compression isn't necessary.
-    /// Brightness-equivalent luminance of the input stimulus is compressed. The non-linearity resembles Reinhard.
-    /// Color hues are preserved during compression, except for a deliberate [Bezold–Brücke shift](https://en.wikipedia.org/wiki/Bezold%E2%80%93Br%C3%BCcke_shift).
-    /// To avoid posterization, selective desaturation is employed, with care to avoid the [Abney effect](https://en.wikipedia.org/wiki/Abney_effect).
-    /// NOTE: Requires the `tonemapping_luts` cargo feature.
-    #[default]
-    TonyMcMapface,
-    /// Default Filmic Display Transform from blender.
-    /// Somewhat neutral. Suffers from hue shifting. Brights desaturate across the spectrum.
-    /// NOTE: Requires the `tonemapping_luts` cargo feature.
-    BlenderFilmic,
-    /// Despite its name, it is not considered to be neutral.
-    /// Highly saturated colors and tends to produce a very high contrast image.
-    /// Suffers from significant [Abney shifting](https://en.wikipedia.org/wiki/Abney_effect), and tends to crush grays and desaturated colors.
-    /// Designed for e-commerce to faithfully reproduce the colors of brand's logos when used with low brightness grayscale lighting.
-    /// See [the KhronosGroup spec](https://github.com/KhronosGroup/ToneMapping/tree/main/PBR_Neutral) for more information.
-    KhronosPbrNeutral,
-}
-
-impl Tonemapping {
-    pub fn is_enabled(&self) -> bool {
-        *self != Tonemapping::None
-    }
 }
 
 bitflags! {
@@ -374,18 +308,6 @@ pub fn prepare_view_tonemapping_pipelines(
             .entity(entity)
             .insert(ViewTonemappingPipeline(pipeline));
     }
-}
-/// Enables a debanding shader that applies dithering to mitigate color banding in the final image for a given [`Camera`] entity.
-#[derive(
-    Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
-)]
-#[extract_component_filter(With<Camera>)]
-#[reflect(Component, Debug, Hash, Default, PartialEq)]
-#[extract_app(RenderApp)]
-pub enum DebandDither {
-    #[default]
-    Disabled,
-    Enabled,
 }
 
 pub fn get_lut_bindings<'a>(

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -209,8 +209,8 @@
 //!       },
 //!       "depth_texture_usages": 16,
 //!     },
-//!     "bevy_core_pipeline::tonemapping::DebandDither": "Enabled",
-//!     "bevy_core_pipeline::tonemapping::Tonemapping": "TonyMcMapface",
+//!     "bevy_render::view::DebandDither": "Enabled",
+//!     "bevy_render::view::Tonemapping": "TonyMcMapface",
 //!     "bevy_light::cluster::ClusterConfig": {
 //!       "FixedZ": {
 //!      "dynamic_resizing": true,

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -264,8 +264,8 @@ impl Msaa {
 
 /// Optionally enables a tonemapping shader that attempts to map linear input stimulus into a perceptually uniform image for a given [`Camera`] entity.
 ///
-/// The tonemapping pass lives in `bevy_core_pipeline`. The type lives here so
-/// render-world systems in `bevy_render` can consume it.
+/// The tonemapping pass lives in `bevy_core_pipeline`. The type is defined in
+/// `bevy_render` so render-world code can read it.
 #[derive(
     Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
 )]

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -2,8 +2,8 @@ pub mod visibility;
 pub mod window;
 
 use bevy_camera::{
-    primitives::Frustum, CameraMainTextureUsages, ClearColor, ClearColorConfig, CompositingSpace,
-    Exposure, MainPassResolutionOverride, NormalizedRenderTarget,
+    primitives::Frustum, Camera, CameraMainTextureUsages, ClearColor, ClearColorConfig,
+    CompositingSpace, Exposure, MainPassResolutionOverride, NormalizedRenderTarget,
 };
 use bevy_diagnostic::FrameCount;
 pub use visibility::*;
@@ -214,7 +214,7 @@ impl Plugin for ViewPlugin {
 }
 
 /// Component for configuring the number of samples for [Multi-Sample Anti-Aliasing](https://en.wikipedia.org/wiki/Multisample_anti-aliasing)
-/// for a [`Camera`](bevy_camera::Camera).
+/// for a [`Camera`].
 ///
 /// Defaults to 4 samples. A higher number of samples results in smoother edges.
 ///
@@ -260,6 +260,87 @@ impl Msaa {
             _ => panic!("Unsupported MSAA sample count: {samples}"),
         }
     }
+}
+
+/// Optionally enables a tonemapping shader that attempts to map linear input stimulus into a perceptually uniform image for a given [`Camera`] entity.
+///
+/// The tonemapping pass lives in `bevy_core_pipeline`. The type lives here so
+/// render-world systems in `bevy_render` can consume it.
+#[derive(
+    Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
+)]
+#[extract_component_filter(With<Camera>)]
+#[reflect(Component, Debug, Hash, Default, PartialEq)]
+#[extract_app(RenderApp)]
+pub enum Tonemapping {
+    /// Bypass tonemapping.
+    None,
+    /// Suffers from lots hue shifting, brights don't desaturate naturally.
+    /// Bright primaries and secondaries don't desaturate at all.
+    Reinhard,
+    /// Suffers from hue shifting. Brights don't desaturate much at all across the spectrum.
+    ReinhardLuminance,
+    /// Same base implementation that Godot 4.0 uses for Tonemap ACES.
+    /// <https://github.com/TheRealMJP/BakingLab/blob/master/BakingLab/ACES.hlsl>
+    /// Not neutral, has a very specific aesthetic, intentional and dramatic hue shifting.
+    /// Bright greens and reds turn orange. Bright blues turn magenta.
+    /// Significantly increased contrast. Brights desaturate across the spectrum.
+    AcesFitted,
+    /// By Troy Sobotka
+    /// <https://github.com/sobotka/AgX>
+    /// Very neutral. Image is somewhat desaturated when compared to other tonemappers.
+    /// Little to no hue shifting. Subtle [Abney shifting](https://en.wikipedia.org/wiki/Abney_effect).
+    /// NOTE: Requires the `tonemapping_luts` cargo feature.
+    AgX,
+    /// By Tomasz Stachowiak
+    /// Has little hue shifting in the darks and mids, but lots in the brights. Brights desaturate across the spectrum.
+    /// Is sort of between Reinhard and `ReinhardLuminance`. Conceptually similar to reinhard-jodie.
+    /// Designed as a compromise if you want e.g. decent skin tones in low light, but can't afford to re-do your
+    /// VFX to look good without hue shifting.
+    SomewhatBoringDisplayTransform,
+    /// Current Bevy default.
+    /// By Tomasz Stachowiak
+    /// <https://github.com/h3r2tic/tony-mc-mapface>
+    /// Very neutral. Subtle but intentional hue shifting. Brights desaturate across the spectrum.
+    /// Comment from author:
+    /// Tony is a display transform intended for real-time applications such as games.
+    /// It is intentionally boring, does not increase contrast or saturation, and stays close to the
+    /// input stimulus where compression isn't necessary.
+    /// Brightness-equivalent luminance of the input stimulus is compressed. The non-linearity resembles Reinhard.
+    /// Color hues are preserved during compression, except for a deliberate [Bezold–Brücke shift](https://en.wikipedia.org/wiki/Bezold%E2%80%93Br%C3%BCcke_shift).
+    /// To avoid posterization, selective desaturation is employed, with care to avoid the [Abney effect](https://en.wikipedia.org/wiki/Abney_effect).
+    /// NOTE: Requires the `tonemapping_luts` cargo feature.
+    #[default]
+    TonyMcMapface,
+    /// Default Filmic Display Transform from blender.
+    /// Somewhat neutral. Suffers from hue shifting. Brights desaturate across the spectrum.
+    /// NOTE: Requires the `tonemapping_luts` cargo feature.
+    BlenderFilmic,
+    /// Despite its name, it is not considered to be neutral.
+    /// Highly saturated colors and tends to produce a very high contrast image.
+    /// Suffers from significant [Abney shifting](https://en.wikipedia.org/wiki/Abney_effect), and tends to crush grays and desaturated colors.
+    /// Designed for e-commerce to faithfully reproduce the colors of brand's logos when used with low brightness grayscale lighting.
+    /// See [the KhronosGroup spec](https://github.com/KhronosGroup/ToneMapping/tree/main/PBR_Neutral) for more information.
+    KhronosPbrNeutral,
+}
+
+impl Tonemapping {
+    pub fn is_enabled(&self) -> bool {
+        *self != Tonemapping::None
+    }
+}
+
+/// Enables a debanding shader that applies dithering to mitigate color banding in the final image for a given [`Camera`] entity.
+#[derive(
+    Component, Debug, Hash, Clone, Copy, Reflect, Default, ExtractComponent, PartialEq, Eq,
+)]
+#[extract_component_filter(With<Camera>)]
+#[reflect(Component, Debug, Hash, Default, PartialEq)]
+#[extract_app(RenderApp)]
+pub enum DebandDither {
+    #[default]
+    Disabled,
+    Enabled,
 }
 
 /// An identifier for a view that is stable across frames.
@@ -390,10 +471,9 @@ impl ExtractedView {
 
 /// Configures filmic color grading parameters to adjust the image appearance.
 ///
-/// Color grading is applied just before tonemapping for a given
-/// [`Camera`](bevy_camera::Camera) entity, with the sole exception of the
-/// `post_saturation` value in [`ColorGradingGlobal`], which is applied after
-/// tonemapping.
+/// Color grading is applied just before tonemapping for a given [`Camera`]
+/// entity, with the sole exception of the `post_saturation` value in
+/// [`ColorGradingGlobal`], which is applied after tonemapping.
 #[derive(Component, Reflect, Debug, Default, Clone)]
 #[reflect(Component, Default, Debug, Clone)]
 pub struct ColorGrading {


### PR DESCRIPTION
# Objective

`bevy_render` can't depend on `bevy_core_pipeline`, so render-world code there can't read a camera's `Tonemapping` component at all. Upcoming render-path work needs to know whether a camera tonemaps, when camera extraction picks the camera's main texture format.

## Solution

Move the `Tonemapping` and `DebandDither` definitions to `bevy_render::view` and re-export them from the old path, so existing imports keep compiling. No runtime changes. The reflected type path changes, which affects scene files and Bevy Remote Protocol keys that spell out the old path. The migration guide covers it. The `Tonemapping::Linear` PR builds on this one.

## Testing

Check, clippy, and unit tests pass for the touched crates, plus a workspace check. Rustdoc with warnings denied passes for `bevy_render`.

---

This PR was built by me with the assistance of Claude Code w/ Fable 5
