### PR TITLE
Migrate ```anisotropy``` to feathers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1211,6 +1211,7 @@ wasm = true
 name = "3d_shapes"
 path = "examples/3d/3d_shapes.rs"
 doc-scrape-examples = true
+required-features = ["bevy_feathers"]
 
 [package.metadata.example.3d_shapes]
 name = "3D Shapes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5025,7 +5025,7 @@ wasm = false
 name = "anisotropy"
 path = "examples/3d/anisotropy.rs"
 doc-scrape-examples = true
-required-features = ["jpeg", "pbr_anisotropy_texture"]
+required-features = ["jpeg", "pbr_anisotropy_texture", "bevy_feathers"]
 
 [package.metadata.example.anisotropy]
 name = "Anisotropy"

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -19,7 +19,7 @@ use bevy::{
     feathers::{controls::FeathersCheckbox, theme::UiTheme, FeathersPlugins},
     ui_widgets::{checkbox_self_update, ValueChange},
 };
-use checkbox::feathers_option_checkbox;
+use checkbox::{feathers_option_checkbox, IsChecked};
 use scene::{bottom_left_scene, top_left_scene};
 
 #[path = "../helpers/checkbox.rs"]
@@ -172,15 +172,15 @@ fn spawn_buttons(commands: &mut Commands) {
         commands.spawn_scene(bsn! {
             bottom_left_scene()
             Children [
-                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
-                feathers_option_checkbox("WIREFRAME", Some(CheckboxInput::Wireframe)),
+                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation), IsChecked(false)),
+                feathers_option_checkbox("WIREFRAME", Some(CheckboxInput::Wireframe), IsChecked(false)),
             ]
         });
     } else {
         commands.spawn_scene(bsn! {
             top_left_scene() // so the user can immediately see the control in browser w/o scrolling
             Children [
-                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
+                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation), IsChecked(false)),
             ]
         });
     }

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -283,7 +283,7 @@ fn spawn_buttons(commands: &mut Commands) {
             Children [
                 feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
                 feathers_option_checkbox("WIREFRAME", Some(CheckboxInput::Wireframe)),
-                feathers_button("ADVANCE ROWS", Some(ButtonInput::AdvanceRows)),
+                feathers_button("ADVANCE ROWS", None::<ButtonInput>),
             ]
         });
     } else {
@@ -291,7 +291,7 @@ fn spawn_buttons(commands: &mut Commands) {
             top_left_scene()
             Children [
                 feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
-                feathers_button("ADVANCE ROWS", Some(ButtonInput::AdvanceRows)),
+                feathers_button("ADVANCE ROWS", None::<ButtonInput>),
             ]
         });
     }

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -20,29 +20,63 @@ use bevy::pbr::wireframe::{WireframeConfig, WireframePlugin};
 use bevy::{
     asset::RenderAssetUsages,
     color::palettes::basic::SILVER,
-    input::common_conditions::{input_just_pressed, input_toggle_active},
+    feathers::{controls::FeathersCheckbox, theme::UiTheme, FeathersPlugins},
     prelude::*,
     render::render_resource::{Extent3d, TextureDimension, TextureFormat},
+    ui_widgets::{checkbox_self_update, Activate, ValueChange},
 };
+use button::feathers_button;
+use checkbox::feathers_option_checkbox;
+use scene::top_left_scene;
+
+#[path = "../helpers/button.rs"]
+mod button;
+
+#[path = "../helpers/checkbox.rs"]
+mod checkbox;
+
+#[path = "../helpers/theme.rs"]
+mod theme;
+
+#[path = "../helpers/scene.rs"]
+#[expect(dead_code, reason = "some scenes are not used in this example")]
+mod scene;
 
 fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins.set(ImagePlugin::default_nearest()),
+            FeathersPlugins,
             #[cfg(not(target_arch = "wasm32"))]
             WireframePlugin::default(),
         ))
+        .insert_resource(UiTheme(theme::basic_example_theme(Color::WHITE)))
+        .init_resource::<AppStatus>()
         .add_systems(Startup, setup)
