### PR TITLE
Upstream Jackdaw tab widget for bevy UI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5481,6 +5481,17 @@ category = "Usage"
 wasm = true
 
 [[example]]
+name = "headless_tabs"
+path = "examples/ui/widgets/headless_tabs.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.headless_tabs]
+name = "Headless Tabs"
+description = "Demonstrates controlled and self-updating headless tab lists"
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "standard_widgets_observers"
 path = "examples/ui/widgets/standard_widgets_observers.rs"
 doc-scrape-examples = true

--- a/_release-content/release-notes/headless_tabs.md
+++ b/_release-content/release-notes/headless_tabs.md
@@ -1,7 +1,7 @@
 ---
 title: Headless tab widgets
 authors: ["@jbuehler23"]
-pull_requests: []
+pull_requests: [25515]
 ---
 
 `bevy_ui_widgets` now has headless tab-strip behavior: a `TabList` container and `Tab` headers, with no built-in visuals.

--- a/_release-content/release-notes/headless_tabs.md
+++ b/_release-content/release-notes/headless_tabs.md
@@ -1,0 +1,27 @@
+---
+title: Headless tab widgets
+authors: ["@jbuehler23"]
+pull_requests: []
+---
+
+`bevy_ui_widgets` now has headless tab-strip behavior: a `TabList` container and `Tab` headers, with no built-in visuals.
+
+Selection is externally owned. `SelectedTab` on the list holds the selected tab; interaction emits `ValueChange<Option<Entity>>` as a request, applied by the app or by the optional `tablist_self_update` observer.
+
+Arrow keys move a roving tab index along the list's axis, Home and End jump to the ends, and Enter or Space activates. `TabActivation::Automatic` selects as focus moves; the default `Manual` keeps focus and selection separate.
+
+Tabs derive `Selected`, install tab accessibility roles, and honor `InteractionDisabled` per tab or on the whole list. Only primary-button clicks change selection.
+
+```rust
+(
+    TabList::default()
+    SelectedTab(Some(first_tab))
+    on(tablist_self_update)
+    Children [
+        (Tab Children [Text("General")]),
+        (Tab Children [Text("Rendering")]),
+    ]
+),
+```
+
+See the `headless_tabs` example for controlled and self-updating tab lists in both orientations.

--- a/crates/bevy_ui_widgets/src/lib.rs
+++ b/crates/bevy_ui_widgets/src/lib.rs
@@ -59,6 +59,7 @@ mod radio;
 mod scrollarea;
 mod scrollbar;
 mod slider;
+mod tabs;
 mod text_input;
 
 use bevy_input_focus::pointer_focus::PointerFocusPlugin;
@@ -73,6 +74,7 @@ pub use radio::*;
 pub use scrollarea::*;
 pub use scrollbar::*;
 pub use slider::*;
+pub use tabs::*;
 pub use text_input::*;
 
 use bevy_app::{PluginGroup, PluginGroupBuilder};
@@ -101,6 +103,7 @@ impl PluginGroup for UiWidgetsPlugins {
             .add(ScrollAreaPlugin)
             .add(ScrollbarPlugin)
             .add(SliderPlugin)
+            .add(TabPlugin)
             .add(PointerFocusPlugin)
     }
 }

