### PR TITLE
into_length_percentage_for_border

### DIFF
--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -60,7 +60,10 @@ impl Val {
     //
     // * A non-zero border smaller than one physical pixel is rounded up to one pixel.
     // * A border larger than one physical pixel is rounded down to a whole pixel.
-    fn into_length_percentage_for_border(self, context: &LayoutContext) -> taffy::style::LengthPercentage {
+    fn into_length_percentage_for_border(
+        self,
+        context: &LayoutContext,
+    ) -> taffy::style::LengthPercentage {
         let length = self.into_length_percentage(context);
         let raw = length.into_raw();
         // we're only snapping if sized in non-zero px

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -53,6 +53,24 @@ impl Val {
         }
     }
 
+    // Only used for border values in `from_node` below. Floors length based borders
+    // to a whole number of physical pixels, following the CSS "snap a length as a
+    // border width" algorithm used by browsers:
+    // <https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width>
+    //
+    // * A non-zero border smaller than one physical pixel is rounded up to one pixel.
+    // * A border larger than one physical pixel is rounded down to a whole pixel.
+    fn into_length_percentage_for_border(self, context: &LayoutContext) -> taffy::style::LengthPercentage {
+        let length = self.into_length_percentage(context);
+        let raw = length.into_raw();
+        // we're only snapping if sized in non-zero px
+        if raw.tag() == taffy::style::CompactLength::LENGTH_TAG && raw.value() > 0.0 {
+            taffy::style::LengthPercentage::length(raw.value().floor().max(1.0))
+        } else {
+            length
+        }
+    }
+
     fn into_dimension(self, context: &LayoutContext) -> taffy::style::Dimension {
         self.into_length_percentage_auto(context).into()
     }
@@ -102,9 +120,10 @@ pub fn from_node(node: &Node, context: &LayoutContext) -> taffy::style::Style {
         padding: node
             .padding
             .map_to_taffy_rect(|m| m.into_length_percentage(context)),
+        // border floors >=1px sized to nearest (>=1) real pixel size, see `into_length_percentage_for_border`.
         border: node
             .border
-            .map_to_taffy_rect(|m| m.into_length_percentage(context)),
+            .map_to_taffy_rect(|m| m.into_length_percentage_for_border(context)),
         flex_grow: node.flex_grow,
         flex_shrink: node.flex_shrink,
         flex_basis: node.flex_basis.into_dimension(context),

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -56,7 +56,7 @@ impl Val {
     // Only used for border values in `from_node` below. Floors length based borders
     // to a whole number of physical pixels, following the CSS "snap a length as a
     // border width" algorithm used by browsers:
-    // <https://drafts.csswg.org/css-values-4/#snap-a-length-as-a-border-width>
+    // https://www.w3.org/TR/css-values-4/#snap-a-length-as-a-border-width
     //
     // * A non-zero border smaller than one physical pixel is rounded up to one pixel.
     // * A border larger than one physical pixel is rounded down to a whole pixel.


### PR DESCRIPTION
Specific treatment for `border` sizing to physical pixels. 

## Objective

https://github.com/bevyengine/bevy/issues/25587

## Solution

Only used for border values in `from_node`. Floors length based borders
to a whole number of physical pixels, following the CSS "snap a length as a
border width" algorithm used by browsers:

https://www.w3.org/TR/css-values-4/#snap-a-length-as-a-border-width
    
- A non-zero border smaller than one physical pixel is rounded up to one pixel.
- A border larger than one physical pixel is rounded down to a whole pixel.

## Showcase

before (125%)

<img width="977" height="924" alt="image" src="https://github.com/user-attachments/assets/667db6a9-7ebe-4fa3-a8d6-f53a27d9c194" />

after (125%)

<img width="977" height="924" alt="image" src="https://github.com/user-attachments/assets/7effc4f5-7cb1-4866-a9d4-f66da8aa22e9" />

zoomed in on checkbox and radios

before

<img width="223" height="279" alt="image" src="https://github.com/user-attachments/assets/f2710563-fcf4-42db-99ba-d5bc303cf6c4" />

after

<img width="223" height="279" alt="image" src="https://github.com/user-attachments/assets/f6ac3d4e-abf6-4234-af13-805132c82de6" />
