### PR TITLE
Implement Send/Sync non-structurally for wgpu wrapper types

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -119,6 +119,7 @@ itertools = "0.14"
 weak-table = "0.3"
 tracing = "0.1"
 static_assertions = "1"
+non_structural_derive = "0.1"
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/bevy_render/src/diagnostic/internal.rs
+++ b/crates/bevy_render/src/diagnostic/internal.rs
@@ -40,6 +40,7 @@ struct DiagnosticsRecorderInternal {
 /// Records diagnostics into [`QuerySet`]'s keeping track of the mapping between
 /// spans and indices to the corresponding entries in the [`QuerySet`].
 #[derive(Resource)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct DiagnosticsRecorder(WgpuWrapper<DiagnosticsRecorderInternal>);
 
 impl DiagnosticsRecorder {

--- a/crates/bevy_render/src/error_handler.rs
+++ b/crates/bevy_render/src/error_handler.rs
@@ -86,6 +86,7 @@ impl Default for RenderErrorHandler {
 /// An error encountered during rendering. These are errors reported by wgpu validation layers,
 /// and typically indicate problems in the way it is being used.
 #[derive(Debug)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct RenderError {
     pub ty: ErrorType,
     pub description: String,
@@ -107,6 +108,7 @@ pub(crate) enum RenderState {
 
 /// Resource to allow polling wgpu error handlers.
 #[derive(Resource)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub(crate) struct DeviceErrorHandler {
     device_lost: Arc<Mutex<Option<(wgpu::DeviceLostReason, String)>>>,
     uncaptured: Arc<Mutex<Option<WgpuWrapper<wgpu::Error>>>>,

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -35,6 +35,7 @@ define_atomic_id!(BindGroupId);
 ///
 /// Can be created via [`RenderDevice::create_bind_group`](RenderDevice::create_bind_group).
 #[derive(Clone, Debug)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct BindGroup {
     id: BindGroupId,
     value: WgpuWrapper<wgpu::BindGroup>,

--- a/crates/bevy_render/src/render_resource/bind_group_layout.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_layout.rs
@@ -13,6 +13,7 @@ define_atomic_id!(BindGroupLayoutId);
 ///
 /// Can be created via [`RenderDevice::create_bind_group_layout`](crate::renderer::RenderDevice::create_bind_group_layout).
 #[derive(Clone, Debug)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct BindGroupLayout {
     id: BindGroupLayoutId,
     value: WgpuWrapper<wgpu::BindGroupLayout>,

--- a/crates/bevy_render/src/render_resource/buffer.rs
+++ b/crates/bevy_render/src/render_resource/buffer.rs
@@ -5,6 +5,7 @@ use core::ops::{Deref, RangeBounds};
 define_atomic_id!(BufferId);
 
 #[derive(Clone, Debug)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct Buffer {
     id: BufferId,
     value: WgpuWrapper<wgpu::Buffer>,

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -9,6 +9,7 @@ define_atomic_id!(RenderPipelineId);
 /// May be converted from and dereferences to a wgpu [`RenderPipeline`](wgpu::RenderPipeline).
 /// Can be created via [`RenderDevice::create_render_pipeline`](crate::renderer::RenderDevice::create_render_pipeline).
 #[derive(Clone, Debug)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct RenderPipeline {
     id: RenderPipelineId,
     value: WgpuWrapper<wgpu::RenderPipeline>,
@@ -46,6 +47,7 @@ define_atomic_id!(ComputePipelineId);
 /// May be converted from and dereferences to a wgpu [`ComputePipeline`](wgpu::ComputePipeline).
 /// Can be created via [`RenderDevice::create_compute_pipeline`](crate::renderer::RenderDevice::create_compute_pipeline).
 #[derive(Clone, Debug)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct ComputePipeline {
     id: ComputePipelineId,
     value: WgpuWrapper<wgpu::ComputePipeline>,

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -90,6 +90,7 @@ type LayoutCacheKey = (
     ImmediateSize,
 );
 #[derive(Default)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 struct LayoutCache {
     layouts: HashMap<LayoutCacheKey, Arc<WgpuWrapper<PipelineLayout>>>,
 }
@@ -208,6 +209,7 @@ impl BindGroupLayoutCache {
 ///
 /// [`RenderSystems::Render`]: crate::RenderSystems::Render
 #[derive(Resource)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct PipelineCache {
     layout_cache: Arc<Mutex<LayoutCache>>,
     bindgroup_layout_cache: Arc<Mutex<BindGroupLayoutCache>>,

--- a/crates/bevy_render/src/render_resource/texture.rs
+++ b/crates/bevy_render/src/render_resource/texture.rs
@@ -24,6 +24,7 @@ define_atomic_id!(TextureId);
 /// * [`StorageBuffer`](crate::render_resource::StorageBuffer)
 /// * [`UniformBuffer`](crate::render_resource::UniformBuffer)
 #[derive(Clone, Debug)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct Texture {
     id: TextureId,
     value: WgpuWrapper<wgpu::Texture>,
@@ -64,11 +65,13 @@ define_atomic_id!(TextureViewId);
 
 /// Describes a [`Texture`] with its associated metadata required by a pipeline or [`BindGroup`](super::BindGroup).
 #[derive(Clone, Debug)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct TextureView {
     id: TextureViewId,
     value: WgpuWrapper<wgpu::TextureView>,
 }
 
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct SurfaceTexture {
     value: WgpuWrapper<wgpu::SurfaceTexture>,
 }
@@ -130,6 +133,7 @@ define_atomic_id!(SamplerId);
 /// May be converted from and dereferences to a wgpu [`Sampler`](wgpu::Sampler).
 /// Can be created via [`RenderDevice::create_sampler`](crate::renderer::RenderDevice::create_sampler).
 #[derive(Clone, Debug)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct Sampler {
     id: SamplerId,
     value: WgpuWrapper<wgpu::Sampler>,

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -140,19 +140,23 @@ pub fn render_system(
 
 /// This queue is used to enqueue tasks for the GPU to execute asynchronously.
 #[derive(Resource, Clone, Deref, DerefMut)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct RenderQueue(pub Arc<WgpuWrapper<Queue>>);
 
 /// The handle to the physical device being used for rendering.
 /// See [`Adapter`] for more info.
 #[derive(Resource, Clone, Debug, Deref, DerefMut)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct RenderAdapter(pub Arc<WgpuWrapper<Adapter>>);
 
 /// The GPU instance is used to initialize the [`RenderQueue`] and [`RenderDevice`],
 #[derive(Resource, Clone, Deref, DerefMut)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct RenderInstance(pub Arc<WgpuWrapper<Instance>>);
 
 /// The [`AdapterInfo`] of the adapter in use by the renderer.
 #[derive(Resource, Clone, Deref, DerefMut)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct RenderAdapterInfo(pub WgpuWrapper<AdapterInfo>);
 
 const GPU_NOT_FOUND_ERROR_MESSAGE: &str = if cfg!(target_os = "linux") {

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -37,6 +37,7 @@ enum PendingCommandBuffer {
 
 /// A resource that holds command buffers and encoders that are pending submission to the render queue.
 #[derive(Resource)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct PendingCommandBuffers(WgpuWrapper<PendingCommandBuffersInner>);
 
 impl Default for PendingCommandBuffers {
@@ -166,6 +167,7 @@ impl RenderContextStateInner {
 /// This is used internally by the [`RenderContext`] system parameter. Implements [`SystemBuffer`] to
 /// append command buffers and unfinished encoders in topological system order. Pending encoders are
 /// finished in parallel immediately before submission.
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct RenderContextState(WgpuWrapper<RenderContextStateInner>);
 
 impl Default for RenderContextState {

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -12,6 +12,7 @@ use wgpu::{
 
 /// This GPU device is responsible for the creation of most rendering and compute resources.
 #[derive(Resource, Clone)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct RenderDevice {
     device: WgpuWrapper<wgpu::Device>,
 }

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -210,6 +210,7 @@ fn extract_windows(
 }
 
 #[derive(Component)]
+#[non_structural_derive::non_structural_derive(Send, Sync)]
 pub struct SurfaceData {
     // TODO: what lifetime should this be?
     surface: WgpuWrapper<wgpu::Surface<'static>>,


### PR DESCRIPTION
# Objective

- Improve compile times in bevy_render
- Helps with https://github.com/bevyengine/bevy/issues/25511
- This is an alternative to #25512 with roughly the same compilation time improvements

## Solution

- Use `non_structural_derive` to short-circuit the `Send`/`Sync` checking
- Compared to #25512 this is not a breaking change, however it is less robust: we might unintentionally add a new wgpu wrapper type without the non-structural annotation, and this would regress without visible errors. It also requires an additional dependency (or a bunch of boilerplate to do it ourselves)
  - This could be used for a non-breaking 0.19.2 update, while picking #25512 as a more robust solution for 0.20

## Testing

Not needed


<details>
  <summary>Click to view showcase</summary>

```rust
println!("My super cool code.");
```

</details>
