### PR TITLE
make ScheduleConfigs must_use

### DIFF
--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -96,6 +96,7 @@ pub struct ScheduleConfig<T: Schedulable> {
 }
 
 /// Single or nested configurations for [`Schedulable`]s.
+#[must_use]
 pub enum ScheduleConfigs<T: Schedulable> {
     /// Configuration for a single [`Schedulable`].
     ScheduleConfig(ScheduleConfig<T>),

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1799,7 +1799,8 @@ mod tests {
         assert_is_system(exclusive_with_state);
         assert_is_system(returning::<bool>.pipe(exclusive_in_out::<bool, ()>));
 
-        returning::<()>.run_if(returning::<bool>.pipe(not));
+        // check that this compiles
+        let _ = returning::<()>.run_if(returning::<bool>.pipe(not));
     }
 
     #[test]


### PR DESCRIPTION
# Objective

- #25591 removes a floating ScheduleConfigs that was unnoticed. This will make it more obvious.

## Solution

- Annotate `ScheduleConfigs` as `must_use`

## Testing

- checked that the line in #25591 triggers 