### PR TITLE
bevy_render: Pass `RawDisplayHandle` to `wgpu` for compositor-aware Instance creation

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -137,7 +137,7 @@ use bevy_extract::ExtractPlugin;
 use bevy_platform::time::Instant;
 use bevy_shader::{load_shader_library, Shader, ShaderLoader};
 use bevy_time::TimeSender;
-use bevy_window::{PrimaryWindow, RawHandleWrapperHolder};
+use bevy_window::{PrimaryWindow, RawDisplayHandleWrapper, RawHandleWrapperHolder};
 use bitflags::bitflags;
 use globals::GlobalsPlugin;
 use occlusion_culling::OcclusionCullingPlugin;
@@ -540,6 +540,8 @@ fn send_time(time_sender: Res<TimeSender>) {
 ///
 /// Returns true if creation was successful, false otherwise.
 fn insert_future_resources(render_creation: &RenderCreation, main_world: &mut World) -> bool {
+    let display = main_world.resource::<RawDisplayHandleWrapper>().clone();
+
     let primary_window = main_world
         .query_filtered::<&RawHandleWrapperHolder, With<PrimaryWindow>>()
         .single(main_world)
@@ -556,6 +558,7 @@ fn insert_future_resources(render_creation: &RenderCreation, main_world: &mut Wo
     let success = render_creation.create_render(
         future_resources.clone(),
         primary_window,
+        display,
         #[cfg(feature = "raw_vulkan_init")]
         raw_vulkan_init_settings,
     );

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -23,7 +23,7 @@ use bevy_ecs::{prelude::*, system::SystemState};
 use bevy_log::info_span;
 use bevy_log::{debug, info, warn};
 use bevy_render::camera::ExtractedCamera;
-use bevy_window::RawHandleWrapperHolder;
+use bevy_window::{RawDisplayHandleWrapper, RawHandleWrapperHolder};
 use wgpu::{
     Adapter, AdapterInfo, Backends, DeviceType, ForceShaderModelToken, Instance, Queue,
     RequestAdapterOptions, Trace,
@@ -199,6 +199,7 @@ async fn find_adapter_by_name(
 pub async fn initialize_renderer(
     backends: Backends,
     primary_window: Option<RawHandleWrapperHolder>,
+    display: RawDisplayHandleWrapper,
     options: &WgpuSettings,
     #[cfg(feature = "raw_vulkan_init")]
     raw_vulkan_init_settings: raw_vulkan_init::RawVulkanInitSettings,
@@ -207,7 +208,7 @@ pub async fn initialize_renderer(
         backends,
         flags: options.instance_flags,
         memory_budget_thresholds: options.instance_memory_budget_thresholds,
-        display: None,
+        display: Some(Box::new(display.clone())),
         backend_options: wgpu::BackendOptions {
             gl: wgpu::GlBackendOptions {
                 gles_minor_version: options.gles3_minor_version,

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -7,7 +7,7 @@ use crate::{
 use alloc::borrow::Cow;
 use bevy_ecs::world::World;
 use bevy_image::{CompressedImageFormatSupport, CompressedImageFormats};
-use bevy_window::RawHandleWrapperHolder;
+use bevy_window::{RawDisplayHandleWrapper, RawHandleWrapperHolder};
 
 use wgpu::MemoryBudgetThresholds;
 pub use wgpu::{
@@ -259,6 +259,7 @@ impl RenderCreation {
         &self,
         future_resources: FutureRenderResources,
         primary_window: Option<RawHandleWrapperHolder>,
+        display: RawDisplayHandleWrapper,
         #[cfg(feature = "raw_vulkan_init")]
         raw_vulkan_init_settings: renderer::raw_vulkan_init::RawVulkanInitSettings,
     ) -> bool {
@@ -276,6 +277,7 @@ impl RenderCreation {
                     let render_resources = renderer::initialize_renderer(
                         backends,
                         primary_window,
+                        display,
                         &settings,
                         #[cfg(feature = "raw_vulkan_init")]
                         raw_vulkan_init_settings,

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -368,7 +368,7 @@ pub fn create_surfaces(
     for (entity, mut window, handle, mut maybe_surface_data) in &mut windows {
         let Some(data) = maybe_surface_data.as_mut() else {
             let surface_target = SurfaceTargetUnsafe::RawHandle {
-                raw_display_handle: Some(handle.get_display_handle()),
+                raw_display_handle: None,
                 raw_window_handle: handle.get_window_handle(),
             };
             // SAFETY: The window handles in ExtractedWindows will always be valid objects to create surfaces on

--- a/crates/bevy_window/src/raw_handle.rs
+++ b/crates/bevy_window/src/raw_handle.rs
@@ -4,7 +4,7 @@
 )]
 
 use alloc::sync::Arc;
-use bevy_ecs::prelude::Component;
+use bevy_ecs::prelude::{Component, Resource};
 use bevy_platform::sync::Mutex;
 use core::{any::Any, marker::PhantomData, ops::Deref};
 use raw_window_handle::{
@@ -127,6 +127,48 @@ impl RawHandleWrapper {
 unsafe impl Send for RawHandleWrapper {}
 // SAFETY: This is safe for the same reasons as the Send impl above.
 unsafe impl Sync for RawHandleWrapper {}
+
+/// A wrapper around a [`RawDisplayHandle`] that can safely be passed between threads.
+///
+/// This is used to provide the display handle to the renderer independently of
+/// any particular window.
+#[derive(Debug, Clone, Resource)]
+pub struct RawDisplayHandleWrapper {
+    display_handle: RawDisplayHandle,
+}
+
+impl RawDisplayHandleWrapper {
+    /// Creates a [`RawDisplayHandleWrapper`] from a type implementing
+    /// [`HasDisplayHandle`].
+    pub fn new<W: HasDisplayHandle + 'static>(display: &W) -> Result<Self, HandleError> {
+        Ok(Self {
+            display_handle: display.display_handle()?.as_raw(),
+        })
+    }
+
+    /// Gets the stored display handle.
+    pub fn get_display_handle(&self) -> RawDisplayHandle {
+        self.display_handle
+    }
+}
+
+// SAFETY: `RawDisplayHandleWrapper` is only exposed through an immutable,
+// safe `HasDisplayHandle` implementation. The raw handle itself is copied
+// and the caller is responsible for ensuring platform-specific usage rules.
+unsafe impl Send for RawDisplayHandleWrapper {}
+
+// SAFETY: `RawDisplayHandleWrapper` is only exposed through an immutable,
+// safe `HasDisplayHandle` implementation. The raw handle itself is copied
+// and the caller is responsible for ensuring platform-specific usage rules.
+unsafe impl Sync for RawDisplayHandleWrapper {}
+
+impl HasDisplayHandle for RawDisplayHandleWrapper {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+        // SAFETY: The handle was obtained from a valid `HasDisplayHandle`
+        // implementation when this wrapper was constructed.
+        Ok(unsafe { DisplayHandle::borrow_raw(self.display_handle) })
+    }
+}
 
 /// A [`RawHandleWrapper`] that cannot be sent across threads.
 ///

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -16,7 +16,7 @@ extern crate alloc;
 
 use bevy_derive::Deref;
 use bevy_reflect::Reflect;
-use bevy_window::{ExitSystems, RawHandleWrapperHolder, WindowEvent};
+use bevy_window::{ExitSystems, RawDisplayHandleWrapper, RawHandleWrapperHolder, WindowEvent};
 use core::cell::RefCell;
 use winit::{event_loop::EventLoop, window::WindowId};
 
@@ -148,6 +148,10 @@ impl Plugin for WinitPlugin {
             });
         }
 
+        app.insert_resource(
+            RawDisplayHandleWrapper::new(&event_loop)
+                .expect("Failed to get the display handle from the event loop"),
+        );
         app.init_resource::<WinitMonitors>()
             .init_resource::<WinitSettings>()
             .insert_resource(DisplayHandleWrapper(event_loop.owned_display_handle()))


### PR DESCRIPTION
This is an AI-assisted (GPT-5.5) update to https://github.com/bevyengine/bevy/pull/20358

With https://github.com/gfx-rs/wgpu/pull/8782 integrated in wgpu-30 this PR doesn't depend on external changes, but just bevy.

EGL backend requires for the wgpu instance creation that a display handle is already passed through. This is necessary to detect which compositor (X11 or wayland) is used.
This is achieved by creating a RawDisplayHandle upfront and store it as a resource inside RawDisplayHandleWrapper.

# Objective

Render creation using EGL on Wayland already requires a display handle upon context creation. 

## Solution

Create that RawDisplayHandle early, store it as a resource and pass it during render creation.

## Testing

Command for test:
```
RUST_LOG=wgpu_hal=debug WGPU_BACKEND=gl cargo r --example 2d_shapes -Fwayland -Fbevy_render/gles -Fdynamic_linking -Fbevy_feathers --no-default-features -F2d -Fdebug -Fui
```

Note: `--no-default-features` is necessary because the `3d` feature raises a different GLSL problem in wgpu unrelated to this issue.

### Before
```
2026-09-02T05:51:18.782935Z DEBUG wgpu_hal::gles::egl: Client extensions: [
    "EGL_EXT_device_base",
   [...]
]
2026-09-02T05:51:18.782988Z DEBUG wgpu_hal::gles::egl: No (or unknown) windowing system ((None, Some(Instance(Dynamic(Library@0x55d1850b7440))))) present. Using surfaceless platform
2026-09-02T05:51:18.783007Z DEBUG wgpu_hal::gles::egl: Enabling EGL debug output
2026-09-02T05:51:18.791771Z DEBUG wgpu_hal::gles::egl: Display vendor "Mesa Project", version (1, 5)
2026-09-02T05:51:18.791819Z DEBUG wgpu_hal::gles::egl: Display extensions: [
    "EGL_ANDROID_blob_cache",
   [...]
]
2026-09-02T05:51:18.791858Z DEBUG wgpu_hal::gles::egl:  EGL surface: +srgb
2026-09-02T05:51:18.792026Z DEBUG wgpu_hal::gles::egl:  Trying native-render
2026-09-02T05:51:18.792041Z DEBUG wgpu_hal::gles::egl: No config found!
2026-09-02T05:51:18.792045Z DEBUG wgpu_hal::gles::egl:  Trying presentation
2026-09-02T05:51:18.792053Z DEBUG wgpu_hal::gles::egl: No config found!
2026-09-02T05:51:18.792057Z DEBUG wgpu_hal::gles::egl:  Trying off-screen
2026-09-02T05:51:18.792080Z DEBUG wgpu_hal::gles::egl:  EGL context: +debug
2026-09-02T05:51:18.793185Z DEBUG wgpu_hal::gles::egl:  EGL context: +robust access
2026-09-02T05:51:18.793201Z DEBUG wgpu_hal::gles::egl:  EGL context: +surfaceless
2026-09-02T05:51:18.794066Z DEBUG wgpu_hal::gles::egl: Max label length: 256
2026-09-02T05:51:18.794074Z DEBUG wgpu_hal::gles::egl: Enabling GLES debug output
2026-09-02T05:51:18.794109Z DEBUG wgpu_hal::gles::adapter: Vendor: AMD
2026-09-02T05:51:18.794114Z DEBUG wgpu_hal::gles::adapter: Renderer: AMD Ryzen 9 9900X 12-Core Processor (radeonsi, raphael_mendocino, ACO, DRM 3.64, 7.2.2-arch1-1)
2026-09-02T05:51:18.794119Z DEBUG wgpu_hal::gles::adapter: Version: 4.6 (Core Profile) Mesa 26.2.1-arch1.1
2026-09-02T05:51:18.794139Z DEBUG wgpu_hal::gles::adapter: SL version: 4.60
2026-09-02T05:51:18.794146Z DEBUG wgpu_hal::gles::adapter: Supported GL Extensions: {
    "GL_EXT_EGL_image_storage",
   [...]
}
2026-09-02T05:51:18.794505Z  INFO bevy_render::renderer: AdapterInfo { name: "AMD Ryzen 9 9900X 12-Core Processor (radeonsi, raphael_mendocino, ACO, DRM 3.64, 7.2.2-arch1-1)", vendor: 4098, device: 0, device_type: Other, device_pci_bus_id: "", driver: "", driver_info: "4.6 (Core Profile) Mesa 26.2.1-arch1.1", backend: Gl, subgroup_min_size: 4, subgroup_max_size: 128, transient_saves_memory: None, limit_bucket: None }
2026-09-02T05:51:18.796113Z DEBUG wgpu_hal::gles::device: Naga generated shader:
[...]
2026-09-02T05:51:18.796190Z DEBUG wgpu_hal::gles::device:       Compiled shader NativeShader(2)
2026-09-02T05:51:18.797894Z DEBUG wgpu_hal::gles::device:       Linked program NativeProgram(1)
2026-09-02T05:51:18.801208Z DEBUG wgpu_hal::gles::device: Naga generated shader:
[...]
2026-09-02T05:51:18.801373Z DEBUG wgpu_hal::gles::device:       Compiled shader NativeShader(4)
2026-09-02T05:51:18.801392Z DEBUG wgpu_hal::gles::device:       Linked program NativeProgram(3)
2026-09-02T05:51:19.094913Z  INFO bevy_winit::system: Creating new window 2d_shapes (67v0)
2026-09-02T05:51:19.157765Z  INFO bevy_render::batching::gpu_preprocessing: GPU preprocessing is not supported on this device. Falling back to CPU preprocessing.

thread 'main' (69840) panicked at crates/bevy_render/src/view/window/mod.rs:488:13:
internal error: entered unreachable code: Fallback system failed to choose present mode. This is a bug. Mode: Fifo, Options: []
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The line
```
2026-09-02T05:51:18.782988Z DEBUG wgpu_hal::gles::egl: No (or unknown) windowing system ((None, Some(Instance(Dynamic(Library@0x55d1850b7440))))) present. Using surfaceless platform
```
indicates there is already a problem which causes to create a native-render EGL surface:
```
2026-09-02T05:51:18.791858Z DEBUG wgpu_hal::gles::egl:  EGL surface: +srgb
2026-09-02T05:51:18.792026Z DEBUG wgpu_hal::gles::egl:  Trying native-render
2026-09-02T05:51:18.792041Z DEBUG wgpu_hal::gles::egl: No config found!
```
### After
```
2026-09-02T05:45:46.188361Z DEBUG wgpu_hal::gles::egl: Client extensions: [
    "EGL_EXT_device_base",
    [...]
]
2026-09-02T05:45:46.188405Z DEBUG wgpu_hal::gles::egl: Using Wayland platform
2026-09-02T05:45:46.188415Z DEBUG wgpu_hal::gles::egl: Enabling EGL debug output
2026-09-02T05:45:46.195187Z DEBUG wgpu_hal::gles::egl: Display vendor "Mesa Project", version (1, 5)
2026-09-02T05:45:46.195225Z DEBUG wgpu_hal::gles::egl: Display extensions: [
    "EGL_ANDROID_blob_cache",
    [...]
]
2026-09-02T05:45:46.195260Z DEBUG wgpu_hal::gles::egl:  EGL surface: +srgb
2026-09-02T05:45:46.195439Z DEBUG wgpu_hal::gles::egl:  Trying native-render
2026-09-02T05:45:46.195465Z DEBUG wgpu_hal::gles::egl:  EGL context: +debug
2026-09-02T05:45:46.196293Z DEBUG wgpu_hal::gles::egl:  EGL context: +robust access
2026-09-02T05:45:46.196304Z DEBUG wgpu_hal::gles::egl:  EGL context: +surfaceless
2026-09-02T05:45:46.197036Z DEBUG wgpu_hal::gles::egl: Max label length: 256
2026-09-02T05:45:46.197043Z DEBUG wgpu_hal::gles::egl: Enabling GLES debug output
2026-09-02T05:45:46.197073Z DEBUG wgpu_hal::gles::adapter: Vendor: AMD
2026-09-02T05:45:46.197078Z DEBUG wgpu_hal::gles::adapter: Renderer: AMD Radeon RX 9070 XT (radeonsi, gfx1201, ACO, DRM 3.64, 7.2.2-arch1-1)
2026-09-02T05:45:46.197082Z DEBUG wgpu_hal::gles::adapter: Version: 4.6 (Core Profile) Mesa 26.2.1-arch1.1
2026-09-02T05:45:46.197095Z DEBUG wgpu_hal::gles::adapter: SL version: 4.60
2026-09-02T05:45:46.197101Z DEBUG wgpu_hal::gles::adapter: Supported GL Extensions: {
    "GL_KHR_robustness",
    [...]
}
2026-09-02T05:45:46.197379Z  INFO bevy_render::renderer: AdapterInfo { name: "AMD Radeon RX 9070 XT (radeonsi, gfx1201, ACO, DRM 3.64, 7.2.2-arch1-1)", vendor: 4098, device: 0, device_type: Other, device_pci_bus_id: "", driver: "", driver_info: "4.6 (Core Profile) Mesa 26.2.1-arch1.1", backend: Gl, subgroup_min_size: 4, subgroup_max_size: 128, transient_saves_memory: None, limit_bucket: None }
```
The important line is
```
2026-09-02T05:45:46.188405Z DEBUG wgpu_hal::gles::egl: Using Wayland platform
```
showing that initialization detected a Wayland platform for which a EGL surface can be created:
```
2026-09-02T05:45:46.195260Z DEBUG wgpu_hal::gles::egl:  EGL surface: +srgb
2026-09-02T05:45:46.195439Z DEBUG wgpu_hal::gles::egl:  Trying native-render
2026-09-02T05:45:46.195465Z DEBUG wgpu_hal::gles::egl:  EGL context: +debug
2026-09-02T05:45:46.196293Z DEBUG wgpu_hal::gles::egl:  EGL context: +robust access
2026-09-02T05:45:46.196304Z DEBUG wgpu_hal::gles::egl:  EGL context: +surfaceless
```