### PR TITLE
`feathers_gallery` crash fix

### DIFF
--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -88,8 +88,8 @@ fn scene() -> impl SceneList {
     bsn_list![Camera2d, demo_root()]
 }
 
-fn demo_root() -> impl Scene {
-    bsn! {
+fn demo_root() -> Box<dyn Scene> {
+    Box::new(bsn! {
         Node {
             width: percent(100),
             height: percent(100),
@@ -105,7 +105,7 @@ fn demo_root() -> impl Scene {
             demo_column_1(),
             demo_column_2(),
         ]
-    }
+    })
 }
 
 #[derive(Component, Debug, Clone, Default, PartialEq)]


### PR DESCRIPTION
# Objective

Stack overflows with

```
cargo run --example feathers_gallery --features="bevy_feathers"
```

## Solution

Box the scene returned by `demo_root`.
