### PR TITLE
make window events observable

### DIFF
--- a/crates/bevy_input/src/gestures.rs
+++ b/crates/bevy_input/src/gestures.rs
@@ -1,8 +1,8 @@
 //! Gestures functionality, from touchscreens and touchpads.
 
-use bevy_ecs::message::Message;
 #[cfg(feature = "bevy_reflect")]
 use bevy_ecs::prelude::ReflectMessage;
+use bevy_ecs::{event::Event, message::Message};
 use bevy_math::Vec2;
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
@@ -19,7 +19,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// - Only available on **`macOS`** and **`iOS`**.
 /// - On **`iOS`**, must be enabled first
-#[derive(Message, Debug, Clone, Copy, PartialEq)]
+#[derive(Message, Event, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -41,7 +41,7 @@ pub struct PinchGesture(pub f32);
 ///
 /// - Only available on **`macOS`** and **`iOS`**.
 /// - On **`iOS`**, must be enabled first
-#[derive(Message, Debug, Clone, Copy, PartialEq)]
+#[derive(Message, Event, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -60,7 +60,7 @@ pub struct RotationGesture(pub f32);
 ///
 /// - Only available on **`macOS`** and **`iOS`**.
 /// - On **`iOS`**, must be enabled first
-#[derive(Message, Debug, Clone, Copy, PartialEq)]
+#[derive(Message, Event, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -78,7 +78,7 @@ pub struct DoubleTapGesture;
 /// ## Platform-specific
 ///
 /// - On **`iOS`**, must be enabled first
-#[derive(Message, Debug, Clone, Copy, PartialEq)]
+#[derive(Message, Event, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -71,6 +71,7 @@ use bevy_ecs::prelude::ReflectMessage;
 use bevy_ecs::{
     change_detection::DetectChangesMut,
     entity::Entity,
+    event::{EntityEvent, Event},
     message::{Message, MessageReader},
     system::ResMut,
 };
@@ -97,7 +98,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// The event is consumed inside of the [`keyboard_input_system`] to update the
 /// [`ButtonInput<KeyCode>`](ButtonInput<KeyCode>) and
 /// [`ButtonInput<Key>`](ButtonInput<Key>) resources.
-#[derive(Message, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Message, EntityEvent, Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -137,6 +138,7 @@ pub struct KeyboardInput {
     /// event is the result of one of those repeats.
     pub repeat: bool,
     /// Window that received the input.
+    #[event_target]
     pub window: Entity,
 }
 
