### PR TITLE
Update PCCM example asset URLs to raw.githubusercontent.com

### DIFF
--- a/examples/3d/pccm.rs
+++ b/examples/3d/pccm.rs
@@ -32,11 +32,11 @@ struct InnerCube;
 const ENVIRONMENT_MAP_INTENSITY: f32 = 100.0;
 
 const OUTER_CUBE_URL: &str =
-    "https://github.com/bevyengine/bevy_asset_files/raw/main/pccm_example/outer_cube.glb#Scene0";
+    "https://raw.githubusercontent.com/bevyengine/bevy_asset_files/main/pccm_example/outer_cube.glb#Scene0";
 const ENV_DIFFUSE_URL: &str =
-    "https://github.com/bevyengine/bevy_asset_files/raw/main/pccm_example/env_diffuse.ktx2";
+    "https://raw.githubusercontent.com/bevyengine/bevy_asset_files/main/pccm_example/env_diffuse.ktx2";
 const ENV_SPECULAR_URL: &str =
-    "https://github.com/bevyengine/bevy_asset_files/raw/main/pccm_example/env_specular.ktx2";
+    "https://raw.githubusercontent.com/bevyengine/bevy_asset_files/main/pccm_example/env_specular.ktx2";
 
 /// The current value of user-customizable settings for this demo.
 #[derive(Resource, Default)]


### PR DESCRIPTION
# Objective

Fixes #25524
https://github.com/bevyengine/bevy/issues/25524
For brevity, not repeating information from the issue.

## Solution

Changed URLs to point to `raw.githubusercontent.com` instead, which fixed the assets failing to load locally.

Note: web version might have another issue - surface isn't as reflective as it is in the desktop version, and the example doesn't demonstrate much considering that, even after the assets load now. If it's a rendering bug I will be out of my depth -- but hey, the networking works now :)  

## Testing

- Tested the example on WebGL and desktop, works well for both
  - Example actually worked fine already on desktop
- Other examples (though ones unlisted on the website) also load assets similarly. Do they need to be looked at as well? 
  - `meshlet`
  - `solari`
  - `compressed_image_saver`
  - `many_meshlet_materials`
- Issue has lots of screenshots and details of what was happening, but the gist of it is that you would only see an unlit box in the scene previously
- Tested on WebGL, desktop (msvc stable)