### PR TITLE
Add an x-ray mode to wireframes

### DIFF
--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -99,6 +99,7 @@ impl Plugin for WireframePlugin {
         .init_resource::<WireframeEntitiesNeedingSpecialization>()
         .register_type::<WireframeLineWidth>()
         .register_type::<WireframeTopology>()
+        .register_type::<WireframeXray>()
         .add_systems(Startup, setup_global_wireframe_material)
         .add_systems(
             PostUpdate,
@@ -107,6 +108,7 @@ impl Plugin for WireframePlugin {
                 wireframe_color_changed,
                 wireframe_line_width_changed,
                 wireframe_topology_changed,
+                wireframe_xray_changed,
                 // Run `apply_global_wireframe_material` after `apply_wireframe_material` so that the global
                 // wireframe setting is applied to a mesh on the same frame its wireframe marker component is removed.
                 (apply_wireframe_material, apply_global_wireframe_material).chain(),
@@ -889,6 +891,13 @@ pub enum WireframeTopology {
     Quads,
 }
 
+/// Controls whether wireframe edges render as an x-ray overlay.
+///
+/// Overrides [`WireframeConfig::xray_mode`].
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Reflect)]
+#[reflect(Component, Default, Debug)]
+pub struct WireframeXray(pub bool);
+
 #[derive(Resource, Debug, Clone, ExtractResource, Reflect)]
 #[reflect(Resource, Debug, Default)]
 #[extract_app(RenderApp)]
@@ -1074,6 +1083,7 @@ fn wireframe_config_changed(
             Option<&WireframeColor>,
             Option<&WireframeLineWidth>,
             Option<&WireframeTopology>,
+            Option<&WireframeXray>,
         ),
         With<Wireframe>,
     >,
@@ -1085,7 +1095,9 @@ fn wireframe_config_changed(
         mat.xray_mode = config.xray_mode;
     }
 
-    for (mut handle, maybe_color, maybe_width, maybe_topology) in &mut per_entity_wireframes {
+    for (mut handle, maybe_color, maybe_width, maybe_topology, maybe_xray) in
+        &mut per_entity_wireframes
+    {
         if handle.0 == global_material.handle {
             continue;
         }
@@ -1095,7 +1107,7 @@ fn wireframe_config_changed(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: config.xray_mode,
+            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
         });
     }
 }
