### PR TITLE
EmptyPathStream is not used on Android

### DIFF
--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -785,11 +785,11 @@ pub(crate) fn get_meta_path(path: &Path) -> PathBuf {
     meta_path
 }
 
-#[cfg(any(target_arch = "wasm32", target_os = "android"))]
+#[cfg(target_arch = "wasm32")]
 /// A [`PathBuf`] [`Stream`] implementation that immediately returns nothing.
 struct EmptyPathStream;
 
-#[cfg(any(target_arch = "wasm32", target_os = "android"))]
+#[cfg(target_arch = "wasm32")]
 impl Stream for EmptyPathStream {
     type Item = PathBuf;
 


### PR DESCRIPTION
# Objective

- Building on Android has a warning:

```
error: struct `EmptyPathStream` is never constructed
   --> crates/bevy_asset/src/io/mod.rs:790:8
    |
790 | struct EmptyPathStream;
    |        ^^^^^^^^^^^^^^^
    |
    = note: `-D dead-code` implied by `-D warnings`
    = help: to override `-D warnings` add `#[expect(dead_code)]` or `#[allow(dead_code)]`
```

## Solution

- Do not build it on Android, it was unused since https://github.com/bevyengine/bevy/pull/11495