@@ -146,7 +148,7 @@ pub struct KeyboardInput {
 /// when, for example, switching between windows with 'Alt-Tab' or using any other
 /// OS specific key combination that leads to Bevy window losing focus and not receiving any
 /// input events
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, Event, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -8,6 +8,7 @@ use bevy_ecs::prelude::ReflectMessage;
 use bevy_ecs::{
     change_detection::DetectChangesMut,
     entity::Entity,
+    event::{EntityEvent, Event},
     message::{Message, MessageReader},
     resource::Resource,
     system::ResMut,
@@ -32,7 +33,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// The event is read inside of the [`mouse_button_input_system`]
 /// to update the [`ButtonInput<MouseButton>`] resource.
-#[derive(Message, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -49,6 +50,7 @@ pub struct MouseButtonInput {
     /// The pressed state of the button.
     pub state: ButtonState,
     /// Window that received the input.
+    #[event_target]
     pub window: Entity,
 }
 
@@ -97,7 +99,7 @@ pub enum MouseButton {
 /// However, the event data does not make it possible to distinguish which device it is referring to.
 ///
 /// [`DeviceEvent::MouseMotion`]: https://docs.rs/winit/latest/winit/event/enum.DeviceEvent.html#variant.MouseMotion
-#[derive(Message, Debug, Clone, Copy, PartialEq)]
+#[derive(Message, Event, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -200,7 +202,7 @@ impl Div<MouseScrollPixelsPerLine> for Vec2 {
 /// A mouse wheel event.
 ///
 /// This event is the translated version of the `WindowEvent::MouseWheel` from the `winit` crate.
-#[derive(Message, Debug, Clone, Copy, PartialEq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -218,7 +220,8 @@ pub struct MouseWheel {
     pub x: f32,
     /// The vertical scroll value.
     pub y: f32,
-    /// Window that received the input.
+    /// Window that received the input.   
+    #[event_target]
     pub window: Entity,
     /// Touch phase of the input.
     ///

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -4,6 +4,7 @@
 use bevy_ecs::prelude::ReflectMessage;
 use bevy_ecs::{
     entity::Entity,
+    event::EntityEvent,
     message::{Message, MessageReader},
     resource::Resource,
     system::ResMut,
@@ -39,7 +40,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// This event is the translated version of the `WindowEvent::Touch` from the `winit` crate.
 /// It is available to the end user and can be used for game logic.
-#[derive(Message, Debug, Clone, Copy, PartialEq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -56,6 +57,7 @@ pub struct TouchInput {
     /// The position of the finger on the touchscreen.
     pub position: Vec2,
     /// The window entity registering the touch.
+    #[event_target]
     pub window: Entity,
     /// Describes how hard the screen was pressed.
     ///

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -1,7 +1,11 @@
 use alloc::string::String;
 #[cfg(feature = "bevy_reflect")]
 use bevy_ecs::prelude::ReflectMessage;
-use bevy_ecs::{entity::Entity, message::Message};
+use bevy_ecs::{
+    entity::Entity,
+    event::{EntityEvent, EntityTrigger, Event},
+    message::Message,
+};
 use bevy_input::{
     gestures::*,
     keyboard::{KeyboardFocusLost, KeyboardInput},
@@ -25,7 +29,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use crate::WindowTheme;
 
 /// A window event that is sent whenever a window's logical size has changed.
-#[derive(Message, Debug, Clone, PartialEq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -38,6 +42,7 @@ use crate::WindowTheme;
 )]
 pub struct WindowResized {
     /// Window that has changed.
+    #[event_target]
     pub window: Entity,
     /// The new logical width of the window.
     pub width: f32,
@@ -47,7 +52,7 @@ pub struct WindowResized {
 
 /// An event that indicates all of the application's windows should be redrawn,
 /// even if their control flow is set to `Wait` and there have been no window events.
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, Event, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -63,7 +68,7 @@ pub struct RequestRedraw;
 /// An event that is sent whenever a new window is created.
 ///
 /// To create a new window, spawn an entity with a [`Window`](`crate::Window`) on it.
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -76,6 +81,8 @@ pub struct RequestRedraw;
 )]
 pub struct WindowCreated {
     /// Window that has been created.
+    #[event_target]
+    #[doc(alias = "entity")]
     pub window: Entity,
 }
 
@@ -89,7 +96,7 @@ pub struct WindowCreated {
 ///
 /// [`WindowPlugin`]: crate::WindowPlugin
 /// [`Window`]: crate::Window
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -102,12 +109,13 @@ pub struct WindowCreated {
 )]
 pub struct WindowCloseRequested {
     /// Window to close.
+    #[event_target]
     pub window: Entity,
 }
 
 /// An event that is sent whenever a window is closed. This will be sent when
 /// the window entity loses its [`Window`](crate::window::Window) component or is despawned.
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -123,12 +131,13 @@ pub struct WindowClosed {
     ///
     /// Note that this entity probably no longer exists
     /// by the time this event is received.
+    #[event_target]
     pub window: Entity,
 }
 
 /// An event that is sent whenever a window is closing. This will be sent when
 /// after a [`WindowCloseRequested`] event is received and the window is in the process of closing.
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -141,6 +150,7 @@ pub struct WindowClosed {
 )]
 pub struct WindowClosing {
     /// Window that has been requested to close and is the process of closing.
+    #[event_target]
     pub window: Entity,
 }
 
@@ -148,7 +158,7 @@ pub struct WindowClosing {
 ///
 /// Note that if your application only has a single window, this event may be your last chance to
 /// persist state before the application terminates.
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -164,6 +174,7 @@ pub struct WindowDestroyed {
     ///
     /// Note that this entity probably no longer exists
     /// by the time this event is received.
+    #[event_target]
     pub window: Entity,
 }
 
@@ -178,7 +189,7 @@ pub struct WindowDestroyed {
 /// you should not use it for non-cursor-like behavior such as 3D camera control. Please see `MouseMotion` instead.
 ///
 /// [`WindowEvent::CursorMoved`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.CursorMoved
-#[derive(Message, Debug, Clone, PartialEq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -191,6 +202,7 @@ pub struct WindowDestroyed {
 )]
 pub struct CursorMoved {
     /// Window that the cursor moved inside.
+    #[event_target]
     pub window: Entity,
     /// The cursor position in logical pixels.
     pub position: Vec2,
@@ -203,7 +215,7 @@ pub struct CursorMoved {
 }
 
 /// An event that is sent whenever the user's cursor enters a window.
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -216,11 +228,12 @@ pub struct CursorMoved {
 )]
 pub struct CursorEntered {
     /// Window that the cursor entered.
+    #[event_target]
     pub window: Entity,
 }
 
 /// An event that is sent whenever the user's cursor leaves a window.
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -233,6 +246,7 @@ pub struct CursorEntered {
 )]
 pub struct CursorLeft {
     /// Window that the cursor left.
+    #[event_target]
     pub window: Entity,
 }
 
