### PR TITLE
Fix missing view shader import in deferred SSAO lighting

### DIFF
--- a/crates/bevy_pbr/src/deferred/deferred_lighting.wesl
+++ b/crates/bevy_pbr/src/deferred/deferred_lighting.wesl
@@ -4,7 +4,7 @@ import package::{
         pbr_types::STANDARD_MATERIAL_FLAGS_UNLIT_BIT,
         pbr_functions,
         pbr_lighting as lighting,
-        mesh_view_bindings::deferred_prepass_texture,
+        mesh_view_bindings::{deferred_prepass_texture, view},
     },
     deferred::{
         functions::pbr_input_from_deferred_gbuffer,
@@ -86,4 +86,3 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
 
     return output_color;
 }
-


### PR DESCRIPTION
# Objective

Fix a shader validation error in deferred rendering when SSAO is enabled. This is a regression from [#25319](https://github.com/bevyengine/bevy/commit/c943247294b2b3ce78460b9f250a02c937bd2901).

```text
Shader '' parsing error: no definition in scope for identifier: `view`
  ┌─ wgsl:32:55
  │
32 │         let ssao_tex_pos = vec2<i32>(in.position.xy - view.viewport.xy);
  │                                                       ^^^^ unknown identifier
```

## Solution

Import `view` from `mesh_view_bindings` in `deferred_lighting.wesl`, where `view.viewport` is used to sample the SSAO texture.

## Testing

- `cargo run --example ssr --features="bluenoise_texture bevy_feathers"`
