### PR TITLE
Add the `Moment` type to `bevy_time` as a Bevy equivalent of `std::time::Instant`

### DIFF
--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -16,6 +16,7 @@ extern crate alloc;
 pub mod common_conditions;
 mod delayed_commands;
 mod fixed;
+mod moment;
 mod real;
 mod stopwatch;
 mod time;
@@ -24,6 +25,7 @@ mod virt;
 
 pub use delayed_commands::*;
 pub use fixed::*;
+pub use moment::*;
 pub use real::*;
 pub use stopwatch::*;
 pub use time::*;

--- a/crates/bevy_time/src/moment.rs
+++ b/crates/bevy_time/src/moment.rs
@@ -1,0 +1,297 @@
+use core::{
+    fmt::Debug,
+    hash::Hash,
+    marker::PhantomData,
+    ops::{Add, AddAssign, Sub, SubAssign},
+    time::Duration,
+};
+
+use bevy_reflect::Reflect;
+
+use crate::Time;
+
+/// A measurement of a point in time from some [`Time<C>`](crate::Time).
+///
+/// Bevy's equivalent to Rust's [`Instant`](std::time::Instant) but captured from a specific [`Time<C>`](crate::Time)
+/// resource instead of the platform's monotonic clock.
+///
+/// `Moments` are captured from clocks, see [`Time::capture`].
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
+pub struct Moment<C = ()> {
+    // How much time has elapsed since the source clock has been added to the world.
+    elapsed: Duration,
+    boo: PhantomData<C>,
+}
+
+impl<C> Moment<C> {
+    /// Casts a moment from one clock source to another.
+    ///
+    /// Clocks may run at different rates meaning they may produce numerically
+    /// different moments during the same world tick. This method is provided
+    /// under the assumption you have a way to deal with this.
+    pub fn cast<T>(self) -> Moment<T> {
+        Moment {
+            elapsed: self.elapsed,
+            boo: PhantomData,
+        }
+    }
+
+    /// Returns how much time has elapsed since we captured this moment.
+    pub fn elapsed(self, time: &Time<C>) -> Duration
+    where
+        C: Default,
+    {
+        time.capture() - self
+    }
+
+    /// Returns how much time has elapsed between this and a later moment.
+    ///
+    /// If `later` happened before this moment returns a zero [`Duration`].
+    /// This method is equivalent to `later - self`.
+    pub fn elapsed_between(self, later: Moment<C>) -> Duration {
+        later - self
+    }
+
+    /// Offsets self by `offset`. Returns `None` if this would cause an overflow.
+    pub fn checked_add(self, offset: Duration) -> Option<Self> {
+        let elapsed = self.elapsed.checked_add(offset)?;
+
+        Some(Self {
+            elapsed,
+            boo: PhantomData,
+        })
+    }
+
+    /// Offsets self backwards by `offset`. Returns `None` if this would cause an overflow.
+    pub fn checked_sub(self, offset: Duration) -> Option<Self> {
+        let elapsed = self.elapsed.checked_sub(offset)?;
+
+        Some(Self {
+            elapsed,
+            boo: PhantomData,
+        })
+    }
+
+    /// Returns the amount of time since the other moment or zero duration if that moment came after
+    /// this one.
+    pub fn duration_since(self, earlier: Moment<C>) -> Duration {
+        self.checked_duration_since(earlier).unwrap_or_default()
+    }
+
+    /// Returns the amount of time since the other moment or `None` if that moment came after
+    /// this one.
+    pub fn checked_duration_since(self, earlier: Moment<C>) -> Option<Duration> {
+        if earlier > self {
+            return None;
+        }
+
+        Some(self.elapsed - earlier.elapsed)
+    }
+
+    /// Returns how much time has passed between the first tick of the source clock and this moment.
+    pub fn into_duration(self) -> Duration {
+        self.elapsed
+    }
+}
+
+impl<C: Default> Moment<C> {
+    pub(crate) fn new(time: &Time<C>) -> Self {
+        Self {
+            elapsed: time.elapsed(),
+            boo: PhantomData,
+        }
+    }
+}
+
+impl<C> Clone for Moment<C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<C> Copy for Moment<C> {}
+
+impl<C> Debug for Moment<C> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Moment")
+            .field("elapsed", &self.elapsed)
+            .finish()
+    }
+}
+
+impl<C> Add<Duration> for Moment<C> {
+    type Output = Self;
+
+    fn add(mut self, rhs: Duration) -> Self::Output {
+        self.elapsed += rhs;
+
+        self
+    }
+}
+
+impl<C> AddAssign<Duration> for Moment<C> {
+    fn add_assign(&mut self, rhs: Duration) {
+        self.elapsed += rhs;
+    }
+}
+
+impl<C> PartialEq for Moment<C> {
+    fn eq(&self, other: &Self) -> bool {
+        self.elapsed == other.elapsed
+    }
+}
+
+impl<C> Eq for Moment<C> {}
+
+impl<C> PartialOrd for Moment<C> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<C> Ord for Moment<C> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.elapsed.cmp(&other.elapsed)
+    }
+}
+
+impl<C> Hash for Moment<C> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.elapsed.hash(state);
+    }
+}
+
+impl<C> Sub for Moment<C> {
+    type Output = Duration;
+
+    /// Returns the amount of time elapsed since the other moment or zero duration if that moment came after
+    /// this one.
+    fn sub(self, other: Self) -> Self::Output {
+        self.duration_since(other)
+    }
+}
+impl<C> Sub<Duration> for Moment<C> {
+    type Output = Self;
+
+    fn sub(mut self, rhs: Duration) -> Self::Output {
+        self.elapsed -= rhs;
+
+        self
+    }
+}
+
+impl<C> SubAssign<Duration> for Moment<C> {
+    fn sub_assign(&mut self, rhs: Duration) {
+        self.elapsed -= rhs;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::time::Duration;
+
+    use crate::Time;
+
+    #[test]
+    fn moments_are_ordered() {
+        const TIME_OFFSET: Duration = Duration::from_secs(1);
+
+        let mut time: Time<()> = Time::default();
+
+        let moment_0 = time.capture();
+
+        time.advance_by(TIME_OFFSET);
+
+        let moment_1_1 = time.capture();
+        let moment_1_2 = time.capture();
+
+        time.advance_by(TIME_OFFSET);
+
+        let moment_2 = time.capture();
+
+        assert!(moment_0 < moment_1_1);
+        // Capturing the same moment again should be idempotent
+        assert!(moment_1_1 == moment_1_2);
+        // Might as well check the cmp implementation invariants
+        assert!(moment_1_1 <= moment_1_2);
+        assert!(moment_1_1 >= moment_1_2);
+
+        assert!(moment_1_1 < moment_2);
+        assert!(moment_1_2 < moment_2);
+        assert!(moment_0 < moment_2);
+    }
+
+    #[test]
+    fn moments_can_be_offset() {
+        const TIME_OFFSET: Duration = Duration::from_secs(1);
+
+        let mut time: Time<()> = Time::default();
+        time.advance_to(TIME_OFFSET);
+
+        let moment_0 = time.capture();
+
+        assert_eq!(moment_0.checked_add(Duration::MAX), None);
+        assert_eq!(
+            moment_0.checked_add(TIME_OFFSET),
+            Some(moment_0 + TIME_OFFSET)
+        );
+        assert_eq!(
+            moment_0.checked_sub(TIME_OFFSET),
+            Some(moment_0 - TIME_OFFSET)
+        );
+
+        assert_eq!(moment_0.checked_sub(TIME_OFFSET * 2), None);
+
+        let moment_1 = moment_0 + TIME_OFFSET;
+        let moment_neg_1 = moment_0 - TIME_OFFSET;
+
+        assert!(moment_1 > moment_0);
+        assert!(moment_0 > moment_neg_1);
+        assert!(moment_1 > moment_neg_1);
+
+        assert_eq!(moment_1 - TIME_OFFSET, moment_0);
+
+        assert_eq!(moment_0 + Duration::ZERO, moment_0);
+        assert_eq!(moment_0 - Duration::ZERO, moment_0);
+        assert_eq!(moment_0.checked_add(Duration::ZERO), Some(moment_0));
+        assert_eq!(moment_0.checked_sub(Duration::ZERO), Some(moment_0));
+    }
+
+    #[test]
+    fn moments_offset_by_moments() {
+        const TIME_OFFSET: Duration = Duration::from_secs(1);
+
+        let mut time: Time<()> = Time::default();
+        time.advance_by(TIME_OFFSET);
+
+        let moment_0 = time.capture();
+
+        time.advance_by(TIME_OFFSET);
+
+        let moment_1 = time.capture();
+
+        assert_eq!(
+            moment_1 - moment_0 + moment_0.into_duration(),
+            moment_1.into_duration()
+        );
+    }
+
+    #[test]
+    fn elapsed() {
+        const TIME_OFFSET: Duration = Duration::from_secs(1);
+
+        let mut time: Time<()> = Time::default();
+        time.advance_by(TIME_OFFSET);
+
+        let moment_0 = time.capture();
+
+        time.advance_by(TIME_OFFSET);
+
+        let moment_1 = time.capture();
+
+        let elapsed = moment_1 - moment_0;
+
+        assert_eq!(moment_0.elapsed(&time), elapsed);
+        assert_eq!(moment_0.elapsed_between(moment_1), elapsed);
+    }
+}

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -1,5 +1,7 @@
+use crate::moment::Moment;
 use bevy_ecs::resource::Resource;
 use core::time::Duration;
+
 #[cfg(feature = "bevy_reflect")]
 use {
     bevy_ecs::reflect::ReflectResource,
@@ -365,6 +367,32 @@ impl<T: Default> Time<T> {
             elapsed_secs_wrapped: self.elapsed_secs_wrapped,
             elapsed_secs_wrapped_f64: self.elapsed_secs_wrapped_f64,
         }
+    }
+
+    /// Captures this moment for later comparison.
+    ///
+    /// ```rust
+    /// # use bevy_time::Time;
+    /// # use core::time::Duration;
+    ///
+    /// let mut time: Time<()> = Time::default();
+    ///
+    /// // capture a moment
+    /// let a = time.capture();
+    ///
+    /// // time passes
+    /// time.advance_by(Duration::from_secs(1));
+    ///
+    /// // capture a second moment
+    /// let b = time.capture();
+    ///
+    /// // we can now determine the ordering of events ...
+    /// assert!(a < b);
+    /// // ... and calculate how much time has passed between them
+    /// assert_eq!(b - a, Duration::from_secs(1));
+    /// ```
+    pub fn capture(&self) -> Moment<T> {
+        Moment::new(self)
     }
 }
 