@@ -284,9 +298,22 @@ pub enum Ime {
         window: Entity,
     },
 }
+impl Event for Ime {
+    type Trigger<'a> = EntityTrigger;
+}
+impl EntityEvent for Ime {
+    fn event_target(&self) -> Entity {
+        match self {
+            Ime::Preedit { window, .. }
+            | Ime::Commit { window, .. }
+            | Ime::Enabled { window }
+            | Ime::Disabled { window } => *window,
+        }
+    }
+}
 
 /// An event that indicates a window has received or lost focus.
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -299,6 +326,7 @@ pub enum Ime {
 )]
 pub struct WindowFocused {
     /// Window that changed focus.
+    #[event_target]
     pub window: Entity,
     /// Whether it was focused (true) or lost focused (false).
     pub focused: bool,
@@ -313,7 +341,7 @@ pub struct WindowFocused {
 /// It is the translated version of [`WindowEvent::Occluded`] from the `winit` crate.
 ///
 /// [`WindowEvent::Occluded`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.Occluded
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -326,13 +354,14 @@ pub struct WindowFocused {
 )]
 pub struct WindowOccluded {
     /// Window that changed occluded state.
+    #[event_target]
     pub window: Entity,
     /// Whether it was occluded (true) or not occluded (false).
     pub occluded: bool,
 }
 
 /// An event that indicates a window's scale factor has changed.
-#[derive(Message, Debug, Clone, PartialEq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -345,13 +374,14 @@ pub struct WindowOccluded {
 )]
 pub struct WindowScaleFactorChanged {
     /// Window that had its scale factor changed.
+    #[event_target]
     pub window: Entity,
     /// The new scale factor.
     pub scale_factor: f64,
 }
 
 /// An event that indicates a window's OS-reported scale factor has changed.
-#[derive(Message, Debug, Clone, PartialEq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -364,6 +394,7 @@ pub struct WindowScaleFactorChanged {
 )]
 pub struct WindowBackendScaleFactorChanged {
     /// Window that had its scale factor changed by the backend.
+    #[event_target]
     pub window: Entity,
     /// The new scale factor.
     pub scale_factor: f64,
@@ -404,9 +435,20 @@ pub enum FileDragAndDrop {
         window: Entity,
     },
 }
