### PR TITLE
Updated `handle_delayed_save` to use `Res<Time<Real>>` instead of `Res<Time>`.

### DIFF
--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -30,7 +30,7 @@ mod store_fs;
 #[cfg(target_arch = "wasm32")]
 mod store_wasm;
 
-use bevy_time::{Time, Timer, TimerMode};
+use bevy_time::{Real, Time, Timer, TimerMode};
 use serde::de::DeserializeSeed;
 #[cfg(not(target_arch = "wasm32"))]
 use store_fs::SettingsStore;
@@ -612,7 +612,7 @@ fn load_properties(value: &toml::Value, resource: &mut dyn PartialReflect, types
 
 fn handle_delayed_save(
     mut settings: ResMut<SettingsFileRegistry>,
-    time: Res<Time>,
+    time: Res<Time<Real>>,
     mut commands: Commands,
 ) {
     settings.save_timer.tick(time.delta());

--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -624,8 +624,9 @@ fn handle_delayed_save(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy_ecs::change_detection::Tick;
+    use bevy_ecs::{change_detection::Tick, schedule::Schedule};
     use bevy_reflect::Reflect;
+    use bevy_time::Virtual;
     // Required to make proc macros work in bevy itself.
     extern crate self as bevy_settings;
 
@@ -1077,5 +1078,37 @@ mod tests {
         // Verify refresh_rate was preserved
         let refresh_rate = world.get_resource::<CounterRefreshRateSettings>().unwrap();
         assert_eq!(*refresh_rate, CounterRefreshRateSettings::Fast);
+    }
+
+    #[test]
+    fn test_handle_delayed_save_ticks_with_real_time_while_paused() {
+        let mut world = World::new();
+        world.insert_resource(Time::<Real>::default());
+        world.insert_resource(Time::<Virtual>::default());
+        // Virtual time is paused, so the delayed save timer must use real time.
+        world.resource_mut::<Time<Virtual>>().pause();
+
+        // SettingsFileRegistry with a delayed save timer
+        world.insert_resource(SettingsFileRegistry {
+            app_name: "test_app".to_string(),
+            files: HashMap::new(),
+            save_timer: {
+                let mut timer = Timer::new(Duration::from_millis(500), TimerMode::Once);
+                timer.unpause();
+                timer
+            },
+        });
+
+        // Simulate real time advancing
+        world
+            .resource_mut::<Time<Real>>()
+            .advance_by(Duration::from_millis(600));
+
+        let mut schedule = Schedule::default();
+        schedule.add_systems(handle_delayed_save);
+        schedule.run(&mut world);
+
+        let registry = world.resource::<SettingsFileRegistry>();
+        assert!(registry.save_timer.just_finished());
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #25571

## Solution

- Made the change as described in the title.
- This ensures the delayed save timer ticks using real elapsed time rather than virtual game time, allowing settings to save even when the game is paused.

## Testing

- Verified that it works correctly through manual testing using the reproduction code below.

### Reproduction code
```rust
//! issue_25571

use std::time::Duration;

use bevy::{
    prelude::*,
    settings::{ReflectSettingsGroup, SaveSettingsDeferred, SettingsGroup, SettingsPlugin},
};

fn main() {
    App::new()
        .add_plugins((DefaultPlugins, SettingsPlugin::new("issue_25571")))
        .add_systems(Startup, setup)
        .add_systems(Update, trigger_save)
        .run();
}

#[derive(Resource, SettingsGroup, Reflect, Default)]
#[reflect(Resource, SettingsGroup, Default)]
struct MySettings {
    volume: f32,
}

fn setup(mut settings: ResMut<MySettings>, mut time: ResMut<Time<Virtual>>) {
    settings.volume = 0.5;
    time.pause();
}

fn trigger_save(mut commands: Commands, mut executed: Local<bool>) {
    if !*executed {
        commands.queue(SaveSettingsDeferred(Duration::from_secs(1)));
        *executed = true;
    }
}

``` 

### Output
```toml
[my_settings]
volume = 0.5
``` 