### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -72,7 +72,7 @@ jobs:
           toolchain: stable
 
       - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "17"
           distribution: "temurin"


### PR DESCRIPTION
# Objective

Upgrade the Java setup action to the current v6 release.

## Solution

Update the digest-pinned `actions/setup-java` reference from v5.2.0 to the v6.0.0 release SHA.

## Testing

Verified the workflow reference resolves to the requested v6.0.0 SHA and ran `git diff --check`. No runtime code is changed.