### PR TITLE
Removes unused `bevy_utils` dependency from `bevy_ptr`

### DIFF
--- a/crates/bevy_ptr/Cargo.toml
+++ b/crates/bevy_ptr/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["bevy", "no_std"]
 rust-version = "1.85.0"
 
 [dependencies]
-bevy_utils = { path = "../bevy_utils", version = "0.20.0-dev", default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

- Remove unnecessary `bevy_utils` dependency from `bevy_ptr`.
- Related to #25264. There was a rewrite in this PR and the dependency became obsolete.

## Solution

- Removed `bevy_utils` from `bevy_ptr` dependency list.

## Testing

- CI and cargo checks.