### PR TITLE
Document how to enable `RenderDebugOverlay`

### DIFF
--- a/crates/bevy_dev_tools/src/render_debug.rs
+++ b/crates/bevy_dev_tools/src/render_debug.rs
@@ -58,7 +58,7 @@ use bevy_pbr::{
 /// let mut world = World::new();
 /// world.insert_resource(RenderDebugOverlayKeybindings {
 ///     enable_keybindings: true,
-///     ..RenderDebugOverlayKeybindings::default()
+///     ..default()
 /// });
 /// ```
 ///

--- a/crates/bevy_dev_tools/src/render_debug.rs
+++ b/crates/bevy_dev_tools/src/render_debug.rs
@@ -54,11 +54,11 @@ use bevy_pbr::{
 ///
 /// ```
 /// # use bevy_dev_tools::render_debug::RenderDebugOverlayKeybindings;
-/// # use bevy_ecs::world::World;
-/// # let mut world = World::new();
+/// # use bevy_ecs::prelude::World;
+/// let mut world = World::new();
 /// world.insert_resource(RenderDebugOverlayKeybindings {
 ///     enable_keybindings: true,
-///     ..default()
+///     ..RenderDebugOverlayKeybindings::default()
 /// });
 /// ```
 ///

--- a/crates/bevy_dev_tools/src/render_debug.rs
+++ b/crates/bevy_dev_tools/src/render_debug.rs
@@ -55,6 +55,7 @@ use bevy_pbr::{
 /// ```
 /// # use bevy_dev_tools::render_debug::RenderDebugOverlayKeybindings;
 /// # use bevy_ecs::prelude::World;
+/// # use bevy_utils::default;
 /// let mut world = World::new();
 /// world.insert_resource(RenderDebugOverlayKeybindings {
 ///     enable_keybindings: true,

--- a/crates/bevy_dev_tools/src/render_debug.rs
+++ b/crates/bevy_dev_tools/src/render_debug.rs
@@ -46,6 +46,25 @@ use bevy_pbr::{
 };
 
 /// Adds a rendering debug overlay to visualize various renderer buffers.
+///
+/// The plugin is part of `DefaultPlugins` when the `dev` feature is enabled.
+/// The overlay is hidden by default. To control it from the keyboard, insert a
+/// [`RenderDebugOverlayKeybindings`] resource with
+/// [`enable_keybindings`](RenderDebugOverlayKeybindings::enable_keybindings) set to `true`:
+///
+/// ```
+/// # use bevy_dev_tools::render_debug::RenderDebugOverlayKeybindings;
+/// # use bevy_ecs::world::World;
+/// # let mut world = World::new();
+/// world.insert_resource(RenderDebugOverlayKeybindings {
+///     enable_keybindings: true,
+///     ..default()
+/// });
+/// ```
+///
+/// With the default keybindings, `F1` enables the overlay and cycles through the
+/// supported modes, `F2` cycles the overlay opacity. The overlay is drawn on every
+/// camera.
 #[derive(Default)]
 pub struct RenderDebugOverlayPlugin;
 
@@ -99,7 +118,14 @@ impl Plugin for RenderDebugOverlayPlugin {
     }
 }
 
-/// keybinding resource for configurable keybindings for the overlay
+/// Resource for configuring the [`RenderDebugOverlayPlugin`] keyboard shortcuts.
+///
+/// Keybindings are disabled by default. Set
+/// [`enable_keybindings`](RenderDebugOverlayKeybindings::enable_keybindings)
+/// to `true` to enable them.
+///
+/// Defaults to `F1` for cycling through the debug modes and `F2` for cycling
+/// the overlay opacity.
 #[derive(Resource, Clone, Copy)]
 pub struct RenderDebugOverlayKeybindings {
     /// Whether to enable the automatic keybindings


### PR DESCRIPTION
Fixes #25510
RenderDebugOverlayPlugin was documented with a single line that
didn't explain how to actually enable the overlay. Added an example
showing the RenderDebugOverlayKeybindings resource, and documented
the default F1/F2 shortcuts on both the plugin and the keybindings
struct.