### PR TITLE
Copy the deferred lighting ID after the prepass set

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -150,10 +150,15 @@ impl Plugin for Core3dPlugin {
                         early_deferred_prepass,
                         late_prepass,
                         late_deferred_prepass,
-                        copy_deferred_lighting_id,
                     )
                         .chain()
                         .in_set(Core3dSystems::Prepass),
+                    // The lighting-ID texture is a snapshot of the completed deferred
+                    // prepass. Keep the copy outside the `Prepass` set so custom prepass
+                    // producers (such as the meshlet G-buffer pass) cannot race it.
+                    copy_deferred_lighting_id
+                        .after(Core3dSystems::Prepass)
+                        .before(Core3dSystems::MainPass),
                     (main_opaque_pass_3d, main_transparent_pass_3d)
                         .chain()
                         .in_set(Core3dSystems::MainPass),


### PR DESCRIPTION
# Objective

`copy_deferred_lighting_id` runs inside the `Core3dSystems::Prepass` set, but other systems in that set also write the G-buffer, such as `meshlet_deferred_gbuffer_prepass`. The schedule does not order the copy against them, so the copy can read an incomplete G-buffer.

## Solution

Order the copy after the whole prepass set instead of inside it.

## Testing

I tested these changes as part of a larger app.

---

Used Claude & Fable in the process of working on meshlets for the Zorah demo scene
