### PR TITLE
Refactor animation timers inside pan_orbit_camera

### DIFF
--- a/crates/bevy_camera_controller/src/pan_orbit_camera/controller/component.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/controller/component.rs
@@ -321,7 +321,7 @@ impl PanOrbitCamera {
             Query<&mut Transform, With<PanOrbitCamera>>,
         )>,
         mut event: MessageWriter<RequestRedraw>,
-        time: Res<Time>,
+        time: Res<Time<Real>>,
     ) {
         camera_set
             .p0()

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/dolly_zoom.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/dolly_zoom.rs
@@ -10,7 +10,8 @@ use bevy_camera::{prelude::*, ScalingMode};
 use bevy_ecs::prelude::*;
 use bevy_log::error_once;
 use bevy_math::{prelude::*, DQuat, DVec3};
-use bevy_platform::{collections::HashMap, time::Instant};
+use bevy_platform::collections::HashMap;
+use bevy_time::{Real, Time, Timer, TimerMode};
 use bevy_transform::components::Transform;
 use bevy_window::RequestRedraw;
 
@@ -107,7 +108,7 @@ impl DollyZoomTrigger {
                 ..Default::default()
             };
             *proj = Projection::Perspective(perspective_start.clone());
-
+            let animation_duration = state.animation_duration;
             state
                 .map
                 .entry(event.camera)
@@ -115,16 +116,14 @@ impl DollyZoomTrigger {
                     e.perspective_start = perspective_start.clone();
                     e.proj_end = event.target_projection.clone();
                     e.triangle_base = triangle_base;
-                    e.start = Instant::now();
-                    e.complete = false;
+                    e.animation_timer = Timer::new(animation_duration, TimerMode::Once);
                 })
                 .or_insert(ZoomEntry {
                     perspective_start,
                     proj_end: event.target_projection.clone(),
                     triangle_base,
-                    start: Instant::now(),
+                    animation_timer: Timer::new(animation_duration, TimerMode::Once),
                     initial_enabled: controller.enabled_motion.clone(),
-                    complete: false,
                 });
 
             controller.end_move();
@@ -146,9 +145,8 @@ struct ZoomEntry {
     perspective_start: PerspectiveProjection,
     proj_end: Projection,
     triangle_base: f64,
-    start: Instant,
+    animation_timer: Timer,
     initial_enabled: EnabledMotion,
-    complete: bool,
 }
 
 /// Stores settings and state for the dolly zoom plugin.
@@ -182,8 +180,8 @@ impl DollyZoom {
             Query<&mut Transform, With<PanOrbitCamera>>,
         )>,
         mut redraw: MessageWriter<RequestRedraw>,
