### PR TITLE
Disambiguate run_if under rustc's nex generation trait solver

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -376,6 +376,7 @@ impl Plugin for PbrPlugin {
                     extract_clusters_for_cpu_clustering
                         .run_if(not(gpu_clustering_is_enabled_during_extraction)),
                     extract_clusters_for_gpu_clustering
+                        .into_configs()
                         .run_if(gpu_clustering_is_enabled_during_extraction),
                 ),
             )

--- a/crates/bevy_render/src/render_phase/mod.rs
+++ b/crates/bevy_render/src/render_phase/mod.rs
@@ -1640,8 +1640,10 @@ where
                     batching::sort_binned_render_phase::<BPI>.in_set(RenderSystems::PhaseSort),
                     (
                         no_gpu_preprocessing::batch_and_prepare_binned_render_phase::<BPI, GFBD>
+                            .into_configs()
                             .run_if(resource_exists::<BatchedInstanceBuffer<GFBD::BufferData>>),
                         gpu_preprocessing::batch_and_prepare_binned_render_phase::<BPI, GFBD>
+                            .into_configs()
                             .run_if(
                                 resource_exists::<
                                     BatchedInstanceBuffers<GFBD::BufferData, GFBD::BufferInputData>,
@@ -1651,6 +1653,7 @@ where
                         .in_set(RenderSystems::PrepareResourcesBatchPhases)
                         .ambiguous_with(RenderSystems::PrepareResourcesBatchPhases),
                     gpu_preprocessing::write_binned_instance_buffers::<BPI, GFBD>
+                        .into_configs()
                         .run_if(
                             resource_exists::<
                                 BatchedInstanceBuffers<GFBD::BufferData, GFBD::BufferInputData>,
@@ -1659,6 +1662,7 @@ where
                         .in_set(RenderSystems::PrepareResourcesWritePhaseBuffers)
                         .ambiguous_with(RenderSystems::PrepareResourcesWritePhaseBuffers),
                     gpu_preprocessing::collect_buffers_for_phase::<BPI, GFBD>
+                        .into_configs()
                         .run_if(
                             resource_exists::<
                                 BatchedInstanceBuffers<GFBD::BufferData, GFBD::BufferInputData>,
@@ -1760,8 +1764,10 @@ where
                 (
                     (
                         no_gpu_preprocessing::batch_and_prepare_sorted_render_phase::<SPI, GFBD>
+                            .into_configs()
                             .run_if(resource_exists::<BatchedInstanceBuffer<GFBD::BufferData>>),
                         gpu_preprocessing::batch_and_prepare_sorted_render_phase::<SPI, GFBD>
+                            .into_configs()
                             .run_if(
                                 resource_exists::<
                                     BatchedInstanceBuffers<GFBD::BufferData, GFBD::BufferInputData>,
@@ -1770,6 +1776,7 @@ where
                     )
                         .in_set(RenderSystems::PrepareResourcesBatchPhases),
                     gpu_preprocessing::collect_buffers_for_phase::<SPI, GFBD>
+                        .into_configs()
                         .run_if(
                             resource_exists::<
                                 BatchedInstanceBuffers<GFBD::BufferData, GFBD::BufferInputData>,

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -55,6 +55,7 @@ impl Plugin for WindowRenderPlugin {
                 .add_systems(
                     Render,
                     create_surfaces
+                        .into_configs()
                         .run_if(need_surface_configuration)
                         .before(prepare_windows),
                 )


### PR DESCRIPTION
# Objective

`rustc` will soon stabilize a next generation trait solver: https://github.com/rust-lang/goals/issues/113.

To use the new solver (and reproduce the compiler error), run the following:

```
RUSTUP_TOOLCHAIN=nightly-2026-08-22 \
  RUSTFLAGS='-Znext-solver=globally' \
  cargo build -p bevy_pbr
```

It turns out that this solver is less equipped to disambiguate in some cases, which affect `bevy_pbr` in a few occasions.

## Solution

Some generic function items implement both `IntoScheduleConfigs` and
`ObserverSystemExt`. Both traits provide `run_if`, so the next solver correctly
reports the method call as ambiguous.

Convert the function item to `ScheduleConfigs` before adding its run condition:

```rust
create_surfaces
    .into_configs()
    .run_if(need_surface_configuration)
```

`ScheduleConfigs::run_if` is then unambiguous.

## Testing

Tested on macOS/aarch64 with separate clean target directories. Looks like this solver is going to shave off meaningful time of bevy's slowest crate 🥳 

| Solver | `bevy_pbr` total | Frontend | Codegen |
| --- | ---: | ---: | ---: |
| Legacy (`-Znext-solver=coherence`) | 40.8s | 33.9s | 6.9s |
| Next (`-Znext-solver=globally`) | 32.9s | 25.5s | 7.4s |

# Open question

I suppose this is technically a regression in `rustc`, although possibly a reasonable one. I can imagine that the disambiguation process was part of the reason that the old solver was less performant. That said, I'll still report this upstream for visiblity.