### PR TITLE
experimenting: remove some env keys from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ env:
   CARGO_PROFILE_DEV_DEBUG: 0
   # If nightly is breaking CI, modify this variable to target a specific nightly version.
   NIGHTLY_TOOLCHAIN: nightly
-  RUSTFLAGS: "-D warnings"
 
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
@@ -57,8 +56,6 @@ jobs:
       - name: Build & run tests
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- test
-        env:
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
   ci:
     runs-on: ubuntu-latest
@@ -417,8 +414,6 @@ jobs:
       - name: Build and check doc
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- doc
-        env:
-          RUSTFLAGS: "-C debuginfo=0 -D warnings"
       # This currently report a lot of false positives
       # Enable it again once it's fixed - https://github.com/bevyengine/bevy/issues/1983
       # - name: Installs cargo-deadlinks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           # key won't match, will rely on restore-keys
-          key: ${{ runner.os }}-stable--${{ hashFiles('**/Cargo.toml') }}-
+          key: ${{ runner.os }}-${{ env.NIGHTLY_TOOLCHAIN }}--${{ hashFiles('**/Cargo.toml') }}-
           # See .github/workflows/update-caches.yml for how keys are generated
           restore-keys: |
-            ${{ runner.os }}-stable--${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-stable--
+            ${{ runner.os }}-${{ env.NIGHTLY_TOOLCHAIN }}--${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-${{ env.NIGHTLY_TOOLCHAIN }}--
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
@@ -50,7 +50,7 @@ jobs:
             target/
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
         with:
-          toolchain: stable
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build & run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
             target/
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
         with:
-          toolchain: nightly-2026-08-20
+          toolchain: nightly-2026-08-21
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build & run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
             target/
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c
         with:
-          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+          toolchain: nightly-2026-08-20
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build & run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Build & run tests
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- test
+        env:
+          CARGO_LOG=cargo::compiler::fingerprint=info
 
   ci:
     runs-on: ubuntu-latest
@@ -92,6 +94,8 @@ jobs:
       - name: CI job
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- lints
+        env:
+          CARGO_LOG=cargo::compiler::fingerprint=info
 
   miri:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- test
         env:
-          CARGO_LOG=cargo::compiler::fingerprint=info
+          CARGO_LOG: "cargo::compiler::fingerprint=info"
 
   ci:
     runs-on: ubuntu-latest
@@ -95,7 +95,7 @@ jobs:
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- lints
         env:
-          CARGO_LOG=cargo::compiler::fingerprint=info
+          CARGO_LOG: "cargo::compiler::fingerprint=info"
 
   miri:
     runs-on: macos-latest

--- a/tools/ci/src/commands/test.rs
+++ b/tools/ci/src/commands/test.rs
@@ -17,7 +17,7 @@ impl Prepare for TestCommand {
         let test_threads_ref = &test_threads;
 
         // The bevy_ecs error tests need this set to test backtraces
-        sh.set_var("RUST_BACKTRACE", "1");
+        // sh.set_var("RUST_BACKTRACE", "1");
 
         vec![
             PreparedCommand::new::<Self>(


### PR DESCRIPTION
# Objective

ci slow.

## Solution
maybe env keys are messing up the caches?

## Testing
remove env keys from ci.yml to test if this pr runs its ci any faster/skips rebuilding
`-C debuginfo=0` should be redundant anyway