@@ -1108,19 +1120,22 @@ fn wireframe_color_changed(
             &WireframeColor,
             Option<&WireframeLineWidth>,
             Option<&WireframeTopology>,
+            Option<&WireframeXray>,
         ),
         (With<Wireframe>, Changed<WireframeColor>),
     >,
     config: Res<WireframeConfig>,
 ) {
-    for (mut handle, wireframe_color, maybe_width, maybe_topology) in &mut colors_changed {
+    for (mut handle, wireframe_color, maybe_width, maybe_topology, maybe_xray) in
+        &mut colors_changed
+    {
         handle.0 = materials.add(WireframeMaterial {
             color: wireframe_color.color,
             line_width: maybe_width
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: config.xray_mode,
+            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
         });
     }
 }
@@ -1133,17 +1148,20 @@ fn wireframe_line_width_changed(
             &WireframeLineWidth,
             Option<&WireframeColor>,
             Option<&WireframeTopology>,
+            Option<&WireframeXray>,
         ),
         (With<Wireframe>, Changed<WireframeLineWidth>),
     >,
     config: Res<WireframeConfig>,
 ) {
-    for (mut handle, wireframe_width, maybe_color, maybe_topology) in &mut widths_changed {
+    for (mut handle, wireframe_width, maybe_color, maybe_topology, maybe_xray) in
+        &mut widths_changed
+    {
         handle.0 = materials.add(WireframeMaterial {
             color: maybe_color.map(|c| c.color).unwrap_or(config.default_color),
             line_width: wireframe_width.width,
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: config.xray_mode,
+            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
         });
     }
 }
@@ -1156,19 +1174,46 @@ fn wireframe_topology_changed(
             &WireframeTopology,
             Option<&WireframeColor>,
             Option<&WireframeLineWidth>,
+            Option<&WireframeXray>,
         ),
         (With<Wireframe>, Changed<WireframeTopology>),
     >,
     config: Res<WireframeConfig>,
 ) {
-    for (mut handle, topology, maybe_color, maybe_width) in &mut topology_changed {
+    for (mut handle, topology, maybe_color, maybe_width, maybe_xray) in &mut topology_changed {
         handle.0 = materials.add(WireframeMaterial {
             color: maybe_color.map(|c| c.color).unwrap_or(config.default_color),
             line_width: maybe_width
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: *topology,
-            xray_mode: config.xray_mode,
+            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
+        });
+    }
+}
+
+fn wireframe_xray_changed(
+    mut materials: ResMut<Assets<WireframeMaterial>>,
+    mut xray_changed: Query<
+        (
+            &mut Mesh3dWireframe,
+            &WireframeXray,
+            Option<&WireframeColor>,
+            Option<&WireframeLineWidth>,
+            Option<&WireframeTopology>,
+        ),
+        (With<Wireframe>, Changed<WireframeXray>),
+    >,
+    config: Res<WireframeConfig>,
+) {
+    for (mut handle, xray, maybe_color, maybe_width, maybe_topology) in &mut xray_changed {
+        handle.0 = materials.add(WireframeMaterial {
+            color: maybe_color.map(|c| c.color).unwrap_or(config.default_color),
+            line_width: maybe_width
+                .map(|w| w.width)
+                .unwrap_or(config.default_line_width),
+            topology: maybe_topology.copied().unwrap_or(config.default_topology),
+            xray_mode: xray.0,
         });
     }
 }
@@ -1184,6 +1229,7 @@ fn apply_wireframe_material(
             Option<&WireframeColor>,
             Option<&WireframeLineWidth>,
             Option<&WireframeTopology>,
+            Option<&WireframeXray>,
         ),
         (With<Wireframe>, Without<Mesh3dWireframe>),
     >,
@@ -1199,11 +1245,12 @@ fn apply_wireframe_material(
     }
 
     let mut material_to_spawn = vec![];
-    for (e, maybe_color, maybe_width, maybe_topology) in &wireframes {
+    for (e, maybe_color, maybe_width, maybe_topology, maybe_xray) in &wireframes {
         let material = get_wireframe_material(
             maybe_color,
             maybe_width,
             maybe_topology,
+            maybe_xray,
             &mut materials,
             &global_material,
             &config,
@@ -1225,6 +1272,7 @@ fn apply_global_wireframe_material(
             Option<&WireframeColor>,
             Option<&WireframeLineWidth>,
             Option<&WireframeTopology>,
+            Option<&WireframeXray>,
         ),
         (WireframeFilter, Without<Mesh3dWireframe>),
     >,
@@ -1234,11 +1282,12 @@ fn apply_global_wireframe_material(
 ) {
     if config.global {
         let mut material_to_spawn = vec![];
-        for (e, maybe_color, maybe_width, maybe_topology) in &meshes_without_material {
+        for (e, maybe_color, maybe_width, maybe_topology, maybe_xray) in &meshes_without_material {
             let material = get_wireframe_material(
                 maybe_color,
                 maybe_width,
                 maybe_topology,
+                maybe_xray,
                 &mut materials,
                 &global_material,
                 &config,
@@ -1260,18 +1309,23 @@ fn get_wireframe_material(
     maybe_color: Option<&WireframeColor>,
     maybe_width: Option<&WireframeLineWidth>,
     maybe_topology: Option<&WireframeTopology>,
+    maybe_xray: Option<&WireframeXray>,
     wireframe_materials: &mut Assets<WireframeMaterial>,
     global_material: &GlobalWireframeMaterial,
     config: &WireframeConfig,
 ) -> Handle<WireframeMaterial> {
-    if maybe_color.is_some() || maybe_width.is_some() || maybe_topology.is_some() {
+    if maybe_color.is_some()
+        || maybe_width.is_some()
+        || maybe_topology.is_some()
+        || maybe_xray.is_some()
+    {
         wireframe_materials.add(WireframeMaterial {
             color: maybe_color.map(|c| c.color).unwrap_or(config.default_color),
             line_width: maybe_width
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: config.xray_mode,
+            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
         })
     } else {
         // If there's no color specified we can use the global material since it's already set to use the default_color
@@ -1345,6 +1399,7 @@ pub fn check_wireframe_entities_needing_specialization(
             AssetChanged<Mesh3dWireframe>,
             Changed<WireframeLineWidth>,
             Changed<WireframeTopology>,
+            Changed<WireframeXray>,
         )>,
     >,
     wireframe_entities: Query<Entity, With<Mesh3dWireframe>>,

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -893,10 +893,10 @@ pub enum WireframeTopology {
 
 /// Controls whether wireframe edges render as an x-ray overlay.
 ///
-/// Overrides [`WireframeConfig::xray_mode`].
+/// Enables x-ray rendering for this entity, regardless of [`WireframeConfig::xray_mode`].
 #[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Reflect)]
 #[reflect(Component, Default, Debug)]
-pub struct WireframeXray(pub bool);
+pub struct WireframeXray;
 
 #[derive(Resource, Debug, Clone, ExtractResource, Reflect)]
 #[reflect(Resource, Debug, Default)]
@@ -1107,7 +1107,7 @@ fn wireframe_config_changed(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
+            xray_mode: maybe_xray.is_some() || config.xray_mode,
         });
     }
 }
@@ -1135,7 +1135,7 @@ fn wireframe_color_changed(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
+            xray_mode: maybe_xray.is_some() || config.xray_mode,
         });
     }
 }
@@ -1161,7 +1161,7 @@ fn wireframe_line_width_changed(
             color: maybe_color.map(|c| c.color).unwrap_or(config.default_color),
             line_width: wireframe_width.width,
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
+            xray_mode: maybe_xray.is_some() || config.xray_mode,
         });
     }
 }
@@ -1187,7 +1187,7 @@ fn wireframe_topology_changed(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: *topology,
-            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
+            xray_mode: maybe_xray.is_some() || config.xray_mode,
         });
     }
 }
@@ -1206,14 +1206,14 @@ fn wireframe_xray_changed(
     >,
     config: Res<WireframeConfig>,
 ) {
-    for (mut handle, xray, maybe_color, maybe_width, maybe_topology) in &mut xray_changed {
+    for (mut handle, _, maybe_color, maybe_width, maybe_topology) in &mut xray_changed {
         handle.0 = materials.add(WireframeMaterial {
             color: maybe_color.map(|c| c.color).unwrap_or(config.default_color),
             line_width: maybe_width
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: xray.0,
+            xray_mode: true,
         });
     }
 }
@@ -1325,7 +1325,7 @@ fn get_wireframe_material(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
+            xray_mode: maybe_xray.is_some() || config.xray_mode,
         })
     } else {
         // If there's no color specified we can use the global material since it's already set to use the default_color

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -735,6 +735,7 @@ pub struct WireframePipelineKey {
     pub wide: bool,
     pub quads: bool,
     pub line_mode: bool,
+    pub xray_mode: bool,
 }
 
 impl SpecializedMeshPipeline for Wireframe3dPipeline {
@@ -746,6 +747,14 @@ impl SpecializedMeshPipeline for Wireframe3dPipeline {
         layout: &MeshVertexBufferLayoutRef,
     ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
         let mut descriptor = self.mesh_pipeline.specialize(key.mesh_key, layout)?;
+
+        if key.xray_mode {
+            descriptor.primitive.cull_mode = None;
+            let depth_stencil = descriptor.depth_stencil.as_mut().unwrap();
+            depth_stencil.depth_compare = Some(CompareFunction::Always);
+            // An x-ray wireframe is an overlay and must not occlude subsequent edges.
+            depth_stencil.depth_write_enabled = Some(false);
+        }
 
         if descriptor.primitive.topology.is_triangles() {
             descriptor.depth_stencil.as_mut().unwrap().bias.slope_scale = 1.0;
@@ -895,6 +904,9 @@ pub struct WireframeConfig {
     pub default_line_width: f32,
     /// Default edge topology.
     pub default_topology: WireframeTopology,
+    /// Whether all wireframe pipelines render as x-ray overlays. When enabled,
+    /// both sides are rendered without depth testing.
+    pub xray_mode: bool,
 }
 
 impl Default for WireframeConfig {
@@ -904,6 +916,7 @@ impl Default for WireframeConfig {
             default_color: Color::default(),
             default_line_width: 1.0,
             default_topology: WireframeTopology::default(),
+            xray_mode: false,
         }
     }
 }
@@ -914,6 +927,7 @@ pub struct WireframeMaterial {
     pub color: Color,
     pub line_width: f32,
     pub topology: WireframeTopology,
+    pub xray_mode: bool,
 }
 
 impl Default for WireframeMaterial {
@@ -922,6 +936,7 @@ impl Default for WireframeMaterial {
             color: Color::default(),
             line_width: 1.0,
             topology: WireframeTopology::default(),
+            xray_mode: false,
         }
     }
 }
@@ -930,6 +945,7 @@ pub struct RenderWireframeMaterial {
     pub color: [f32; 4],
     pub line_width: f32,
     pub topology: WireframeTopology,
+    pub xray_mode: bool,
 }
 
 #[derive(
@@ -960,6 +976,7 @@ impl RenderAsset for RenderWireframeMaterial {
             color: source_asset.color.to_linear().to_f32_array(),
             line_width: source_asset.line_width,
             topology: source_asset.topology,
+            xray_mode: source_asset.xray_mode,
         })
     }
 }
