### PR TITLE
Swap gizmo storage and buffer to keep the allocation

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -22,6 +22,8 @@ bevy_math = { path = "../crates/bevy_math" }
 bevy_picking = { path = "../crates/bevy_picking", features = ["mesh_picking"] }
 bevy_reflect = { path = "../crates/bevy_reflect", features = ["functions"] }
 bevy_camera = { path = "../crates/bevy_camera" }
+bevy_color = { path = "../crates/bevy_color" }
+bevy_gizmos = { path = "../crates/bevy_gizmos" }
 bevy_mesh = { path = "../crates/bevy_mesh" }
 bevy_asset = { path = "../crates/bevy_asset" }
 bevy_render = { path = "../crates/bevy_render" }
@@ -123,6 +125,11 @@ harness = false
 [[bench]]
 name = "camera"
 path = "benches/bevy_camera/main.rs"
+harness = false
+
+[[bench]]
+name = "gizmos"
+path = "benches/bevy_gizmos/main.rs"
 harness = false
 
 [[bench]]

--- a/benches/benches/bevy_gizmos/immediate_mode.rs
+++ b/benches/benches/bevy_gizmos/immediate_mode.rs
@@ -1,0 +1,68 @@
+use benches::bench;
+use bevy_app::{App, Update};
+use bevy_asset::AssetPlugin;
+use bevy_color::Color;
+use bevy_ecs::prelude::*;
+use bevy_gizmos::{prelude::Gizmos, GizmoPlugin};
+use bevy_math::Vec3;
+use core::time::Duration;
+use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+
+criterion_group!(benches, system_count_scaling);
+
+#[derive(Resource)]
+struct LinesPerSystem(usize);
+
+fn draw_lines(mut gizmos: Gizmos, lines_per_system: Res<LinesPerSystem>) {
+    for _ in 0..lines_per_system.0 {
+        gizmos.line(
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(1.0, 1.0, 1.0),
+            Color::WHITE,
+        );
+    }
+}
+
+fn build_app(system_count: usize, lines_per_system: usize) -> App {
+    let mut app = App::new();
+    app.add_plugins(AssetPlugin::default());
+    app.add_plugins(GizmoPlugin);
+    app.insert_resource(LinesPerSystem(lines_per_system));
+
+    for _ in 0..system_count {
+        app.add_systems(Update, draw_lines);
+    }
+
+    app.finish();
+    app.cleanup();
+    app
+}
+
+// Measures the impact of having multiple systems drawing gizmos
+fn system_count_scaling(c: &mut Criterion) {
+    let mut group = c.benchmark_group(bench!("system_count_scaling"));
+    group.warm_up_time(Duration::from_millis(1000));
+    group.measurement_time(Duration::from_secs(10));
+
+    for total_lines in [10_000usize, 100_000] {
+        group.throughput(Throughput::Elements(total_lines as u64));
+
+        for system_count in [1usize, 10, 100] {
+            let lines_per_system = total_lines / system_count;
+            group.bench_with_input(
+                BenchmarkId::new(total_lines.to_string(), system_count),
+                &(system_count, lines_per_system),
+                |b, &(system_count, lines_per_system)| {
+                    let mut app = build_app(system_count, lines_per_system);
+                    app.update();
+
+                    b.iter(|| {
+                        app.update();
+                    });
+                },
+            );
+        }
+    }
+
+    group.finish();
+}

--- a/benches/benches/bevy_gizmos/main.rs
+++ b/benches/benches/bevy_gizmos/main.rs
@@ -1,0 +1,5 @@
+use criterion::criterion_main;
+
+mod immediate_mode;
+
+criterion_main!(immediate_mode::benches);

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -297,10 +297,17 @@ fn update_gizmo_meshes<Config: GizmoConfigGroup>(
         if let Some(handle) = handle {
             let mut gizmo = gizmo_assets.get_mut(handle.id()).unwrap();
 
-            gizmo.buffer.list_positions = mem::take(&mut storage.list_positions);
-            gizmo.buffer.list_colors = mem::take(&mut storage.list_colors);
-            gizmo.buffer.strip_positions = mem::take(&mut storage.strip_positions);
-            gizmo.buffer.strip_colors = mem::take(&mut storage.strip_colors);
+            mem::swap(
+                &mut gizmo.buffer.list_positions,
+                &mut storage.list_positions,
+            );
+            mem::swap(&mut gizmo.buffer.list_colors, &mut storage.list_colors);
+            mem::swap(
+                &mut gizmo.buffer.strip_positions,
+                &mut storage.strip_positions,
+            );
+            mem::swap(&mut gizmo.buffer.strip_colors, &mut storage.strip_colors);
+            storage.clear();
         } else {
             let gizmo = GizmoAsset {
                 config_ty: TypeId::of::<Config>(),


### PR DESCRIPTION
# Objective

- When drawing gizmos from multiple systems, combining the buffers at the end of the frame can trigger a lot of new allocations

## Solution

- Instead of taking the buffer and creating a new one, swap with the existing buffer and clear the one that stays in the main world. This way the allocation is reused.
- Technically, if someone spawns a lot of gizmos for a single frame then never spawns them again then the memory will never be cleared but I believe this isn't a common use case for gizmos but this is a tradeoff. If it becomes an issue we could check how the capacity vs len compares over a few frame and shrink it.

## Testing

- I added a new benchmark that measures the impact of this over multiple lines drawn and systems.
- If you have a single system drawing a few lines then this new approach is marginally slower but in every other case it's faster.

---

## Showcase

<img width="1368" height="171" alt="image" src="https://github.com/user-attachments/assets/148d9c21-3080-44f5-8c5e-90ae67b7aae6" />