### PR TITLE
Fix bevy not exporting bevy::extract

### DIFF
--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -41,6 +41,8 @@ pub use bevy_core_pipeline as core_pipeline;
 pub use bevy_dev_tools as dev_tools;
 pub use bevy_diagnostic as diagnostic;
 pub use bevy_ecs as ecs;
+#[cfg(feature = "bevy_extract")]
+pub use bevy_extract as extract;
 #[cfg(feature = "bevy_feathers")]
 pub use bevy_feathers as feathers;
 #[cfg(feature = "bevy_gilrs")]


### PR DESCRIPTION
# Objective

Fixes #25488

## Solution

- Export it

## Testing

- Successfully compiled a local project that did not build before the change.

## Additional Info

This PR does not address the fact that currently the `ExtractComponent` macro must be imported via `bevy::render::extract_component::ExtractComponent`, in downstream projects as `bevy_extract_macros` is not exported.

This pattern is also used just in bevy itself:

https://github.com/bevyengine/bevy/blob/17e28cdedca8f66cd01ba88bd40ec33591e6bf37/crates/bevy_anti_alias/src/fxaa/mod.rs#L11-L15

I am happy to also include fixes for these things in this PR if wanted, however I would need guidance on how, or if that should be solved.