### PR TITLE
Panic safe component drop through abort

### DIFF
--- a/crates/bevy_ecs/src/bundle/info.rs
+++ b/crates/bevy_ecs/src/bundle/info.rs
@@ -4,7 +4,7 @@ use bevy_platform::{
     hash::FixedHasher,
 };
 use bevy_ptr::{MovingPtr, OwningPtr};
-use bevy_utils::TypeIdHashMap;
+use bevy_utils::{AbortOnPanic, TypeIdHashMap};
 use core::{any::TypeId, ptr::NonNull};
 use indexmap::{IndexMap, IndexSet};
 
@@ -260,6 +260,10 @@ impl BundleInfo {
             };
             // SAFETY: bundle_component is a valid index per unsafe bundle impl
             let status = unsafe { bundle_component_status.get_status(bundle_component) };
+            // Overwriting a component can cause the previous value to get dropped,
+            // which may panic, in which case our World will end up in an inconsistent state
+            // and being able to use it again would be unsound.
+            let guard = AbortOnPanic;
             match storage_type {
                 StorageType::Table => {
                     let column =
@@ -307,6 +311,7 @@ impl BundleInfo {
                     }
                 }
             }
+            core::mem::forget(guard);
             bundle_component += 1;
         });
         // Remove this once closure_lifetime_binder is stable

