### PR TITLE
Populate PointerMap using hooks

### DIFF
--- a/crates/bevy_picking/src/events.rs
+++ b/crates/bevy_picking/src/events.rs
@@ -1318,8 +1318,6 @@ mod tests {
     use bevy_app::App;
     use bevy_camera::{Camera, ManualTextureViewHandle};
 
-    use crate::pointer::update_pointer_map;
-
     use super::*;
 
     const POINTER_ID: PointerId = PointerId::Mouse;
@@ -1334,6 +1332,7 @@ mod tests {
             .init_resource::<PreviousHoverMap>()
             .init_resource::<PickingSettings>()
             .init_resource::<PointerState>()
+            .init_resource::<PointerMap>()
             .add_message::<PointerInput>()
             .add_message::<PointerCancel>()
             .add_message::<PointerClick>()
@@ -1356,11 +1355,6 @@ mod tests {
         // Initialize the pointer map resource manually with a stub location for the mouse
         app.world_mut()
             .spawn((POINTER_ID, PointerLocation::new(STUB_LOCATION)));
-        app.world_mut().insert_resource(PointerMap::default());
-        assert!(app
-            .world_mut()
-            .run_system_cached(update_pointer_map)
-            .is_ok());
     }
 
     fn update_hover_map_with_hovered_entities(app: &mut App, camera: Entity, entities: &[Entity]) {

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -380,7 +380,6 @@ impl Plugin for PickingPlugin {
             .add_systems(
                 PreUpdate,
                 (
-                    pointer::update_pointer_map,
                     pointer::PointerInput::receive,
                     backend::ray::RayMap::repopulate.after(pointer::PointerInput::receive),
                 )

--- a/crates/bevy_picking/src/pointer.rs
+++ b/crates/bevy_picking/src/pointer.rs
@@ -8,27 +8,23 @@
 //! The purpose of this module is primarily to provide a common interface that can be
 //! driven by lower-level input devices and consumed by higher-level interaction systems.
 
-use bevy_camera::NormalizedRenderTarget;
-use bevy_camera::{Camera, RenderTarget};
-use bevy_ecs::prelude::*;
-use bevy_input::mouse::MouseScrollUnit;
-use bevy_input::touch::TouchPhase;
+use crate::backend::HitData;
+use bevy_camera::{Camera, NormalizedRenderTarget, RenderTarget};
+use bevy_ecs::{lifecycle::HookContext, prelude::*, world::DeferredWorld};
+use bevy_input::{mouse::MouseScrollUnit, touch::TouchPhase};
 use bevy_math::Vec2;
 use bevy_platform::collections::HashMap;
 use bevy_reflect::prelude::*;
 use bevy_window::PrimaryWindow;
-
-use uuid::Uuid;
-
 use core::{fmt::Debug, ops::Deref};
-
-use crate::backend::HitData;
+use uuid::Uuid;
 
 /// Identifies a unique pointer entity. `Mouse` and `Touch` pointers are automatically spawned.
 ///
 /// This component is needed because pointers can be spawned and despawned, but they need to have a
 /// stable ID that persists regardless of the Entity they are associated with.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash, Component, Reflect)]
+#[component(immutable, on_insert, on_remove)]
 #[require(PointerLocation, PointerPressState, PointerInteraction)]
 #[reflect(Component, Default, Debug, Hash, PartialEq, Clone)]
 pub enum PointerId {
@@ -44,6 +40,21 @@ pub enum PointerId {
 }
 
 impl PointerId {
+    fn on_insert(mut world: DeferredWorld, context: HookContext) {
+        if let Some(id) = world.entity(context.entity).get::<PointerId>().copied() {
+            world
+                .resource_mut::<PointerMap>()
+                .inner
+                .insert(id, context.entity);
+        }
+    }
+
+    fn on_remove(mut world: DeferredWorld, context: HookContext) {
+        if let Some(id) = world.entity(context.entity).get::<PointerId>().copied() {
+            world.resource_mut::<PointerMap>().inner.remove(&id);
+        }
+    }
+
     /// Returns true if the pointer is a touch input.
     pub fn is_touch(&self) -> bool {
         matches!(self, PointerId::Touch(_))
@@ -100,14 +111,6 @@ impl PointerMap {
     /// Get the [`Entity`] of the supplied [`PointerId`].
     pub fn get_entity(&self, pointer_id: PointerId) -> Option<Entity> {
         self.inner.get(&pointer_id).copied()
-    }
-}
-
-/// Update the [`PointerMap`] resource with the current frame's data.
-pub fn update_pointer_map(pointers: Query<(Entity, &PointerId)>, mut map: ResMut<PointerMap>) {
-    map.inner.clear();
-    for (entity, id) in &pointers {
-        map.inner.insert(*id, entity);
     }
 }
 


### PR DESCRIPTION
# Objective

We should use hooks on the `PointerId` component to populate `PointerMap`. This cuts down on complexity and ensures that it is always valid.

## Solution

- d use hooks on the `PointerId` component to populate `PointerMap`. Remove update_pointer_map system (and the code that runs it on startup).

## Testing

The picking example still runs as expected