### PR TITLE
Attempt a fix for flakiness of `dropping_subasset_handle_while_loading_cancels_load`.

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -766,7 +766,7 @@ mod tests {
     use bevy_tasks::{block_on, futures::check_ready, AsyncComputeTaskPool};
     use core::{any::TypeId, assert_matches, time::Duration};
     use crossbeam_channel::TryRecvError;
-    use futures_lite::AsyncReadExt;
+    use futures_lite::{future::yield_now, AsyncReadExt};
     use ron::ser::PrettyConfig;
     use serde::{Deserialize, Serialize};
     use std::path::{Path, PathBuf};
@@ -2444,6 +2444,20 @@ mod tests {
 
             self.in_loader_sender.send_blocking(()).unwrap();
             let _ = self.gate_receiver.recv().await;
+            // There's technically a race condition above. It is possible that this order happens:
+            // 1. This loader sends through `in_loader_sender`.
+            // 2. The cancellation tests receive through the `in_loader_sender` channel.
+            // 3. The cancellation tests drop their handle, then update the app, which drops the
+            //    `Task` (which cancels the task).
+            // 4. The cancellation tests send through the `gate_receiver` channel.
+            // 5. This loader receives through `gate_receiver` **without yielding** because there's
+            //    already a message in the channel.
+            // This would mean that the loader never yields and therefore never gets a chance to be
+            // cancelled. This explicit yield gives us that chance to be cancelled. This however
+            // depends on the async runtime not doing anything "clever" (e.g., re-polling the future
+            // if it's woken immediately after returning `Poll::Pending`).
+            yield_now().await;
+
             if let Some(finished_sender) = self.finished_sender.as_ref() {
                 finished_sender.send(1).unwrap();
             }


### PR DESCRIPTION
# Objective

- This test appears to be flaky: https://github.com/bevyengine/bevy/actions/runs/33444013236/job/99658765826
- There is a hypothetical race condition in the loader used by the test.

## Solution

- Yield after getting the signal that the loader should proceed. The test cancels the task before sending the gate signal, but the task only gets cancelled if it actually yields and the async runtime gets a chance to drop it. So by explicitly yielding we give it that chance, and we know for sure that the task will be marked cancelled since we cancelled before sending the gate signal.

I'm not 100% certain this is the problem though. A lot of things need to happen between when the loader notifying the test it is ready and the loader receives the gate signal (those two things are one after another in the loader). This would be a crazy race condition if this is the problem! Like we need the test thread to receiver the channel notification, then run the app (which itself spawns and executes a bunch of tasks), which then cancels the task, and the test thread needs to send another message through another channel to the task, and then finally the task needs to run and not yield. If this stops the flakes, I will never again assume race conditions are unlikely: if it's possible, it happens all the dang time.

## Testing

- I ran this in a loop for a long time, and didn't seem to get any flakes. But this bug is also very rare on main, so it's hard to tell if I just got lucky.