--- a/crates/bevy_ecs/src/bundle/remove.rs
+++ b/crates/bevy_ecs/src/bundle/remove.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 use bevy_ptr::ConstNonNull;
+use bevy_utils::AbortOnPanic;
 use core::ptr::NonNull;
 
 use crate::{
@@ -241,6 +242,9 @@ impl<'w> BundleRemover<'w> {
                 // Make sure to drop components stored in sparse sets.
                 // Dense components are dropped later in `move_to_and_drop_missing_unchecked`.
                 if let Some(StorageType::SparseSet) = old_archetype.get_storage_type(component_id) {
+                    // If the drop panics, our World will end up in an inconsistent state
+                    // and being able to use it again would be unsound.
+                    let guard = AbortOnPanic;
                     world
                         .storages
                         .sparse_sets
@@ -249,6 +253,7 @@ impl<'w> BundleRemover<'w> {
                         .unwrap()
                         // If it was already forgotten, it would not be in the set.
                         .remove(entity);
+                    core::mem::forget(guard);
                 }
             }
         }

--- a/crates/bevy_ecs/src/storage/blob_array.rs
+++ b/crates/bevy_ecs/src/storage/blob_array.rs
@@ -1,6 +1,6 @@
 use alloc::alloc::handle_alloc_error;
 use bevy_ptr::{OwningPtr, Ptr, PtrMut};
-use bevy_utils::OnDrop;
+use bevy_utils::AbortOnPanic;
 use core::{alloc::Layout, cell::UnsafeCell, num::NonZeroUsize, ptr::NonNull};
 
 use crate::query::DebugCheckedUnwrap;
@@ -179,6 +179,9 @@ impl BlobArray {
     ///
     /// Note that this method will behave exactly the same as [`Vec::clear`].
     ///
+    /// # Panics
+    /// This function may panic.
+    ///
     /// # Safety
     /// - For every element with index `i`, if `i` < `len`: It must be safe to call [`Self::get_unchecked_mut`] with `i`.
     ///   (If the safety requirements of every method that has been used on `Self` have been fulfilled, the caller just needs to ensure that `len` is correct.)
@@ -188,9 +191,6 @@ impl BlobArray {
         #[cfg(debug_assertions)]
         debug_assert!(self.capacity >= len);
         if let Some(drop) = self.drop {
-            // We set `self.drop` to `None` before dropping elements for unwind safety. This ensures we don't
-            // accidentally drop elements twice in the event of a drop impl panicking.
-            self.drop = None;
             let size = self.item_layout.size();
             for i in 0..len {
                 // SAFETY:
@@ -202,12 +202,14 @@ impl BlobArray {
                 // SAFETY: `item` was obtained from this `BlobArray`, so its underlying type must match `drop`.
                 unsafe { drop(item) };
             }
-            self.drop = Some(drop);
         }
     }
 
     /// Because this method needs parameters, it can't be the implementation of the `Drop` trait.
     /// The owner of this [`BlobArray`] must call this method with the correct information.
+    ///
+    /// # Panics
+    /// This function may panic.
     ///
     /// # Safety
     /// - `cap` and `len` are indeed the capacity and length of this [`BlobArray`]
@@ -231,6 +233,9 @@ impl BlobArray {
 
     /// Drops the last element in this [`BlobArray`].
     ///
+    /// # Panics
+    /// This function may panic.
+    ///
     /// # Safety
     // - `last_element_index` must correspond to the last element in the array.
     // - After this method is called, the last element must not be used
@@ -239,14 +244,10 @@ impl BlobArray {
         #[cfg(debug_assertions)]
         debug_assert!(self.capacity > last_element_index);
         if let Some(drop) = self.drop {
-            // We set `self.drop` to `None` before dropping elements for unwind safety. This ensures we don't
-            // accidentally drop elements twice in the event of a drop impl panicking.
-            self.drop = None;
             // SAFETY:
             let item = self.get_unchecked_mut(last_element_index).promote();
             // SAFETY:
             unsafe { drop(item) };
-            self.drop = Some(drop);
         }
     }
 
@@ -379,6 +380,9 @@ impl BlobArray {
 
     /// Replaces the value at `index` with `value`. This function does not do any bounds checking.
     ///
+    /// # Panics
+    /// Does not panic. Aborts the execution if the component drop function panics.
+    ///
     /// # Safety
     /// - Index must be in-bounds (`index` < `len`)
     /// - `value`'s [`Layout`] must match this [`BlobArray`]'s `item_layout`,
@@ -393,40 +397,23 @@ impl BlobArray {
         let source = value.as_ptr();
 
         if let Some(drop) = self.drop {
-            // We set `self.drop` to `None` before dropping elements for unwind safety. This ensures we don't
-            // accidentally drop elements twice in the event of a drop impl panicking.
-            self.drop = None;
-
+            let guard = AbortOnPanic;
             // Transfer ownership of the old value out of the vector, so it can be dropped.
             // SAFETY:
             // - `destination` was obtained from a `PtrMut` in this vector, which ensures it is non-null,
             //   well-aligned for the underlying type, and has proper provenance.
             // - The storage location will get overwritten with `value` later, which ensures
             //   that the element will not get observed or double dropped later.
-            // - If a panic occurs, `self.len` will remain `0`, which ensures a double-drop
-            //   does not occur. Instead, all elements will be forgotten.
             let old_value = unsafe { OwningPtr::new(destination) };
-
-            // This closure will run in case `drop()` panics,
-            // which ensures that `value` does not get forgotten.
-            let on_unwind = OnDrop::new(|| drop(value));
-
             drop(old_value);
-
-            // If the above code does not panic, make sure that `value` doesn't get dropped.
-            core::mem::forget(on_unwind);
-
-            self.drop = Some(drop);
+            core::mem::forget(guard);
         }
 
         // Copy the new value into the vector, overwriting the previous value.
         // SAFETY:
-        // - `source` and `destination` were obtained from `OwningPtr`s, which ensures they are
-        //   valid for both reads and writes.
-        // - The value behind `source` will only be dropped if the above branch panics,
-        //   so it must still be initialized and it is safe to transfer ownership into the vector.
-        // - `source` and `destination` were obtained from different memory locations,
-        //   both of which we have exclusive access to, so they are guaranteed not to overlap.
+        // `source` and `destination` were obtained from `OwningPtr`s, which ensures they
+        // - are valid for both reads and writes
+        // - don't overlap.
         unsafe {
             core::ptr::copy_nonoverlapping::<u8>(
                 source,
@@ -498,6 +485,9 @@ impl BlobArray {
 
     /// This method will call [`Self::swap_remove_unchecked`] and drop the result.
     ///
+    /// # Panics
+    /// May panic due to component drop function.
+    ///
     /// # Safety
     /// - `index_to_keep` must be safe to access (within the bounds of the length of the array).
     /// - `index_to_remove` must be safe to access (within the bounds of the length of the array).
@@ -523,6 +513,9 @@ impl BlobArray {
     }
 
     /// The same as [`Self::swap_remove_and_drop_unchecked`] but the two elements must non-overlapping.
+    ///
+    /// # Panics
+    /// May panic due to component drop function.
     ///
     /// # Safety
     /// - `index_to_keep` must be safe to access (within the bounds of the length of the array).

--- a/crates/bevy_ecs/src/storage/mod.rs
+++ b/crates/bevy_ecs/src/storage/mod.rs
@@ -64,16 +64,6 @@ impl Storages {
     }
 }
 
-/// Guards against allocator panics. Needs to be `mem::forget`en on success.
-struct AbortOnPanic;
-
-impl Drop for AbortOnPanic {
-    fn drop(&mut self) {
-        // Panicking while unwinding will force an abort.
-        panic!("Aborting due to allocator error");
-    }
-}
-
 /// Unsafe extension functions for `Vec<T>`
 trait VecExtensions<T> {
     /// Removes an element from the vector and returns it.

--- a/crates/bevy_ecs/src/storage/non_send.rs
+++ b/crates/bevy_ecs/src/storage/non_send.rs
@@ -233,9 +233,9 @@ impl NonSendData {
     pub(crate) fn remove_and_drop(&mut self) {
         if self.is_present() {
             self.validate_access();
+            self.is_present = false;
             // SAFETY: There is only one element, and it's always allocated.
             unsafe { self.data.drop_last_element(Self::ROW) };
-            self.is_present = false;
         }
     }
 

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -3,10 +3,11 @@ use crate::{
     component::{ComponentId, ComponentInfo},
     entity::{Entity, EntityIndex},
     query::DebugCheckedUnwrap,
-    storage::{AbortOnPanic, Column, TableRow, VecExtensions},
+    storage::{Column, TableRow, VecExtensions},
 };
 use alloc::{boxed::Box, vec::Vec};
 use bevy_ptr::{OwningPtr, Ptr};
+use bevy_utils::AbortOnPanic;
 use core::{cell::UnsafeCell, hash::Hash, marker::PhantomData, num::NonZero, panic::Location};
 use nonmax::{NonMaxU32, NonMaxUsize};
 
@@ -419,6 +420,9 @@ impl ComponentSparseSet {
     /// Removes (and drops) the entity's component value from the sparse set.
     ///
     /// Returns `true` if `entity` had a component value in the sparse set.
+    ///
+    /// # Panics
+    /// May panic due to component drop function.
     pub(crate) fn remove(&mut self, entity: Entity) -> bool {
         self.sparse
             .remove(entity.index())

--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -4,6 +4,7 @@ use crate::{
     storage::{blob_array::BlobArray, thin_array_ptr::ThinArrayPtr, TableRow},
 };
 use bevy_ptr::{OwningPtr, Ptr, UnsafeCellDeref};
+use bevy_utils::AbortOnPanic;
 use core::{cell::UnsafeCell, mem::needs_drop, num::NonZeroUsize, panic::Location};
 
 /// A type-erased contiguous container for data of a homogeneous type.
@@ -68,8 +69,6 @@ impl Column {
         last_element_index: usize,
         row: TableRow,
     ) {
-        self.data
-            .swap_remove_and_drop_unchecked_nonoverlapping(row.index(), last_element_index);
         self.added_ticks
             .swap_remove_unchecked_nonoverlapping(row.index(), last_element_index);
         self.changed_ticks
@@ -77,6 +76,8 @@ impl Column {
         self.changed_by.as_mut().map(|changed_by| {
             changed_by.swap_remove_unchecked_nonoverlapping(row.index(), last_element_index);
         });
+        self.data
+            .swap_remove_and_drop_unchecked_nonoverlapping(row.index(), last_element_index);
     }
 
     /// Swap-remove the provided row.
@@ -84,6 +85,9 @@ impl Column {
     /// If `DROP` is `true`, the removed element will be dropped as needed.
     ///
     /// If `DROP` is `false`, the removed element will be forgotten.
+    ///
+    /// # Panics
+    /// May panic due to component drop function.
     ///
     /// # Safety
     /// - `last_element_index` must be the index of the last element.
@@ -94,6 +98,13 @@ impl Column {
         last_element_index: usize,
         row: TableRow,
     ) {
+        self.added_ticks
+            .swap_remove_unchecked(row.index(), last_element_index);
+        self.changed_ticks
+            .swap_remove_unchecked(row.index(), last_element_index);
+        self.changed_by.as_mut().map(|changed_by| {
+            changed_by.swap_remove_unchecked(row.index(), last_element_index);
+        });
         if DROP {
             self.data
                 .swap_remove_and_drop_unchecked(row.index(), last_element_index);
@@ -102,13 +113,6 @@ impl Column {
                 .data
                 .swap_remove_unchecked(row.index(), last_element_index);
         }
-        self.added_ticks
-            .swap_remove_unchecked(row.index(), last_element_index);
-        self.changed_ticks
-            .swap_remove_unchecked(row.index(), last_element_index);
-        self.changed_by.as_mut().map(|changed_by| {
-            changed_by.swap_remove_unchecked(row.index(), last_element_index);
-        });
     }
 
     /// Swap-remove and forgets the removed element, but the component at `row` must not be the last element.
@@ -329,17 +333,20 @@ impl Column {
     }
 
     /// Clear all the components from this column.
+    /// Aborts the execution if the component drop function panics.
     ///
     /// # Safety
     /// - `len` must match the actual length of the column
     /// -   The caller must not use the elements this column's data until [`initializing`](Self::initialize) it again (set `len` to 0).
     pub(crate) unsafe fn clear(&mut self, len: usize) {
+        let guard = AbortOnPanic;
         self.added_ticks.clear_elements(len);
         self.changed_ticks.clear_elements(len);
         self.data.clear(len);
         self.changed_by
             .as_mut()
             .map(|changed_by| changed_by.clear_elements(len));
+        core::mem::forget(guard);
     }
 
     /// Because this method needs parameters, it can't be the implementation of the `Drop` trait.

--- a/crates/bevy_ecs/src/storage/table/mod.rs
+++ b/crates/bevy_ecs/src/storage/table/mod.rs
@@ -7,11 +7,12 @@ use crate::{
     component::{ComponentId, ComponentInfo, Components},
     entity::Entity,
     query::DebugCheckedUnwrap,
-    storage::{AbortOnPanic, ImmutableSparseSet, SparseSet},
+    storage::{ImmutableSparseSet, SparseSet},
 };
 use alloc::{boxed::Box, vec, vec::Vec};
 use bevy_platform::collections::HashMap;
 use bevy_ptr::{OwningPtr, Ptr};
+use bevy_utils::AbortOnPanic;
 use core::{
     cell::UnsafeCell,
     num::NonZeroUsize,
@@ -228,6 +229,9 @@ impl Table {
     pub(crate) unsafe fn swap_remove_unchecked(&mut self, row: TableRow) -> Option<Entity> {
         debug_assert!(row.index_u32() < self.entity_count());
         let last_element_index = self.entity_count() - 1;
+        // If dropping the old entity panics, our World will end up in an inconsistent state
+        // and being able to use it again would be unsound.
+        let guard = AbortOnPanic;
         if row.index_u32() != last_element_index {
             // Instead of checking this condition on every `swap_remove` call, we
             // check it here and use `swap_remove_nonoverlapping`.
@@ -251,6 +255,7 @@ impl Table {
                 col.drop_last_component(last_element_index as usize);
             }
         }
+        core::mem::forget(guard);
         let is_last = row.index_u32() == last_element_index;
         self.entities.swap_remove(row.index());
         if is_last {
@@ -795,6 +800,7 @@ impl Tables {
                     );
                 }
             } else {
+                let guard = AbortOnPanic;
                 // SAFETY:
                 // - `last_index` is the index of the last element.
                 // - The caller ensures `row` <= `last_index`.
@@ -803,6 +809,7 @@ impl Tables {
                 unsafe {
                     src_column.swap_remove_unchecked::<DROP>(last_index, row);
                 }
+                core::mem::forget(guard);
             }
         }
 

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -27,6 +27,7 @@ use crate::{
 
 use alloc::vec::Vec;
 use bevy_ptr::{move_as_ptr, MovingPtr, OwningPtr};
+use bevy_utils::AbortOnPanic;
 use core::{any::TypeId, marker::PhantomData, mem::MaybeUninit};
 
 /// A mutable reference to a particular [`Entity`], and the entire world.
@@ -1698,6 +1699,7 @@ impl<'w> EntityWorldMut<'w> {
 
     /// This despawns this entity if it is currently spawned, storing the new [`EntityGeneration`](crate::entity::EntityGeneration) in [`Self::entity`] but not freeing it.
     pub(crate) fn despawn_no_free_with_caller(&mut self, caller: MaybeLocation) {
+        let guard = AbortOnPanic;
         // setup
         let Some(location) = self.location else {
             // If there is no location, we are already despawned
@@ -1862,6 +1864,7 @@ impl<'w> EntityWorldMut<'w> {
         // SAFETY: We just despawned it.
         self.entity = unsafe { self.world.entities.mark_free(self.entity.index(), 1) };
         self.world.flush();
+        core::mem::forget(guard);
     }
 
     /// Despawns the current entity.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -4000,7 +4000,6 @@ impl<T: Default> FromWorld for T {
 }
 
 #[cfg(test)]
-#[expect(clippy::print_stdout, reason = "Allowed in tests.")]
 mod tests {
     use super::{FromWorld, World};
     use crate::{

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -4014,9 +4014,7 @@ mod tests {
         world::{error::EntityMutableFetchError, DeferredWorld},
     };
     use alloc::{
-        borrow::ToOwned,
         string::{String, ToString},
-        sync::Arc,
         vec,
         vec::Vec,
     };
@@ -4025,124 +4023,8 @@ mod tests {
     use bevy_utils::prelude::DebugName;
     use core::{
         any::TypeId,
-        panic,
-        sync::atomic::{AtomicBool, AtomicU32, Ordering},
+        sync::atomic::{AtomicU32, Ordering},
     };
-    use std::{println, sync::Mutex};
-
-    type ID = u8;
-
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    enum DropLogItem {
-        Create(ID),
-        Drop(ID),
-    }
-
-    #[derive(Component)]
-    struct MayPanicInDrop {
-        drop_log: Arc<Mutex<Vec<DropLogItem>>>,
-        expected_panic_flag: Arc<AtomicBool>,
-        should_panic: bool,
-        id: u8,
-    }
-
-    impl MayPanicInDrop {
-        fn new(
-            drop_log: &Arc<Mutex<Vec<DropLogItem>>>,
-            expected_panic_flag: &Arc<AtomicBool>,
-            should_panic: bool,
-            id: u8,
-        ) -> Self {
-            println!("creating component with id {id}");
-            drop_log.lock().unwrap().push(DropLogItem::Create(id));
-
-            Self {
-                drop_log: Arc::clone(drop_log),
-                expected_panic_flag: Arc::clone(expected_panic_flag),
-                should_panic,
-                id,
-            }
-        }
-    }
-
-    impl Drop for MayPanicInDrop {
-        fn drop(&mut self) {
-            println!("dropping component with id {}", self.id);
-
-            {
-                let mut drop_log = self.drop_log.lock().unwrap();
-                drop_log.push(DropLogItem::Drop(self.id));
-                // Don't keep the mutex while panicking, or we'll poison it.
-                drop(drop_log);
-            }
-
-            if self.should_panic {
-                self.expected_panic_flag.store(true, Ordering::SeqCst);
-                panic!("testing what happens on panic inside drop");
-            }
-        }
-    }
-
-    struct DropTestHelper {
-        drop_log: Arc<Mutex<Vec<DropLogItem>>>,
-        /// Set to `true` right before we intentionally panic, so that if we get
-        /// a panic, we know if it was intended or not.
-        expected_panic_flag: Arc<AtomicBool>,
-    }
-
-    impl DropTestHelper {
-        pub fn new() -> Self {
-            Self {
-                drop_log: Arc::new(Mutex::new(Vec::<DropLogItem>::new())),
-                expected_panic_flag: Arc::new(AtomicBool::new(false)),
-            }
-        }
-
-        pub fn make_component(&self, should_panic: bool, id: ID) -> MayPanicInDrop {
-            MayPanicInDrop::new(&self.drop_log, &self.expected_panic_flag, should_panic, id)
-        }
-
-        pub fn finish(self, panic_res: std::thread::Result<()>) -> Vec<DropLogItem> {
-            let drop_log = self.drop_log.lock().unwrap();
-            let expected_panic_flag = self.expected_panic_flag.load(Ordering::SeqCst);
-
-            if !expected_panic_flag {
-                match panic_res {
-                    Ok(()) => panic!("Expected a panic but it didn't happen"),
-                    Err(e) => std::panic::resume_unwind(e),
-                }
-            }
-
-            drop_log.to_owned()
-        }
-    }
-
-    #[test]
-    fn panic_while_overwriting_component() {
-        let helper = DropTestHelper::new();
-
-        let res = std::panic::catch_unwind(|| {
-            let mut world = World::new();
-            world
-                .spawn_empty()
-                .insert(helper.make_component(true, 0))
-                .insert(helper.make_component(false, 1));
-
-            println!("Done inserting! Dropping world...");
-        });
-
-        let drop_log = helper.finish(res);
-
-        assert_eq!(
-            &*drop_log,
-            [
-                DropLogItem::Create(0),
-                DropLogItem::Create(1),
-                DropLogItem::Drop(0),
-                DropLogItem::Drop(1),
-            ]
-        );
-    }
 
     #[derive(Resource)]
     struct TestResource(u32);

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -131,3 +131,13 @@ impl<F: FnOnce()> Drop for OnDrop<F> {
         callback();
     }
 }
+
+/// Like [`OnDrop`], but specialized to abort the program.
+pub struct AbortOnPanic;
+
+impl Drop for AbortOnPanic {
+    fn drop(&mut self) {
+        // Panicking during unwinding guarantees abort.
+        panic!("Aborting due to previous panic");
+    }
+}


### PR DESCRIPTION
# Objective

Panic safety wrt. component drop functions.

Fixes #2860

## Solution

Alternative to #24393 (as per @chescock's suggestion)

Whereas #24393 tries to keep internal state consistent and only aborts if `catch_unwind` is not available, this PR always aborts if a panic in a component drop function would cause unsoundness.

The advantage of always aborting is that the resulting code is easier to reason about.

While aborting could theoretically also be used to fix the unsoundness of panics in required component constructors and hooks,
panics in these are much more likely and should allow proper unwinding.

## Testing

No automated tests due to abort; in fact a test related to component drops has been obsoleted.
Running the cases from the `panic_in_component_drop` test from #24393 results in an abort except during world drop.