--- a/crates/bevy_ui_widgets/src/tabs.rs
+++ b/crates/bevy_ui_widgets/src/tabs.rs
@@ -1,0 +1,796 @@
+use accesskit::Role;
+use bevy_a11y::AccessibilityNode;
+use bevy_app::{App, Plugin, PostUpdate};
+use bevy_ecs::{
+    change_detection::DetectChanges,
+    component::Component,
+    entity::Entity,
+    hierarchy::{ChildOf, Children},
+    lifecycle::RemovedComponents,
+    observer::On,
+    query::{Added, Changed, Has, Or, With},
+    reflect::ReflectComponent,
+    system::{Commands, Query, Res, ResMut},
+    template::FromTemplate,
+};
+use bevy_input::{
+    keyboard::{KeyCode, KeyboardInput},
+    ButtonState,
+};
+use bevy_input_focus::{
+    tab_navigation::TabIndex, FocusCause, FocusedInput, InputFocus, InputFocusVisible,
+};
+use bevy_picking::{events::PointerClick, pointer::PointerButton};
+use bevy_reflect::{prelude::ReflectDefault, Reflect};
+use bevy_ui::{InteractionDisabled, Selectable, Selected};
+
+use crate::ControlOrientation;
+
+/// Determines whether moving keyboard focus also requests tab selection.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Reflect)]
+#[reflect(Default, Clone, PartialEq)]
+pub enum TabActivation {
+    /// Enter or Space requests selection of the focused tab.
+    #[default]
+    Manual,
+    /// Moving focus with a navigation key requests selection of the focused tab.
+    Automatic,
+}
+
+/// Headless tab-strip behavior and policy.
+///
+/// Selection is stored separately in [`SelectedTab`]. User interaction emits
+/// [`crate::ValueChange<Option<Entity>>`] from this entity and does not update that state unless
+/// [`tablist_self_update`] is attached as an observer. Activating the already-selected tab does
+/// not re-emit.
+///
+/// Only primary-button clicks change selection. [`InteractionDisabled`] on this entity disables
+/// the whole strip; disabled strips and disabled tabs let pointer and keyboard events propagate
+/// instead of consuming them.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Reflect)]
+#[require(AccessibilityNode(accesskit::Node::new(Role::TabList)), SelectedTab)]
+#[reflect(Component, Default, Clone, PartialEq)]
+pub struct TabList {
+    /// The axis used by arrow-key navigation.
+    pub orientation: ControlOrientation,
+    /// Whether keyboard navigation requests selection immediately.
+    pub activation: TabActivation,
+}
+
+impl Default for TabList {
+    fn default() -> Self {
+        Self {
+            orientation: ControlOrientation::Horizontal,
+            activation: TabActivation::default(),
+        }
+    }
+}
+
+/// The selected [`Tab`] within a [`TabList`].
+///
+/// The referenced entity must be an enabled direct child of the list. Missing, stale, disabled,
+/// and unrelated entities are treated as no selection.
+#[derive(Component, FromTemplate, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Default, PartialEq)]
+pub struct SelectedTab(#[template(built_in)] pub Option<Entity>);
+
+/// A headless tab header.
+///
+/// Tabs are focusable using a roving [`TabIndex`]. Their derived [`Selected`] state mirrors the
+/// containing list's valid [`SelectedTab`] value.
+#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[require(
+    AccessibilityNode(accesskit::Node::new(Role::Tab)),
+    Selectable,
+    TabIndex(-1)
+)]
+#[reflect(Component, Default, Clone)]
+pub struct Tab;
+
+/// Plugin that registers tab-list observers and derived state.
+pub struct TabPlugin;
+
+impl Plugin for TabPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(tablist_on_click)
+            .add_observer(tab_on_key_input)
+            .add_systems(PostUpdate, update_tablist_derived_state);
+    }
+}
+
+/// Observer that applies tab selection requests to [`SelectedTab`].
+pub fn tablist_self_update(
+    change: On<crate::ValueChange<Option<Entity>>>,
+    tablists: Query<(), With<TabList>>,
+    mut commands: Commands,
+) {
+    if tablists.contains(change.source) {
+        commands
+            .entity(change.source)
+            .insert(SelectedTab(change.value));
+    }
+}
+
+fn tablist_on_click(
+    mut click: On<PointerClick>,
+    tablists: Query<(&SelectedTab, Has<InteractionDisabled>), With<TabList>>,
+    tabs: Query<Has<InteractionDisabled>, With<Tab>>,
+    parents: Query<&ChildOf>,
+    mut commands: Commands,
+) {
+    if click.button != PointerButton::Primary {
+        return;
+    }
+    let Ok((selection, list_disabled)) = tablists.get(click.entity) else {
+        return;
+    };
+
+    let target = click.original_event_target();
+    let tab = if tabs.contains(target) {
+        Some(target)
+    } else {
+        parents
+            .iter_ancestors(target)
+            .take_while(|ancestor| *ancestor != click.entity)
+            .find(|ancestor| tabs.contains(*ancestor))
+    };
+    let Some(tab) = tab else {
+        return;
+    };
+    let Ok(parent) = parents.get(tab) else {
+        return;
+    };
+    if parent.parent() != click.entity {
+        return;
+    }
+    if list_disabled || tabs.get(tab).is_ok_and(|disabled| disabled) {
+        return;
+    }
+
+    click.propagate(false);
+    if selection.0 != Some(tab) {
+        commands.trigger(crate::ValueChange::<Option<Entity>> {
+            source: click.entity,
+            value: Some(tab),
+            is_final: true,
+        });
+    }
+}
+
+fn tab_on_key_input(
+    mut input: On<FocusedInput<KeyboardInput>>,
+    tablists: Query<(&TabList, &SelectedTab, &Children, Has<InteractionDisabled>)>,
+    tabs: Query<Has<InteractionDisabled>, With<Tab>>,
+    parents: Query<&ChildOf>,
+    mut focus: ResMut<InputFocus>,
+    mut focus_visible: ResMut<InputFocusVisible>,
+    mut commands: Commands,
+) {
+    if !tabs.contains(input.focused_entity) {
+        return;
+    }
+    let Ok(parent) = parents.get(input.focused_entity) else {
+        return;
+    };
+    let Ok((tablist, selection, children, list_disabled)) = tablists.get(parent.parent()) else {
+        return;
+    };
+    if list_disabled {
+        return;
+    }
+    let event = &input.input;
+    if event.state != ButtonState::Pressed || event.repeat {
+        return;
+    }
+
+    enum Navigation {
+        Previous,
+        Next,
+        First,
+        Last,
+        Activate,
+    }
+
+    let navigation = match event.key_code {
+        KeyCode::ArrowLeft if tablist.orientation == ControlOrientation::Horizontal => {
+            Navigation::Previous
+        }
+        KeyCode::ArrowRight if tablist.orientation == ControlOrientation::Horizontal => {
+            Navigation::Next
+        }
+        KeyCode::ArrowUp if tablist.orientation == ControlOrientation::Vertical => {
+            Navigation::Previous
+        }
+        KeyCode::ArrowDown if tablist.orientation == ControlOrientation::Vertical => {
+            Navigation::Next
+        }
+        KeyCode::Home => Navigation::First,
+        KeyCode::End => Navigation::Last,
+        KeyCode::Enter | KeyCode::Space => Navigation::Activate,
+        _ => return,
+    };
+
+    if matches!(navigation, Navigation::Activate) {
+        if tabs
+            .get(input.focused_entity)
+            .is_ok_and(|disabled| disabled)
+        {
+            return;
+        }
+        input.propagate(false);
+        if selection.0 != Some(input.focused_entity) {
+            commands.trigger(crate::ValueChange::<Option<Entity>> {
+                source: parent.parent(),
+                value: Some(input.focused_entity),
+                is_final: true,
+            });
+        }
+        return;
+    }
+    input.propagate(false);
+
+    let enabled = children
+        .iter()
+        .copied()
+        .filter(|child| tabs.get(*child).is_ok_and(|disabled| !disabled))
+        .collect::<Vec<_>>();
+    if enabled.is_empty() {
+        return;
+    }
+
+    let current = enabled
+        .iter()
+        .position(|tab| *tab == input.focused_entity)
+        .or_else(|| {
+            selection
+                .0
+                .and_then(|selected| enabled.iter().position(|tab| *tab == selected))
+        });
+    let next_index = match navigation {
+        Navigation::Previous => current
+            .filter(|index| *index > 0)
+            .map_or(enabled.len() - 1, |index| index - 1),
+        Navigation::Next => current.map_or(0, |index| (index + 1) % enabled.len()),
+        Navigation::First => 0,
+        Navigation::Last => enabled.len() - 1,
+        Navigation::Activate => unreachable!(),
+    };
+    let next = enabled[next_index];
+    if focus.get() != Some(next) {
+        focus.set(next, FocusCause::Navigated);
+    }
+    focus_visible.0 = true;
+    if tablist.activation == TabActivation::Automatic && selection.0 != Some(next) {
+        commands.trigger(crate::ValueChange::<Option<Entity>> {
+            source: parent.parent(),
+            value: Some(next),
+            is_final: true,
+        });
+    }
+}
+
+fn update_tablist_derived_state(
+    tablists: Query<(&SelectedTab, &Children), With<TabList>>,
+    tabs: Query<(Has<InteractionDisabled>, Has<Selected>, &TabIndex), With<Tab>>,
+    focus: Option<Res<InputFocus>>,
+    changed_tablists: Query<(), (With<TabList>, Or<(Changed<SelectedTab>, Changed<Children>)>)>,
+    changed_tabs: Query<(), (With<Tab>, Or<(Added<Tab>, Added<InteractionDisabled>)>)>,
+    mut removed_disabled: RemovedComponents<InteractionDisabled>,
+    mut commands: Commands,
+) {
+    let focus_changed = focus.as_ref().is_some_and(DetectChanges::is_changed);
+    let disabled_removed = !removed_disabled.is_empty();
+    removed_disabled.clear();
+    if !focus_changed && !disabled_removed && changed_tablists.is_empty() && changed_tabs.is_empty()
+    {
+        return;
+    }
+
+    for (selection, children) in tablists.iter() {
+        let selected = selection.0.filter(|entity| {
+            children.contains(entity) && tabs.get(*entity).is_ok_and(|(disabled, _, _)| !disabled)
+        });
+        let focused = focus
+            .as_ref()
+            .and_then(|focus| focus.get())
+            .filter(|entity| {
+                children.contains(entity)
+                    && tabs.get(*entity).is_ok_and(|(disabled, _, _)| !disabled)
+            });
+        let roving = focused.or(selected).or_else(|| {
+            children
+                .iter()
+                .find(|child| tabs.get(**child).is_ok_and(|(disabled, _, _)| !disabled))
+                .copied()
+        });
+
+        for child in children.iter() {
+            let Ok((_, is_selected, tab_index)) = tabs.get(*child) else {
+                continue;
+            };
+            let should_select = selected == Some(*child);
+            if should_select && !is_selected {
+                commands.entity(*child).insert(Selected);
+            } else if !should_select && is_selected {
+                commands.entity(*child).remove::<Selected>();
+            }
+
+            let desired_index = if roving == Some(*child) { 0 } else { -1 };
+            if tab_index.0 != desired_index {
+                commands.entity(*child).insert(TabIndex(desired_index));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_ecs::{hierarchy::ChildOf, observer::On, resource::Resource, system::ResMut};
+    use bevy_input::{keyboard::Key, InputPlugin};
+    use bevy_input_focus::{FocusCause, InputDispatchPlugin, InputFocusPlugin};
+    use bevy_math::Vec2;
+    use bevy_picking::{
+        backend::HitData,
+        events::Pointer,
+        pointer::{Location, PointerButton, PointerId},
+    };
+    use bevy_window::{PrimaryWindow, Window, WindowRef};
+
+    #[derive(Resource, Default)]
+    struct SelectionRequests(Vec<(Entity, Option<Entity>)>);
+
+    fn tab_app() -> (App, Entity) {
+        let mut app = App::new();
+        app.add_plugins((
+            InputPlugin,
+            InputFocusPlugin,
+            InputDispatchPlugin,
+            TabPlugin,
+        ))
+        .init_resource::<SelectionRequests>()
+        .add_observer(
+            |change: On<crate::ValueChange<Option<Entity>>>,
+             mut requests: ResMut<SelectionRequests>| {
+                requests.0.push((change.source, change.value));
+            },
+        );
+        let window = app
+            .world_mut()
+            .spawn((Window::default(), PrimaryWindow))
+            .id();
+        app.update();
+        (app, window)
+    }
+
+    fn press_key(app: &mut App, key_code: KeyCode, window: Entity) {
+        let logical_key = match key_code {
+            KeyCode::ArrowLeft => Key::ArrowLeft,
+            KeyCode::ArrowRight => Key::ArrowRight,
+            KeyCode::ArrowUp => Key::ArrowUp,
+            KeyCode::ArrowDown => Key::ArrowDown,
+            KeyCode::Home => Key::Home,
+            KeyCode::End => Key::End,
+            KeyCode::Enter => Key::Enter,
+            KeyCode::Space => Key::Space,
+            _ => Key::Unidentified(bevy_input::keyboard::NativeKey::Unidentified),
+        };
+        app.world_mut().write_message(KeyboardInput {
+            key_code,
+            logical_key,
+            state: ButtonState::Pressed,
+            text: None,
+            repeat: false,
+            window,
+        });
+        app.update();
+    }
+
+    fn click(app: &mut App, target: Entity, window: Entity) {
+        click_with_button(app, target, window, PointerButton::Primary);
+    }
+
+    fn click_with_button(app: &mut App, target: Entity, window: Entity, button: PointerButton) {
+        let location = Location {
+            target: bevy_camera::NormalizedRenderTarget::Window(
+                WindowRef::Entity(window).normalize(Some(window)).unwrap(),
+            ),
+            position: Vec2::ZERO,
+        };
+        app.world_mut().trigger(PointerClick {
+            entity: target,
+            pointer: Pointer::new(PointerId::Mouse, location),
+            button,
+            hit: HitData::new(window, 0.0, None, None),
+            duration: core::time::Duration::from_millis(10),
+            count: 1,
+        });
+        app.update();
+    }
+
+    #[test]
+    fn clicking_enabled_tab_requests_selection_without_mutating_controlled_state() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((TabList::default(), ChildOf(window)))
+            .id();
+        let first = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        let second = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.world_mut()
+            .entity_mut(list)
+            .insert(SelectedTab(Some(first)));
+        app.update();
+
+        click(&mut app, second, window);
+
+        assert_eq!(
+            app.world().resource::<SelectionRequests>().0,
+            [(list, Some(second))]
+        );
+        assert_eq!(
+            app.world().entity(list).get::<SelectedTab>(),
+            Some(&SelectedTab(Some(first)))
+        );
+    }
+
+    #[test]
+    fn self_update_observer_applies_selection_request() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((TabList::default(), ChildOf(window)))
+            .observe(tablist_self_update)
+            .id();
+        let tab = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.update();
+
+        click(&mut app, tab, window);
+
+        assert_eq!(
+            app.world().entity(list).get::<SelectedTab>(),
+            Some(&SelectedTab(Some(tab)))
+        );
+    }
+
+    #[test]
+    fn valid_selection_derives_selected_state_and_roving_entry() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((TabList::default(), ChildOf(window)))
+            .id();
+        let first = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        let second = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.world_mut()
+            .entity_mut(list)
+            .insert(SelectedTab(Some(second)));
+
+        app.update();
+
+        assert!(!app.world().entity(first).contains::<Selected>());
+        assert!(app.world().entity(second).contains::<Selected>());
+        assert_eq!(
+            app.world().entity(first).get::<TabIndex>(),
+            Some(&TabIndex(-1))
+        );
+        assert_eq!(
+            app.world().entity(second).get::<TabIndex>(),
+            Some(&TabIndex(0))
+        );
+    }
+
+    #[test]
+    fn invalid_selection_clears_selected_state_and_uses_first_enabled_roving_entry() {
+        let (mut app, window) = tab_app();
+        let stale = app.world_mut().spawn_empty().id();
+        let list = app
+            .world_mut()
+            .spawn((
+                TabList::default(),
+                SelectedTab(Some(stale)),
+                ChildOf(window),
+            ))
+            .id();
+        let disabled = app
+            .world_mut()
+            .spawn((Tab, Selected, InteractionDisabled, ChildOf(list)))
+            .id();
+        let enabled = app.world_mut().spawn((Tab, ChildOf(list))).id();
+
+        app.update();
+
+        assert!(!app.world().entity(disabled).contains::<Selected>());
+        assert!(!app.world().entity(enabled).contains::<Selected>());
+        assert_eq!(
+            app.world().entity(disabled).get::<TabIndex>(),
+            Some(&TabIndex(-1))
+        );
+        assert_eq!(
+            app.world().entity(enabled).get::<TabIndex>(),
+            Some(&TabIndex(0))
+        );
+    }
+
+    #[test]
+    fn horizontal_manual_arrow_navigation_wraps_and_skips_disabled_tabs() {
+        use bevy_input::keyboard::KeyCode;
+
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((TabList::default(), ChildOf(window)))
+            .id();
+        let first = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.world_mut()
+            .spawn((Tab, InteractionDisabled, ChildOf(list)));
+        let last = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.world_mut()
+            .entity_mut(list)
+            .insert(SelectedTab(Some(first)));
+        app.world_mut()
+            .resource_mut::<InputFocus>()
+            .set(first, FocusCause::Navigated);
+        app.update();
+
+        press_key(&mut app, KeyCode::ArrowRight, window);
+        assert_eq!(app.world().resource::<InputFocus>().get(), Some(last));
+
+        press_key(&mut app, KeyCode::ArrowRight, window);
+        assert_eq!(app.world().resource::<InputFocus>().get(), Some(first));
+
+        press_key(&mut app, KeyCode::ArrowLeft, window);
+        assert_eq!(app.world().resource::<InputFocus>().get(), Some(last));
+        assert!(
+            app.world().resource::<SelectionRequests>().0.is_empty(),
+            "manual navigation must not request selection"
+        );
+    }
+
+    #[test]
+    fn automatic_navigation_requests_selection_when_focus_moves() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((
+                TabList {
+                    activation: TabActivation::Automatic,
+                    ..Default::default()
+                },
+                ChildOf(window),
+            ))
+            .id();
+        let first = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        let second = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.world_mut()
+            .entity_mut(list)
+            .insert(SelectedTab(Some(first)));
+        app.world_mut()
+            .resource_mut::<InputFocus>()
+            .set(first, FocusCause::Navigated);
+        app.update();
+
+        press_key(&mut app, KeyCode::ArrowRight, window);
+
+        assert_eq!(app.world().resource::<InputFocus>().get(), Some(second));
+        assert_eq!(
+            app.world().resource::<SelectionRequests>().0,
+            [(list, Some(second))]
+        );
+        assert_eq!(
+            app.world().entity(list).get::<SelectedTab>(),
+            Some(&SelectedTab(Some(first))),
+            "automatic activation remains a controlled selection request"
+        );
+    }
+
+    #[test]
+    fn manual_tabs_request_selection_on_enter_and_space() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((TabList::default(), ChildOf(window)))
+            .id();
+        let tab = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.world_mut()
+            .resource_mut::<InputFocus>()
+            .set(tab, FocusCause::Navigated);
+        app.update();
+
+        press_key(&mut app, KeyCode::Enter, window);
+        press_key(&mut app, KeyCode::Space, window);
+
+        assert_eq!(
+            app.world().resource::<SelectionRequests>().0,
+            [(list, Some(tab)), (list, Some(tab))]
+        );
+    }
+
+    #[test]
+    fn vertical_tabs_use_up_and_down_arrows_only() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((
+                TabList {
+                    orientation: ControlOrientation::Vertical,
+                    ..Default::default()
+                },
+                ChildOf(window),
+            ))
+            .id();
+        let first = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        let second = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.world_mut()
+            .resource_mut::<InputFocus>()
+            .set(first, FocusCause::Navigated);
+        app.update();
+
+        press_key(&mut app, KeyCode::ArrowRight, window);
+        assert_eq!(app.world().resource::<InputFocus>().get(), Some(first));
+
+        press_key(&mut app, KeyCode::ArrowDown, window);
+        assert_eq!(app.world().resource::<InputFocus>().get(), Some(second));
+
+        press_key(&mut app, KeyCode::ArrowUp, window);
+        assert_eq!(app.world().resource::<InputFocus>().get(), Some(first));
+    }
+
+    #[test]
+    fn home_and_end_focus_first_and_last_enabled_tabs() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((TabList::default(), ChildOf(window)))
+            .id();
+        app.world_mut()
+            .spawn((Tab, InteractionDisabled, ChildOf(list)));
+        let first_enabled = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        let last_enabled = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.world_mut()
+            .spawn((Tab, InteractionDisabled, ChildOf(list)));
+        app.world_mut()
+            .resource_mut::<InputFocus>()
+            .set(first_enabled, FocusCause::Navigated);
+        app.update();
+
+        press_key(&mut app, KeyCode::End, window);
+        assert_eq!(
+            app.world().resource::<InputFocus>().get(),
+            Some(last_enabled)
+        );
+
+        press_key(&mut app, KeyCode::Home, window);
+        assert_eq!(
+            app.world().resource::<InputFocus>().get(),
+            Some(first_enabled)
+        );
+    }
+
+    #[test]
+    fn focused_tab_is_the_roving_entry_during_manual_navigation() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((TabList::default(), ChildOf(window)))
+            .id();
+        let selected = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        let focused = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.world_mut()
+            .entity_mut(list)
+            .insert(SelectedTab(Some(selected)));
+        app.world_mut()
+            .resource_mut::<InputFocus>()
+            .set(focused, FocusCause::Navigated);
+
+        app.update();
+
+        assert_eq!(
+            app.world().entity(selected).get::<TabIndex>(),
+            Some(&TabIndex(-1))
+        );
+        assert_eq!(
+            app.world().entity(focused).get::<TabIndex>(),
+            Some(&TabIndex(0))
+        );
+        assert!(app.world().entity(selected).contains::<Selected>());
+        assert!(!app.world().entity(focused).contains::<Selected>());
+    }
+
+    #[test]
+    fn tablist_and_tab_install_accessibility_semantics() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((TabList::default(), ChildOf(window)))
+            .id();
+        let tab = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.update();
+
+        let list_node = app.world().entity(list).get::<AccessibilityNode>().unwrap();
+        let tab_node = app.world().entity(tab).get::<AccessibilityNode>().unwrap();
+        assert_eq!(list_node.role(), Role::TabList);
+        assert_eq!(tab_node.role(), Role::Tab);
+        assert!(app.world().entity(tab).contains::<Selectable>());
+    }
+
+    #[test]
+    fn disabled_tab_does_not_request_selection() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((TabList::default(), ChildOf(window)))
+            .id();
+        let disabled = app
+            .world_mut()
+            .spawn((Tab, InteractionDisabled, ChildOf(list)))
+            .id();
+        app.update();
+
+        click(&mut app, disabled, window);
+
+        assert!(app.world().resource::<SelectionRequests>().0.is_empty());
+    }
+
+    #[test]
+    fn secondary_click_does_not_change_selection() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((TabList::default(), ChildOf(window)))
+            .id();
+        let tab = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.update();
+
+        click_with_button(&mut app, tab, window, PointerButton::Secondary);
+        click_with_button(&mut app, tab, window, PointerButton::Middle);
+
+        assert!(app.world().resource::<SelectionRequests>().0.is_empty());
+    }
+
+    #[test]
+    fn activating_the_selected_tab_does_not_reemit() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((TabList::default(), ChildOf(window)))
+            .observe(tablist_self_update)
+            .id();
+        let tab = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.update();
+
+        click(&mut app, tab, window);
+        click(&mut app, tab, window);
+
+        assert_eq!(
+            app.world().resource::<SelectionRequests>().0,
+            [(list, Some(tab))]
+        );
+        assert_eq!(
+            app.world().entity(list).get::<SelectedTab>(),
+            Some(&SelectedTab(Some(tab)))
+        );
+    }
+
+    #[test]
+    fn disabled_tablist_ignores_clicks_and_keys() {
+        let (mut app, window) = tab_app();
+        let list = app
+            .world_mut()
+            .spawn((TabList::default(), InteractionDisabled, ChildOf(window)))
+            .id();
+        let first = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        let second = app.world_mut().spawn((Tab, ChildOf(list))).id();
+        app.world_mut()
+            .resource_mut::<InputFocus>()
+            .set(first, FocusCause::Navigated);
+        app.update();
+
+        click(&mut app, second, window);
+        press_key(&mut app, KeyCode::ArrowRight, window);
+        press_key(&mut app, KeyCode::Enter, window);
+
+        assert!(app.world().resource::<SelectionRequests>().0.is_empty());
+        assert_eq!(app.world().resource::<InputFocus>().get(), Some(first));
+    }
+}

