### PR TITLE
Fix missing Ok() in template(|ctx|{}) docs

### DIFF
--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -531,7 +531,7 @@
 //! bsn! {
 //!     #Foo
 //!     template(|ctx| {
-//!         Foo(ctx.resource::<MyAssetCollection>().get("generated_asset_name"))
+//!         Ok(GameMap(ctx.resource::<MyAssetCollection>().get("generated_asset_name")?))
 //!     })
 //! }
 //! ```


### PR DESCRIPTION
# Objective

Doc codeblock was wrong

## Solution

fixed it. Also used a less confusing example component and added a ? at the end of the `.get()` (imaginary MyAssetCollection API, so i think showing the schema is fine even if most `.get()` return Option) 

## Testing

nope, did this in web editor