### PR TITLE
fix: disabled number input field isn't editable

### DIFF
--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -997,7 +997,11 @@ fn scrubber_on_release(
         &UiGlobalTransform,
     )>,
     q_parent: Query<&ChildOf>,
-    q_units: Query<(&NumberInputValue, Option<&NumberInputUnits>)>,
+    q_units: Query<(
+        &NumberInputValue,
+        Has<InteractionDisabled>,
+        Option<&NumberInputUnits>,
+    )>,
     ui_scale: Res<UiScale>,
     units_registry: Res<UnitsRegistry>,
     mut commands: Commands,
@@ -1006,7 +1010,8 @@ fn scrubber_on_release(
         && let Ok((mut editable_text, mut drag_state, node, target, transform)) =
             q_text.get_mut(text_id)
         && let Ok(&ChildOf(root_id)) = q_parent.get(text_id)
-        && let Ok((value, units)) = q_units.get(root_id)
+        && let Ok((value, disabled, units)) = q_units.get(root_id)
+        && !disabled
     {
         // If we're in editing mode, let event propagate so that text input can handle it.
         if drag_state.mode == EditMode::Editing {

--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -997,11 +997,7 @@ fn scrubber_on_release(
         &UiGlobalTransform,
     )>,
     q_parent: Query<&ChildOf>,
-    q_units: Query<(
-        &NumberInputValue,
-        Has<InteractionDisabled>,
-        Option<&NumberInputUnits>,
-    )>,
+    q_units: Query<(&NumberInputValue, Option<&NumberInputUnits>), Without<InteractionDisabled>>,
     ui_scale: Res<UiScale>,
     units_registry: Res<UnitsRegistry>,
     mut commands: Commands,
@@ -1010,8 +1006,7 @@ fn scrubber_on_release(
         && let Ok((mut editable_text, mut drag_state, node, target, transform)) =
             q_text.get_mut(text_id)
         && let Ok(&ChildOf(root_id)) = q_parent.get(text_id)
-        && let Ok((value, disabled, units)) = q_units.get(root_id)
-        && !disabled
+        && let Ok((value, units)) = q_units.get(root_id)
     {
         // If we're in editing mode, let event propagate so that text input can handle it.
         if drag_state.mode == EditMode::Editing {


### PR DESCRIPTION
# Objective

- Disabled number input fields were editable
- "Fixes #25454

## Solution

- The `scrubber_on_release` system unconditionally set the text input fields mode back to `Editing` even if the number input field was marked with `InteractionDisabled`

## Testing

- Ran the `bevy_feathers` gallery example both before and after this commit. The vec4 edit fields are disabled. Before the commit you could highlight AND edit the displayed numbers. After the commit you can still put the cursor into the field but can't edit it.