### PR TITLE
text input: Shift+Backspace is also backspace

### DIFF
--- a/crates/bevy_ui_widgets/src/text_input.rs
+++ b/crates/bevy_ui_widgets/src/text_input.rs
@@ -200,7 +200,7 @@ fn on_focused_keyboard_input(
         (COMMAND | SHIFT_COMMAND, Key::End) => queue_edit(TextEdit::TextEnd(shift_pressed)),
         (NONE | SHIFT, Key::Home) => queue_edit(TextEdit::LineStart(shift_pressed)),
         (NONE | SHIFT, Key::End) => queue_edit(TextEdit::LineEnd(shift_pressed)),
-        (NONE, Key::Backspace) => queue_edit(TextEdit::Backspace),
+        (NONE | SHIFT, Key::Backspace) => queue_edit(TextEdit::Backspace),
         (NONE, Key::Delete) => queue_edit(TextEdit::Delete),
         (NONE, Key::Escape) => {
             queue_edit(TextEdit::CollapseSelection);


### PR DESCRIPTION
# Objective

Standard keyboard behavior is to also backspace with `Shift` pressed.

A late `Shift` for a capital letter might be followed by a quick `Backspace` while `Shift` still pressed resulting in a missed `Backspace` action.

## Solution

Accept `NONE | SHIFT` in the Backspace arm.

## Testing

Tested in the text_input example and various text fields in two production apps.