### PR TITLE
replace drain and collect with `mem::take` in `bevy_reflect`

### DIFF
--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -251,7 +251,7 @@ impl List for DynamicList {
     }
 
     fn drain(&mut self) -> Vec<Box<dyn PartialReflect>> {
-        self.values.drain(..).collect()
+        core::mem::take(&mut self.values)
     }
 }
 


### PR DESCRIPTION
# Objective

New CI failure:

```
error: draining all elements of a collection into a new collection of the same type
   --> crates/bevy_reflect/src/list.rs:254:9
    |
254 |         self.values.drain(..).collect()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `mem::take` to avoid creating a new allocation: `core::mem::take(&mut self.values)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#drain_collect
    = note: `-D clippy::drain-collect` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::drain_collect)]`
```

## Solution

Replace drain and collect with `mem::take`

https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#drain_collect