@@ -981,7 +998,10 @@ pub struct WireframeEntitiesNeedingSpecialization {
 #[derive(Resource, Default)]
 pub struct SpecializedWireframePipelineCache {
     views: HashMap<RetainedViewEntity, SpecializedWireframeViewPipelineCache>,
-    wide: HashMap<(MeshPipelineKey, MeshVertexBufferLayoutRef, bool, bool), CachedRenderPipelineId>,
+    wide: HashMap<
+        (MeshPipelineKey, MeshVertexBufferLayoutRef, bool, bool, bool),
+        CachedRenderPipelineId,
+    >,
 }
 
 #[derive(Deref, DerefMut, Default)]
@@ -1039,6 +1059,7 @@ fn setup_global_wireframe_material(
             color: config.default_color,
             line_width: config.default_line_width,
             topology: config.default_topology,
+            xray_mode: config.xray_mode,
         }),
     });
 }
@@ -1061,6 +1082,7 @@ fn wireframe_config_changed(
         mat.color = config.default_color;
         mat.line_width = config.default_line_width;
         mat.topology = config.default_topology;
+        mat.xray_mode = config.xray_mode;
     }
 
     for (mut handle, maybe_color, maybe_width, maybe_topology) in &mut per_entity_wireframes {
@@ -1073,6 +1095,7 @@ fn wireframe_config_changed(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
+            xray_mode: config.xray_mode,
         });
     }
 }