-        .add_systems(
-            Update,
-            (
-                rotate.run_if(input_toggle_active(true, KeyCode::KeyR)),
-                advance_rows.run_if(input_just_pressed(KeyCode::Tab)),
-                #[cfg(not(target_arch = "wasm32"))]
-                toggle_wireframe,
-            ),
-        )
+        .add_systems(Update, (rotate.run_if(rotate_checkbox_checked),))
+        .add_observer(handle_value_change_checkbox)
+        .add_observer(handle_button_press)
+        .add_observer(checkbox_self_update)
         .run();
+}
+
+/// Settings for the example.
+#[derive(Resource, Default)]
+struct AppStatus {
+    rotation: bool,
+}
+
+#[derive(Clone, Copy, Component, Debug, Default, PartialEq)]
+enum CheckboxInput {
+    #[default]
+    Rotation,
+    Wireframe,
+}
+
+#[derive(Clone, Copy, Component, Debug, Default, PartialEq)]
+enum ButtonInput {
+    #[default]
+    AdvanceRows,
 }
 
 /// A marker component for our shapes so we can query them separately from the ground plane
@@ -203,23 +237,7 @@ fn setup(
         Camera3d::default(),
         Transform::from_xyz(0.0, 7., 14.0).looking_at(Vec3::new(0., 1., 0.), Vec3::Y),
     ));
