### PR TITLE
Fix window-picking entity

### DIFF
--- a/crates/bevy_picking/src/window.rs
+++ b/crates/bevy_picking/src/window.rs
@@ -13,9 +13,10 @@
 
 use bevy_camera::NormalizedRenderTarget;
 use bevy_ecs::prelude::*;
+use bevy_platform::collections::HashMap;
 
 use crate::{
-    backend::{HitData, PointerHits},
+    backend::{ray::RayMap, HitData, PointerHits},
     pointer::{Location, PointerId, PointerLocation},
 };
 
@@ -28,19 +29,26 @@ use crate::{
 pub fn update_window_hits(
     pointers: Query<(&PointerId, &PointerLocation)>,
     mut pointer_hits_writer: MessageWriter<PointerHits>,
+    ray_map: Res<RayMap>,
 ) {
-    for (pointer_id, pointer_location) in pointers.iter() {
-        if let Some(Location {
-            target: NormalizedRenderTarget::Window(window_ref),
-            position,
-            ..
-        }) = pointer_location.location
-        {
-            let entity = window_ref.entity();
-            let hit_data = HitData::new(entity, 0.0, Some(position.extend(0.0)), None);
+    for (&ray_id, _) in ray_map.iter() {
+        if let Some((position, window_entity)) = pointers.iter().find_map(|(id, loc)| {
+            if *id == ray_id.pointer {
+                match loc.location {
+                    Some(Location {
+                        target: NormalizedRenderTarget::Window(window_ref),
+                        position,
+                        ..
+                    }) => return Some((position, window_ref.entity())),
+                    _ => (),
+                }
+            }
+            None
+        }) {
+            let hit_data = HitData::new(ray_id.camera, 0.0, Some(position.extend(0.0)), None);
             pointer_hits_writer.write(PointerHits::new(
-                *pointer_id,
-                vec![(entity, hit_data)],
+                ray_id.pointer,
+                vec![(window_entity, hit_data)],
                 f32::NEG_INFINITY,
             ));
         }

--- a/crates/bevy_picking/src/window.rs
+++ b/crates/bevy_picking/src/window.rs
@@ -16,7 +16,7 @@ use bevy_ecs::prelude::*;
 
 use crate::{
     backend::{ray::RayMap, HitData, PointerHits},
-    pointer::{Location, PointerId, PointerLocation},
+    pointer::{Location, PointerLocation, PointerMap},
 };
 
 /// Generates pointer hit events for window entities.
@@ -26,23 +26,30 @@ use crate::{
 ///
 /// The depth of the hit will be listed as zero.
 pub fn update_window_hits(
-    pointers: Query<(&PointerId, &PointerLocation)>,
+    pointer_locations: Query<&PointerLocation>,
     mut pointer_hits_writer: MessageWriter<PointerHits>,
     ray_map: Res<RayMap>,
+    pointer_map: Res<PointerMap>,
 ) {
     for (&ray_id, _) in ray_map.iter() {
-        if let Some((position, window_entity)) = pointers.iter().find_map(|(id, loc)| {
-            if *id == ray_id.pointer
-                && let Some(Location {
-                    target: NormalizedRenderTarget::Window(window_ref),
-                    position,
-                    ..
-                }) = loc.location
-            {
-                return Some((position, window_ref.entity()));
-            }
-            None
-        }) {
+        if let Some((position, window_entity)) =
+            pointer_map
+                .get_entity(ray_id.pointer)
+                .and_then(|pointer_e| {
+                    if let Ok(PointerLocation {
+                        location:
+                            Some(Location {
+                                target: NormalizedRenderTarget::Window(window_ref),
+                                position,
+                                ..
+                            }),
+                    }) = pointer_locations.get(pointer_e)
+                    {
+                        return Some((position, window_ref.entity()));
+                    }
+                    None
+                })
+        {
             let hit_data = HitData::new(ray_id.camera, 0.0, Some(position.extend(0.0)), None);
             pointer_hits_writer.write(PointerHits::new(
                 ray_id.pointer,

--- a/crates/bevy_picking/src/window.rs
+++ b/crates/bevy_picking/src/window.rs
@@ -13,7 +13,6 @@
 
 use bevy_camera::NormalizedRenderTarget;
 use bevy_ecs::prelude::*;
-use bevy_platform::collections::HashMap;
 
 use crate::{
     backend::{ray::RayMap, HitData, PointerHits},
@@ -33,15 +32,14 @@ pub fn update_window_hits(
 ) {
     for (&ray_id, _) in ray_map.iter() {
         if let Some((position, window_entity)) = pointers.iter().find_map(|(id, loc)| {
-            if *id == ray_id.pointer {
-                match loc.location {
-                    Some(Location {
-                        target: NormalizedRenderTarget::Window(window_ref),
-                        position,
-                        ..
-                    }) => return Some((position, window_ref.entity())),
-                    _ => (),
-                }
+            if *id == ray_id.pointer
+                && let Some(Location {
+                    target: NormalizedRenderTarget::Window(window_ref),
+                    position,
+                    ..
+                }) = loc.location
+            {
+                return Some((position, window_ref.entity()));
             }
             None
         }) {


### PR DESCRIPTION
# Objective

Window picking, when triggered directly on the window instead of through propagation from a entity, reported the *window* entity in `event.hit.camera`. This is wrong, it should be the *camera* entity.

## Solution

Use RayMap like all other backends, but ignore the rays, just rely on it to map windows and cameras.

## Testing

- Compiles
- Fixed the window picking observers in my pan_orbit_camera input plugin branch: https://github.com/laundmo/bevy/tree/pan_orbit_picking_inputs

This might warrant a migration guide entry, in case anyone was falsely relying on this (or working around it, more likely)