### PR TITLE
Make sure to init fallback resources in bevy_sprite_render

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -30,10 +30,7 @@ pub mod contact_shadows;
 #[cfg(feature = "bevy_gltf")]
 pub mod gltf;
 use bevy_light::cluster::GlobalClusterSettings;
-use bevy_render::{
-    material_bind_groups::init_fallback_resources, sync_component::SyncComponent,
-    view::RenderShadowLodOrigin,
-};
+use bevy_render::{sync_component::SyncComponent, view::RenderShadowLodOrigin};
 pub use contact_shadows::{
     ContactShadows, ContactShadowsBuffer, ContactShadowsPlugin, ContactShadowsUniform,
     ViewContactShadowsUniformOffset,
@@ -364,11 +361,7 @@ impl Plugin for PbrPlugin {
         render_app
             .add_systems(
                 RenderStartup,
-                (
-                    init_shadow_samplers,
-                    init_global_clusterable_object_meta,
-                    init_fallback_resources,
-                ),
+                (init_shadow_samplers, init_global_clusterable_object_meta),
             )
             .add_systems(
                 ExtractSchedule,

--- a/crates/bevy_render/src/material_bind_groups.rs
+++ b/crates/bevy_render/src/material_bind_groups.rs
@@ -29,7 +29,7 @@ use crate::{
         OwnedBindingResource, PipelineCache, UnpreparedBindingResource, UnpreparedBindingResources,
     },
     storage::ShaderBuffer,
-    GpuResourceAppExt as _, Render, RenderApp, RenderSystems,
+    GpuResourceAppExt as _, Render, RenderApp, RenderStartup, RenderSystems,
 };
 use crate::{
     render_resource::{
@@ -536,6 +536,7 @@ impl Plugin for MaterialBindGroupPlugin {
             .allow_ambiguous_resource::<MaterialBindGroupAllocators>()
             .init_gpu_resource::<RenderMaterialBindings>()
             .allow_ambiguous_resource::<RenderMaterialBindings>()
+            .add_systems(RenderStartup, init_fallback_resources)
             .add_systems(
                 Render,
                 (
@@ -2328,48 +2329,39 @@ impl MaterialBindlessSlab {
 }
 
 /// Creates and inserts the [`FallbackBindlessResources`] and [`FallbackBuffer`].
-pub fn init_fallback_resources(
-    mut commands: Commands,
-    render_device: Res<RenderDevice>,
-    maybe_fallback_bindless: Option<Res<FallbackBindlessResources>>,
-    maybe_fallback_buffer: Option<Res<FallbackBuffer>>,
-) {
-    if maybe_fallback_bindless.is_none() {
-        // Create the `FallbackBindlessResources`.
-        commands.insert_resource(FallbackBindlessResources {
-            filtering_sampler: render_device.create_sampler(&SamplerDescriptor {
-                label: Some("fallback filtering sampler"),
-                ..default()
-            }),
-            non_filtering_sampler: render_device.create_sampler(&SamplerDescriptor {
-                label: Some("fallback non-filtering sampler"),
-                mag_filter: FilterMode::Nearest,
-                min_filter: FilterMode::Nearest,
-                mipmap_filter: MipmapFilterMode::Nearest,
-                ..default()
-            }),
-            comparison_sampler: render_device.create_sampler(&SamplerDescriptor {
-                label: Some("fallback comparison sampler"),
-                compare: Some(CompareFunction::Always),
-                ..default()
-            }),
-        });
-    }
+fn init_fallback_resources(mut commands: Commands, render_device: Res<RenderDevice>) {
+    // Create the `FallbackBindlessResources`.
+    commands.insert_resource(FallbackBindlessResources {
+        filtering_sampler: render_device.create_sampler(&SamplerDescriptor {
+            label: Some("fallback filtering sampler"),
+            ..default()
+        }),
+        non_filtering_sampler: render_device.create_sampler(&SamplerDescriptor {
+            label: Some("fallback non-filtering sampler"),
+            mag_filter: FilterMode::Nearest,
+            min_filter: FilterMode::Nearest,
+            mipmap_filter: MipmapFilterMode::Nearest,
+            ..default()
+        }),
+        comparison_sampler: render_device.create_sampler(&SamplerDescriptor {
+            label: Some("fallback comparison sampler"),
+            compare: Some(CompareFunction::Always),
+            ..default()
+        }),
+    });
 
-    if maybe_fallback_buffer.is_none() {
-        // Creates the `FallbackBuffer`.
-        commands.insert_resource(FallbackBuffer(render_device.create_buffer(
-            &BufferDescriptor {
-                label: Some("fallback buffer"),
-                size: 1,
-                usage: BufferUsages::COPY_SRC
-                    | BufferUsages::COPY_DST
-                    | BufferUsages::STORAGE
-                    | BufferUsages::UNIFORM,
-                mapped_at_creation: false,
-            },
-        )));
-    }
+    // Creates the `FallbackBuffer`.
+    commands.insert_resource(FallbackBuffer(render_device.create_buffer(
+        &BufferDescriptor {
+            label: Some("fallback buffer"),
+            size: 1,
+            usage: BufferUsages::COPY_SRC
+                | BufferUsages::COPY_DST
+                | BufferUsages::STORAGE
+                | BufferUsages::UNIFORM,
+            mapped_at_creation: false,
+        },
+    )));
 }
 
 impl MaterialBindGroupNonBindlessAllocator {

--- a/crates/bevy_render/src/material_bind_groups.rs
+++ b/crates/bevy_render/src/material_bind_groups.rs
@@ -2328,39 +2328,48 @@ impl MaterialBindlessSlab {
 }
 
 /// Creates and inserts the [`FallbackBindlessResources`] and [`FallbackBuffer`].
-pub fn init_fallback_resources(mut commands: Commands, render_device: Res<RenderDevice>) {
-    // Create the `FallbackBindlessResources`.
-    commands.insert_resource(FallbackBindlessResources {
-        filtering_sampler: render_device.create_sampler(&SamplerDescriptor {
-            label: Some("fallback filtering sampler"),
-            ..default()
-        }),
-        non_filtering_sampler: render_device.create_sampler(&SamplerDescriptor {
-            label: Some("fallback non-filtering sampler"),
-            mag_filter: FilterMode::Nearest,
-            min_filter: FilterMode::Nearest,
-            mipmap_filter: MipmapFilterMode::Nearest,
-            ..default()
-        }),
-        comparison_sampler: render_device.create_sampler(&SamplerDescriptor {
-            label: Some("fallback comparison sampler"),
-            compare: Some(CompareFunction::Always),
-            ..default()
-        }),
-    });
+pub fn init_fallback_resources(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    maybe_fallback_bindless: Option<Res<FallbackBindlessResources>>,
+    maybe_fallback_buffer: Option<Res<FallbackBuffer>>,
+) {
+    if maybe_fallback_bindless.is_none() {
+        // Create the `FallbackBindlessResources`.
+        commands.insert_resource(FallbackBindlessResources {
+            filtering_sampler: render_device.create_sampler(&SamplerDescriptor {
+                label: Some("fallback filtering sampler"),
+                ..default()
+            }),
+            non_filtering_sampler: render_device.create_sampler(&SamplerDescriptor {
+                label: Some("fallback non-filtering sampler"),
+                mag_filter: FilterMode::Nearest,
+                min_filter: FilterMode::Nearest,
+                mipmap_filter: MipmapFilterMode::Nearest,
+                ..default()
+            }),
+            comparison_sampler: render_device.create_sampler(&SamplerDescriptor {
+                label: Some("fallback comparison sampler"),
+                compare: Some(CompareFunction::Always),
+                ..default()
+            }),
+        });
+    }
 
-    // Creates the `FallbackBuffer`.
-    commands.insert_resource(FallbackBuffer(render_device.create_buffer(
-        &BufferDescriptor {
-            label: Some("fallback buffer"),
-            size: 1,
-            usage: BufferUsages::COPY_SRC
-                | BufferUsages::COPY_DST
-                | BufferUsages::STORAGE
-                | BufferUsages::UNIFORM,
-            mapped_at_creation: false,
-        },
-    )));
+    if maybe_fallback_buffer.is_none() {
+        // Creates the `FallbackBuffer`.
+        commands.insert_resource(FallbackBuffer(render_device.create_buffer(
+            &BufferDescriptor {
+                label: Some("fallback buffer"),
+                size: 1,
+                usage: BufferUsages::COPY_SRC
+                    | BufferUsages::COPY_DST
+                    | BufferUsages::STORAGE
+                    | BufferUsages::UNIFORM,
+                mapped_at_creation: false,
+            },
+        )));
+    }
 }
 
 impl MaterialBindGroupNonBindlessAllocator {

--- a/crates/bevy_sprite_render/src/lib.rs
+++ b/crates/bevy_sprite_render/src/lib.rs
@@ -42,9 +42,10 @@ use bevy_ecs::prelude::*;
 use bevy_image::{prelude::*, TextureAtlasPlugin};
 use bevy_mesh::Mesh2d;
 use bevy_render::{
-    batching::sort_binned_render_phase, render_phase::AddRenderCommand,
-    render_resource::SpecializedRenderPipelines, sync_world::SyncToRenderWorld, ExtractSchedule,
-    GpuResourceAppExt, Render, RenderApp, RenderStartup, RenderSystems,
+    batching::sort_binned_render_phase, material_bind_groups::init_fallback_resources,
+    render_phase::AddRenderCommand, render_resource::SpecializedRenderPipelines,
+    sync_world::SyncToRenderWorld, ExtractSchedule, GpuResourceAppExt, Render, RenderApp,
+    RenderStartup, RenderSystems,
 };
 use bevy_sprite::Sprite;
 
@@ -101,7 +102,10 @@ impl Plugin for SpriteRenderPlugin {
                 .init_resource::<SpriteAssetEvents>()
                 .init_resource::<SpriteBatches>()
                 .add_render_command::<Transparent2d, DrawSprite>()
-                .add_systems(RenderStartup, init_sprite_pipeline)
+                .add_systems(
+                    RenderStartup,
+                    (init_sprite_pipeline, init_fallback_resources),
+                )
                 .add_systems(
                     ExtractSchedule,
                     (

--- a/crates/bevy_sprite_render/src/lib.rs
+++ b/crates/bevy_sprite_render/src/lib.rs
@@ -42,10 +42,9 @@ use bevy_ecs::prelude::*;
 use bevy_image::{prelude::*, TextureAtlasPlugin};
 use bevy_mesh::Mesh2d;
 use bevy_render::{
-    batching::sort_binned_render_phase, material_bind_groups::init_fallback_resources,
-    render_phase::AddRenderCommand, render_resource::SpecializedRenderPipelines,
-    sync_world::SyncToRenderWorld, ExtractSchedule, GpuResourceAppExt, Render, RenderApp,
-    RenderStartup, RenderSystems,
+    batching::sort_binned_render_phase, render_phase::AddRenderCommand,
+    render_resource::SpecializedRenderPipelines, sync_world::SyncToRenderWorld, ExtractSchedule,
+    GpuResourceAppExt, Render, RenderApp, RenderStartup, RenderSystems,
 };
 use bevy_sprite::Sprite;
 
@@ -102,10 +101,7 @@ impl Plugin for SpriteRenderPlugin {
                 .init_resource::<SpriteAssetEvents>()
                 .init_resource::<SpriteBatches>()
                 .add_render_command::<Transparent2d, DrawSprite>()
-                .add_systems(
-                    RenderStartup,
-                    (init_sprite_pipeline, init_fallback_resources),
-                )
+                .add_systems(RenderStartup, init_sprite_pipeline)
                 .add_systems(
                     ExtractSchedule,
                     (


### PR DESCRIPTION
# Objective

- bevy_sprite_render is not adding the fallback resources which can cause a crash when only 2d features are enabled.

## Solution

- Add init_fallback_resources to the RenderStartup of the MaterialBindGroupPlugin so it's always initialized

## Testing

- I tested a separate empty project with only the 2d feature enabled and it stopped crashing after this change

Closes #25572
Closes #25570