### PR TITLE
bevy-settings requires more validity  

### DIFF
--- a/_release-content/migration-guides/migration_guides_template.md
+++ b/_release-content/migration-guides/migration_guides_template.md
@@ -1,0 +1,12 @@
+---
+title: bevy-settings errors on useless `SettingsGroup`s
+pull_requests: [25548]
+---
+
+The `SettingsGroup` trait now has trait bounds `Resource + Reflect + Default`, as opposed to (originally) `Resource`. This is because types that implement `SettingsGroup` will not gain any of the benefits of `SettingsGroup` (ie automatic saving and loading caused by the system included in the settings plugin) unless the type is `Reflect + Default`.
+
+To migrate code:
+- Implement the `Reflect` and `Default` traits on your settings group type.
+- Annotate your settings group type with `#[reflect(Default, SettingsGroup)]`.
+
+If your code was already working, and the type implementing `SettingsGroup` was already saving and loading, you should not need to change anything in your code. The changes were intended to avoid breaking any already functioning code. 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -630,6 +630,9 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
 /// test = true
 /// ```
 ///
+/// Note that it's possible to make multiple different types share the same group and file
+/// using this, and that case isn't well tested
+///
 /// ## File Override
 /// ```ignore
 /// #[derive(SettingsGroup)]

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -630,8 +630,11 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
 /// test = true
 /// ```
 ///
-/// Note that it's possible to make multiple different types share the same group and file
-/// using this, and that case isn't well tested
+/// Note that it's possible to make multiple different settings types share the same file,
+/// group, and even key. When loading, all fields sharing the same key will load from that
+/// same key. If the value is not valid for the type of a field, that field will be reset to
+/// the default value in that settings type. If two or more types are contending for a single
+/// key, which type ultimately saves in that key is not specified.
 ///
 /// ## File Override
 /// ```ignore

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -7,10 +7,11 @@
 //!
 //! Settings are loaded into resources that implement [`SettingsGroup`](trait@SettingsGroup),
 //! which is best implemented using the derive macro [`SettingsGroup`](derive@SettingsGroup).
-//! In addition, the resource have the `#[reflect(SettingsGroup, Default)]` annotation.
+//! In addition, the resource must have the `#[reflect(SettingsGroup, Default)]` annotation in
+//! order to be saved and loaded by the plugin.
 //!
 //! Once all these conditions are met, and when [`SettingsPlugin`] is added, systems can query
-//! for settings using like any other resource.
+//! for settings using [`Res`] and [`ResMut`] like any other resource.
 //!
 //! Refer to [`SettingsPlugin`] for detailed usage information.
 

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -1,6 +1,16 @@
 //! Framework for saving and loading user settings files in Bevy
 //! applications.
 //!