-
+impl Event for FileDragAndDrop {
+    type Trigger<'a> = EntityTrigger;
+}
+impl EntityEvent for FileDragAndDrop {
+    fn event_target(&self) -> Entity {
+        match self {
+            FileDragAndDrop::HoveredFile { window, .. }
+            | FileDragAndDrop::DroppedFile { window, .. }
+            | FileDragAndDrop::HoveredFileCanceled { window } => *window,
+        }
+    }
+}
 /// An event that is sent when a window is repositioned in physical pixels.
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -419,6 +461,7 @@ pub enum FileDragAndDrop {
 )]
 pub struct WindowMoved {
     /// Window that moved.
+    #[event_target]
     pub window: Entity,
     /// Where the window moved to in physical pixels.
     pub position: IVec2,
@@ -428,7 +471,7 @@ pub struct WindowMoved {
 ///
 /// This event is only sent when the window is relying on the system theme to control its appearance.
 /// i.e. It is only sent when [`Window::window_theme`](crate::window::Window::window_theme) is `None` and the system theme changes.
-#[derive(Message, Debug, Clone, PartialEq, Eq)]
+#[derive(Message, EntityEvent, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -441,13 +484,14 @@ pub struct WindowMoved {
 )]
 pub struct WindowThemeChanged {
     /// Window for which the system theme has changed.
+    #[event_target]
     pub window: Entity,
     /// The new system theme.
     pub theme: WindowTheme,
 }
 
 /// Application lifetime events