--- a/crates/bevy_ui_widgets/src/tabs.rs
+++ b/crates/bevy_ui_widgets/src/tabs.rs
@@ -269,21 +269,16 @@ fn tab_on_key_input(
     }
 }
 
-/// Derives per-tab state from each [`TabList`]'s [`SelectedTab`] value and the current keyboard
-/// focus. [`SelectedTab`] is the single source of truth; everything here is a projection of it.
+/// Derives per-tab state from each [`TabList`]'s [`SelectedTab`] and the current keyboard focus:
 ///
-/// Two pieces of state are maintained on the list's child tabs:
+/// - [`Selected`] markers mirror a validated `SelectedTab` (the referenced entity must be an
+///   enabled direct child; anything else counts as no selection).
+/// - [`TabIndex`] follows the roving-tabindex pattern: one tab per list is focusable (the
+///   focused tab, else the selected tab, else the first enabled tab), so Tab/Shift+Tab skip
+///   the strip while arrow keys move within it.
 ///
-/// - [`Selected`] markers mirror the list's `SelectedTab`, after validating it (the referenced
-///   entity must be an enabled direct child; anything else counts as no selection). Styling and
-///   accessibility read the marker rather than re-validating the list state themselves.
-/// - [`TabIndex`] implements the roving-tabindex pattern: exactly one tab per list is focusable
-///   (index 0) so that Tab/Shift+Tab move past the strip as a whole while arrow keys move within
-///   it. The roving entry is the focused tab if focus is inside the list, otherwise the selected
-///   tab, otherwise the first enabled tab.
-///
-/// Runs in `PostUpdate`, early-returning unless a selection, child list, focus, or disabled
-/// state changed since the last run.
+/// Runs in `PostUpdate`, early-returning unless selection, children, focus, or disabled state
+/// changed.
 fn update_tablist_derived_state(
     tablists: Query<(&SelectedTab, &Children), With<TabList>>,
     tabs: Query<(Has<InteractionDisabled>, Has<Selected>, &TabIndex), With<Tab>>,

--- a/crates/bevy_ui_widgets/src/tabs.rs
+++ b/crates/bevy_ui_widgets/src/tabs.rs
@@ -10,6 +10,7 @@ use bevy_ecs::{
     observer::On,
     query::{Added, Changed, Has, Or, With},
     reflect::ReflectComponent,
+    schedule::IntoScheduleConfigs,
     system::{Commands, Query, Res, ResMut},
     template::FromTemplate,
 };
@@ -18,7 +19,8 @@ use bevy_input::{
     ButtonState,
 };
 use bevy_input_focus::{
-    tab_navigation::TabIndex, FocusCause, FocusedInput, InputFocus, InputFocusVisible,
+    tab_navigation::TabIndex, FocusCause, FocusedInput, InputFocus, InputFocusSystems,
+    InputFocusVisible,
 };
 use bevy_picking::{events::PointerClick, pointer::PointerButton};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
@@ -94,7 +96,12 @@ impl Plugin for TabPlugin {
     fn build(&self, app: &mut App) {
         app.add_observer(tablist_on_click)
             .add_observer(tab_on_key_input)
-            .add_systems(PostUpdate, update_tablist_derived_state);
+            .add_systems(
+                PostUpdate,
+                update_tablist_derived_state
+                    .after(crate::MenuFocusSystem)
+                    .before(InputFocusSystems::FocusChangeEvents),
+            );
     }
 }
 

--- a/crates/bevy_ui_widgets/src/tabs.rs
+++ b/crates/bevy_ui_widgets/src/tabs.rs
@@ -269,6 +269,21 @@ fn tab_on_key_input(
     }
 }
 