@@ -1097,6 +1120,7 @@ fn wireframe_color_changed(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
+            xray_mode: config.xray_mode,
         });
     }
 }
@@ -1119,6 +1143,7 @@ fn wireframe_line_width_changed(
             color: maybe_color.map(|c| c.color).unwrap_or(config.default_color),
             line_width: wireframe_width.width,
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
+            xray_mode: config.xray_mode,
         });
     }
 }
@@ -1143,6 +1168,7 @@ fn wireframe_topology_changed(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: *topology,
+            xray_mode: config.xray_mode,
         });
     }
 }
@@ -1245,6 +1271,7 @@ fn get_wireframe_material(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
+            xray_mode: config.xray_mode,
         })
     } else {
         // If there's no color specified we can use the global material since it's already set to use the default_color
@@ -1320,6 +1347,8 @@ pub fn check_wireframe_entities_needing_specialization(
             Changed<WireframeTopology>,
         )>,
     >,
+    wireframe_entities: Query<Entity, With<Mesh3dWireframe>>,
+    config: Res<WireframeConfig>,
     mut entities_needing_specialization: ResMut<WireframeEntitiesNeedingSpecialization>,
     mut removed_mesh_3d_components: RemovedComponents<Mesh3d>,
     mut removed_mesh_3d_wireframe_components: RemovedComponents<Mesh3dWireframe>,
@@ -1330,6 +1359,12 @@ pub fn check_wireframe_entities_needing_specialization(
     // Gather all entities that need their specializations regenerated.
     for entity in &needs_specialization {
         entities_needing_specialization.changed.push(entity);
+    }
+
+    if config.is_changed() {
+        entities_needing_specialization
+            .changed
+            .extend(wireframe_entities.iter());
     }
 
     // All entities that removed their `Mesh3d` or `Mesh3dWireframe` components
@@ -1482,17 +1517,19 @@ pub fn specialize_wireframes(
                 .map(|m| m.topology == WireframeTopology::Quads)
                 .unwrap_or(false);
             let thick = mat.map(|m| m.line_width > 1.0).unwrap_or(false);
+            let xray_mode = mat.map(|m| m.xray_mode).unwrap_or(false);
             let wide = thick || quads;
             let line_mode = wide && !thick;
 
             let pipeline_id = if wide {
-                let cache_key = (mesh_key, mesh.layout.clone(), quads, line_mode);
+                let cache_key = (mesh_key, mesh.layout.clone(), quads, line_mode, xray_mode);
                 *wide_pipeline_cache.entry(cache_key).or_insert_with(|| {
                     let wireframe_key = WireframePipelineKey {
                         mesh_key,
                         wide: true,
                         quads,
                         line_mode,
+                        xray_mode,
                     };
                     match pipeline.specialize(wireframe_key, &mesh.layout) {
                         Ok(descriptor) => pipeline_cache.queue_render_pipeline(descriptor),
@@ -1508,6 +1545,7 @@ pub fn specialize_wireframes(
                     wide: false,
                     quads: false,
                     line_mode: false,
+                    xray_mode,
                 };
                 match pipelines.specialize(&pipeline_cache, &pipeline, wireframe_key, &mesh.layout)
                 {

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -893,10 +893,10 @@ pub enum WireframeTopology {
 
 /// Controls whether wireframe edges render as an x-ray overlay.
 ///
-/// Enables x-ray rendering for this entity, regardless of [`WireframeConfig::xray_mode`].
+/// Overrides [`WireframeConfig::xray_mode`].
 #[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Reflect)]
 #[reflect(Component, Default, Debug)]
-pub struct WireframeXray;
+pub struct WireframeXray(pub bool);
 
 #[derive(Resource, Debug, Clone, ExtractResource, Reflect)]
 #[reflect(Resource, Debug, Default)]
@@ -1107,7 +1107,7 @@ fn wireframe_config_changed(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: maybe_xray.is_some() || config.xray_mode,
+            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
         });
     }
 }
@@ -1135,7 +1135,7 @@ fn wireframe_color_changed(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: maybe_xray.is_some() || config.xray_mode,
+            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
         });
     }
 }
@@ -1161,7 +1161,7 @@ fn wireframe_line_width_changed(
             color: maybe_color.map(|c| c.color).unwrap_or(config.default_color),
             line_width: wireframe_width.width,
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: maybe_xray.is_some() || config.xray_mode,
+            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
         });
     }
 }
