### PR TITLE
enable ScreenSpaceTransmission on anisotropy camera

### DIFF
--- a/examples/3d/anisotropy.rs
+++ b/examples/3d/anisotropy.rs
@@ -6,6 +6,7 @@ use bevy::{
     color::palettes::{self, css::WHITE},
     light::Skybox,
     math::vec3,
+    pbr::ScreenSpaceTransmission,
     prelude::*,
     time::Stopwatch,
 };
@@ -100,6 +101,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, app_status: Res<AppStatus>) {
     commands.spawn((
         Camera3d::default(),
+        ScreenSpaceTransmission::default(),
         Transform::from_translation(CAMERA_INITIAL_POSITION).looking_at(Vec3::ZERO, Vec3::Y),
     ));
 


### PR DESCRIPTION
# Objective

- anisotropy example has a transparent material for the light bulb
- it uses ScreenSpaceTransmission which is opt in since #25201

<img width="1280" height="720" alt="anisotropy" src="https://github.com/user-attachments/assets/2ace37a4-1b24-4fa2-bee7-b9bdfa6f1437" />


## Solution

- opt in

## Testing

- `cargo run --example anisotropy --features "jpeg pbr_anisotropy_texture"`

