### PR TITLE
Theorycraft despawn_with_all

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -324,6 +324,7 @@ impl Edges {
 }
 
 /// Metadata about an [`Entity`] in a [`Archetype`].
+#[derive(Clone, Copy)]
 pub struct ArchetypeEntity {
     entity: Entity,
     table_row: TableRow,

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -33,7 +33,7 @@ use nonmax::NonMaxU32;
 /// [`World`]: crate::world::World
 /// [`Archetype`]: crate::archetype::Archetype
 /// [`Archetype::table_id`]: crate::archetype::Archetype::table_id
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TableId(u32);
 
 impl TableId {
@@ -218,6 +218,11 @@ impl Table {
     #[inline]
     pub fn capacity(&self) -> usize {
         self.entities.capacity()
+    }
+
+    #[inline]
+    pub(crate) fn components(&self) -> &[ComponentId] {
+        self.columns.indices()
     }
 
     /// Removes the entity at the given row and returns the entity swapped in to replace it (if an

--- a/crates/bevy_ecs/src/world/despawn_all.rs
+++ b/crates/bevy_ecs/src/world/despawn_all.rs
@@ -1,14 +1,19 @@
 use core::debug_assert_matches;
 
 use alloc::vec::Vec;
+use bevy_platform::collections::{HashMap, HashSet};
 use nonmax::NonMaxU32;
 
 use crate::{
-    archetype::ArchetypeRow,
+    archetype::{ArchetypeId, ArchetypeRow},
     change_detection::MaybeLocation,
-    component::Component,
+    component::{Component, StorageType},
     entity::{Entity, EntityLocation},
+    event::EntityComponentsTrigger,
+    lifecycle::{DespawnEvent, DiscardEvent, RemoveEvent, DESPAWN, DISCARD, REMOVE},
     query::With,
+    relationship::RelationshipHookMode,
+    storage::TableId,
     world::World,
 };
 
@@ -22,6 +27,139 @@ impl World {
         let Some(cid) = self.component_id::<C>() else {
             return;
         };
+
+        if let StorageType::Table = C::STORAGE_TYPE {
+            let Some(archetype_map) = self.archetypes.by_component.get(&cid) else {
+                // Component hasn't been used in any archetypes, so there's nothing to despawn
+                return;
+            };
+
+            let mut tables: HashMap<TableId, Vec<ArchetypeId>> = HashMap::new();
+
+            for archetype_id in archetype_map.keys() {
+                tables
+                    .entry(self.archetypes[*archetype_id].table_id())
+                    .or_default()
+                    .push(*archetype_id);
+            }
+
+            for (table_id, archetypes) in tables {
+                for i in 0..self.storages.tables[table_id].entities().len() {
+                    let entity = self.storages.tables[table_id].entities()[i];
+
+                    let Ok(entity_loc) = self.entities.get_spawned(entity) else {
+                        // Is continue the right thing here??
+                        continue;
+                    };
+
+                    let archetype = &self.archetypes[entity_loc.archetype_id];
+                    // SAFETY: Archetype cannot be mutably aliased by DeferredWorld
+                    let (archetype, mut deferred_world) = unsafe {
+                        let archetype: *const _ = archetype;
+                        let world = self.as_unsafe_world_cell();
+                        (&*archetype, world.into_deferred())
+                    };
+
+                    // SAFETY: All components in the archetype exist in world
+                    unsafe {
+                        if archetype.has_despawn_observer() {
+                            // SAFETY: the DESPAWN event_key corresponds to the Despawn event's type
+                            deferred_world.trigger_raw(
+                                DESPAWN,
+                                &mut DespawnEvent { entity },
+                                &mut EntityComponentsTrigger {
+                                    components: archetype.components(),
+                                    old_archetype: Some(archetype),
+                                    new_archetype: None,
+                                },
+                                caller,
+                            );
+                        }
+
+                        deferred_world.trigger_on_despawn(
+                            archetype,
+                            entity,
+                            archetype.iter_components(),
+                            caller,
+                        );
+                        if archetype.has_discard_observer() {
+                            // SAFETY: the DISCARD event_key corresponds to the Discard event's type
+                            deferred_world.trigger_raw(
+                                DISCARD,
+                                &mut DiscardEvent { entity },
+                                &mut EntityComponentsTrigger {
+                                    components: archetype.components(),
+                                    old_archetype: Some(archetype),
+                                    new_archetype: None,
+                                },
+                                caller,
+                            );
+                        }
+                        deferred_world.trigger_on_discard(
+                            archetype,
+                            entity,
+                            archetype.iter_components(),
+                            caller,
+                            RelationshipHookMode::Run,
+                        );
+                        if archetype.has_remove_observer() {
+                            // SAFETY: the REMOVE event_key corresponds to the Remove event's type
+                            deferred_world.trigger_raw(
+                                REMOVE,
+                                &mut RemoveEvent { entity },
+                                &mut EntityComponentsTrigger {
+                                    components: archetype.components(),
+                                    old_archetype: Some(archetype),
+                                    new_archetype: None,
+                                },
+                                caller,
+                            );
+                        }
+                        deferred_world.trigger_on_remove(
+                            archetype,
+                            entity,
+                            archetype.iter_components(),
+                            caller,
+                        );
+                    }
+
+                    for component_id in self.storages.tables[table_id].components() {
+                        self.removed_components.write(*component_id, entity);
+                    }
+
+                    unsafe {
+                        self.entities.update_existing_location(entity.index(), None);
+                        self.entities.mark_spawned_or_despawned(
+                            entity.index(),
+                            caller,
+                            change_tick,
+                        );
+                    }
+
+                    if let Ok(entity_loc) = self.entities.get_spawned(entity) {
+                        for component_id in
+                            self.archetypes[entity_loc.archetype_id].sparse_set_components()
+                        {
+                            let sparse_set =
+                                self.storages.sparse_sets.get_mut(component_id).unwrap();
+                            sparse_set.remove(entity);
+                        }
+                    }
+
+                    unsafe {
+                        self.entities.mark_free(entity.index(), 1);
+                    }
+                }
+
+                for archetype_id in archetypes {
+                    self.archetypes[archetype_id].clear_entities();
+                }
+
+                self.storages.tables[table_id].clear();
+            }
+        }
+
+        // --- Previous attempt below ---
 
         let Some(arches) = self
             .archetypes

--- a/crates/bevy_ecs/src/world/despawn_all.rs
+++ b/crates/bevy_ecs/src/world/despawn_all.rs
@@ -1,0 +1,127 @@
+use core::debug_assert_matches;
+
+use alloc::vec::Vec;
+use nonmax::NonMaxU32;
+
+use crate::{
+    archetype::ArchetypeRow,
+    change_detection::MaybeLocation,
+    component::Component,
+    entity::{Entity, EntityLocation},
+    query::With,
+    world::World,
+};
+
+impl World {
+    /// Bulk despawn all entities with a given [`Component`]
+    pub fn despawn_all_with<C: Component>(&mut self) {
+        let caller = MaybeLocation::caller();
+
+        let change_tick = self.change_tick();
+
+        let Some(cid) = self.component_id::<C>() else {
+            return;
+        };
+
+        let Some(arches) = self
+            .archetypes
+            .by_component
+            .get(&cid)
+            .map(|m| m.keys().copied().collect::<Vec<_>>())
+        else {
+            return;
+        };
+
+        // mostly adoped from EntityWorldMut::despawn_no_free_with_caller
+
+        for arch_id in arches {
+            let archetype = &mut self.archetypes[arch_id];
+
+            let table_id = archetype.table_id();
+
+            let entities = archetype.entities().to_vec();
+
+            let components = archetype.components().to_vec();
+            let sparse_components = archetype.sparse_set_components().collect::<Vec<_>>();
+
+            for (idx, entity) in entities.iter().rev().enumerate() {
+                let archetype_row =
+                    unsafe { ArchetypeRow::new(NonMaxU32::new_unchecked(idx as u32)) };
+
+                {
+                    // TODO:
+                    //   despawn_observer
+                    //   discard_observer
+                    //   remove_observer
+                }
+
+                for component_id in &components {
+                    self.removed_components.write(*component_id, entity.id());
+                }
+
+                unsafe {
+                    self.entities
+                        .update_existing_location(entity.id().index(), None);
+                    self.entities.mark_spawned_or_despawned(
+                        entity.id().index(),
+                        caller,
+                        change_tick,
+                    );
+                }
+
+                let remove_result = self.archetypes[arch_id].swap_remove(archetype_row);
+
+                // Assuming there is no swapped entity because we're iterating the entities in reverse order
+                debug_assert_matches!(remove_result.swapped_entity, None);
+
+                // SAFETY ?? skipping world.entities.update_existing_location
+
+                for component_id in &sparse_components {
+                    // set must have existed for the component to be added.
+                    let sparse_set = self.storages.sparse_sets.get_mut(*component_id).unwrap();
+                    sparse_set.remove(entity.id());
+                }
+
+                let moved_entity = unsafe {
+                    self.storages.tables[table_id].swap_remove_unchecked(entity.table_row())
+                };
+
+                if let Some(moved_entity) = moved_entity {
+                    let moved_location = self.entities.get_spawned(moved_entity).unwrap();
+                    // SAFETY ??
+                    unsafe {
+                        self.entities.update_existing_location(
+                            moved_entity.index(),
+                            Some(EntityLocation {
+                                archetype_id: moved_location.archetype_id,
+                                archetype_row: moved_location.archetype_row,
+                                table_id: moved_location.table_id,
+                                table_row: entity.table_row(),
+                            }),
+                        );
+                    }
+                    self.archetypes[moved_location.archetype_id]
+                        .set_entity_table_row(moved_location.archetype_row, entity.table_row());
+                }
+
+                unsafe {
+                    self.entities.mark_free(entity.id().index(), 1);
+                }
+            }
+        }
+
+        self.flush();
+    }
+
+    /// Bulk despawn all entities with a given [`Component`], naive implementation for comparison
+    pub fn despawn_all_with_naive<C: Component>(&mut self) {
+        let entities = self
+            .query_filtered::<Entity, With<C>>()
+            .iter(self)
+            .collect::<Vec<_>>();
+
+        for e in entities {
+            self.despawn(e);
+        }
+    }
+}

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod command_queue;
 mod deferred_world;
+mod despawn_all;
 mod entity_access;
 mod entity_fetch;
 mod filtered_resource;


### PR DESCRIPTION
# Objective

Explore a more efficient way of bulk despawning all entities that have a specific `Component`.

Inspired by talking to Giooschi on [discord](https://discord.com/channels/691052431525675048/743663924229963868/1542055003500453888).

The inspiration was [this](https://discord.com/channels/691052431525675048/743663924229963868/1541315592022392862) message in relation to a more optimal way to despawn many entities.

> FYI you might be able to save some time on the ECS side by:
> - collecting the entities into a `Vec`, then calling `despawn` using a `&mut World` (i.e. skip `Commands`)
> - when despawning, iterate the `Vec` in reverse (it should avoid a bunch of table moves)

In my code I commonly use a pattern like this to despawn entities in bulk that don't fit the use case of the [State based despawning components](https://docs.rs/bevy/0.19.1/bevy/state/state_scoped/), eg a crude "scene system" (unity/godot scene style not bsn), among other things.

```rust
#[derive(Component)]
struct FooTag;

fn gameplay(mut cmd: Commands) {
    cmd.run_system_cached(despawn_all::<FooTag>);
}

fn despawn_all<C: Component>(q: Query<Entity, With<C>>, mut cmd: Commands) {
    for e in &q {
        cmd.entity(e).despawn();
    }
}
```

I see two "obvious" ways to make it easier for users to fall into the pit of success regarding mass despawning, and avoid Bevy relying upon this kind of perf trivia.

1. `despawn_batch`, the "reverse" of [spawn_batch](https://docs.rs/bevy/0.19.1/bevy/prelude/struct.Commands.html#method.spawn_batch), taking a `IntoIterator<Item = Entity>`
2. `despawn_all_with`, despawn all entities that essentially match the filter `With<C>`

I decided to explore `despawn_all_with` for a few reasons.
- It is what I'm actually trying to achieve with my code above, I don't care about the order or how the `Entity`'s are discovered
- I think it has the highest performance potential that gives the behaviour I'm after (aka more restrictive API = more impl flexibility)
- If we take an iterator of `Entity` from the user, we can't actually be sure if they are in any specific order, so we can't just reverse it to avoid table moves, it would require sorting first

## Solution

Added `World::despawn_all_with` to experiment with the API & implementation. It is a modified version of `EntityWorldMut::despawn_no_free_with_caller`, with some parts omitted (noted in comments, mostly observer related stuff) since this is more of a proof of concept.

I've never contributed to the ECS before, so it's likely not in the correct spot/not calling the correct API methods, and probably not correctly adhering to all the `SAFETY` things.

### Further thoughts/Notes :ghost: 

I have no idea the implications of the component being Sparse vs Dense.

I don't know enough about ECS ordering to say whether we could batch the observer events together, or whether we need to dispatch them as we go. And if we do need to dispatch them as we go, does that mean we can't "drop" all the entities of a particular `Archetype` and/or `Table` in bulk?

We can probably calculate if a `Table` and therefore `Archetype` is able to be dropped entirely, and therefore skip all code related to `swap_remove` since we won't need what it's providing, and maybe some location tracking. This would probably mean a whole new set of methods on `Archetype`??

Most if not all of the APIs called deal with a single `Entity`, and therefore may be paying costs N times that we'd only actually need to pay once.
- `removed_components.write(component_id, entity.id()` does a `SparseSet` lookup per component, per entity (aka `M*N`)
- `swap_remove` in general does a `is_last` on everything which we will never need
- Being able to drop whole Vecs of entities etc at once would be I assume much better than repeated calls to `remove`
- `entities.mark_free` calls `ensure_index_index_is_valid` on every entity, but it has already been validated earlier when we called `entities.get_spawned`
- probably more like this I've missed

## Testing

None