-#[derive(Message, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Message, Event, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),
@@ -490,7 +534,7 @@ impl AppLifecycle {
 /// access window events in the order they were received from the
 /// operating system. Otherwise, the event types are individually
 /// readable with `MessageReader<E>` (e.g. `MessageReader<KeyboardInput>`).
-#[derive(Message, Debug, Clone, PartialEq)]
+#[derive(Message, Event, Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(Reflect),

--- a/crates/bevy_winit/src/state.rs
+++ b/crates/bevy_winit/src/state.rs
@@ -678,12 +678,12 @@ impl WinitAppRunnerState {
                         target_os = "android",
                         target_os = "ios",
                         all(target_os = "linux", any(feature = "x11", feature = "wayland"))
-                    )) =>
-                    {
+                    )) => {
                         let visible = WINIT_WINDOWS.with_borrow(|winit_windows| {
-                            winit_windows.windows.iter().any(|(_, w)| {
-                                w.is_visible().unwrap_or(false)
-                            })
+                            winit_windows
+                                .windows
+                                .iter()
+                                .any(|(_, w)| w.is_visible().unwrap_or(false))
                         });
 
                         event_loop.set_control_flow(if visible {
@@ -795,87 +795,115 @@ impl WinitAppRunnerState {
         }
 
         for window_event in window_events.iter() {
+            world.trigger(window_event.clone());
             match window_event.clone() {
                 BevyWindowEvent::AppLifecycle(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::CursorEntered(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::CursorLeft(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::CursorMoved(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::FileDragAndDrop(e) => {
-                    world.write_message(e);
+                    world.write_message(e.clone());
+                    world.trigger(e);
                 }
                 BevyWindowEvent::Ime(e) => {
-                    world.write_message(e);
+                    world.write_message(e.clone());
+                    world.trigger(e);
                 }
                 BevyWindowEvent::RequestRedraw(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::WindowBackendScaleFactorChanged(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::WindowCloseRequested(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::WindowCreated(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::WindowDestroyed(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::WindowFocused(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::WindowMoved(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::WindowOccluded(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::WindowResized(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::WindowScaleFactorChanged(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::WindowThemeChanged(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::MouseButtonInput(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::MouseMotion(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::MouseWheel(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::PinchGesture(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::RotationGesture(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::DoubleTapGesture(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::PanGesture(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::TouchInput(e) => {
                     world.write_message(e);
+                    world.trigger(e);
                 }
                 BevyWindowEvent::KeyboardInput(e) => {
-                    world.write_message(e);
+                    world.write_message(e.clone());
+                    world.trigger(e);
                 }
                 BevyWindowEvent::KeyboardFocusLost(e) => {
-                    world.write_message(e);
+                    world.write_message(e.clone());
+                    world.trigger(e);
                 }
             }
         }
@@ -1114,12 +1142,12 @@ mod tests {
                 let (window_backend_scale_factor_changed, window_scale_factor_changed) =
                     react_to_scale_factor_change(window.0, &mut window.1, changed_scale_factor);
                 window_backend_scale_factor_changed_writer
-                    .write(window_backend_scale_factor_changed.clone());
+                    .write(window_backend_scale_factor_changed);
                 window_event.write(BevyWindowEvent::WindowBackendScaleFactorChanged(
                     window_backend_scale_factor_changed,
                 ));
                 if let Some(window_scale_factor_changed) = window_scale_factor_changed {
-                    window_scale_factor_changed_writer.write(window_scale_factor_changed.clone());
+                    window_scale_factor_changed_writer.write(window_scale_factor_changed);
                     window_event.write(BevyWindowEvent::WindowScaleFactorChanged(
                         window_scale_factor_changed,
                     ));
@@ -1227,7 +1255,7 @@ mod tests {
                   mut window_resized_writer: MessageWriter<WindowResized>,
                   mut window_event: MessageWriter<BevyWindowEvent>| {
                 let window_resized = react_to_resize(window.0, &mut window.1, changed_size);
-                window_resized_writer.write(window_resized.clone());
+                window_resized_writer.write(window_resized);
                 window_event.write(BevyWindowEvent::WindowResized(window_resized));
             },
         );

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -129,8 +129,9 @@ pub fn create_windows(
                         winit_window.focus_window();
                     }
                 }
-
-                window_created_events.write(WindowCreated { window: entity });
+                let window_create = WindowCreated { window: entity };
+                window_created_events.write(window_create);
+                commands.trigger(window_create);
             }
         });
     });
@@ -406,7 +407,8 @@ pub(crate) fn changed_windows(
                     if let Some(new_physical_size) = winit_window.request_inner_size(requested_physical_size) {
                         let event = react_to_resize(entity, &mut window, new_physical_size);
                         // Need to send two very similar events because different systems rely on those.
-                        window_resized.write(event.clone());
+                        window_resized.write(event);
+                        commands.trigger(event);
                         window_event.write(event.into());
                     }
                 }
@@ -418,7 +420,8 @@ pub(crate) fn changed_windows(
                     // If the scale factor has changed we don't query anything from winit, but send events for camera system to handle.
                     let event = WindowScaleFactorChanged { scale_factor: requested_scale_factor as f64, window: entity};
                     // Need to send two very similar events because different systems rely on those.
-                    window_rescaled.write(event.clone());
+                    window_rescaled.write(event);
+                    commands.trigger(event);
                     window_event.write(event.into());
                 }
             }


### PR DESCRIPTION
# Objective

Allow windowing events to be recieved by observers

## Solution

- Implement `Event` and `EntityEvent`, for windowing event types, the latter only when `window: Entity` is given
- Call world/commands.trigger with all event types

## Testing

- make sure it compiles and runs: `cargo run --package bevy --example empty_defaults`
- preliminary PR to see if we event want this
- TODO:
   - performance overhead benchmarking
   - unit tests

---

<details><summary>Showcase section todo</summary>
<p>


## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR adds a new feature or public API, consider adding a brief pseudo-code snippet of it in action
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - If you want, you could even include a before/after comparison!
- If the Migration Guide adequately covers the changes, you can delete this section

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

```rust
println!("My super cool code.");
```

</details>



</p>
</details> 
