### PR TITLE
Move an asset's MetaTransform into its `AssetInfo`.

### DIFF
--- a/_release-content/migration-guides/meta_transform_deleted.md
+++ b/_release-content/migration-guides/meta_transform_deleted.md
@@ -1,0 +1,7 @@
+---
+title: meta_transform accessor on `UntypedHandle` has been deleted.
+pull_requests: [25509]
+---
+
+The `meta_transform` accessor on `UntypedHandle` has been deleted. If you were relying on this, come
+chat with us so we can learn about your use-case!

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -401,7 +401,7 @@ impl<A: Asset> Assets<A> {
     pub fn add(&mut self, asset: impl Into<A>) -> Handle<A> {
         let index = self.dense_storage.allocator.reserve();
         self.insert_with_index(index, asset.into()).unwrap();
-        Handle::Strong(self.handle_provider.get_handle(index, false, None, None))
+        Handle::Strong(self.handle_provider.get_handle(index, false, None))
     }
 
     /// Upgrade an `AssetId` into a strong `Handle` that will prevent asset drop.
@@ -420,7 +420,7 @@ impl<A: Asset> Assets<A> {
         };
         *self.duplicate_handles.entry(index).or_insert(0) += 1;
         Some(Handle::Strong(
-            self.handle_provider.get_handle(index, false, None, None),
+            self.handle_provider.get_handle(index, false, None),
         ))
     }
 

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -1,6 +1,6 @@
 use crate::{
-    meta::MetaTransform, Asset, AssetId, AssetIndex, AssetIndexAllocator, AssetPath, AssetServer,
-    Assets, ErasedAssetIndex, ReflectHandle, UntypedAssetId,
+    Asset, AssetId, AssetIndex, AssetIndexAllocator, AssetPath, AssetServer, Assets,
+    ErasedAssetIndex, ReflectHandle, UntypedAssetId,
 };
 use alloc::sync::Arc;
 use bevy_ecs::template::{FromTemplate, SpecializeFromTemplate, Template, TemplateContext};
@@ -47,7 +47,7 @@ impl AssetHandleProvider {
     /// [`UntypedHandle`] will match the [`Asset`] [`TypeId`] assigned to this [`AssetHandleProvider`].
     pub fn reserve_handle(&self) -> UntypedHandle {
         let index = self.allocator.reserve();
-        UntypedHandle::Strong(self.get_handle(index, false, None, None))
+        UntypedHandle::Strong(self.get_handle(index, false, None))
     }
 
     pub(crate) fn get_handle(
@@ -55,13 +55,11 @@ impl AssetHandleProvider {
         index: AssetIndex,
         asset_server_managed: bool,
         path: Option<AssetPath<'static>>,
-        meta_transform: Option<MetaTransform>,
     ) -> Arc<StrongHandle> {
         Arc::new(StrongHandle {
             index,
             type_id: self.type_id,
             drop_sender: self.drop_sender.clone(),
-            meta_transform,
             path,
             asset_server_managed,
         })
@@ -71,25 +69,20 @@ impl AssetHandleProvider {
         &self,
         asset_server_managed: bool,
         path: Option<AssetPath<'static>>,
-        meta_transform: Option<MetaTransform>,
     ) -> Arc<StrongHandle> {
         let index = self.allocator.reserve();
-        self.get_handle(index, asset_server_managed, path, meta_transform)
+        self.get_handle(index, asset_server_managed, path)
     }
 }
 
 /// The internal "strong" [`Asset`] handle storage for [`Handle::Strong`] and [`UntypedHandle::Strong`]. When this is dropped,
 /// the [`Asset`] will be freed. It also stores some asset metadata for easy access from handles.
-#[derive(TypePath)]
+#[derive(TypePath, Debug)]
 pub struct StrongHandle {
     pub(crate) index: AssetIndex,
     pub(crate) type_id: TypeId,
     pub(crate) asset_server_managed: bool,
     pub(crate) path: Option<AssetPath<'static>>,
-    /// Modifies asset meta. This is stored on the handle because it is:
-    /// 1. configuration tied to the lifetime of a specific asset load
-    /// 2. configuration that must be repeatable when the asset is hot-reloaded
-    pub(crate) meta_transform: Option<MetaTransform>,
     pub(crate) drop_sender: Sender<DropEvent>,
 }
 
@@ -99,18 +92,6 @@ impl Drop for StrongHandle {
             index: ErasedAssetIndex::new(self.index, self.type_id),
             asset_server_managed: self.asset_server_managed,
         });
-    }
-}
-
-impl core::fmt::Debug for StrongHandle {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("StrongHandle")
-            .field("index", &self.index)
-            .field("type_id", &self.type_id)
-            .field("asset_server_managed", &self.asset_server_managed)
-            .field("path", &self.path)
-            .field("drop_sender", &self.drop_sender)
-            .finish()
     }
 }
 