+/// Derives per-tab state from each [`TabList`]'s [`SelectedTab`] value and the current keyboard
+/// focus. [`SelectedTab`] is the single source of truth; everything here is a projection of it.
+///
+/// Two pieces of state are maintained on the list's child tabs:
+///
+/// - [`Selected`] markers mirror the list's `SelectedTab`, after validating it (the referenced
+///   entity must be an enabled direct child; anything else counts as no selection). Styling and
+///   accessibility read the marker rather than re-validating the list state themselves.
+/// - [`TabIndex`] implements the roving-tabindex pattern: exactly one tab per list is focusable
+///   (index 0) so that Tab/Shift+Tab move past the strip as a whole while arrow keys move within
+///   it. The roving entry is the focused tab if focus is inside the list, otherwise the selected
+///   tab, otherwise the first enabled tab.
+///
+/// Runs in `PostUpdate`, early-returning unless a selection, child list, focus, or disabled
+/// state changed since the last run.
 fn update_tablist_derived_state(
     tablists: Query<(&SelectedTab, &Children), With<TabList>>,
     tabs: Query<(Has<InteractionDisabled>, Has<Selected>, &TabIndex), With<Tab>>,

--- a/examples/README.md
+++ b/examples/README.md
@@ -614,6 +614,7 @@ Example | Description
 [Generic Font Families](../examples/ui/text/generic_font_families.rs) | Demonstrates how to use generic font families
 [Ghost Nodes](../examples/ui/layout/ghost_nodes.rs) | Demonstrates the use of Ghost Nodes to skip entities in the UI layout hierarchy
 [Gradients](../examples/ui/styling/gradients.rs) | An example demonstrating gradients
+[Headless Tabs](../examples/ui/widgets/headless_tabs.rs) | Demonstrates controlled and self-updating headless tab lists
 [IME Support](../examples/ui/text/ime_support.rs) | Demonstrates IME (Input Method Editor) support for text input
 [Image Node](../examples/ui/images/image_node.rs) | Demonstrates how to create an image node
 [Image Node Resizing](../examples/ui/images/image_node_resizing.rs) | Demonstrates how to resize an image node

--- a/examples/ui/widgets/headless_tabs.rs
+++ b/examples/ui/widgets/headless_tabs.rs
@@ -1,0 +1,218 @@
+//! Demonstrates the behavior-only tab widgets in `bevy_ui_widgets`.
+
+use bevy::{
+    ecs::template::{EntityTemplate, OptionTemplate},
+    input_focus::{
+        tab_navigation::{TabGroup, TabNavigationPlugin},
+        InputFocus, InputFocusVisible,
+    },
+    picking::hover::Hovered,
+    prelude::*,
+    ui::{InteractionDisabled, Selected},
+    ui_widgets::{
+        tablist_self_update, ControlOrientation, SelectedTab, Tab, TabActivation, TabList,
+        ValueChange,
+    },
+};
+
+#[derive(Component, Default, Clone)]
+struct ShowcaseTab;
+
+#[derive(Resource, Default)]
+struct ControlledSelection(Option<Entity>);
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, TabNavigationPlugin))
+        .init_resource::<ControlledSelection>()
+        .add_systems(Startup, showcase.spawn())
+        .add_systems(Update, update_tab_styles)
+        .run();
+}
+
+fn showcase() -> impl SceneList {
+    bsn_list![
+        Camera2d,
+        (
+            Node {
+                width: percent(100),
+                height: percent(100),
+                padding: UiRect::all(px(24)),
+                display: Display::Flex,
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::Start,
+                row_gap: px(18),
+                overflow: Overflow::scroll_y(),
+            }
+            BackgroundColor(Color::srgb(0.06, 0.07, 0.09))
+            TabGroup
+            Children [
+                section_label("Horizontal automatic - self-updating"),
+                (
+                    #automatic
+                    tab_strip(ControlOrientation::Horizontal)
+                    TabList {
+                        orientation: ControlOrientation::Horizontal,
+                        activation: TabActivation::Automatic,
+                    }
+                    selected_tab(#automatic_general)
+                    on(tablist_self_update)
+                    Children [
+                        (
+                            #automatic_general
+                            tab_header("General")
+                        ),
+                        tab_header("Rendering"),
+                        (
+                            tab_header("Disabled")
+                            InteractionDisabled
+                        ),
+                    ]
+                ),
+                section_label("Horizontal manual - focus and selection are separate"),
+                (
+                    tab_strip(ControlOrientation::Horizontal)
+                    TabList::default()
+                    selected_tab(#manual_scene)
+                    on(tablist_self_update)
+                    Children [
+                        (
+                            #manual_scene
+                            tab_header("Scene")
+                        ),
+                        tab_header("Assets"),
+                        tab_header("Inspector"),
+                    ]
+                ),
+                section_label("Vertical manual"),
+                (
+                    tab_strip(ControlOrientation::Vertical)
+                    TabList {
+                        orientation: ControlOrientation::Vertical,
+                        activation: TabActivation::Manual,
+                    }
+                    selected_tab(#vertical_transform)
+                    on(tablist_self_update)
+                    Children [
+                        (
+                            #vertical_transform
+                            tab_header("Transform")
+                        ),
+                        tab_header("Visibility"),
+                        tab_header("Metadata"),
+                    ]
+                ),
+                section_label("Controlled - observer updates external state"),
+                (
+                    tab_strip(ControlOrientation::Horizontal)
+                    TabList::default()
+                    selected_tab(#controlled_a)
+                    on(controlled_selection)
+                    Children [
+                        (
+                            #controlled_a
+                            tab_header("External A")
+                        ),
+                        tab_header("External B"),
+                    ]
+                ),
+            ]
+        )
+    ]
+}
+
+fn tab_strip(orientation: ControlOrientation) -> impl Scene {
+    let flex_direction = match orientation {
+        ControlOrientation::Horizontal => FlexDirection::Row,
+        ControlOrientation::Vertical => FlexDirection::Column,
+    };
+    bsn! {
+        Node {
+            display: Display::Flex,
+            flex_direction,
+            align_items: AlignItems::Stretch,
+        }
+        BackgroundColor(Color::srgb(0.10, 0.11, 0.14))
+    }
+}
+
+fn tab_header(label: &'static str) -> impl Scene {
+    bsn! {
+        ShowcaseTab
+        Tab
+        Hovered
+        Node {
+            min_width: px(112),
+            min_height: px(36),
+            padding: UiRect::axes(px(12), px(8)),
+            border: UiRect::all(px(1)),
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+        }
+        BackgroundColor(Color::srgb(0.13, 0.14, 0.18))
+        template_value(BorderColor::all(Color::srgb(0.24, 0.25, 0.30)))
+        Children [(
+            Text(label)
+            TextFont {
+                font_size: FontSize::Px(16.0)
+            }
+            TextColor(Color::srgb(0.88, 0.89, 0.92))
+        )]
+    }
+}
+
+fn selected_tab(tab: EntityTemplate) -> impl Scene {
+    let tab = OptionTemplate::Some(tab);
+    bsn! {
+        SelectedTab({tab})
+    }
+}
+
+fn section_label(label: &'static str) -> impl Scene {
+    bsn! {
+        Text(label)
+        TextFont {
+            font_size: FontSize::Px(17.0)
+        }
+        TextColor(Color::srgb(0.72, 0.76, 0.84))
+    }
+}
+
+fn controlled_selection(
+    change: On<ValueChange<Option<Entity>>>,
+    mut state: ResMut<ControlledSelection>,
+    mut commands: Commands,
+) {
+    state.0 = change.value;
+    commands.entity(change.source).insert(SelectedTab(state.0));
+}
+
+fn update_tab_styles(
+    focus: Res<InputFocus>,
+    focus_visible: Res<InputFocusVisible>,
+    mut tabs: Query<
+        (
+            Entity,
+            &Hovered,
+            Has<Selected>,
+            Has<InteractionDisabled>,
+            &mut BackgroundColor,
+            &mut BorderColor,
+        ),
+        With<ShowcaseTab>,
+    >,
+) {
+    for (entity, hovered, selected, disabled, mut background, mut border) in &mut tabs {
+        background.0 = match (disabled, selected, hovered.get()) {
+            (true, _, _) => Color::srgb(0.10, 0.10, 0.11),
+            (false, true, _) => Color::srgb(0.18, 0.34, 0.52),
+            (false, false, true) => Color::srgb(0.20, 0.21, 0.26),
+            _ => Color::srgb(0.13, 0.14, 0.18),
+        };
+        border.set_all(if focus_visible.0 && focus.get() == Some(entity) {
+            Color::srgb(0.45, 0.78, 1.0)
+        } else {
+            Color::srgb(0.24, 0.25, 0.30)
+        });
+    }
+}


### PR DESCRIPTION
# Objective

Implement the "Tab Deck" item from the widgets roadmap (#19236).

This is the first PR in an effort to upstream the tab and docking functionality built for jackdaw, following the layered design
from the tab panes and docking specification written by @viridia here: https://hackmd.io/@dreamertalin/HkA2okNSzx. This starts with the first PR: headless tab behavior, with no styling.

## Solution

- Headless tab list and tab components in `bevy_ui_widgets`.
- Selection is externally owned, matching the crate's controlled-widget convention: interaction emits a selection request, and the app either applies it itself or attaches the provided self-update observer.
- Keyboard navigation with a roving tab index, in both orientations, with manual or automatic activation.
- Accessibility roles, and disabled handling for individual tabs or whole strips.
- A `headless_tabs` example and a release note.


Dragging tabs, reodering tabs, styling, and dock layout are all planned for follow-ups

## Testing

- `cargo test -p bevy_ui_widgets tabs`
- `cargo run --example headless_tabs`:


## Showcase
<img width="948" height="1025" alt="image" src="https://github.com/user-attachments/assets/7981b88c-e2f4-4ee8-8d5f-398fa2de97c9" />

https://github.com/user-attachments/assets/c70a002c-6a17-450b-906f-7b3622a1094f

## AI Disclaimer
I used an LLM (claude code) to help with the transfer of code from jackdaw to bevy, and to post-check/review before committing/submitting the PR
