### PR TITLE
Fix empty bundle effect in `Bundle` derive macro

### DIFF
--- a/crates/bevy_ecs/compile_fail/tests/ui/bundle_on_drop_impl.rs
+++ b/crates/bevy_ecs/compile_fail/tests/ui/bundle_on_drop_impl.rs
@@ -6,6 +6,7 @@ pub struct A(usize);
 // this should fail since destructuring T: Drop cannot be split.
 #[derive(Bundle, Debug)]
 //~^ E0509
+//~^^ E0509
 pub struct DropBundle {
     component_a: A,
 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -158,7 +158,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
 
     let dynamic_bundle_impl = quote! {
         impl #impl_generics #ecs_path::bundle::DynamicBundle for #struct_name #ty_generics #where_clause {
-            type Effect = ();
+            type Effect = Self;
             #[allow(unused_variables)]
             #[allow(non_snake_case, reason = "deconstruct_moving_ptr uses #active_field_locals as a local binding name")]
             #[inline]
@@ -179,14 +179,41 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
                 )*
             }
 
-            #[allow(unused_variables)]
+            #[allow(unused_variables, unused_unsafe)]
+            #[allow(non_snake_case, reason = "deconstruct_moving_ptr uses #active_field_locals as a local binding name")]
             #[inline]
             unsafe fn apply_effect(
                 ptr: #ecs_path::ptr::MovingPtr<'_, ::core::mem::MaybeUninit<Self>>,
-                func: &mut #ecs_path::world::EntityWorldMut<'_>,
+                entity: &mut #ecs_path::world::EntityWorldMut<'_>,
             ) {
+                #ecs_path::ptr::deconstruct_moving_ptr!({
+                    let MaybeUninit::<Self> { #(#active_field_members: #active_field_locals,)* #(#inactive_field_members: _,)* } = ptr;
+                });
+                // SAFETY: Ensured by caller.
+                unsafe {
+                    #(
+                        <#active_field_types as #ecs_path::bundle::DynamicBundle>::apply_effect(
+                            #active_field_locals,
+                            entity
+                        );
+                    )*
+                }
             }
         }
+    };
+
+    let mut no_bundle_effect_where_clause =
+        where_clause.cloned().unwrap_or_else(|| syn::WhereClause {
+            where_token: Default::default(),
+            predicates: Default::default(),
+        });
+    no_bundle_effect_where_clause
+        .predicates
+        .extend(active_field_types.iter().map(|t| -> syn::WherePredicate {
+            parse_quote! { for<'__a> <#t as #ecs_path::bundle::DynamicBundle>::Effect: #ecs_path::bundle::NoBundleEffect }
+        }));
+    let no_bundle_effect_impl = quote! {
+        impl #impl_generics #ecs_path::bundle::NoBundleEffect for #struct_name #ty_generics #no_bundle_effect_where_clause {}
     };
 
     let fqdefault = FQDefault.into_token_stream();
@@ -210,6 +237,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
         #bundle_impl
         #from_components_impl
         #dynamic_bundle_impl
+        #no_bundle_effect_impl
     })
 }
 


### PR DESCRIPTION
# Objective

- Fix empty bundle effect in the `Bundle` trait implementation generated by `#[derive(Bundle)]` macro.
- Fixes #22756.

## Solution

- Added a proper `apply_effect()` implementation.
- `NoBundleEffect` is implemented separately to prevent leaking private component types outside.

## Testing

- The following code now works as expected:
```rust
use bevy::{ecs::spawn::SpawnOneRelated, prelude::*};

#[derive(Bundle)]
#[bundle(ignore_from_components)]
pub struct MyBundle(
    MyPrivateComponent, // ← Not pub type, but compiles okay.
    SpawnOneRelated<ChildOf, MyChildComponent>,
);

impl Default for MyBundle {
    fn default() -> Self {
        Self(MyPrivateComponent, Children::spawn_one(MyChildComponent))
    }
}

#[derive(Component)]
struct MyPrivateComponent;

#[derive(Component)]
struct MyChildComponent;

fn setup(mut commands: Commands) {
    commands.spawn(MyBundle::default());

    // ↓ Error: unsatisfied `NoBundleEffect` bound.
    // commands.spawn_batch([MyBundle::default()]);
}

fn check_child_exists(_: Populated<(), Added<MyChildComponent>>) {
    // ↓ This should be printed.
    eprintln!("MyChildComponent spawns okay");
}

fn main() {
    App::new()
        .add_systems(Startup, setup)
        .add_systems(Update, check_child_exists)
        .run();
}
```