+        time: Res<Time<Real>>,
     ) {
-        let animation_duration = state.animation_duration;
         let animation_curve = state.animation_curve;
         for (
             camera_entity,
@@ -191,22 +189,22 @@ impl DollyZoom {
                 perspective_start,
                 proj_end,
                 triangle_base,
-                start,
+                animation_timer,
                 initial_enabled,
-                complete,
             },
         ) in state.map.iter_mut()
         {
+            animation_timer.tick(time.delta());
             let mut cameras = camera_set.p0();
             let Ok((camera, mut projection, mut controller)) = cameras.get_mut(*camera_entity)
             else {
-                *complete = true;
+                animation_timer.finish();
                 continue;
             };
             let Projection::Perspective(last_perspective) = projection.clone() else {
                 *projection = proj_end.clone();
                 controller.enabled_motion = initial_enabled.clone();
-                *complete = true;
+                animation_timer.finish();
                 continue;
             };
 
@@ -223,8 +221,7 @@ impl DollyZoom {
                     return;
                 }
             };
-            let progress = start.elapsed().as_secs_f32() / animation_duration.as_secs_f32();
-            let progress = animation_curve.ease(progress);
+            let progress = animation_curve.ease(animation_timer.fraction());
             let next_fov = (1.0 - progress as f64) * fov_start + progress as f64 * fov_end;
 
             let last_dist = *triangle_base / (last_fov / 2.0).tan();
@@ -236,7 +233,7 @@ impl DollyZoom {
             delta_translation += next_translation;
             controller.last_anchor_depth += forward_dist;
 
-            if progress < 1.0 {
+            if !animation_timer.is_finished() {
                 *projection = Projection::Perspective(PerspectiveProjection {
                     fov: next_fov as f32,
                     ..last_perspective
@@ -248,7 +245,6 @@ impl DollyZoom {
                     ortho.scale = (*triangle_base * multiplier) as f32;
                 }
                 controller.enabled_motion = initial_enabled.clone();
-                *complete = true;
             }
             redraw.write(RequestRedraw);
 
@@ -256,7 +252,7 @@ impl DollyZoom {
             let mut camera_mut = camera_muts.get_mut(*camera_entity).unwrap();
             apply_delta(&mut camera_mut, delta_translation, DQuat::IDENTITY);
         }
-        state.map.retain(|_, v| !v.complete);
+        state.map.retain(|_, v| !v.animation_timer.is_finished());
     }
 }
 

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/look_to.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/look_to.rs
@@ -8,7 +8,7 @@ use bevy_ecs::prelude::*;
 use bevy_ecs::resource::IsResource;
 use bevy_math::{prelude::*, DAffine3, DQuat, DVec3};
 use bevy_platform::collections::HashMap;
-use bevy_time::{Real, Time, Timer};
+use bevy_time::{Real, Time, Timer, TimerMode};
 use bevy_transform::components::Transform;
 use bevy_window::RequestRedraw;
 
@@ -121,14 +121,14 @@ impl LookToTrigger {
                 .map
                 .entry(event.camera)
                 .and_modify(|e| {
-                    e.animation_timer = Timer::new(animation_duration, bevy_time::TimerMode::Once);
+                    e.animation_timer = Timer::new(animation_duration, TimerMode::Once);
                     e.initial_facing_direction = camera_forward;
                     e.initial_up_direction = camera_up;
                     e.target_facing_direction = event.target_facing_direction;
                     e.target_up_direction = event.target_up_direction;
                 })
                 .or_insert(LookToEntry {
-                    animation_timer: Timer::new(animation_duration, bevy_time::TimerMode::Once),
+                    animation_timer: Timer::new(animation_duration, TimerMode::Once),
                     initial_facing_direction: camera_forward,
                     initial_up_direction: camera_up,
                     target_facing_direction: event.target_facing_direction,

--- a/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/look_to.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/extensions/look_to.rs
@@ -7,7 +7,8 @@ use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_ecs::resource::IsResource;
 use bevy_math::{prelude::*, DAffine3, DQuat, DVec3};
-use bevy_platform::{collections::HashMap, time::Instant};
+use bevy_platform::collections::HashMap;
+use bevy_time::{Real, Time, Timer};
 use bevy_transform::components::Transform;
 use bevy_window::RequestRedraw;
 
@@ -115,24 +116,23 @@ impl LookToTrigger {
             redraw.write(RequestRedraw);
             let camera_forward = camera_rotation * DVec3::NEG_Z;
             let camera_up = camera_rotation * DVec3::Y;
+            let animation_duration = state.animation_duration;
             state
                 .map
                 .entry(event.camera)
                 .and_modify(|e| {
-                    e.start = Instant::now();
+                    e.animation_timer = Timer::new(animation_duration, bevy_time::TimerMode::Once);
                     e.initial_facing_direction = camera_forward;
                     e.initial_up_direction = camera_up;
                     e.target_facing_direction = event.target_facing_direction;
                     e.target_up_direction = event.target_up_direction;
-                    e.complete = false;
                 })
                 .or_insert(LookToEntry {
-                    start: Instant::now(),
+                    animation_timer: Timer::new(animation_duration, bevy_time::TimerMode::Once),
                     initial_facing_direction: camera_forward,
                     initial_up_direction: camera_up,
                     target_facing_direction: event.target_facing_direction,
                     target_up_direction: event.target_up_direction,
-                    complete: false,
                 });
 
             controller.end_move();
@@ -142,12 +142,11 @@ impl LookToTrigger {
 }
 
 struct LookToEntry {
-    start: Instant,
+    animation_timer: Timer,
     initial_facing_direction: DVec3,
     initial_up_direction: DVec3,
     target_facing_direction: DVec3,
     target_up_direction: DVec3,
-    complete: bool,
 }
 
 /// Stores settings and state for the dolly zoom plugin.
@@ -182,21 +181,21 @@ impl LookTo {
             Query<&mut Transform, With<PanOrbitCamera>>,
         )>,
         mut redraw: MessageWriter<RequestRedraw>,
+        time: Res<Time<Real>>,
     ) {
-        let animation_duration = state.animation_duration;
         let animation_curve = state.animation_curve;
         for (
             camera,
             LookToEntry {
-                start,
+                animation_timer,
                 initial_facing_direction,
                 initial_up_direction,
                 target_facing_direction,
                 target_up_direction,
-                complete,
             },
         ) in state.map.iter_mut()
         {
+            animation_timer.tick(time.delta());
             let camera_refs = camera_set.p1();
             let Ok(cam_transform) = camera_refs.get(*camera) else {
                 continue;
@@ -207,12 +206,10 @@ impl LookTo {
             };
             let mut cameras = camera_set.p0();
             let Ok(controller) = cameras.get_mut(*camera) else {
-                *complete = true;
+                animation_timer.finish();
                 continue;
             };
-            let progress_t =
-                (start.elapsed().as_secs_f32() / animation_duration.as_secs_f32()).clamp(0.0, 1.0);
-            let progress = animation_curve.ease(progress_t);
+            let progress = animation_curve.ease(animation_timer.fraction());
 
             let anchor_view_space = controller.anchor_view_space().unwrap_or(DVec3::new(
                 0.0,
@@ -249,11 +246,8 @@ impl LookTo {
             let mut camera_muts = camera_set.p2();
             let mut camera_mut = camera_muts.get_mut(*camera).unwrap();
             apply_delta(&mut camera_mut, delta_translation, delta_rotation);
-            if progress_t >= 1.0 {
-                *complete = true;
-            }
             redraw.write(RequestRedraw);
         }
-        state.map.retain(|_, v| !v.complete);
+        state.map.retain(|_, v| !v.animation_timer.is_finished());
     }
 }


### PR DESCRIPTION
Closes #25469 

## Objective

Upstreamed version uses global ``Instant::now()`` for timekeeping for some animations.

Replace that logic with `Res<Time<Real>>` and ``Timer``