### PR TITLE
text input: EditableText::value() -> Cow<str>

### DIFF
--- a/_release-content/migration-guides/editable_text_value.md
+++ b/_release-content/migration-guides/editable_text_value.md
@@ -1,0 +1,12 @@
+---
+title: "`EditableText::value` returns `Cow<str>`"
+pull_requests: [25532]
+---
+`EditableText::value` now returns `Cow<'_, str>` instead of a parley
+`SplitString`. Most call sites keep working unchanged: comparisons against
+`&str` and `.to_string()` behave as before, and the returned value derefs
+to `&str`. The text is usually borrowed and an owned copy is only made as
+needed (e.g. while IME composition is active with the editor's text split
+around the preedit). Comparisons against `&String` will need the borrow
+removed (`Cow<str>` implements `PartialEq<String>` but not
+`PartialEq<&String>`).

--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -682,7 +682,7 @@ fn number_input_on_insert_value(
         let new_digits = units_registry
             .resolve(units)
             .format(clamped_value, drag_state.mode == EditMode::Editing);
-        if editable_text.value() != &new_digits {
+        if editable_text.value() != new_digits {
             editable_text.queue_edit(TextEdit::SelectAll);
             editable_text.queue_edit(TextEdit::Insert(new_digits.into()));
         }
@@ -798,8 +798,7 @@ fn number_input_init(
         let new_digits = units_registry
             .resolve(units)
             .format(*input_value, drag_state.mode == EditMode::Editing);
-        let old_digits = editable_text.value().to_string();
-        if old_digits != new_digits {
+        if editable_text.value() != new_digits {
             editable_text.queue_edit(TextEdit::SelectAll);
             editable_text.queue_edit(TextEdit::Insert(new_digits.into()));
         }
@@ -879,7 +878,7 @@ fn number_input_on_enter_key(
         && let Ok((input_value, hard_limit, wrap, units)) = q_number_input.get(root)
         && let Ok((editable_text, mut drag_state)) = q_text_input.get_mut(text_id)
     {
-        let text_value = editable_text.value().to_string();
+        let text_value = editable_text.value().into_owned();
         drag_state.mode = EditMode::Idle; // Boot us out of editing mode
         commands
             .entity(text_id)
@@ -931,7 +930,7 @@ fn number_input_on_focus_lost(
         && let Ok((input_value, disabled, hard_limit, wrap, units)) = q_number_input.get(root)
         && let Ok((editable_text, mut drag_state)) = q_text_input.get_mut(editable_text_id)
     {
-        let text_value = editable_text.value().to_string();
+        let text_value = editable_text.value().into_owned();
         emit_value_change(
             text_value,
             input_value.format(),
@@ -1044,8 +1043,7 @@ fn scrubber_on_release(
             // Replace the text before editing; this let's us change the degree symbol (°), which
             // is hard to type, into `d`, which is easier.
             let editable_digits = units_registry.resolve(units).format(*value, true);
-            let old_digits = editable_text.value().to_string();
-            if old_digits != editable_digits {
+            if editable_text.value() != editable_digits {
                 editable_text.queue_edit(TextEdit::SelectAll);
                 editable_text.queue_edit(TextEdit::Insert(editable_digits.into()));
             }

--- a/crates/bevy_text/src/editing.rs
+++ b/crates/bevy_text/src/editing.rs
@@ -77,13 +77,14 @@ use crate::{
     text_edit::{poll_and_apply_paste, reveal_cursor, TextEdit},
     FontCx, FontHinting, LayoutCx, LineHeight, TextBrush, TextColor, TextFont, TextLayout,
 };
+use alloc::borrow::Cow;
 use alloc::sync::Arc;
 use bevy_clipboard::ClipboardRead;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::prelude::*;
 use bevy_math::Vec2;
 use core::time::Duration;
-use parley::{FontContext, LayoutContext, PlainEditor, SplitString};
+use parley::{FontContext, LayoutContext, PlainEditor};
 
 /// A plain-text text input field.
 ///
@@ -196,11 +197,19 @@ impl EditableText {
         &mut self.editor
     }
 
-    /// Get the current text input as a [`SplitString`].
+    /// Get the current text input as a [`Cow<str>`].
     ///
-    /// A [`SplitString`] can be converted into a [`String`] using `to_string` if needed.
-    pub fn value(&self) -> SplitString<'_> {
-        self.editor.text()
+    /// Borrowed as default, owned copy returned when there is a split
+    /// (e.g. IME preedit).
+    pub fn value(&self) -> Cow<'_, str> {
+        let mut segments = self.editor.text().into_iter();
+        let first = segments.next().unwrap_or("");
+        let second = segments.next().unwrap_or("");
+        if second.is_empty() {
+            Cow::Borrowed(first)
+        } else {
+            Cow::Owned(alloc::format!("{first}{second}"))
+        }
     }
 
     /// Queue a [`TextEdit`] action to be applied later by the [`apply_text_edits`] system.

--- a/examples/ui/text/multiline_text_input.rs
+++ b/examples/ui/text/multiline_text_input.rs
@@ -135,11 +135,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         };
 
                                         let mut output = String::new();
-                                        output
-                                            .reserve(input.value().into_iter().map(str::len).sum());
-                                        for sub_str in input.value() {
-                                            output.push_str(sub_str);
-                                        }
+                                        output.push_str(&input.value());
 
                                         info!("{output}");
                                     },
@@ -244,10 +240,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 };
 
                                 let mut output = String::new();
-                                output.reserve(input.value().into_iter().map(str::len).sum());
-                                for sub_str in input.value() {
-                                    output.push_str(sub_str);
-                                }
+                                output.push_str(&input.value());
 
                                 let Ok(lines) = output.parse::<f32>() else {
                                     return;
@@ -330,10 +323,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 };
 
                                 let mut output = String::new();
-                                output.reserve(input.value().into_iter().map(str::len).sum());
-                                for sub_str in input.value() {
-                                    output.push_str(sub_str);
-                                }
+                                output.push_str(&input.value());
 
                                 let Ok(font_size) = output.parse::<f32>() else {
                                     return;
@@ -412,10 +402,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 };
 
                                 let mut output = String::new();
-                                output.reserve(input.value().into_iter().map(str::len).sum());
-                                for sub_str in input.value() {
-                                    output.push_str(sub_str);
-                                }
+                                output.push_str(&input.value());
 
                                 let Ok(radius) = output.parse::<f32>() else {
                                     return;

--- a/examples/ui/text/multiple_text_inputs.rs
+++ b/examples/ui/text/multiple_text_inputs.rs
@@ -299,18 +299,11 @@ fn synchronize_output_text(
     if let Ok((editable_text, input_row)) = &inputs.get(on.event_target()) {
         for (mut text, output_row) in &mut outputs {
             if output_row.0 == input_row.0 {
-                // `EditableText::value()` returns a `SplitString` because Parley may keep IME preedit text
-                // in a contiguous range of the editor’s internal `String` buffer during composition.
-                // The returned `SplitString` omits that preedit range, exposing only the text before and after it.
-                //
-                // To avoid allocating a new `String`, we reserve the total length of the `SplitString`'s slices,
-                // then append them to the output `Text`.
+                // Reuse the output string's allocation: `value()` borrows in
+                // the common case, so this copies the text without an
+                // intermediate `String`.
                 text.0.clear();
-                text.0
-                    .reserve(editable_text.value().into_iter().map(str::len).sum());
-                for sub_str in editable_text.value() {
-                    text.0.push_str(sub_str);
-                }
+                text.0.push_str(&editable_text.value());
             }
         }
     }
@@ -331,11 +324,7 @@ fn submit_text(
         for (mut text, output_row) in &mut text_output {
             if input_row.0 == output_row.0 {
                 text.0.clear();
-                text.0
-                    .reserve(editable_text.value().into_iter().map(str::len).sum());
-                for sub_str in editable_text.value() {
-                    text.0.push_str(sub_str);
-                }
+                text.0.push_str(&editable_text.value());
                 break;
             }
         }

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -1206,7 +1206,7 @@ fn handle_hex_color_change(
     mut colors: ResMut<DemoWidgetStates>,
 ) {
     let editable_text = *q_text_input;
-    if let Ok(color) = Srgba::hex(editable_text.value().to_string())
+    if let Ok(color) = Srgba::hex(editable_text.value())
         && color != colors.rgb_color
     {
         colors.rgb_color = color;


### PR DESCRIPTION
# Objective

Split out of #25117 as a standalone PR by reviewer suggestion to benefit other parley edit consumers.

Previously `EditableText::value()` returned a parley `SplitString`, which required every consumer to reassemble the segments by hand for just about any use case.

## Solution

By returning a `Cow<str>` (usually borrowed) most existing code continues working unchanged using deref, IME being an owned exception because of the preedit split during composition.

## Testing

FeathersNumberInput and the multiline/multiple-input examples converted to the new API (manual reassembly now one liners) run and exercised. Also tested with several call sites in a 0.19 backport for a production WASM and desktop app exercised by 1-8 grade students on their login screen every morning.

## Migration

Guide included, existing call sites adopted in the PR.