@@ -566,16 +547,6 @@ impl UntypedHandle {
     #[inline]
     pub fn try_typed<A: Asset>(self) -> Result<Handle<A>, UntypedAssetConversionError> {
         Handle::try_from(self)
-    }
-
-    /// The "meta transform" for the strong handle. This will only be [`Some`] if the handle is strong and there is a meta transform
-    /// associated with it.
-    #[inline]
-    pub fn meta_transform(&self) -> Option<&MetaTransform> {
-        match self {
-            UntypedHandle::Strong(handle) => handle.meta_transform.as_ref(),
-            UntypedHandle::Uuid { .. } => None,
-        }
     }
 }
 

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -400,7 +400,6 @@ impl<'a> SavedAssetBuilder<'a> {
                 .reserve_handle_internal(
                     false,
                     Some(self.asset_path.clone().with_label(label.to_string())),
-                    None,
                 ),
         );
         self.add_labeled_asset_with_existing_handle(label, asset, handle.clone());
@@ -447,7 +446,6 @@ impl<'a> SavedAssetBuilder<'a> {
                 .reserve_handle_internal(
                     false,
                     Some(self.asset_path.clone().with_label(label.to_string())),
-                    None,
                 ),
         );
         self.add_labeled_asset_with_existing_handle_erased(label, asset, handle.clone());

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -22,10 +22,10 @@ use crossbeam_channel::Sender;
 use thiserror::Error;
 use tracing::warn;
 