@@ -1187,7 +1187,7 @@ fn wireframe_topology_changed(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: *topology,
-            xray_mode: maybe_xray.is_some() || config.xray_mode,
+            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
         });
     }
 }
@@ -1206,14 +1206,14 @@ fn wireframe_xray_changed(
     >,
     config: Res<WireframeConfig>,
 ) {
-    for (mut handle, _, maybe_color, maybe_width, maybe_topology) in &mut xray_changed {
+    for (mut handle, xray, maybe_color, maybe_width, maybe_topology) in &mut xray_changed {
         handle.0 = materials.add(WireframeMaterial {
             color: maybe_color.map(|c| c.color).unwrap_or(config.default_color),
             line_width: maybe_width
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: true,
+            xray_mode: xray.0,
         });
     }
 }
@@ -1325,7 +1325,7 @@ fn get_wireframe_material(
                 .map(|w| w.width)
                 .unwrap_or(config.default_line_width),
             topology: maybe_topology.copied().unwrap_or(config.default_topology),
-            xray_mode: maybe_xray.is_some() || config.xray_mode,
+            xray_mode: maybe_xray.map(|xray| xray.0).unwrap_or(config.xray_mode),
         })
     } else {
         // If there's no color specified we can use the global material since it's already set to use the default_color

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -753,8 +753,8 @@ impl SpecializedMeshPipeline for Wireframe3dPipeline {
         if key.xray_mode {
             descriptor.primitive.cull_mode = None;
             let depth_stencil = descriptor.depth_stencil.as_mut().unwrap();
+            // An x-ray wireframe must not occlude or be occluded by anything
             depth_stencil.depth_compare = Some(CompareFunction::Always);
-            // An x-ray wireframe is an overlay and must not occlude subsequent edges.
             depth_stencil.depth_write_enabled = Some(false);
         }
 

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -12,7 +12,7 @@ use bevy::{
     color::palettes::css::*,
     pbr::wireframe::{
         NoWireframe, Wireframe, WireframeColor, WireframeConfig, WireframeLineWidth,
-        WireframePlugin, WireframeTopology,
+        WireframePlugin, WireframeTopology, WireframeXray,
     },
     prelude::*,
     render::{render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin},
@@ -81,6 +81,7 @@ fn setup(
         // This lets you configure the wireframe color of this entity.
         // If not set, this will use the color in `WireframeConfig`
         WireframeColor { color: LIME.into() },
+        WireframeXray(false),
         ColorToggleCube,
     ));
 
@@ -134,6 +135,7 @@ fn update_colors(
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mut config: ResMut<WireframeConfig>,
     mut wireframe_colors: Query<&mut WireframeColor, With<ColorToggleCube>>,
+    mut xray_cubes: Query<&mut WireframeXray, With<ColorToggleCube>>,
     mut wireframe_widths: Query<&mut WireframeLineWidth>,
     mut text: Single<&mut Text>,
 ) {
@@ -142,6 +144,7 @@ fn update_colors(
         .next()
         .map(|w| w.width)
         .unwrap_or(1.0);
+    let green_cube_xray = xray_cubes.iter().any(|xray| xray.0);
 
     text.0 = format!(
         "Controls
@@ -152,6 +155,7 @@ C - Change color of the green cube wireframe
 V - Line width (current: {current_width:.1}px)
 B - Toggle topology (current: {:?})
 N - Toggle x-ray mode (current: {:?})
+M - Toggle x-ray override for the green cube (current: {green_cube_xray})
 
 WireframeConfig
 -------------
@@ -205,5 +209,11 @@ Color: {:?}",
 
     if keyboard_input.just_pressed(KeyCode::KeyN) {
         config.xray_mode = !config.xray_mode;
+    }
+
+    if keyboard_input.just_pressed(KeyCode::KeyM) {
+        for mut xray in &mut xray_cubes {
+            xray.0 = !xray.0;
+        }
     }
 }

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -42,6 +42,7 @@ fn main() {
             // Controls the default color of all wireframes. Used as the default color for global wireframes.
             // Can be changed per mesh using the `WireframeColor` component.
             default_color: WHITE.into(),
+            xray_mode: false,
             ..default()
         })
         .add_systems(Startup, setup)
@@ -150,12 +151,13 @@ X - Change global color
 C - Change color of the green cube wireframe
 V - Line width (current: {current_width:.1}px)
 B - Toggle topology (current: {:?})
+N - Toggle x-ray mode (current: {:?})
 
 WireframeConfig
 -------------
 Global: {}
 Color: {:?}",
-        config.default_topology, config.global, config.default_color,
+        config.default_topology, config.xray_mode, config.global, config.default_color,
     );
 
     // Toggle showing a wireframe on all meshes
@@ -199,5 +201,9 @@ Color: {:?}",
             WireframeTopology::Triangles => WireframeTopology::Quads,
             WireframeTopology::Quads => WireframeTopology::Triangles,
         };
+    }
+
+    if keyboard_input.just_pressed(KeyCode::KeyN) {
+        config.xray_mode = !config.xray_mode;
     }
 }

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -154,8 +154,8 @@ X - Change global color
 C - Change color of the green cube wireframe
 V - Line width (current: {current_width:.1}px)
 B - Toggle topology (current: {:?})
-N - Toggle x-ray mode (current: {:?})
-M - Toggle x-ray override for the green cube (current: {green_cube_xray})
+N - Toggle global x-ray mode (current: {:?})
+M - Toggle x-ray mode for the green cube (current: {green_cube_xray})
 
 WireframeConfig
 -------------


### PR DESCRIPTION
# Objective

Add an x-ray mode to wireframes, similar to Blender's X-Ray mode, so edges on the far side of a mesh stay visible.

## Solution

Add a default `WireframeConfig::xray_mode` and a per-entity `WireframeXray(bool)` override. X-ray wireframes skip culling and depth testing, and do not write to depth.

## Testing

Run `cargo run --example wireframe` and press `N` to toggle the xray mode. Press `M` to toggle the `WireframeXray` override on the green cube.

## Showcase

https://github.com/user-attachments/assets/49b30da3-723c-45da-81ca-a91b164911e7

