### PR TITLE
made RegisteredSystem public

### DIFF
--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -29,7 +29,7 @@ pub struct RegisteredSystem<I, O> {
 }
 
 impl<I, O> RegisteredSystem<I, O> {
-    /// Create an uninitialized RegisteredSystem component with the provided boxed system
+    /// Create an uninitialized [`RegisteredSystem`] component with the provided boxed system
     pub fn new(system: BoxedSystem<I, O>) -> Self {
         RegisteredSystem {
             initialized: false,

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -29,6 +29,7 @@ pub struct RegisteredSystem<I, O> {
 }
 
 impl<I, O> RegisteredSystem<I, O> {
+    /// Create an uninitialized RegisteredSystem component with the provided boxed system
     pub fn new(system: BoxedSystem<I, O>) -> Self {
         RegisteredSystem {
             initialized: false,

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 /// A small wrapper for [`BoxedSystem`] that also keeps track whether or not the system has been initialized.
 #[derive(Component)]
 #[require(SystemIdMarker = SystemIdMarker::typed_system_id_marker::<I, O>())]
-pub(crate) struct RegisteredSystem<I, O> {
+pub struct RegisteredSystem<I, O> {
     initialized: bool,
     system: Option<BoxedSystem<I, O>>,
 }


### PR DESCRIPTION
# Objective

- Encountered a situation where I would need to construct RegisteredSystem without command/world access

## Solution

- made RegisteredSystem public

## Testing

- untested (1 line, only vis-modifier changed)

---

## Concerns
The `RegisteredSystem` struct might have been made `pub(crate)` to allow the internal API to structure and `RegisteredSystem::new` method to change. If this is the case, it should be stated clearly in a doc comment