-#[derive(Debug)]
 pub(crate) struct AssetInfo {
     weak_handle: Weak<StrongHandle>,
     pub(crate) path: Option<AssetPath<'static>>,
+    pub(crate) meta_transform: Option<MetaTransform>,
     pub(crate) load_state: LoadState,
     pub(crate) dep_load_state: DependencyLoadState,
     pub(crate) rec_dep_load_state: RecursiveDependencyLoadState,
@@ -49,11 +49,52 @@ pub(crate) struct AssetInfo {
     pub(crate) waiting_tasks: Vec<Waker>,
 }
 
+// Manual Debug impl since MetaTransform is not Debug.
+impl core::fmt::Debug for AssetInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AssetInfo")
+            .field("weak_handle", &self.weak_handle)
+            .field("path", &self.path)
+            .field(
+                "meta_transform",
+                if self.meta_transform.is_some() {
+                    &"yes"
+                } else {
+                    &"no"
+                },
+            )
+            .field("load_state", &self.load_state)
+            .field("dep_load_state", &self.dep_load_state)
+            .field("rec_dep_load_state", &self.rec_dep_load_state)
+            .field("loading_dependencies", &self.loading_dependencies)
+            .field("failed_dependencies", &self.failed_dependencies)
+            .field("loading_rec_dependencies", &self.loading_rec_dependencies)
+            .field("failed_rec_dependencies", &self.failed_rec_dependencies)
+            .field(
+                "dependents_waiting_on_load",
+                &self.dependents_waiting_on_load,
+            )
+            .field(
+                "dependents_waiting_on_recursive_dep_load",
+                &self.dependents_waiting_on_recursive_dep_load,
+            )
+            .field("loader_dependencies", &self.loader_dependencies)
+            .field("handle_drops_to_skip", &self.handle_drops_to_skip)
+            .field("waiting_tasks", &self.waiting_tasks)
+            .finish()
+    }
+}
+
 impl AssetInfo {
-    fn new(weak_handle: Weak<StrongHandle>, path: Option<AssetPath<'static>>) -> Self {
+    fn new(
+        weak_handle: Weak<StrongHandle>,
+        path: Option<AssetPath<'static>>,
+        meta_transform: Option<MetaTransform>,
+    ) -> Self {
         Self {
             weak_handle,
             path,
+            meta_transform,
             load_state: LoadState::NotLoaded,
             dep_load_state: DependencyLoadState::NotLoaded,
             rec_dep_load_state: RecursiveDependencyLoadState::NotLoaded,
@@ -153,8 +194,8 @@ impl AssetInfos {
             }
         }
 
-        let handle = provider.reserve_handle_internal(true, path.clone(), meta_transform);
-        let mut info = AssetInfo::new(Arc::downgrade(&handle), path);
+        let handle = provider.reserve_handle_internal(true, path.clone());
+        let mut info = AssetInfo::new(Arc::downgrade(&handle), path, meta_transform);
         if loading {
             info.load_state = LoadState::Loading;
             info.dep_load_state = DependencyLoadState::Loading;
@@ -223,6 +264,13 @@ impl AssetInfos {
 
         match handles.entry(type_id) {
             TypeIdHashMapEntry::Occupied(entry) => {
+                // If we already have an entry for this path + type_id combo, we will ignore the
+                // meta_transform. This means that loading with_settings after the first load are
+                // **ignored**. It would be nice to fix this in the future
+                // (https://github.com/bevyengine/bevy/issues/11111). For now, drop the
+                // meta_transform to make sure we don't use it.
+                drop(meta_transform);
+
                 let index = *entry.get();
                 // if there is a path_to_id entry, info always exists
                 let info = self
@@ -258,7 +306,7 @@ impl AssetInfos {
                         .handle_providers
                         .get(&type_id)
                         .ok_or(MissingHandleProviderError(type_id))?;
-                    let handle = provider.get_handle(index, true, Some(path), meta_transform);
+                    let handle = provider.get_handle(index, true, Some(path));
                     info.weak_handle = Arc::downgrade(&handle);
                     Ok((UntypedHandle::Strong(handle), should_load))
                 }

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -568,8 +568,19 @@ impl AssetServer {
         // meta_transform directly. Assert that at most one is Some. If this is wrong, we likely
         // need to rethink the logic here.
         assert!(input_handle.is_none() || meta_transform.is_none());
-        if let Some(meta_transform) = input_handle.as_ref().and_then(|h| h.meta_transform()) {
-            (*meta_transform)(&mut *meta);
+        if let Some(input_handle) = input_handle.as_ref() {
+            let index = match input_handle.id() {
+                UntypedAssetId::Uuid { .. } => unreachable!("we never load a UUID handle"),
+                UntypedAssetId::Index { type_id, index } => ErasedAssetIndex::new(index, type_id),
+            };
+            // Lookup the meta_transform in the AssetInfos.
+            let infos = self.read_infos();
+            // Unwrap is safe because we are holding the `input_handle`, and we only pass Some for
+            // `input_handle` if we just allocated the handle or are reloading an existing asset.
+            let info = infos.get(index).unwrap();
+            if let Some(meta_transform) = info.meta_transform.as_ref() {
+                (*meta_transform)(&mut *meta);
+            }
         }
         if let Some(meta_transform) = meta_transform.as_ref() {
             (*meta_transform)(&mut *meta);


### PR DESCRIPTION
# Objective

- Previously, the MetaTransform of an asset (sort-of like its settings) lived on the Handle of an asset. This can lead to weird situations that don't make sense like some handles for an asset reporting a meta transform while others don't, or loading an asset with settings, which then get erased on a reload later on.

## Solution

- Move the MetaTransform into the `AssetInfo`. This is the canonical location of info about the asset, and it is centralized.

This makes it easier to create handles for an asset, since now you only need the path + type ID, and you don't have to be confused about the meta transform. I don't think this makes it any harder to solve #11111, since we'll need to store the meta transform somewhere on the `AssetInfo`s to be able to reload them, and it feels weird to need to upgrade a handle just to fetch its meta transform.

Note that accessing the meta transform isn't particularly informative. In order to get anything useful out of it, you'd need to know what loader it's targeting, then apply the meta transform, and then read the mutated settings. Very confusing! If we are to solve #11111, we need something more interpretable other than a function (since we can't diff a function).

## Testing

- Unit tests pass.