### PR TITLE
bevy_camera_controller dependencies: uniformise path/version order

### DIFF
--- a/crates/bevy_camera_controller/Cargo.toml
+++ b/crates/bevy_camera_controller/Cargo.toml
@@ -29,9 +29,9 @@ bevy_image = { path = "../bevy_image", version = "0.20.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.20.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.20.0-dev" }
 
-bevy_asset = { version = "0.20.0-dev", path = "../bevy_asset", optional = true }
-bevy_core_pipeline = { version = "0.20.0-dev", path = "../bevy_core_pipeline", optional = true }
-bevy_gizmos = { version = "0.20.0-dev", path = "../bevy_gizmos", optional = true }
+bevy_asset = { path = "../bevy_asset", version = "0.20.0-dev", optional = true }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.20.0-dev", optional = true }
+bevy_gizmos = { path = "../bevy_gizmos", version = "0.20.0-dev", optional = true }
 
 
 [features]


### PR DESCRIPTION
# Objective

- some bevy_camera_controller internal dependencies are not in the same order as all the other crates

## Solution

- put them in the same order
