### PR TITLE
fix rust 1.98.0 CI failures

### DIFF
--- a/crates/bevy_camera_controller/src/pan_orbit_camera/controller/component.rs
+++ b/crates/bevy_camera_controller/src/pan_orbit_camera/controller/component.rs
@@ -246,7 +246,7 @@ impl PanOrbitCamera {
             CurrentMotion::UserControlled {
                 ref mut motion_inputs,
                 ..
-            } => InputQueue(motion_inputs.zoom_inputs_mut().0.drain(..).collect()),
+            } => InputQueue(core::mem::take(&mut motion_inputs.zoom_inputs_mut().0)),
         };
         self.current_motion = CurrentMotion::UserControlled {
             anchor,

--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -717,10 +717,12 @@ mod tests {
 
         // On mac backtraces can start with Backtrace::create
         // Rust 1.95 changed the format to use angle brackets: <std::backtrace::Backtrace>::create
+        // Rust 1.98 renamed create to capture
         let mut skip = false;
         if let Some(line) = lines.peek()
             && (line[6..] == *"std::backtrace::Backtrace::create"
-                || line[6..] == *"<std::backtrace::Backtrace>::create")
+                || line[6..] == *"<std::backtrace::Backtrace>::create"
+                || line[6..] == *"<std::backtrace::Backtrace>::capture")
         {
             skip = true;
         }

--- a/crates/bevy_ecs/src/error/bevy_error.rs
+++ b/crates/bevy_ecs/src/error/bevy_error.rs
@@ -225,7 +225,9 @@ impl BevyError {
                             skip_next_location_line = true;
                             continue;
                         }
-                        if line.contains("std::backtrace::Backtrace::") {
+                        if line.contains(": std::backtrace::Backtrace::")
+                            || line.contains(": <std::backtrace::Backtrace>::")
+                        {
                             skip_next_location_line = true;
                             continue;
                         }
@@ -717,17 +719,12 @@ mod tests {
 
         // On mac backtraces can start with Backtrace::create
         // Rust 1.95 changed the format to use angle brackets: <std::backtrace::Backtrace>::create
-        // Rust 1.98 renamed create to capture
-        let mut skip = false;
-        if let Some(line) = lines.peek()
-            && (line[6..] == *"std::backtrace::Backtrace::create"
-                || line[6..] == *"<std::backtrace::Backtrace>::create"
-                || line[6..] == *"<std::backtrace::Backtrace>::capture")
-        {
-            skip = true;
-        }
-
-        if skip {
+        // Rust 1.98 stopped inlining create into capture, so more than one of these frames can appear
+        while lines.peek().is_some_and(|line| {
+            let symbol = line.get(6..).unwrap_or("");
+            symbol.starts_with("std::backtrace::Backtrace::")
+                || symbol.starts_with("<std::backtrace::Backtrace>::")
+        }) {
             lines.next().unwrap();
         }
 
@@ -771,7 +768,7 @@ mod tests {
         // on linux there is a second call_once
         let mut skip = false;
         if let Some(line) = lines.peek()
-            && &line[6..] == "<fn() -> core::result::Result<(), alloc::string::String> as core::ops::function::FnOnce<()>>::call_once"
+            && line.get(6..) == Some("<fn() -> core::result::Result<(), alloc::string::String> as core::ops::function::FnOnce<()>>::call_once")
         {
             skip = true;
         }

--- a/crates/bevy_image/src/dds.rs
+++ b/crates/bevy_image/src/dds.rs
@@ -348,18 +348,10 @@ mod test {
         let (block_width, block_height) = desc.format.block_dimensions();
         let layer_iterations = desc.array_layer_count();
 
-        let outer_iteration;
-        let inner_iteration;
-        match TextureDataOrder::default() {
-            TextureDataOrder::LayerMajor => {
-                outer_iteration = layer_iterations;
-                inner_iteration = desc.mip_level_count;
-            }
-            TextureDataOrder::MipMajor => {
-                outer_iteration = desc.mip_level_count;
-                inner_iteration = layer_iterations;
-            }
-        }
+        let (outer_iteration, inner_iteration) = match TextureDataOrder::default() {
+            TextureDataOrder::LayerMajor => (layer_iterations, desc.mip_level_count),
+            TextureDataOrder::MipMajor => (desc.mip_level_count, layer_iterations),
+        };
 
         let mut binary_offset = 0;
         for outer in 0..outer_iteration {

--- a/crates/bevy_light/src/cluster/assign.rs
+++ b/crates/bevy_light/src/cluster/assign.rs
@@ -806,9 +806,7 @@ fn compute_aabb_for_cluster(
     let p_min = ijk.xy() * tile_size;
     let p_max = p_min + tile_size;
 
-    let cluster_min;
-    let cluster_max;
-    if is_orthographic {
+    let (cluster_min, cluster_max) = if is_orthographic {
         // Use linear depth slicing for orthographic
 
         // Convert to view space at the cluster near and far planes
@@ -820,8 +818,7 @@ fn compute_aabb_for_cluster(
         p_min.z = -z_near + (z_near - z_far) * ijk.z / cluster_dimensions.z as f32;
         p_max.z = -z_near + (z_near - z_far) * (ijk.z + 1.0) / cluster_dimensions.z as f32;
 
-        cluster_min = p_min.min(p_max);
-        cluster_max = p_min.max(p_max);
+        (p_min.min(p_max), p_min.max(p_max))
     } else {
         // Convert to view space at the near plane
         // NOTE: 1.0 is the near plane due to using reverse z projections
@@ -852,9 +849,11 @@ fn compute_aabb_for_cluster(
         let p_max_near = line_intersection_to_z_plane(Vec3::ZERO, p_max.xyz(), cluster_near);
         let p_max_far = line_intersection_to_z_plane(Vec3::ZERO, p_max.xyz(), cluster_far);
 
-        cluster_min = p_min_near.min(p_min_far).min(p_max_near.min(p_max_far));
-        cluster_max = p_min_near.max(p_min_far).max(p_max_near.max(p_max_far));
-    }
+        (
+            p_min_near.min(p_min_far).min(p_max_near.min(p_max_far)),
+            p_min_near.max(p_min_far).max(p_max_near.max(p_max_far)),
+        )
+    };
 
     Aabb::from_min_max(cluster_min, cluster_max)
 }

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -251,7 +251,7 @@ impl List for DynamicList {
     }
 
     fn drain(&mut self) -> Vec<Box<dyn PartialReflect>> {
-        self.values.drain(..).collect()
+        core::mem::take(&mut self.values)
     }
 }
 

--- a/crates/bevy_render/src/gpu_readback.rs
+++ b/crates/bevy_render/src/gpu_readback.rs
@@ -394,8 +394,12 @@ pub(crate) fn submit_readback_commands(world: &World, command_encoder: &mut Comm
 }
 
 /// Move requested readbacks to mapped readbacks after commands have been submitted in render system
+#[expect(
+    clippy::drain_collect,
+    reason = "draining preserves the capacity of `requested`, which is refilled every frame"
+)]
 fn map_buffers(mut readbacks: ResMut<GpuReadbacks>) {
-    let requested = core::mem::take(&mut readbacks.requested);
+    let requested = readbacks.requested.drain(..).collect::<Vec<GpuReadback>>();
     for readback in requested {
         let slice = readback.buffer.slice(..);
         let entity = readback.entity;

--- a/crates/bevy_render/src/gpu_readback.rs
+++ b/crates/bevy_render/src/gpu_readback.rs
@@ -395,7 +395,7 @@ pub(crate) fn submit_readback_commands(world: &World, command_encoder: &mut Comm
 
 /// Move requested readbacks to mapped readbacks after commands have been submitted in render system
 fn map_buffers(mut readbacks: ResMut<GpuReadbacks>) {
-    let requested = readbacks.requested.drain(..).collect::<Vec<GpuReadback>>();
+    let requested = core::mem::take(&mut readbacks.requested);
     for readback in requested {
         let slice = readback.buffer.slice(..);
         let entity = readback.entity;

--- a/crates/bevy_solari/src/scene/binder.rs
+++ b/crates/bevy_solari/src/scene/binder.rs
@@ -62,10 +62,8 @@ pub fn prepare_raytracing_scene_bindings(
     let previous_frame_tlas = raytracing_scene_bindings.previous_frame_tlas.take();
 
     let mut this_frame_entity_to_light_id = EntityHashMap::<u32>::default();
-    let previous_frame_light_entities: Vec<_> = raytracing_scene_bindings
-        .previous_frame_light_entities
-        .drain(..)
-        .collect();
+    let previous_frame_light_entities =
+        core::mem::take(&mut raytracing_scene_bindings.previous_frame_light_entities);
 
     if instances_query.iter().len() == 0 {
         return;

--- a/crates/bevy_solari/src/scene/binder.rs
+++ b/crates/bevy_solari/src/scene/binder.rs
@@ -36,6 +36,10 @@ pub struct RaytracingSceneBindings {
     previous_frame_light_entities: Vec<Entity>,
 }
 
+#[expect(
+    clippy::drain_collect,
+    reason = "draining preserves the capacity of `previous_frame_light_entities`, which is refilled below"
+)]
 pub fn prepare_raytracing_scene_bindings(
     instances_query: Query<(
         Entity,
@@ -62,8 +66,10 @@ pub fn prepare_raytracing_scene_bindings(
     let previous_frame_tlas = raytracing_scene_bindings.previous_frame_tlas.take();
 
     let mut this_frame_entity_to_light_id = EntityHashMap::<u32>::default();
-    let previous_frame_light_entities =
-        core::mem::take(&mut raytracing_scene_bindings.previous_frame_light_entities);
+    let previous_frame_light_entities: Vec<_> = raytracing_scene_bindings
+        .previous_frame_light_entities
+        .drain(..)
+        .collect();
 
     if instances_query.iter().len() == 0 {
         return;

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -779,9 +779,13 @@ impl WinitAppRunnerState {
         }
     }
 
+    #[expect(
+        clippy::drain_collect,
+        reason = "draining preserves the capacity of the event buffers, which are refilled every frame"
+    )]
     fn forward_bevy_events(&mut self) {
-        let raw_winit_events = core::mem::take(&mut self.raw_winit_events);
-        let window_events = core::mem::take(&mut self.bevy_window_events);
+        let raw_winit_events = self.raw_winit_events.drain(..).collect::<Vec<_>>();
+        let window_events = self.bevy_window_events.drain(..).collect::<Vec<_>>();
         let world = self.world_mut();
 
         if !raw_winit_events.is_empty() {

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -780,8 +780,8 @@ impl WinitAppRunnerState {
     }
 
     fn forward_bevy_events(&mut self) {
-        let raw_winit_events = self.raw_winit_events.drain(..).collect::<Vec<_>>();
-        let window_events = self.bevy_window_events.drain(..).collect::<Vec<_>>();
+        let raw_winit_events = core::mem::take(&mut self.raw_winit_events);
+        let window_events = core::mem::take(&mut self.bevy_window_events);
         let world = self.world_mut();
 
         if !raw_winit_events.is_empty() {


### PR DESCRIPTION
# Objective

- Rust 1.98.0 broke CI due to new clippy warnings.

## Solution

- Fix them

## Testing

---

Reviewed by me, but driven by the AI