-
-    let mut text = "\
-        Press 'R' to pause/resume rotation\n\
-        Press 'Tab' to cycle through rows"
-        .to_string();
-    #[cfg(not(target_arch = "wasm32"))]
-    text.push_str("\nPress 'Space' to toggle wireframes");
-
-    commands.spawn((
-        Text::new(text),
-        Node {
-            position_type: PositionType::Absolute,
-            top: px(12),
-            left: px(12),
-            ..default()
-        },
-    ));
+    spawn_buttons(&mut commands);
 }
 
 fn rotate(mut query: Query<&mut Transform, With<Shape>>, time: Res<Time>) {
@@ -257,14 +275,58 @@ fn uv_debug_texture() -> Image {
     )
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-fn toggle_wireframe(
-    mut wireframe_config: ResMut<WireframeConfig>,
-    keyboard: Res<ButtonInput<KeyCode>>,
-) {
-    if keyboard.just_pressed(KeyCode::Space) {
-        wireframe_config.global = !wireframe_config.global;
+/// Spawns the control widgets in the top left corner of the screen.
+fn spawn_buttons(commands: &mut Commands) {
+    if !cfg!(target_arch = "wasm32") {
+        commands.spawn_scene(bsn! {
+            top_left_scene()
+            Children [
+                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
+                feathers_option_checkbox("WIREFRAME", Some(CheckboxInput::Wireframe)),
+                feathers_button("ADVANCE ROWS", Some(ButtonInput::AdvanceRows)),
+            ]
+        });
+    } else {
+        commands.spawn_scene(bsn! {
+            top_left_scene()
+            Children [
+                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
+                feathers_button("ADVANCE ROWS", Some(ButtonInput::AdvanceRows)),
+            ]
+        });
     }
+}
+
+fn rotate_checkbox_checked(app_status: Res<AppStatus>) -> bool {
+    app_status.rotation
+}
+
+fn handle_value_change_checkbox(
+    event: On<ValueChange<bool>>,
+    #[cfg(not(target_arch = "wasm32"))] mut wireframe_config: ResMut<WireframeConfig>,
+    mut app_status: ResMut<AppStatus>,
+    checkbox_input_q: Query<&CheckboxInput, With<FeathersCheckbox>>,
+) {
+    if let Ok(checkbox_input) = checkbox_input_q.get(event.source) {
+        match checkbox_input {
+            CheckboxInput::Rotation => {
+                app_status.rotation = event.value;
+            }
+            #[cfg(target_arch = "wasm32")]
+            CheckboxInput::Wireframe => {}
+            #[cfg(not(target_arch = "wasm32"))]
+            CheckboxInput::Wireframe => {
+                wireframe_config.global = event.value;
+            }
+        }
+    }
+}
+
+fn handle_button_press(
+    _activate: On<Activate>,
+    shapes: Query<(&mut Row, &mut Transform), With<Shape>>,
+) {
+    advance_rows(shapes);
 }
 
 #[derive(Component, Clone, Copy)]

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -26,7 +26,7 @@ use bevy::{
     ui_widgets::{checkbox_self_update, Activate, ValueChange},
 };
 use button::feathers_button;
-use checkbox::{feathers_option_checkbox, IsChecked}; 
+use checkbox::{feathers_option_checkbox, IsChecked};
 use scene::top_left_scene;
 
 #[path = "../helpers/button.rs"]

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -10,7 +10,7 @@
 //!
 //! The mesh and material are [`Handle<Mesh>`] and [`Handle<StandardMaterial>`] at the moment, neither of which implement `Component` on their own. Handles are put behind "newtypes" to prevent ambiguity, as some entities might want to have handles to meshes (or images, or materials etc.) for different purposes! All we need to do to make them rendering-relevant components is wrap the mesh handle and the material handle in [`Mesh3d`] and [`MeshMaterial3d`] respectively.
 //!
-//! You can toggle wireframes with the space bar except on wasm. Wasm does not support
+//! You can toggle wireframes via checkbox except on wasm. Wasm does not support
 //! `POLYGON_MODE_LINE` on the gpu.
 
 use std::f32::consts::PI;

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -26,7 +26,7 @@ use bevy::{
     ui_widgets::{checkbox_self_update, Activate, ValueChange},
 };
 use button::feathers_button;
-use checkbox::feathers_option_checkbox;
+use checkbox::{feathers_option_checkbox, IsChecked}; 
 use scene::top_left_scene;
 
 #[path = "../helpers/button.rs"]
@@ -281,8 +281,8 @@ fn spawn_buttons(commands: &mut Commands) {
         commands.spawn_scene(bsn! {
             top_left_scene()
             Children [
-                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
-                feathers_option_checkbox("WIREFRAME", Some(CheckboxInput::Wireframe)),
+                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation), IsChecked(false)),
+                feathers_option_checkbox("WIREFRAME", Some(CheckboxInput::Wireframe), IsChecked(false)),
                 feathers_button("ADVANCE ROWS", None::<ButtonInput>),
             ]
         });
@@ -290,7 +290,7 @@ fn spawn_buttons(commands: &mut Commands) {
         commands.spawn_scene(bsn! {
             top_left_scene()
             Children [
-                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
+                feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation), IsChecked(false)),
                 feathers_button("ADVANCE ROWS", None::<ButtonInput>),
             ]
         });

--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -1,14 +1,31 @@
 //! Demonstrates anisotropy with the glTF sample barn lamp model.
 
-use std::fmt::Display;
-
 use bevy::{
     color::palettes::{self, css::WHITE},
+    feathers::{controls::FeathersCheckbox, theme::UiTheme, FeathersPlugins},
     light::Skybox,
     math::vec3,
     prelude::*,
     time::Stopwatch,
+    ui_widgets::{checkbox_self_update, radio_self_update, ValueChange},
 };
+use checkbox::{feathers_option_checkbox, IsChecked};
+use radio::{feathers_option_buttons, RadioButtonOptionValue};
+use scene::bottom_left_scene;
+
+#[path = "../helpers/radio.rs"]
+#[expect(dead_code, reason = "main_ui_node_scene not used in this example")]
+mod radio;
+
+#[path = "../helpers/theme.rs"]
+mod theme;
+
+#[path = "../helpers/checkbox.rs"]
+mod checkbox;
+
+#[path = "../helpers/scene.rs"]
+#[expect(dead_code, reason = "some scenes are not used in this example")]
+mod scene;
 
 /// The initial position of the camera.
 const CAMERA_INITIAL_POSITION: Vec3 = vec3(-0.4, 0.0, 0.0);
@@ -26,7 +43,7 @@ struct AppStatus {
 
 /// Which type of light we're using: a directional light, a point light, or an
 /// environment map.
-#[derive(Clone, Copy, PartialEq, Default)]
+#[derive(Clone, Copy, PartialEq, Resource, Default, Debug)]
 enum LightMode {
     /// A rotating directional light.
     #[default]
@@ -51,30 +68,17 @@ struct MaterialVariants {
     isotropic: Handle<StandardMaterial>,
 }
 
-#[derive(Default, Clone, Copy, PartialEq, Eq, Component)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Component)]
 enum Scene {
     #[default]
     BarnLamp,
     Sphere,
 }
 
-impl Scene {
-    fn next(&self) -> Self {
-        match self {
-            Self::BarnLamp => Self::Sphere,
-            Self::Sphere => Self::BarnLamp,
-        }
-    }
-}
-
-impl Display for Scene {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let scene_name = match self {
-            Self::BarnLamp => "Barn Lamp",
-            Self::Sphere => "Sphere",
-        };
-        write!(f, "{scene_name}")
-    }
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Component)]
+enum CheckboxInput {
+    #[default]
+    Anisotropy,
 }
 
 /// The application entry point.
@@ -88,16 +92,23 @@ fn main() {
             }),
             ..default()
         }))
