### PR TITLE
Take `impl Fn() -> C` as constructors for required components

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1027,7 +1027,7 @@ impl App {
     /// ```
     pub fn register_required_components_with<T: Component, R: Component>(
         &mut self,
-        constructor: fn() -> R,
+        constructor: impl Fn() -> R + 'static,
     ) -> &mut Self {
         self.world_mut()
             .register_required_components_with::<T, R>(constructor);
@@ -1157,7 +1157,7 @@ impl App {
     /// ```
     pub fn try_register_required_components_with<T: Component, R: Component>(
         &mut self,
-        constructor: fn() -> R,
+        constructor: impl Fn() -> R + 'static,
     ) -> Result<(), RequiredComponentsError> {
         self.world_mut()
             .try_register_required_components_with::<T, R>(constructor)

--- a/crates/bevy_ecs/src/component/required.rs
+++ b/crates/bevy_ecs/src/component/required.rs
@@ -362,7 +362,7 @@ impl Components {
         &mut self,
         requiree: ComponentId,
         required: ComponentId,
-        constructor: fn() -> R,
+        constructor: impl Fn() -> R + 'static,
     ) -> Result<(), RequiredComponentsError> {
         // First step: validate inputs and return errors.
 
@@ -613,7 +613,7 @@ impl<'a, 'w> RequiredComponentsRegistrator<'a, 'w> {
     pub unsafe fn register_required_by_id<C: Component>(
         &mut self,
         component_id: ComponentId,
-        constructor: fn() -> C,
+        constructor: impl Fn() -> C + 'static,
     ) {
         // SAFETY:
         // - the caller guarantees `component_id` is a valid component in `components` for `C`;

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -461,7 +461,7 @@ impl World {
     /// ```
     pub fn register_required_components_with<T: Component, R: Component>(
         &mut self,
-        constructor: fn() -> R,
+        constructor: impl Fn() -> R + 'static,
     ) {
         self.try_register_required_components_with::<T, R>(constructor)
             .unwrap();
@@ -572,7 +572,7 @@ impl World {
     /// ```
     pub fn try_register_required_components_with<T: Component, R: Component>(
         &mut self,
-        constructor: fn() -> R,
+        constructor: impl Fn() -> R + 'static,
     ) -> Result<(), RequiredComponentsError> {
         let requiree = self.register_component::<T>();
 


### PR DESCRIPTION
# Objective

We currently use function pointers (`fn() -> C`) for required component constructors even when a `impl Fn() -> C + 'static` would work.

## Solution

Take any callable instead of just function pointers in `register_required_components_with` and it's ilk. 

There's only on real reason why we shouldn't do this and that is how much code we generate. Thing is, in general we expect each `component -> component` requirement to be registered only once and the given methods are already generic over both component types so make the constructor generic won't increase the number of instantiations.

Just in case I compiled `alien_cake_addict` on `main` and on this branch and the binary size difference was less than a one hundredth of a percent.

I don't think this is a breaking change. The number of types `register_required_components_with` has strictly increased and I don't see a way for type inference to depend on the difference between `fn()` and `impl Fn()`.

## Testing

Both `alien_cake_addict` and `mines` compiled and ran successfully.
