### PR TITLE
Improve bevy settings docs

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -630,6 +630,9 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
 /// test = true
 /// ```
 ///
+/// Note that it's possible to make multiple different types share the same group and file
+/// using this, and that case isn't well tested
+///
 /// ## File Override
 /// ```ignore
 /// #[derive(SettingsGroup)]

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -190,7 +190,10 @@ impl Plugin for SettingsPlugin {
 /// Since these resources are loaded from storage, it is possible for them to be modified by hand by users,
 /// so it's important to not rely on the validity of the data. In particular, it is important to ensure you do not
 /// rely on any invariants of the input data to ensure safety elsewhere in your code.
-pub trait SettingsGroup: Resource + bevy_reflect::Reflect + Default {
+///
+// FIXME(settings-reduce-silent-errors) This should be `pub trait SettingsGroup: Resource + Reflect + Default` since
+// that's the minimum needed to make the SettingsPlugin actually do things with this.
+pub trait SettingsGroup: Resource {
     /// The name of the logical section within the settings file.
     fn settings_group_name() -> &'static str;
 
@@ -446,7 +449,6 @@ fn build_settings_registry(
     };
     file_index.save_timer.pause(); // Ensure timer is initially paused
 
-    let mut error_list = Vec::new();
     // Scan through types looking for resources that have the necessary traits and
     // annotations.
     for ty in types.iter() {
@@ -456,13 +458,13 @@ fn build_settings_registry(
         };
 
         if !ty.contains::<ReflectDefault>() {
-            // If you reflect SettingsGroup, you also need to reflect Default. Collect it all into a single
-            // list so that users don't have to fix one error and recompile and run in order to find the next
-            // error.
-            error_list.push(format!(
+            // FIXME(settings-reduce-silent-errors) In the future, as a breaking change, we could possibly change this to a panic,
+            // which is a much stronger hint to users that if you're reflecting SettingsGroup, you also need to reflect Default.
+            // But for now, to avoid breaking changes, this will just be a warning.
+            warn!(
                 "Type {} has #[reflect(SettingsGroup)], which requires #[reflect(Default)]. It will not be saved or loaded.",
                 ty.type_info().type_path()
-            ));
+            );
             continue;
         };
 
@@ -477,10 +479,6 @@ fn build_settings_registry(
             });
         pending_file.last_save = last_save;
         pending_file.resource_types.push(ty.type_id());
-    }
-
-    if !error_list.is_empty() {
-        panic!("{}", error_list.join("\n"));
     }
 
     file_index

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -1,6 +1,16 @@
 //! Framework for saving and loading user settings files in Bevy
 //! applications.
 //!
+//! The core of the framework is [`SettingsPlugin`], which
+//! loads and synchronises settings with the filesystem or browser
+//! local storage, depending on platform.
+//!
+//! Settings are loaded to types that implement [`trait.SettingsGroup`],
+//! which is best implemented using the derive macro [`derive.SettingsGroup`]. 
+//!
+//! Afterwards, systems can query for settings using `Res` and
+//! `ResMut` queries.
+//!
 //! Refer to [`SettingsPlugin`] for detailed usage information.
 
 use core::any::TypeId;

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -432,11 +432,19 @@ fn build_settings_registry(
     // Scan through types looking for resources that have the necessary traits and
     // annotations.
     for ty in types.iter() {
-        if !ty.contains::<ReflectDefault>() {
+        // All types that are relevant
+        let Some(reflect_group) = ty.data::<ReflectSettingsGroup>() else {
             continue;
         };
 
-        let Some(reflect_group) = ty.data::<ReflectSettingsGroup>() else {
+        if !ty.contains::<ReflectDefault>() {
+            // FIXME(settings-reduce-silent-errors) In the future, as a breaking change, we could possibly change this to a panic,
+            // which is a much stronger hint to users that if you're reflecting SettingsGroup, you also need to reflect Default.
+            // But for now, to avoid breaking changes, this will just be a warning.
+            warn!(
+                "Type {} has #[reflect(SettingsGroup)], which requires #[reflect(Default)]. It will not be saved or loaded.",
+                ty.type_info().type_path()
+            );
             continue;
         };
 

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -190,10 +190,7 @@ impl Plugin for SettingsPlugin {
 /// Since these resources are loaded from storage, it is possible for them to be modified by hand by users,
 /// so it's important to not rely on the validity of the data. In particular, it is important to ensure you do not
 /// rely on any invariants of the input data to ensure safety elsewhere in your code.
-///
-// FIXME(settings-reduce-silent-errors) This should be `pub trait SettingsGroup: Resource + Reflect + Default` since
-// that's the minimum needed to make the SettingsPlugin actually do things with this.
-pub trait SettingsGroup: Resource {
+pub trait SettingsGroup: Resource + bevy_reflect::Reflect + Default {
     /// The name of the logical section within the settings file.
     fn settings_group_name() -> &'static str;
 
@@ -449,6 +446,7 @@ fn build_settings_registry(
     };
     file_index.save_timer.pause(); // Ensure timer is initially paused
 
+    let mut error_list = Vec::new();
     // Scan through types looking for resources that have the necessary traits and
     // annotations.
     for ty in types.iter() {
@@ -458,13 +456,13 @@ fn build_settings_registry(
         };
 
         if !ty.contains::<ReflectDefault>() {
-            // FIXME(settings-reduce-silent-errors) In the future, as a breaking change, we could possibly change this to a panic,
-            // which is a much stronger hint to users that if you're reflecting SettingsGroup, you also need to reflect Default.
-            // But for now, to avoid breaking changes, this will just be a warning.
-            warn!(
+            // If you reflect SettingsGroup, you also need to reflect Default. Collect it all into a single
+            // list so that users don't have to fix one error and recompile and run in order to find the next
+            // error.
+            error_list.push(format!(
                 "Type {} has #[reflect(SettingsGroup)], which requires #[reflect(Default)]. It will not be saved or loaded.",
                 ty.type_info().type_path()
-            );
+            ));
             continue;
         };
 
@@ -479,6 +477,10 @@ fn build_settings_registry(
             });
         pending_file.last_save = last_save;
         pending_file.resource_types.push(ty.type_id());
+    }
+
+    if !error_list.is_empty() {
+        panic!("{}", error_list.join("\n"));
     }
 
     file_index

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -2,7 +2,7 @@
 //! applications.
 //!
 //! The core of the framework is [`SettingsPlugin`], which
-//! loads and synchronises settings with the filesystem or browser
+//! loads and synchronizes settings with the filesystem or browser
 //! local storage, depending on platform.
 //!
 //! Settings are loaded into resources that implement [`SettingsGroup`](trait@SettingsGroup),

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -5,10 +5,9 @@
 //! loads and synchronises settings with the filesystem or browser
 //! local storage, depending on platform.
 //!
-//! Settings are loaded to types that implement [`trait.SettingsGroup`],
-//! which is best implemented using the derive macro [`derive.SettingsGroup`]. 
-//!
-//! Afterwards, systems can query for settings using `Res` and
+//! Settings are loaded to types that implement [`SettingsGroup`](trait@SettingsGroup),
+//! which is best implemented using the derive macro [`SettingsGroup`](derive@SettingsGroup). 
+//!  Afterwards, systems can query for settings using `Res` and
 //! `ResMut` queries.
 //!
 //! Refer to [`SettingsPlugin`] for detailed usage information.

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -7,9 +7,7 @@
 //!
 //! Settings are loaded into resources that implement [`SettingsGroup`](trait@SettingsGroup),
 //! which is best implemented using the derive macro [`SettingsGroup`](derive@SettingsGroup).
-//! In addition, the resource must implement [`Default`](std::default::Default),
-//! [`Resource`](bevy::prelude::Resource), and [`Reflect`](bevy::reflect::Reflect), as well
-//! as have the `#[reflect(SettingsGroup, Default)]` annotation.
+//! In addition, the resource must have the `#[reflect(SettingsGroup, Default)]` annotation.
 //!
 //! Once all these conditions are met, and when [`SettingsPlugin`] is added, systems can query
 //! for settings using like any other resource.
@@ -55,7 +53,7 @@ use store_wasm::SettingsStore;
 ///
 /// When added to an app, `SettingsPlugin` will load settings from storage (either the filesystem
 /// or browser local storage) into resources that implement the [`SettingsGroup`](trait@SettingsGroup),
-/// [`Default`](std::default::Default), and [`Reflect`](bevy::reflect::Reflect) traits, and, in
+/// [`Default`], and [`Reflect`](bevy_reflect::Reflect) traits, and, in
 /// addition, are also annotated with `#[reflect(Default, SettingsGroup)]`. The plugin can also be used
 /// to write these settings back to storage after they are changed.
 ///

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -5,10 +5,14 @@
 //! loads and synchronises settings with the filesystem or browser
 //! local storage, depending on platform.
 //!
-//! Settings are loaded to types that implement [`SettingsGroup`](trait@SettingsGroup),
-//! which is best implemented using the derive macro [`SettingsGroup`](derive@SettingsGroup). 
-//!  Afterwards, systems can query for settings using `Res` and
-//! `ResMut` queries.
+//! Settings are loaded into resources that implement [`SettingsGroup`](trait@SettingsGroup),
+//! which is best implemented using the derive macro [`SettingsGroup`](derive@SettingsGroup).
+//! In addition, the resource must implement [`Default`](std::default::Default),
+//! [`Resource`](bevy::prelude::Resource), and [`Reflect`](bevy::reflect::Reflect), as well
+//! as have the `#[reflect(SettingsGroup, Default)]` annotation.
+//!
+//! Once all these conditions are met, and when [`SettingsPlugin`] is added, systems can query
+//! for settings using like any other resource.
 //!
 //! Refer to [`SettingsPlugin`] for detailed usage information.
 
@@ -48,6 +52,12 @@ use store_fs::SettingsStore;
 use store_wasm::SettingsStore;
 
 /// Plugin to orchestrate loading and saving settings.
+///
+/// When added to an app, `SettingsPlugin` will load settings from storage (either the filesystem
+/// or browser local storage) into resources that implement the [`SettingsGroup`](trait@SettingsGroup),
+/// [`Default`](std::default::Default), and [`Reflect`](bevy::reflect::Reflect) traits, and, in
+/// addition, are also annotated with `#[reflect(Default, SettingsGroup)]`. The plugin can also be used
+/// to write these settings back to storage after they are changed.
 ///
 /// You are required to provide a unique application name, so that your settings don't overwrite
 /// those of other apps. To ensure global uniqueness, it is recommended to use a
@@ -163,6 +173,9 @@ impl Plugin for SettingsPlugin {
 
 /// Trait which identifies a type as corresponding to a section with a settings file.
 ///
+/// In order for [`SettingsPlugin`] to do anything with types that implement this trait, the type must also
+/// implement `Default` and `Reflect`, and be annotated with `#[reflect(SettingsGroup, Default)]`.
+///
 /// You can override the name of the section with `settings_group(group = "<name>")`.
 /// For enum `SettingGroup`s, you can also override the name of its key with `settings_group(key = "<name>")`
 /// The name should be in ``snake_case`` to be consistent with TOML style.
@@ -173,6 +186,13 @@ impl Plugin for SettingsPlugin {
 /// `settings_group(file = "<filename>")`. This should be the base name of the file without the
 /// extension. The default name is `settings`, which will cause the settings to be written out
 /// to `settings.toml` in the app's settings directory.
+///
+/// Since these resources are loaded from storage, it is possible for them to be modified by hand by users,
+/// so it's important to not rely on the validity of the data. In particular, it is important to ensure you do not
+/// rely on any invariants of the input data to ensure safety elsewhere in your code.
+///
+// FIXME(settings-reduce-silent-errors) This should be `pub trait SettingsGroup: Resource + Reflect + Default` since
+// that's the minimum needed to make the SettingsPlugin actually do things with this.
 pub trait SettingsGroup: Resource {
     /// The name of the logical section within the settings file.
     fn settings_group_name() -> &'static str;


### PR DESCRIPTION
# Objective

Due to bad documentation, it took me half a day to get bevy-settings to create the settings file. There were multiple hidden preconditions that resulted in nothing happening and no errors being printed. This was a problem that needed fixing.

## Solution

I'm adding documentation to outline exactly what is necessary to make bevy-settings work, and also add some error messages for if you've gotten halfway there but missed one of the preconditions. I'd also want to propose a type-level way to make it not even compile if the type-level preconditions are not met, but that is a breaking change and therefore will come in a different PR. 

## Testing

- Did you test these changes? Yep, there was some code reordering to make more useful error messages. I didn't think that there was any chance of breakage, but I ran through the tests in the bevy-settings crate anyway and they all passed
- Are there any parts that need more testing? Yes, but this is a pre-existing condition. I've noticed that it's possible to configure bevy-settings so that multiple types save to and load from the same section of the same file. However, I didn't notice any test cases covering this.
- How can other people (reviewers) test your changes? Is the new documentation easier to understand? 
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? I only tested it on linux, but the actual amount of code changes were minimal as this is primarily a documentation improvement.
