### PR TITLE
Simplify Column::swap_remove_unchecked

### DIFF
--- a/crates/bevy_ecs/src/storage/blob_array.rs
+++ b/crates/bevy_ecs/src/storage/blob_array.rs
@@ -436,36 +436,7 @@ impl BlobArray {
         }
     }
 
-    /// This method will swap two elements in the array, and return the one at `index_to_remove`.
-    /// It is the caller's responsibility to drop the returned pointer, if that is desirable.
-    ///
-    /// # Safety
-    /// - `index_to_keep` must be safe to access (within the bounds of the length of the array).
-    /// - `index_to_remove` must be safe to access (within the bounds of the length of the array).
-    /// -  The caller should address the inconsistent state of the array that has occurred after the swap, either:
-    ///     1) initialize a different value in `index_to_keep`
-    ///     2) update the saved length of the array if `index_to_keep` was the last element.
-    #[inline]
-    #[must_use = "The returned pointer should be used to drop the removed element"]
-    pub unsafe fn swap_remove_unchecked(
-        &mut self,
-        index_to_remove: usize,
-        index_to_keep: usize,
-    ) -> OwningPtr<'_> {
-        #[cfg(debug_assertions)]
-        {
-            debug_assert!(self.capacity > index_to_keep);
-            debug_assert!(self.capacity > index_to_remove);
-        }
-        if index_to_remove != index_to_keep {
-            return self.swap_remove_unchecked_nonoverlapping(index_to_remove, index_to_keep);
-        }
-        // Now the element that used to be in index `index_to_remove` is now in index `index_to_keep` (after swap)
-        // If we are storing ZSTs than the index doesn't actually matter because the size is 0.
-        self.get_unchecked_mut(index_to_keep).promote()
-    }
-
-    /// The same as [`Self::swap_remove_unchecked`] but the two elements must non-overlapping.
+    /// Swap-remove the provided row. Returns the removed value.
     ///
     /// # Safety
     /// - `index_to_keep` must be safe to access (within the bounds of the length of the array).
