### PR TITLE
Build the skybox ray from the main pass viewport

### DIFF
--- a/crates/bevy_core_pipeline/src/skybox/skybox.wesl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wesl
@@ -74,7 +74,7 @@ fn skybox_vertex(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
 
 @fragment
 fn skybox_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
-    let ray_direction = coords_to_ray_direction(in.position.xy, view.viewport);
+    let ray_direction = coords_to_ray_direction(in.position.xy, view.main_pass_viewport);
 
     // Cube maps are left-handed so we negate the z coordinate.
     let out = textureSample(skybox, skybox_sampler, ray_direction * vec3(1.0, 1.0, -1.0));


### PR DESCRIPTION
# Objective

- The skybox is drawn in the wrong direction when a `MainPassResolutionOverride` is active (DLSS), because it maps fragments through `view.viewport`, which holds the output size rather than the render size the main pass runs at.

## Solution

- Build the ray from `view.main_pass_viewport`, like the other main pass shaders.

## Testing

- Tested in an example app with DLSS enabled.

---

Used Claude & Fable in the process of finding this while working on other things
