### PR TITLE
Adjust what is responsible for last_trigger_id modification and enforcement.

### DIFF
--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -389,10 +389,10 @@ impl<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>>
         if let Some(map) = observers.entity_observers().get(&target_entity) {
             for (observer, runner) in map {
                 // SAFETY:
-                // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_entity_internal`
-                // - the passed in event pointer is an `Event`, enforced by the call to `trigger_entity_internal`
-                // - `trigger` is a matching trigger type, enforced by the call to `trigger_entity_internal`
-                // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_entity_internal`
+                // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
+                // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
+                // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
+                // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
                 unsafe {
                     (runner)(
                         world.reborrow(),

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -1,10 +1,11 @@
 use crate::event::{EventPattern, SetEntityEventTarget};
 use crate::{
+    __macro_exports::DebugCheckedUnwrap,
     archetype::Archetype,
     component::ComponentId,
     entity::Entity,
     event::{EntityEvent, Event},
-    observer::{CachedObservers, TriggerContext},
+    observer::{CachedObservers, Observer, TriggerContext},
     traversal::Traversal,
     world::DeferredWorld,
 };
@@ -100,11 +101,18 @@ impl GlobalTrigger {
         trigger_context: &TriggerContext,
         mut event: PtrMut,
     ) {
-        // SAFETY: `observers` is the only active reference to something in `world`
-        unsafe {
-            world.as_unsafe_world_cell().increment_trigger_id();
-        }
+        let current_trigger_id = world.last_trigger_id;
+
         for (observer, runner) in observers.global_observers() {
+            // SAFETY:
+            // - observers from the CachedObservers should always have an Observer component
+            let observer_component =
+                unsafe { world.get::<Observer>(*observer).debug_checked_unwrap() };
+
+            if observer_component.last_trigger_id == current_trigger_id {
+                continue;
+            }
+
             // SAFETY:
             // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
             // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
@@ -184,11 +192,16 @@ pub unsafe fn trigger_entity_internal(
     target_entity: Entity,
     trigger_context: &TriggerContext,
 ) {
-    // SAFETY: there are no outstanding world references
-    unsafe {
-        world.as_unsafe_world_cell().increment_trigger_id();
-    }
+    let current_trigger_id = world.last_trigger_id;
+
     for (observer, runner) in observers.global_observers() {
+        // SAFETY:
+        // - observers from the CachedObservers should always have an Observer component
+        let observer_component = unsafe { world.get::<Observer>(*observer).debug_checked_unwrap() };
+
+        if observer_component.last_trigger_id == current_trigger_id {
+            continue;
+        }
         // SAFETY:
         // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_entity_internal`
         // - the passed in event pointer is an `Event`, enforced by the call to `trigger_entity_internal`
@@ -207,6 +220,14 @@ pub unsafe fn trigger_entity_internal(
 
     if let Some(map) = observers.entity_observers().get(&target_entity) {
         for (observer, runner) in map {
+            // SAFETY:
+            // - observers from the CachedObservers should always have an Observer component
+            let observer_component =
+                unsafe { world.get::<Observer>(*observer).debug_checked_unwrap() };
+
+            if observer_component.last_trigger_id == current_trigger_id {
+                continue;
+            }
             // SAFETY:
             // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_entity_internal`
             // - the passed in event pointer is an `Event`, enforced by the call to `trigger_entity_internal`
@@ -291,11 +312,10 @@ unsafe impl<
         // - `trigger` is a matching trigger type, as it comes from `self`, which is the Trigger for `E`
         // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger`
         unsafe {
-            trigger_entity_internal(
+            self.trigger_internal(
                 world.reborrow(),
                 observers,
                 event.into(),
-                self.into(),
                 current_entity,
                 trigger_context,
             );
@@ -321,14 +341,67 @@ unsafe impl<
             // - `trigger` is a matching trigger type, as it comes from `self`, which is the Trigger for `E`
             // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger`
             unsafe {
-                trigger_entity_internal(
+                self.trigger_internal(
                     world.reborrow(),
                     observers,
                     event.into(),
-                    self.into(),
                     current_entity,
                     trigger_context,
                 );
+            }
+        }
+    }
+}
+
+impl<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>>
+    PropagateEntityTrigger<AUTO_PROPAGATE, E, T>
+{
+    /// # Safety
+    /// - `observers` must come from the `world` [`DeferredWorld`], and correspond to observers that match the `event` type
+    /// - `event` must point to an [`Event`]
+    /// -  The `event` [`Event::Trigger`] must be [`EntityTrigger`]
+    /// - `trigger_context`'s [`TriggerContext::event_key`] must correspond to the `event` type.
+    pub unsafe fn trigger_internal(
+        &mut self,
+        mut world: DeferredWorld,
+        observers: &CachedObservers,
+        mut event: PtrMut,
+        target_entity: Entity,
+        trigger_context: &TriggerContext,
+    ) {
+        for (observer, runner) in observers.global_observers() {
+            // SAFETY:
+            // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_entity_internal`
+            // - the passed in event pointer is an `Event`, enforced by the call to `trigger_entity_internal`
+            // - `trigger` is a matching trigger type, enforced by the call to `trigger_entity_internal`
+            // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_entity_internal`
+            unsafe {
+                (runner)(
+                    world.reborrow(),
+                    *observer,
+                    trigger_context,
+                    event.reborrow(),
+                    self.into(),
+                );
+            }
+        }
+
+        if let Some(map) = observers.entity_observers().get(&target_entity) {
+            for (observer, runner) in map {
+                // SAFETY:
+                // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_entity_internal`
+                // - the passed in event pointer is an `Event`, enforced by the call to `trigger_entity_internal`
+                // - `trigger` is a matching trigger type, enforced by the call to `trigger_entity_internal`
+                // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_entity_internal`
+                unsafe {
+                    (runner)(
+                        world.reborrow(),
+                        *observer,
+                        trigger_context,
+                        event.reborrow(),
+                        self.into(),
+                    );
+                }
             }
         }
     }
@@ -462,6 +535,8 @@ impl<'a> EntityComponentsTrigger<'a> {
         entity: Entity,
         trigger_context: &TriggerContext,
     ) {
+        let current_trigger_id = world.last_trigger_id();
+
         // SAFETY:
         // - `observers` come from `world` and match the event type `E`, enforced by the call to `trigger`
         // - the passed in event pointer comes from `event`, which is an `Event`
@@ -483,6 +558,14 @@ impl<'a> EntityComponentsTrigger<'a> {
             if let Some(component_observers) = observers.component_observers().get(id) {
                 for (observer, runner) in component_observers.global_observers() {
                     // SAFETY:
+                    // - observers from the CachedObservers should always have an Observer component
+                    let observer_component =
+                        unsafe { world.get::<Observer>(*observer).debug_checked_unwrap() };
+
+                    if observer_component.last_trigger_id == current_trigger_id {
+                        continue;
+                    }
+                    // SAFETY:
                     // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
                     // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
                     // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
@@ -503,6 +586,15 @@ impl<'a> EntityComponentsTrigger<'a> {
                     .get(&entity)
                 {
                     for (observer, runner) in map {
+                        // SAFETY:
+                        // - observers from the CachedObservers should always have an Observer component
+                        let observer_component =
+                            unsafe { world.get::<Observer>(*observer).debug_checked_unwrap() };
+
+                        if observer_component.last_trigger_id == current_trigger_id {
+                            continue;
+                        }
+
                         // SAFETY:
                         // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
                         // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -13,7 +13,7 @@ use bevy_ptr::PtrMut;
 use core::{fmt, marker::PhantomData};
 
 /// [`Trigger`] determines _how_ an [`Event`] is triggered when [`World::trigger`](crate::world::World::trigger) is called.
-/// This decides which [`Observer`](crate::observer::Observer)s will run, what data gets passed to them, and the order they will
+/// This decides which [`Observer`]s will run, what data gets passed to them, and the order they will
 /// be executed in.
 ///
 /// Implementing [`Trigger`] is "advanced-level" territory, and is generally unnecessary unless you are developing highly specialized
@@ -37,7 +37,7 @@ use core::{fmt, marker::PhantomData};
 ///   This is not expressed as an explicit type constraint,, as the `for<'a> Event::Trigger<'a>` lifetime can mismatch explicit lifetimes in
 ///   some impls.
 pub unsafe trait Trigger<E: Event> {
-    /// Trigger the given `event`, running every [`Observer`](crate::observer::Observer) that matches the `event`, as defined by this
+    /// Trigger the given `event`, running every [`Observer`] that matches the `event`, as defined by this
     /// [`Trigger`] and the state stored on `self`.
     ///
     /// # Safety
@@ -59,7 +59,7 @@ pub unsafe trait Trigger<E: Event> {
 /// Shorthand for accessing an [`EventPattern`]s [`Trigger`] via its [`Event`].
 pub type EventPatternTrigger<'a, E> = <<E as EventPattern>::Event as Event>::Trigger<'a>;
 
-/// A [`Trigger`] that runs _every_ "global" [`Observer`](crate::observer::Observer) (ex: registered via [`World::add_observer`](crate::world::World::add_observer))
+/// A [`Trigger`] that runs _every_ "global" [`Observer`] (ex: registered via [`World::add_observer`](crate::world::World::add_observer))
 /// that matches the given [`Event`].
 ///
 /// The [`Event`] derive defaults to using this [`Trigger`], and it is usable for any [`Event`] type.

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -371,10 +371,10 @@ impl<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>>
     ) {
         for (observer, runner) in observers.global_observers() {
             // SAFETY:
-            // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_entity_internal`
-            // - the passed in event pointer is an `Event`, enforced by the call to `trigger_entity_internal`
-            // - `trigger` is a matching trigger type, enforced by the call to `trigger_entity_internal`
-            // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_entity_internal`
+            // - `observers` come from `world` and match the `event` type, enforced by the call to `trigger_internal`
+            // - the passed in event pointer is an `Event`, enforced by the call to `trigger_internal`
+            // - `trigger` is a matching trigger type, enforced by the call to `trigger_internal`
+            // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger_internal`
             unsafe {
                 (runner)(
                     world.reborrow(),

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -206,7 +206,7 @@ impl World {
     ) {
         // SAFETY: We have exclusive access via `&mut self` and will not
         // access observer storage through the returned `DeferredWorld`.
-        let Some((world, observers)) = (unsafe { self.split_for_event(event_key) }) else {
+        let Some((mut world, observers)) = (unsafe { self.split_for_event(event_key) }) else {
             return;
         };
 
@@ -214,6 +214,11 @@ impl World {
             event_key,
             caller: MaybeLocation::caller(),
         };
+
+        // SAFETY: no outstanding world references besides `observers`
+        unsafe {
+            world.as_unsafe_world_cell().increment_trigger_id();
+        }
 
         // SAFETY:
         // - `observers` come from `world` and correspond to `event_key`
@@ -264,6 +269,11 @@ impl World {
             event_key,
             caller: MaybeLocation::caller(),
         };
+
+        // SAFETY: no outstanding world references besides `observers`
+        unsafe {
+            world.as_unsafe_world_cell().increment_trigger_id();
+        }
 
         // SAFETY:
         // - `observers` come from `world` and correspond to `event_key`

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -46,12 +46,7 @@ pub(super) unsafe fn observer_system_runner<E: EventPattern, S: ObserverSystem<E
     // SAFETY: Observer was triggered so must have an `Observer`
     let mut state = unsafe { observer_cell.get_mut::<Observer>().debug_checked_unwrap() };
 
-    // TODO: Move this check into the observer cache to avoid dynamic dispatch
-    let last_trigger = world.last_trigger_id();
-    if state.last_trigger_id == last_trigger {
-        return;
-    }
-    state.last_trigger_id = last_trigger;
+    state.last_trigger_id = world.last_trigger_id();
 
     // SAFETY:
     // - Conditions are initialized during observer registration (hook_on_add)

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -767,6 +767,10 @@ impl<'w> DeferredWorld<'w> {
             let Some(observers) = observers.try_get_observers(event_key) else {
                 return;
             };
+
+            // SAFETY: There are no references to last_trigger_id
+            world.increment_trigger_id();
+
             // SAFETY: The only outstanding reference to world is `observers`
             (world.into_deferred(), observers)
         };


### PR DESCRIPTION
# Objective

This is an alternate PR solution to (https://github.com/bevyengine/bevy/pull/25573) for (https://github.com/bevyengine/bevy/issues/21441)

Fundamental issue is the inability to properly implement a custom `Trigger` due to the lack of public interface to increment `World::last_trigger_id`

The original (and simplest) fix (https://github.com/bevyengine/bevy/pull/25573) was to make `UnsafeWorldCell::increment_trigger_id` public.  I believe that is a bandage over an underlying mis-alignment of responsibilities and that this PR is a better alternative.

Problems with that solution :
- Exposes an unsafe API
- Maintains a hidden requirement on all custom `Trigger` implementations to increment the `last_trigger_id` or fail silently and/or erratically.  

Issues with current implementation : 
- Requires non-obvious work-around if you want to execute your observers multiple times per trigger, like `PropagateEntityTrigger` does.
- `last_trigger_id` is opaque in what it represents, as some triggers update it once, and others multiple times per invocation.
- As noted in a `TODO` in `observer_system_runner`,  a dynamic dispatch is done to the runner, even if it is going to abort its execution.

Reasons for change: 

The [Trigger](https://docs.rs/bevy/latest/bevy/ecs/event/trait.Trigger.html) trait documentation states a trigger's  responsibility 
is: 

> Trigger determines how an Event is triggered when World::trigger is called. This decides which Observers will run, what data gets passed to them, and the order they will be executed in.

As we see in both the current behavior of  `PropagateEntityTrigger` and the docs, the logic to decide if an observer should run multiple times per trigger should be moved from `observer_system_runner` to the `Trigger`.

## Solution

1. Move the responsibility of incrementing `last_trigger_id` from the trigger to the call sites of triggers. 
2. Move the responsibility of determining if a runner should execute from `observer_system_runner` to the trigger.

Benefits :
- `UnsafeWorldCell::increment_trigger_id`  no longer needs to be made `pub`.
- Triggers (both internal and custom) no longer need to be responsible for calling `UnsafeWorldCell::increment_trigger_id`  to work properly.

Drawbacks: 
- Triggers have to implement (simple) logic to prevent duplicate runner execution. (See unanswered questions below)
- Any new trigger call sites need to increment `last_trigger_id`.

As this is my first PR into the internals of bevy there was some uncertainty in these changes on my part. 

Unanswered questions:
1. How relevant is duplicate observer invocation checking for global and entity observers? It's implemented in the PR to maintain current behavior, but I *believe* it may only be relevant for component observers?
2.  Is `debug_checked_unwrap()` ok to use here? The pattern was taken from the runner code, but I'm unsure if it's the correct check.
3. Are there any concerns around dynamic events I may not be appreciating? 
4. Is the additional `world.get::<Observer>()` per observer any kind of performance concern?
5. Since only internals were update, are there any additional unit tests needed?