+        .add_plugins(FeathersPlugins)
+        .init_resource::<LightMode>()
+        .insert_resource(UiTheme(theme::basic_example_theme(Color::WHITE)))
         .add_systems(Startup, setup)
         .add_systems(Update, create_material_variants)
         .add_systems(Update, animate_light)
         .add_systems(Update, rotate_camera)
-        .add_systems(Update, (handle_input, update_help_text).chain())
+        .add_observer(handle_value_change_checkbox)
+        .add_observer(handle_scene_selection_change)
+        .add_observer(handle_light_mode_selection_change)
+        .add_observer(radio_self_update)
+        .add_observer(checkbox_self_update)
         .run();
 }
 
 /// Creates the initial scene.
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_status: Res<AppStatus>) {
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>, light_mode: Res<LightMode>) {
     commands.spawn((
         Camera3d::default(),
         Transform::from_translation(CAMERA_INITIAL_POSITION).looking_at(Vec3::ZERO, Vec3::Y),
@@ -131,25 +142,162 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_status: Res
         Visibility::Hidden,
     ));
 
-    spawn_text(&mut commands, &app_status);
+    spawn_buttons(&mut commands, light_mode, Scene::BarnLamp);
 }
 
-/// Spawns the help text.
-fn spawn_text(commands: &mut Commands, app_status: &AppStatus) {
-    commands.spawn((
-        app_status.create_help_text(),
-        Node {
-            position_type: PositionType::Absolute,
-            bottom: px(12),
-            left: px(12),
-            ..default()
-        },
-    ));
+/// Spawns UI controls in the bottom left corner of the screen.
+fn spawn_buttons(commands: &mut Commands, light_mode: Res<LightMode>, scene: Scene) {
+    commands.spawn_scene(bsn! {
+        bottom_left_scene()
+            Children [
+            feathers_option_checkbox("Enable Anisotropy",
+                Some(CheckboxInput::Anisotropy),
+                IsChecked(true),
+            ),
+            feathers_option_buttons(
+                "",
+                &[
+                    (Scene::BarnLamp, "Barn Lamp"),
+                    (Scene::Sphere, "Sphere"),
+                ],
+                if scene == Scene::Sphere { 1 } else { 0 },
+            ),
+            feathers_option_buttons(
+                "",
+                &[
+                    (LightMode::EnvironmentMap, "Environment Map"),
+                    (LightMode::Directional, "Directional"),
+                    (LightMode::Point, "Point"),
+                ],
+                if *light_mode == LightMode::Point { 0 } else { 1 },
+            ),
+        ]
+    });
+}
+
+/// Updates the light mode when the user toggles that setting's radio.
+fn handle_light_mode_selection_change(
+    event: On<ValueChange<Entity>>,
+    commands: Commands,
+    cameras: Query<Entity, With<Camera>>,
+    asset_server: Res<AssetServer>,
+    mut app_status: ResMut<AppStatus>,
+    lights: Query<Entity, Or<(With<PointLight>, With<DirectionalLight>)>>,
+    new_value_query: Query<&RadioButtonOptionValue<LightMode>>,
+) {
+    let Ok(RadioButtonOptionValue(selection)) = new_value_query.get(event.value) else {
+        return;
+    };
+    let old_setting = app_status.light_mode;
+
+    app_status.light_mode = *selection;
+    light_mode_update_helper(
+        commands,
+        asset_server,
+        old_setting,
+        app_status.light_mode,
+        cameras,
+        lights,
+    );
+}
+
+/// Helper to spawn new light entities on a selection change.
+fn light_mode_spawn_helper(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    new_setting: LightMode,
+    cameras: Query<Entity, With<Camera>>,
+) {
+    match new_setting {
+        LightMode::Directional => {
+            spawn_directional_light(&mut commands);
+        }
+        LightMode::Point => {
+            spawn_point_light(&mut commands);
+        }
+        LightMode::EnvironmentMap => {
+            for camera in cameras.iter() {
+                add_skybox_and_environment_map(&mut commands, &asset_server, camera);
+            }
+        }
+    }
+}
+
+/// Helper to teardown light entities on a selection change.
+fn light_mode_update_helper(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    old_setting: LightMode,
+    new_setting: LightMode,
+    cameras: Query<Entity, With<Camera>>,
+    lights: Query<Entity, Or<(With<PointLight>, With<DirectionalLight>)>>,
+) {
+    match old_setting {
+        LightMode::Directional | LightMode::Point => {
+            for light in lights.iter() {
+                commands.entity(light).despawn();
+            }
+        }
+        LightMode::EnvironmentMap => {
+            for camera in cameras.iter() {
+                commands
+                    .entity(camera)
+                    .remove::<Skybox>()
+                    .remove::<EnvironmentMapLight>();
+            }
+        }
+    }
+    light_mode_spawn_helper(commands, asset_server, new_setting, cameras);
+}
+
+/// Updates the scene when the user toggles that setting's radio.
+fn handle_scene_selection_change(
+    event: On<ValueChange<Entity>>,
+    mut app_status: ResMut<AppStatus>,
+    new_value_query: Query<&RadioButtonOptionValue<Scene>>,
+    mut scenes: Query<(&mut Visibility, &Scene)>,
+) {
+    let Ok(RadioButtonOptionValue(scene_selection)) = new_value_query.get(event.value) else {
+        return;
+    };
+    app_status.visible_scene = *scene_selection;
+    for (mut visibility, scene) in scenes.iter_mut() {
+        let new_vis = if *scene == app_status.visible_scene {
+            Visibility::Inherited
+        } else {
+            Visibility::Hidden
+        };
+        *visibility = new_vis;
+    }
+}
+
+fn handle_value_change_checkbox(
+    event: On<ValueChange<bool>>,
+    mut app_status: ResMut<AppStatus>,
+    checkbox_input_q: Query<&CheckboxInput, With<FeathersCheckbox>>,
+    mut meshes: Query<(&mut MeshMaterial3d<StandardMaterial>, &MaterialVariants)>,
+) {
+    if let Ok(checkbox_input) = checkbox_input_q.get(event.source) {
+        match checkbox_input {
+            CheckboxInput::Anisotropy => {
+                app_status.anisotropy_enabled = event.value;
+            }
+        }
+    };
+
+    // Go through each mesh and alter its material.
+    for (mut material_handle, material_variants) in meshes.iter_mut() {
+        material_handle.0 = if app_status.anisotropy_enabled {
+            material_variants.anisotropic.clone()
+        } else {
+            material_variants.isotropic.clone()
+        }
+    }
 }
 
 /// For each material, creates a version with the anisotropy removed.
 ///
-/// This allows the user to press Enter to toggle anisotropy on and off.
+/// This allows the user to check a checkbox to toggle anisotropy on and off.
 fn create_material_variants(
     mut commands: Commands,
     mut materials: ResMut<Assets<StandardMaterial>>,
@@ -169,7 +317,6 @@ fn create_material_variants(
         commands.entity(entity).insert(MaterialVariants {
             anisotropic: anisotropic_material_handle.0.clone(),
             isotropic: materials.add(StandardMaterial {
-                anisotropy_texture: None,
                 anisotropy_strength: 0.0,
                 anisotropy_rotation: 0.0,
                 ..anisotropic_material
@@ -210,91 +357,6 @@ fn rotate_camera(
     }
 }
 
-/// Handles requests from the user to change the lighting or toggle anisotropy.
-fn handle_input(
-    mut commands: Commands,
-    asset_server: Res<AssetServer>,
-    cameras: Query<Entity, With<Camera>>,
-    lights: Query<Entity, Or<(With<DirectionalLight>, With<PointLight>)>>,
-    mut meshes: Query<(&mut MeshMaterial3d<StandardMaterial>, &MaterialVariants)>,
-    mut scenes: Query<(&mut Visibility, &Scene)>,
-    keyboard: Res<ButtonInput<KeyCode>>,
-    mut app_status: ResMut<AppStatus>,
-) {
-    // If Space was pressed, change the lighting.
-    if keyboard.just_pressed(KeyCode::Space) {
-        match app_status.light_mode {
-            LightMode::Directional => {
-                // Switch to a point light. Despawn all existing lights and
-                // create the light point.
-                app_status.light_mode = LightMode::Point;
-                for light in lights.iter() {
-                    commands.entity(light).despawn();
-                }
-                spawn_point_light(&mut commands);
-            }
-
-            LightMode::Point => {
-                // Switch to the environment map. Despawn all existing lights,
-                // and create the skybox and environment map.
-                app_status.light_mode = LightMode::EnvironmentMap;
-                for light in lights.iter() {
-                    commands.entity(light).despawn();
-                }
-                for camera in cameras.iter() {
-                    add_skybox_and_environment_map(&mut commands, &asset_server, camera);
-                }
-            }
-
-            LightMode::EnvironmentMap => {
-                // Switch back to a directional light. Despawn the skybox and
-                // environment map light, and recreate the directional light.
-                app_status.light_mode = LightMode::Directional;
-                for camera in cameras.iter() {
-                    commands
-                        .entity(camera)
-                        .remove::<Skybox>()
-                        .remove::<EnvironmentMapLight>();
-                }
-                spawn_directional_light(&mut commands);
-            }
-        }
-    }
-
-    // If Enter was pressed, toggle anisotropy on and off.
-    if keyboard.just_pressed(KeyCode::Enter) {
-        app_status.anisotropy_enabled = !app_status.anisotropy_enabled;
-
-        // Go through each mesh and alter its material.
-        for (mut material_handle, material_variants) in meshes.iter_mut() {
-            material_handle.0 = if app_status.anisotropy_enabled {
-                material_variants.anisotropic.clone()
-            } else {
-                material_variants.isotropic.clone()
-            }
-        }
-    }
-
-    if keyboard.just_pressed(KeyCode::KeyQ) {
-        app_status.visible_scene = app_status.visible_scene.next();
-        for (mut visibility, scene) in scenes.iter_mut() {
-            let new_vis = if *scene == app_status.visible_scene {
-                Visibility::Inherited
-            } else {
-                Visibility::Hidden
-            };
-            *visibility = new_vis;
-        }
-    }
-}
-
-/// A system that updates the help text based on the current app status.
-fn update_help_text(mut text_query: Query<&mut Text>, app_status: Res<AppStatus>) {
-    for mut text in text_query.iter_mut() {
-        *text = app_status.create_help_text();
-    }
-}
-
 /// Adds the skybox and environment map to the scene.
 fn add_skybox_and_environment_map(
     commands: &mut Commands,
@@ -332,31 +394,6 @@ fn spawn_point_light(commands: &mut Commands) {
         intensity: 200000.0,
         ..default()
     });
-}
-
-impl AppStatus {
-    /// Creates the help text as appropriate for the current app status.
-    fn create_help_text(&self) -> Text {
-        // Choose the appropriate help text for the anisotropy toggle.
-        let material_variant_help_text = if self.anisotropy_enabled {
-            "Press Enter to disable anisotropy"
-        } else {
-            "Press Enter to enable anisotropy"
-        };
-
-        // Choose the appropriate help text for the light toggle.
-        let light_help_text = match self.light_mode {
-            LightMode::Directional => "Press Space to switch to a point light",
-            LightMode::Point => "Press Space to switch to an environment map",
-            LightMode::EnvironmentMap => "Press Space to switch to a directional light",
-        };
-
-        // Choose the appropriate help text for the scene selector.
-        let mesh_help_text = format!("Press Q to change to {}", self.visible_scene.next());
-
-        // Build the `Text` object.
-        format!("{material_variant_help_text}\n{light_help_text}\n{mesh_help_text}",).into()
-    }
 }
 
 impl Default for AppStatus {

--- a/examples/helpers/button.rs
+++ b/examples/helpers/button.rs
@@ -1,0 +1,46 @@
+/// Helpers to create an action button using `FeathersButtons`.
+/// Using these helpers requires the `bevy_feathers` feature to be enabled.
+use bevy::{
+    feathers::{controls::FeathersButton, display::caption},
+    picking::hover::Hovered,
+    prelude::*,
+};
+
+/// Creates a single feathers button that allows activation of a setting.  
+///
+/// Examples that use this to create a button should handle its `On<Activate>` trigger.
+/// If there is a need to identify the button that originated the activation trigger,
+/// query which `button_identifier` with the `FeathersButton` is the trigger's source entity.
+pub fn feathers_button<T>(option_name: &str, button_identifier: Option<T>) -> Box<dyn Scene>
+where
+    T: Template<Output: Component> + Clone + Default + Send + Sync + Unpin + 'static,
+{
+    if let Some(identifier) = button_identifier {
+        Box::new(bsn! {
+            Node {
+                align_items: AlignItems::Center,
+                column_gap: px(5),
+            }
+            Children [
+                @FeathersButton {
+                    @caption: bsn! { caption(option_name) }
+                }
+                Hovered::default()
+                template_value(identifier)
+            ]
+        })
+    } else {
+        Box::new(bsn! {
+            Node {
+                align_items: AlignItems::Center,
+                column_gap: px(5),
+            }
+            Children [
+                @FeathersButton {
+                    @caption: bsn! { caption(option_name) }
+                }
+                Hovered::default()
+            ]
+        })
+    }
+}

--- a/examples/helpers/checkbox.rs
+++ b/examples/helpers/checkbox.rs
@@ -4,19 +4,54 @@ use bevy::{
     feathers::{controls::FeathersCheckbox, display::caption},
     picking::hover::Hovered,
     prelude::*,
+    ui::Checked,
     ui_widgets::checkbox_self_update,
 };
 
-/// Creates a single feathers checkbox that allows configuration of a setting.  
-///
-/// Examples that use this to create a checkbox should handle its `ValueChange<bool>` events.
-/// If there is a need to identify the checkbox that originated the value change,
-/// query which `checkbox_identifier` with the `FeathersCheckbox` is the value change's
-/// source entity.
-pub fn feathers_option_checkbox<T>(
-    option_name: &str,
-    checkbox_identifier: Option<T>,
-) -> Box<dyn Scene>
+/// A newtype bool wrapper to indicate a widget's checked status.
+pub struct IsChecked(pub bool);
+
+/// Helper to create a single checked feathers checkbox.
+fn checked_checkbox<T>(option_name: &str, checkbox_identifier: Option<T>) -> Box<dyn Scene>
+where
+    T: Template<Output: Component> + Clone + Default + Send + Sync + Unpin + 'static,
+{
+    if let Some(identifier) = checkbox_identifier {
+        Box::new(bsn! {
+            Node {
+                align_items: AlignItems::Center,
+                column_gap: px(5),
+            }
+            Children [
+                @FeathersCheckbox {
+                    @caption: bsn! { caption(option_name) }
+                }
+                Checked
+                Hovered::default()
+                template_value(identifier)
+                on(checkbox_self_update)
+            ]
+        })
+    } else {
+        Box::new(bsn! {
+            Node {
+                align_items: AlignItems::Center,
+                column_gap: px(5),
+            }
+            Children [
+                @FeathersCheckbox {
+                    @caption: bsn! { caption(option_name) }
+                }
+                Checked
+                Hovered::default()
+                on(checkbox_self_update)
+            ]
+        })
+    }
+}
+
+/// Helper to create a single unchecked feathers checkbox.
+fn unchecked_checkbox<T>(option_name: &str, checkbox_identifier: Option<T>) -> Box<dyn Scene>
 where
     T: Template<Output: Component> + Clone + Default + Send + Sync + Unpin + 'static,
 {
@@ -49,5 +84,25 @@ where
                 on(checkbox_self_update)
             ]
         })
+    }
+}
+
+/// Creates a single feathers checkbox that allows configuration of a setting.  
+///
+/// Examples that use this to create a checkbox should handle its `ValueChange<bool>` events.
+/// If there is a need to identify the checkbox that originated the value change,
+/// query which `checkbox_identifier` with the `FeathersCheckbox` is the value change's
+/// source entity.
+pub fn feathers_option_checkbox<T>(
+    option_name: &str,
+    checkbox_identifier: Option<T>,
+    status: IsChecked,
+) -> Box<dyn Scene>
+where
+    T: Template<Output: Component> + Clone + Default + Send + Sync + Unpin + 'static,
+{
+    match status {
+        IsChecked(true) => checked_checkbox(option_name, checkbox_identifier),
+        IsChecked(false) => unchecked_checkbox(option_name, checkbox_identifier),
     }
 }

--- a/examples/helpers/theme.rs
+++ b/examples/helpers/theme.rs
@@ -114,15 +114,15 @@ pub fn basic_example_theme(text_color: Color) -> ThemeProps {
     // Feathers Button / Select
     color.insert(
         bevy::feathers::tokens::BUTTON_BG,
-        bevy::feathers::palette::TRANSPARENT,
+        bevy::feathers::palette::BLACK,
     );
     color.insert(
         bevy::feathers::tokens::BUTTON_BG_HOVER,
-        bevy::feathers::palette::TRANSPARENT,
+        bevy::feathers::palette::GRAY_0,
     );
     color.insert(
         bevy::feathers::tokens::BUTTON_BG_PRESSED,
-        bevy::feathers::palette::TRANSPARENT,
+        bevy::feathers::palette::GRAY_1,
     );
     color.insert(
         bevy::feathers::tokens::MENU_BG,


### PR DESCRIPTION
# Objective
Addresses one part of #25032

## Solution
- Switch the 3d/anisotropy.rs example to use Feathers checkboxes and radios  
- Refactor the checkbox helper to accept an "IsChecked" flag and spawn both checked and unchecked variants (the previous version only let callers create unchecked boxes; I think this caused some mild awkwardness for #25431). 
- The checkbox refactor was necessary here because anisotropy is turned on by default, but the previous helper only allowed callers to create unchecked boxes, so to a user it looked like anisotropy was toggled off even though it was actually on
- Updated the other users of checkbox.rs (2d_shapes.rs and the pending #25436) to pass `IsChecked` to the helper 

Because the checkbox refactor touches #25436, that PR blocks this one.

## Testing
``` cargo run --example anisotropy --features="bevy_feathers jpeg pbr_anisotropy_texture" ``` 

I also tested the other callers of ``` feathers_option_checkbox ``` and verified that they still work with the refactor.

https://github.com/user-attachments/assets/055274a5-0332-43b2-9148-29856e0682f9


