### PR TITLE
Fix panic in `Timer::almost_finish`

### DIFF
--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -210,6 +210,8 @@ impl Timer {
     /// This can be useful when needing an immediate action without having
     /// to wait for the set duration of the timer in the first tick.
     ///
+    /// If the timer is already finished, this does nothing.
+    ///
     /// # Examples
     /// ```
     /// # use bevy_time::*;
@@ -221,7 +223,7 @@ impl Timer {
     /// ```
     #[inline]
     pub fn almost_finish(&mut self) {
-        let remaining = self.remaining() - Duration::from_nanos(1);
+        let remaining = self.remaining().saturating_sub(Duration::from_nanos(1));
         self.tick(remaining);
     }
 


### PR DESCRIPTION
# Objective
The previous implementation would panic due to underflow if the timer was already finished, since `remaining` would return 0.This is surprising behavior that is difficult to diagnose as an API user. This case should either be handled or the panic should be documented.

## Solution

This PR simply substitutes the subtraction operator for a `saturating_sub` call.

If it is deemed preferable to keep the panic, I am willing to adjust the PR to instead add documentation.

## Testing

Given the extremely simple nature of this change, I reason that testing isn't really warranted.