### PR TITLE
increase visibility of UnsafeWorldCell::increment_trigger_id to pub

### DIFF
--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -683,7 +683,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// # Safety
     /// It is the caller's responsibility to ensure that there are no outstanding
     /// references to `last_trigger_id`.
-    pub(crate) unsafe fn increment_trigger_id(self) {
+    pub unsafe fn increment_trigger_id(self) {
         self.assert_allows_mutable_access();
         // SAFETY: Caller ensure there are no outstanding references
         unsafe {


### PR DESCRIPTION

# Objective

It is not currently possible to create functional custom event Triggers with logic that differs from `trigger::trigger_entity_internal` because `UnsafeWorldCell::increment_trigger_id` is `pub(crate)`.  

This was raised in this [issue](https://github.com/bevyengine/bevy/issues/21441).

 That issue mentions making a change to pass the deferred world to the trigger trait, I'm not sure if that is still relevant as `DeferredWorld` is passed to `trigger`. That part isn't covered here.

## Solution
- Make `UnsafeWorldCell::increment_trigger_id` `pub` instead of `pub(crate)`, so custom `Trigger` implementations can use it the same way built in ones do.

## Testing

Given the nature of the change, no tests were run. 