### PR DESCRIPTION
# Objective

Give Bevy an equivalent to `std::time::Instant`

Closes #25495

## Solution

Add a new type (`Moment`) that's captured from a `Time` instance and can be offset + ordered.

I chose not to name it `Instant` since the type is already connected to the `time` namespace (offsets are `Duration`-based), and I didn't users confusing the type with `std::time::Instant`.

Otherwise, the API is nearly the identical to `Instant` but `Moments` have to be captured from an existing `Time` source. 

I didn't update the smoothing camera controller to use `Moments` yet. It would be a breaking change (`InputStreamEntry` has `Default`, and there isn't one for `Moment`), and I don't have the time left today. I'll try to do it and open a PR later.

## Testing

The code comes with a few test cases and a single doctest.

---

## Showcase

Added a new `Moment` type to `bevy_time` as an equivalent to `std::time::Instant`.

```rust
fn wait_print_system(time: Time<Real>, wait_until: Local<Option<Moment<Real>>>) {
    const WAIT_TIME: Duration = Duration::from_secs(1);

    // Moments are captured points of a specific clock's time.
    let now: Moment<Real> = time.capture();

    if let Some(time) = *wait_until {
        // We can compare moments to figure out what happened when.
        if now >= wait_until {
            log::info!("Waited {WAIT_TIME:?}");
            // Moments can be offset to represent moments both in the future and the past.
            *wait_until = now + WAIT_TIME;
        }
    } else {
        *wait_until = now + WAIT_TIME;
    }
}
```