### PR TITLE
Make fullscreen material pipeline IDs material-specific

### DIFF
--- a/crates/bevy_core_pipeline/src/fullscreen_material.rs
+++ b/crates/bevy_core_pipeline/src/fullscreen_material.rs
@@ -188,7 +188,10 @@ fn init_pipeline<T: FullscreenMaterial>(
 }
 
 #[derive(Component)]
-pub struct FullscreenMaterialPipelineId(pub CachedRenderPipelineId);
+pub struct FullscreenMaterialPipelineId<T: FullscreenMaterial>(
+    pub CachedRenderPipelineId,
+    PhantomData<T>,
+);
 
 fn prepare_fullscreen_material_pipelines<T: FullscreenMaterial>(
     mut commands: Commands,
@@ -200,7 +203,7 @@ fn prepare_fullscreen_material_pipelines<T: FullscreenMaterial>(
         if material.is_none() {
             commands
                 .entity(entity)
-                .remove::<FullscreenMaterialPipelineId>();
+                .remove::<FullscreenMaterialPipelineId<T>>();
             continue;
         }
 
@@ -213,7 +216,7 @@ fn prepare_fullscreen_material_pipelines<T: FullscreenMaterial>(
 
         commands
             .entity(entity)
-            .insert(FullscreenMaterialPipelineId(pipeline_id));
+            .insert(FullscreenMaterialPipelineId::<T>(pipeline_id, PhantomData));
     }
 
     Ok(())
@@ -292,7 +295,7 @@ pub fn fullscreen_material_system<T: FullscreenMaterial>(
         &ViewTarget,
         &DynamicUniformIndex<T>,
         &FullscreenMaterialBindGroup<T>,
-        &FullscreenMaterialPipelineId,
+        &FullscreenMaterialPipelineId<T>,
     )>,
     pipeline_cache: Res<PipelineCache>,
     mut ctx: RenderContext,


### PR DESCRIPTION
# Objective

Fixes #25560.

Multiple `FullscreenMaterialPlugin` instances currently share one `FullscreenMaterialPipelineId` component type.
Their prepare systems can therefore remove or overwrite each other's pipeline ID.

# Solution

Make `FullscreenMaterialPipelineId` generic over the fullscreen material type and use the typed component when inserting, removing, and querying the pipeline ID.
This ensures that adding another `FullscreenMaterial` cannot remove or overwrite the pipeline ID of an unrelated fullscreen material.

# Testing

- `cargo clippy -p bevy_core_pipeline --lib --no-deps -- -D warnings`
- `cargo fmt -p bevy_core_pipeline --check`