### PR TITLE
Make `Dlss` implement `Default` for all feature types

### DIFF
--- a/crates/bevy_anti_alias/src/dlss/mod.rs
+++ b/crates/bevy_anti_alias/src/dlss/mod.rs
@@ -218,7 +218,7 @@ pub struct Dlss<F: DlssFeature = DlssSuperResolutionFeature> {
     pub _phantom_data: PhantomData<F>,
 }
 
-impl Default for Dlss<DlssSuperResolutionFeature> {
+impl<F: DlssFeature> Default for Dlss<F> {
     fn default() -> Self {
         Self {
             perf_quality_mode: Default::default(),

--- a/examples/3d/solari.rs
+++ b/examples/3d/solari.rs
@@ -164,11 +164,7 @@ fn setup_pica_pica(
     // Using DLSS Ray Reconstruction for denoising (and cheaper rendering via upscaling) is _highly_ recommended when using Solari
     #[cfg(all(feature = "dlss", not(feature = "force_disable_dlss")))]
     if dlss_rr_supported.is_some() {
-        camera.insert(Dlss::<DlssRayReconstructionFeature> {
-            perf_quality_mode: Default::default(),
-            reset: Default::default(),
-            _phantom_data: Default::default(),
-        });
+        camera.insert(Dlss::<DlssRayReconstructionFeature>::default());
     }
 
     commands.spawn((
@@ -349,11 +345,7 @@ fn setup_many_lights(
     // Using DLSS Ray Reconstruction for denoising (and cheaper rendering via upscaling) is _highly_ recommended when using Solari
     #[cfg(all(feature = "dlss", not(feature = "force_disable_dlss")))]
     if dlss_rr_supported.is_some() {
-        camera.insert(Dlss::<DlssRayReconstructionFeature> {
-            perf_quality_mode: Default::default(),
-            reset: Default::default(),
-            _phantom_data: Default::default(),
-        });
+        camera.insert(Dlss::<DlssRayReconstructionFeature>::default());
     }
 
     commands.spawn((
@@ -475,11 +467,7 @@ fn toggle_dlss_rr(
         } else {
             commands
                 .entity(entity)
-                .insert(Dlss::<DlssRayReconstructionFeature> {
-                    perf_quality_mode: Default::default(),
-                    reset: Default::default(),
-                    _phantom_data: Default::default(),
-                });
+                .insert(Dlss::<DlssRayReconstructionFeature>::default());
         }
     }
 }

--- a/examples/3d/solari_reflections.rs
+++ b/examples/3d/solari_reflections.rs
@@ -250,11 +250,7 @@ fn setup(
 
     #[cfg(all(feature = "dlss", not(feature = "force_disable_dlss")))]
     if dlss_rr_supported.is_some() {
-        camera.insert(Dlss::<DlssRayReconstructionFeature> {
-            perf_quality_mode: Default::default(),
-            reset: Default::default(),
-            _phantom_data: Default::default(),
-        });
+        camera.insert(Dlss::<DlssRayReconstructionFeature>::default());
     }
     let _ = &mut camera;
 
@@ -810,11 +806,7 @@ fn toggle_dlss_rr(
         } else {
             commands
                 .entity(entity)
-                .insert(Dlss::<DlssRayReconstructionFeature> {
-                    perf_quality_mode: Default::default(),
-                    reset: Default::default(),
-                    _phantom_data: Default::default(),
-                });
+                .insert(Dlss::<DlssRayReconstructionFeature>::default());
         }
     }
 }


### PR DESCRIPTION
# Objective

Allow `Dlss<DlssRayReconstructionFeature>` to use `Default`, consistent with DLSS Super Resolution.

## Solution

```rust
impl<F: DlssFeature> Default for Dlss<F> {}
```

## Testing

- Ran `cargo fmt`.
- Ran `cargo clippy -p bevy_anti_alias --features dlss,force_disable_dlss --lib`.

## Showcase

```rust
camera.insert(Dlss::<DlssRayReconstructionFeature>::default());