@@ -475,7 +446,7 @@ impl BlobArray {
     ///     1) initialize a different value in `index_to_keep`
     ///     2) update the saved length of the array if `index_to_keep` was the last element.
     #[inline]
-    pub unsafe fn swap_remove_unchecked_nonoverlapping(
+    pub unsafe fn swap_remove_take_unchecked_nonoverlapping(
         &mut self,
         index_to_remove: usize,
         index_to_keep: usize,
@@ -496,58 +467,74 @@ impl BlobArray {
         self.get_unchecked_mut(index_to_keep).promote()
     }
 
-    /// This method will call [`Self::swap_remove_unchecked`] and drop the result.
+    /// Swap-remove the provided row.
+    ///
+    /// If `DROP` is `true`, the removed element will be dropped as needed.
+    ///
+    /// If `DROP` is `false`, the removed element will be forgotten.
     ///
     /// # Safety
-    /// - `index_to_keep` must be safe to access (within the bounds of the length of the array).
-    /// - `index_to_remove` must be safe to access (within the bounds of the length of the array).
+    /// - `index_of_value_to_keep` must be safe to access (within the bounds of the length of the array).
+    /// - `index_of_value_to_remove` must be safe to access (within the bounds of the length of the array).
     /// -  The caller should address the inconsistent state of the array that has occurred after the swap, either:
-    ///     1) initialize a different value in `index_to_keep`
-    ///     2) update the saved length of the array if `index_to_keep` was the last element.
+    ///     1) initialize a different value in `index_of_value_to_keep`
+    ///     2) decrement the saved length of the array if `index_of_value_to_keep` was the last element.
     #[inline]
-    pub unsafe fn swap_remove_and_drop_unchecked(
+    pub unsafe fn swap_remove_unchecked<const DROP: bool>(
         &mut self,
-        index_to_remove: usize,
-        index_to_keep: usize,
+        index_of_value_to_remove: usize,
+        index_of_value_to_keep: usize,
     ) {
         #[cfg(debug_assertions)]
         {
-            debug_assert!(self.capacity > index_to_keep);
-            debug_assert!(self.capacity > index_to_remove);
+            debug_assert!(self.capacity > index_of_value_to_keep);
+            debug_assert!(self.capacity > index_of_value_to_remove);
         }
         let drop = self.drop;
-        let value = self.swap_remove_unchecked(index_to_remove, index_to_keep);
-        if let Some(drop) = drop {
-            drop(value);
+        if let Some(drop) = drop
+            && DROP
+        {
+            let to_remove = self.get_unchecked_mut(index_of_value_to_remove).promote();
+            drop(to_remove);
         }
+        core::ptr::copy::<u8>(
+            self.get_unchecked_mut(index_of_value_to_keep).as_ptr(),
+            self.get_unchecked_mut(index_of_value_to_remove).as_ptr(),
+            self.item_layout.size(),
+        );
     }
 
-    /// The same as [`Self::swap_remove_and_drop_unchecked`] but the two elements must non-overlapping.
+    /// Swap-remove the provided row.
     ///
     /// # Safety
-    /// - `index_to_keep` must be safe to access (within the bounds of the length of the array).
-    /// - `index_to_remove` must be safe to access (within the bounds of the length of the array).
-    /// - `index_to_remove` != `index_to_keep`
+    /// - `index_of_value_to_keep` must be safe to access (within the bounds of the length of the array).
+    /// - `index_of_value_to_remove` must be safe to access (within the bounds of the length of the array).
+    /// - `index_of_value_to_remove` != `index_of_value_to_keep`
     /// -  The caller should address the inconsistent state of the array that has occurred after the swap, either:
-    ///     1) initialize a different value in `index_to_keep`
-    ///     2) update the saved length of the array if `index_to_keep` was the last element.
+    ///     1) initialize a different value in `index_of_value_to_keep`
+    ///     2) update the saved length of the array if `index_of_value_to_keep` was the last element.
     #[inline]
     pub unsafe fn swap_remove_and_drop_unchecked_nonoverlapping(
         &mut self,
-        index_to_remove: usize,
-        index_to_keep: usize,
+        index_of_value_to_remove: usize,
+        index_of_value_to_keep: usize,
     ) {
         #[cfg(debug_assertions)]
         {
-            debug_assert!(self.capacity > index_to_keep);
-            debug_assert!(self.capacity > index_to_remove);
-            debug_assert_ne!(index_to_keep, index_to_remove);
+            debug_assert!(self.capacity > index_of_value_to_keep);
+            debug_assert!(self.capacity > index_of_value_to_remove);
+            debug_assert_ne!(index_of_value_to_keep, index_of_value_to_remove);
         }
         let drop = self.drop;
-        let value = self.swap_remove_unchecked_nonoverlapping(index_to_remove, index_to_keep);
         if let Some(drop) = drop {
-            drop(value);
+            let to_remove = self.get_unchecked_mut(index_of_value_to_remove).promote();
+            drop(to_remove);
         }
+        core::ptr::copy_nonoverlapping::<u8>(
+            self.get_unchecked_mut(index_of_value_to_keep).as_ptr(),
+            self.get_unchecked_mut(index_of_value_to_remove).as_ptr(),
+            self.item_layout.size(),
+        );
     }
 }
 

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -369,7 +369,7 @@ impl ComponentSparseSet {
     /// Removes the `entity` from this sparse set and returns a pointer to the associated value (if
     /// it exists).
     #[must_use = "The returned pointer must be used to drop the removed component."]
-    pub(crate) fn remove_and_forget(&mut self, entity: Entity) -> Option<OwningPtr<'_>> {
+    pub(crate) fn take(&mut self, entity: Entity) -> Option<OwningPtr<'_>> {
         self.sparse.remove(entity.index()).map(|dense_index| {
             #[cfg(debug_assertions)]
             assert_eq!(entity, self.entities[dense_index.index()]);
@@ -410,7 +410,7 @@ impl ComponentSparseSet {
                 // overlapping, and thus also within bounds.
                 unsafe {
                     self.dense
-                        .swap_remove_and_forget_unchecked_nonoverlapping(last, dense_index)
+                        .swap_remove_take_unchecked_nonoverlapping(last, dense_index)
                 }
             }
         })

--- a/crates/bevy_ecs/src/storage/table/column.rs
+++ b/crates/bevy_ecs/src/storage/table/column.rs
@@ -94,14 +94,8 @@ impl Column {
         last_element_index: usize,
         row: TableRow,
     ) {
-        if DROP {
-            self.data
-                .swap_remove_and_drop_unchecked(row.index(), last_element_index);
-        } else {
-            _ = self
-                .data
-                .swap_remove_unchecked(row.index(), last_element_index);
-        }
+        self.data
+            .swap_remove_unchecked::<DROP>(row.index(), last_element_index);
         self.added_ticks
             .swap_remove_unchecked(row.index(), last_element_index);
         self.changed_ticks
@@ -118,14 +112,14 @@ impl Column {
     /// - `last_element_index` = `len - 1`
     /// - `last_element_index` != `row.as_usize()`
     /// -   The caller should update the `len` to `len - 1`, or immediately initialize another element in the `last_element_index`
-    pub(crate) unsafe fn swap_remove_and_forget_unchecked_nonoverlapping(
+    pub(crate) unsafe fn swap_remove_take_unchecked_nonoverlapping(
         &mut self,
         last_element_index: usize,
         row: TableRow,
     ) -> OwningPtr<'_> {
         let data = self
             .data
-            .swap_remove_unchecked_nonoverlapping(row.index(), last_element_index);
+            .swap_remove_take_unchecked_nonoverlapping(row.index(), last_element_index);
         self.added_ticks
             .swap_remove_unchecked_nonoverlapping(row.index(), last_element_index);
         self.changed_ticks

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -1309,11 +1309,9 @@ impl<'w> EntityWorldMut<'w> {
                                         // SAFETY: The remover is cleaning this up.
                                         .take_component(component_id, location.table_row)
                                 }
-                                StorageType::SparseSet => sets
-                                    .get_mut(component_id)
-                                    .unwrap()
-                                    .remove_and_forget(entity)
-                                    .unwrap(),
+                                StorageType::SparseSet => {
+                                    sets.get_mut(component_id).unwrap().take(entity).unwrap()
+                                }
                             }
                         }),
                     )


### PR DESCRIPTION
# Objective

Simplify the logic behind `Column::swap_remove_unchecked`. 

As a side-effect a swap in `BlockArray::swap_remove_unchecked` got turned into a memcopy, so I did the same for `swap_remove_and_drop_unchecked_nonoverlapping`.

The methods returning ownership of the removed value were named inconsistently either:
- swap_remove…, the same as the ones that dropped/forgot the value, or
- swap_remove_forget…, but they transferred ownership rather than forgetting

Therefore renamed these to `swap_remove_take…`

TODO: See if `BlobVec`/`Column::swap_remove_and_drop_unchecked_nonoverlapping` can be removed (and if `swap_remove_unchecked_nonoverlapping` can have its non-overlapping restriction removed) without performance impact as they are only called from two places, both of which are preceded by equality checks.