+//! The core of the framework is [`SettingsPlugin`], which
+//! loads and synchronises settings with the filesystem or browser
+//! local storage, depending on platform.
+//!
+//! Settings are loaded to types that implement [`trait.SettingsGroup`],
+//! which is best implemented using the derive macro [`derive.SettingsGroup`]. 
+//!
+//! Afterwards, systems can query for settings using `Res` and
+//! `ResMut` queries.
+//!
 //! Refer to [`SettingsPlugin`] for detailed usage information.
 
 use core::any::TypeId;

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -432,11 +432,19 @@ fn build_settings_registry(
     // Scan through types looking for resources that have the necessary traits and
     // annotations.
     for ty in types.iter() {
-        if !ty.contains::<ReflectDefault>() {
+        // All types that are relevant
+        let Some(reflect_group) = ty.data::<ReflectSettingsGroup>() else {
             continue;
         };
 
-        let Some(reflect_group) = ty.data::<ReflectSettingsGroup>() else {
+        if !ty.contains::<ReflectDefault>() {
+            // FIXME(settings-reduce-silent-errors) In the future, as a breaking change, we could possibly change this to a panic,
+            // which is a much stronger hint to users that if you're reflecting SettingsGroup, you also need to reflect Default.
+            // But for now, to avoid breaking changes, this will just be a warning.
+            warn!(
+                "Type {} has #[reflect(SettingsGroup)], which requires #[reflect(Default)]. It will not be saved or loaded.",
+                ty.type_info().type_path()
+            );
             continue;
         };
 

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -174,7 +174,7 @@ impl Plugin for SettingsPlugin {
 /// Trait which identifies a type as corresponding to a section with a settings file.
 ///
 /// In order for [`SettingsPlugin`] to do anything with types that implement this trait, the type must also
-/// implement `Default` and `Reflect`, and be annotated with `#[reflect(SettingsGroup, Default)]`.
+/// be annotated with `#[reflect(SettingsGroup, Default)]`.
 ///
 /// You can override the name of the section with `settings_group(group = "<name>")`.
 /// For enum `SettingGroup`s, you can also override the name of its key with `settings_group(key = "<name>")`
@@ -190,10 +190,7 @@ impl Plugin for SettingsPlugin {
 /// Since these resources are loaded from storage, it is possible for them to be modified by hand by users,
 /// so it's important to not rely on the validity of the data. In particular, it is important to ensure you do not
 /// rely on any invariants of the input data to ensure safety elsewhere in your code.
-///
-// FIXME(settings-reduce-silent-errors) This should be `pub trait SettingsGroup: Resource + Reflect + Default` since
-// that's the minimum needed to make the SettingsPlugin actually do things with this.
-pub trait SettingsGroup: Resource {
+pub trait SettingsGroup: Resource + bevy_reflect::Reflect + Default {
     /// The name of the logical section within the settings file.
     fn settings_group_name() -> &'static str;
 
@@ -449,6 +446,7 @@ fn build_settings_registry(
     };
     file_index.save_timer.pause(); // Ensure timer is initially paused
 
+    let mut errors = Vec::new();
     // Scan through types looking for resources that have the necessary traits and
     // annotations.
     for ty in types.iter() {
@@ -458,13 +456,12 @@ fn build_settings_registry(
         };
 
         if !ty.contains::<ReflectDefault>() {
-            // FIXME(settings-reduce-silent-errors) In the future, as a breaking change, we could possibly change this to a panic,
-            // which is a much stronger hint to users that if you're reflecting SettingsGroup, you also need to reflect Default.
-            // But for now, to avoid breaking changes, this will just be a warning.
-            warn!(
+            // Collect all the errors into a single list so that a user can see all of them at once rather than chasing them
+            // down one by one as they fix the errors.
+            errors.push(format!(
                 "Type {} has #[reflect(SettingsGroup)], which requires #[reflect(Default)]. It will not be saved or loaded.",
                 ty.type_info().type_path()
-            );
+            ));
             continue;
         };
 
@@ -479,6 +476,9 @@ fn build_settings_registry(
             });
         pending_file.last_save = last_save;
         pending_file.resource_types.push(ty.type_id());
+    }
+    if !errors.is_empty() {
+        panic!("{}", errors.join("\n"));
     }
 
     file_index

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -2,7 +2,7 @@
 //! applications.
 //!
 //! The core of the framework is [`SettingsPlugin`], which
-//! loads and synchronises settings with the filesystem or browser
+//! loads and synchronizes settings with the filesystem or browser
 //! local storage, depending on platform.
 //!
 //! Settings are loaded into resources that implement [`SettingsGroup`](trait@SettingsGroup),

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -5,10 +5,9 @@
 //! loads and synchronises settings with the filesystem or browser
 //! local storage, depending on platform.
 //!
-//! Settings are loaded to types that implement [`trait.SettingsGroup`],
-//! which is best implemented using the derive macro [`derive.SettingsGroup`]. 
-//!
-//! Afterwards, systems can query for settings using `Res` and
+//! Settings are loaded to types that implement [`SettingsGroup`](trait@SettingsGroup),
+//! which is best implemented using the derive macro [`SettingsGroup`](derive@SettingsGroup). 
+//!  Afterwards, systems can query for settings using `Res` and
 //! `ResMut` queries.
 //!
 //! Refer to [`SettingsPlugin`] for detailed usage information.

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -7,9 +7,7 @@
 //!
 //! Settings are loaded into resources that implement [`SettingsGroup`](trait@SettingsGroup),
 //! which is best implemented using the derive macro [`SettingsGroup`](derive@SettingsGroup).
-//! In addition, the resource must implement [`Default`](std::default::Default),
-//! [`Resource`](bevy::prelude::Resource), and [`Reflect`](bevy::reflect::Reflect), as well
-//! as have the `#[reflect(SettingsGroup, Default)]` annotation.
+//! In addition, the resource have the `#[reflect(SettingsGroup, Default)]` annotation.
 //!
 //! Once all these conditions are met, and when [`SettingsPlugin`] is added, systems can query
 //! for settings using like any other resource.
@@ -33,8 +31,8 @@ use bevy_log::warn;
 use bevy_reflect::{
     prelude::ReflectDefault,
     serde::{TypedReflectDeserializer, TypedReflectSerializer},
-    CreateTypeData, FromReflect, PartialReflect, ReflectMut, TypeInfo, TypePath, TypeRegistration,
-    TypeRegistry,
+    CreateTypeData, FromReflect, PartialReflect, Reflect, ReflectMut, TypeInfo, TypePath,
+    TypeRegistration, TypeRegistry,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -55,7 +53,7 @@ use store_wasm::SettingsStore;
 ///
 /// When added to an app, `SettingsPlugin` will load settings from storage (either the filesystem
 /// or browser local storage) into resources that implement the [`SettingsGroup`](trait@SettingsGroup),
-/// [`Default`](std::default::Default), and [`Reflect`](bevy::reflect::Reflect) traits, and, in
+/// [`Default`], and [`Reflect`] traits, and, in
 /// addition, are also annotated with `#[reflect(Default, SettingsGroup)]`. The plugin can also be used
 /// to write these settings back to storage after they are changed.
 ///
@@ -190,7 +188,7 @@ impl Plugin for SettingsPlugin {
 /// Since these resources are loaded from storage, it is possible for them to be modified by hand by users,
 /// so it's important to not rely on the validity of the data. In particular, it is important to ensure you do not
 /// rely on any invariants of the input data to ensure safety elsewhere in your code.
-pub trait SettingsGroup: Resource + bevy_reflect::Reflect + Default {
+pub trait SettingsGroup: Resource + Reflect + Default {
     /// The name of the logical section within the settings file.
     fn settings_group_name() -> &'static str;
 

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -5,10 +5,14 @@
 //! loads and synchronises settings with the filesystem or browser
 //! local storage, depending on platform.
 //!
-//! Settings are loaded to types that implement [`SettingsGroup`](trait@SettingsGroup),
-//! which is best implemented using the derive macro [`SettingsGroup`](derive@SettingsGroup). 
-//!  Afterwards, systems can query for settings using `Res` and
-//! `ResMut` queries.
+//! Settings are loaded into resources that implement [`SettingsGroup`](trait@SettingsGroup),
+//! which is best implemented using the derive macro [`SettingsGroup`](derive@SettingsGroup).
+//! In addition, the resource must implement [`Default`](std::default::Default),
+//! [`Resource`](bevy::prelude::Resource), and [`Reflect`](bevy::reflect::Reflect), as well
+//! as have the `#[reflect(SettingsGroup, Default)]` annotation.
+//!
+//! Once all these conditions are met, and when [`SettingsPlugin`] is added, systems can query
+//! for settings using like any other resource.
 //!
 //! Refer to [`SettingsPlugin`] for detailed usage information.
 
@@ -48,6 +52,12 @@ use store_fs::SettingsStore;
 use store_wasm::SettingsStore;
 
 /// Plugin to orchestrate loading and saving settings.
+///
+/// When added to an app, `SettingsPlugin` will load settings from storage (either the filesystem
+/// or browser local storage) into resources that implement the [`SettingsGroup`](trait@SettingsGroup),
+/// [`Default`](std::default::Default), and [`Reflect`](bevy::reflect::Reflect) traits, and, in
+/// addition, are also annotated with `#[reflect(Default, SettingsGroup)]`. The plugin can also be used
+/// to write these settings back to storage after they are changed.
 ///
 /// You are required to provide a unique application name, so that your settings don't overwrite
 /// those of other apps. To ensure global uniqueness, it is recommended to use a
@@ -163,6 +173,9 @@ impl Plugin for SettingsPlugin {
 
 /// Trait which identifies a type as corresponding to a section with a settings file.
 ///
+/// In order for [`SettingsPlugin`] to do anything with types that implement this trait, the type must also
+/// implement `Default` and `Reflect`, and be annotated with `#[reflect(SettingsGroup, Default)]`.
+///
 /// You can override the name of the section with `settings_group(group = "<name>")`.
 /// For enum `SettingGroup`s, you can also override the name of its key with `settings_group(key = "<name>")`
 /// The name should be in ``snake_case`` to be consistent with TOML style.
@@ -173,6 +186,13 @@ impl Plugin for SettingsPlugin {
 /// `settings_group(file = "<filename>")`. This should be the base name of the file without the
 /// extension. The default name is `settings`, which will cause the settings to be written out
 /// to `settings.toml` in the app's settings directory.
+///
+/// Since these resources are loaded from storage, it is possible for them to be modified by hand by users,
+/// so it's important to not rely on the validity of the data. In particular, it is important to ensure you do not
+/// rely on any invariants of the input data to ensure safety elsewhere in your code.
+///
+// FIXME(settings-reduce-silent-errors) This should be `pub trait SettingsGroup: Resource + Reflect + Default` since
+// that's the minimum needed to make the SettingsPlugin actually do things with this.
 pub trait SettingsGroup: Resource {
     /// The name of the logical section within the settings file.
     fn settings_group_name() -> &'static str;

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -459,7 +459,7 @@ fn build_settings_registry(
             // Collect all the errors into a single list so that a user can see all of them at once rather than chasing them
             // down one by one as they fix the errors.
             errors.push(format!(
-                "Type {} has #[reflect(SettingsGroup)], which requires #[reflect(Default)]. It will not be saved or loaded.",
+                "Type {} has #[reflect(SettingsGroup)], which requires #[reflect(Default)] in order to save or load.",
                 ty.type_info().type_path()
             ));
             continue;

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -56,7 +56,8 @@ use store_wasm::SettingsStore;
 /// or browser local storage) into resources that implement the [`SettingsGroup`](trait@SettingsGroup),
 /// [`Default`], and [`Reflect`] traits, and, in
 /// addition, are also annotated with `#[reflect(Default, SettingsGroup)]`. The plugin can also be used
-/// to write these settings back to storage after they are changed.
+/// to write these settings back to storage after they are changed by sending the [`SaveSettingsDeferred`]
+/// or [`SaveSettingsSync`] commands.
 ///
 /// You are required to provide a unique application name, so that your settings don't overwrite
 /// those of other apps. To ensure global uniqueness, it is recommended to use a


### PR DESCRIPTION
# Objective

It took me half a day to get bevy-settings working. This is in part due to lacking documentation and in part due to it failing without any errors. In my first PR (#25547), I improved the situation by improving the documentation. However, even with the improved documentation, it's still possible to write a program that compiles and runs without any errors or warnings, but still is multiple lines annotations and trait implementations away from actually letting `SettingsPlugin` save and load the settings.

## Solution

**THIS IS A BREAKING CHANGE**

This PR adds trait bounds so that types that implement the `SettingsGroup` trait must also implement `Default` and `Reflect`, which are both required for `SettingsPlugin` to save and load the settings. Furthermore, `SettingsPlugin` will now panic if a type is registered `#[reflect(SettingsGroup)]` but doesn't register `#[reflect(Default)]`, since only types that are registered `ReflectDefault` and `ReflectSettingsGroup` will be saved and loaded by `SettingsPlugin`.

I justify these breaking changes by how only invalid code (that is, code that tries to use `SettingsPlugin` and `SettingsGroup` but does not manage to let `SettingsPlugin` save and load all the `SettingsGroup` types) can have compile errors.

## Testing

- Did you test these changes? Yes, the test suite passes like before.
- Are there any parts that need more testing? Oh, absolutely. Since this is a breaking change, it should be determined how much code "in the wild" will be negatively affected by this change.
- How can other people (reviewers) test your changes? Are there any applications of the `SettingsGroup` trait that the trait bounds are getting in the way of?
- If relevant, what platforms did you test these changes on, and are there any important ones you can't test? I only tested this on Linux, as the changes were small enough and confined to cross-platform code so it shouldn't be affected by which platform the tests run on.
