### PR TITLE
Mutable `NestedQuery` by relaxing `ReadOnly::State == State` constraint

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -311,8 +311,10 @@ use variadics_please::all_tuples;
 ///
 /// # Safety
 ///
-/// - Component access of `Self::ReadOnly` must be a subset of `Self`
-///   and `Self::ReadOnly` must match exactly the same archetypes/tables as `Self`
+/// - It must be valid to transmute `Self::State` to `Self::ReadOnly::State`,
+///   and the resulting `Self::ReadOnly` must have a subset of the access of `Self`
+///   and must match exactly the same archetypes/tables as `Self`.
+///   Note that this is trivially true if `Self::ReadOnly == Self`.
 /// - `IS_READ_ONLY` must be `true` if and only if `Self: ReadOnlyQueryData`
 ///
 /// [`ReadOnly`]: Self::ReadOnly
@@ -335,7 +337,7 @@ pub unsafe trait QueryData: WorldQuery {
     const IS_ARCHETYPAL: bool;
 
     /// The read-only variant of this [`QueryData`], which satisfies the [`ReadOnlyQueryData`] trait.
-    type ReadOnly: ReadOnlyQueryData<State = <Self as WorldQuery>::State>;
+    type ReadOnly: ReadOnlyQueryData;
 
     /// The item returned by this [`WorldQuery`]
     /// This will be the data retrieved by the query,
@@ -879,9 +881,7 @@ unsafe impl WorldQuery for SpawnDetails {
     fn update_archetypes(_state: &mut Self::State, _world: UnsafeWorldCell) {}
 }
 
-// SAFETY:
-// No components are accessed.
-// Is its own ReadOnlyQueryData.
+// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl QueryData for SpawnDetails {
     const IS_READ_ONLY: bool = true;
     const IS_ARCHETYPAL: bool = true;
@@ -1149,7 +1149,11 @@ unsafe impl<'a> WorldQuery for EntityMut<'a> {
     fn update_archetypes(_state: &mut Self::State, _world: UnsafeWorldCell) {}
 }
 
-// SAFETY: access of `EntityRef` is a subset of `EntityMut`
+// SAFETY:
+// - `State` is `()` for both `EntityMut` and `EntityRef`,
+//   so transmuting always results in a valid state.
+// - Access of `EntityRef` is a subset of `EntityMut`.
+// - Both `EntityMut` and `EntityRef` match all entities.
 unsafe impl<'a> QueryData for EntityMut<'a> {
     const IS_READ_ONLY: bool = false;
     const IS_ARCHETYPAL: bool = true;
@@ -1415,7 +1419,11 @@ unsafe impl WorldQuery for FilteredEntityMut<'_, '_> {
     fn update_archetypes(_state: &mut Self::State, _world: UnsafeWorldCell) {}
 }
 
-// SAFETY: access of `FilteredEntityRef` is a subset of `FilteredEntityMut`
+// SAFETY:
+// - `State` is `Access` for both `FilteredEntityMut` and `FilteredEntityRef`.
+//   `FilteredEntityRef` accepts any `Access`, so the transmute is always valid.
+// - Access of `FilteredEntityRef` is a subset of `FilteredEntityMut` for the same `Access`.
+// - Both `FilteredEntityMut` and `FilteredEntityRef` match all entities.
 unsafe impl<'a, 'b> QueryData for FilteredEntityMut<'a, 'b> {
     const IS_READ_ONLY: bool = false;
     const IS_ARCHETYPAL: bool = true;
@@ -1697,8 +1705,12 @@ where
     fn update_archetypes(_state: &mut Self::State, _world: UnsafeWorldCell) {}
 }
 
-// SAFETY: All accesses that `EntityRefExcept` provides are also accesses that
-// `EntityMutExcept` provides.
+// SAFETY:
+// - `State` for both `EntityRefExcept` and `EntityMutExcept` is an `Access`
+//   with access to all components except those in `B` in the current world.
+//  `EntityRefExcept` will ignore the extra write access in the transmuted `Access`.
+// - Access of `EntityRefExcept` is a subset of `EntityMutExcept` for the same `Access`.
+// - Both `EntityMutExcept` and `EntityRefExcept` match all entities.
 unsafe impl<'a, 'b, B> QueryData for EntityMutExcept<'a, 'b, B>
 where
     B: Bundle,
@@ -2514,7 +2526,10 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
     fn update_archetypes(_state: &mut Self::State, _world: UnsafeWorldCell) {}
 }
 
-// SAFETY: access of `&T` is a subset of `&mut T`
+// SAFETY: `State` for both `&T` and `&mut T` is
+// the `ComponentId` of `T` in the current world,
+// and `&T` matches the same archetypes as `&mut T`
+// with a subset of the access.
 unsafe impl<'__w, T: Component<Mutability = Mutable>> QueryData for &'__w mut T {
     const IS_READ_ONLY: bool = false;
     const IS_ARCHETYPAL: bool = true;
@@ -2746,7 +2761,10 @@ unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
     fn update_archetypes(_state: &mut Self::State, _world: UnsafeWorldCell) {}
 }
 
-// SAFETY: access of `Ref<T>` is a subset of `Mut<T>`
+// SAFETY: `State` for both `Ref<T>` and `Mut<T>` is
+// the `ComponentId` of `T` in the current world,
+// and `Ref<T>` matches the same archetypes as `Mut<T>`
+// with a subset of the access.
 unsafe impl<'__w, T: Component<Mutability = Mutable>> QueryData for Mut<'__w, T> {
     const IS_READ_ONLY: bool = false;
     const IS_ARCHETYPAL: bool = true;
@@ -3049,9 +3067,7 @@ pub struct NestedQueryFetch<'w> {
 // SAFETY:
 // Does not access any components on the current entity
 // Accesses through the nested query are registered in `init_nested_access`
-unsafe impl<D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> WorldQuery
-    for NestedQuery<D, F>
-{
+unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> WorldQuery for NestedQuery<D, F> {
     type Fetch<'w> = NestedQueryFetch<'w>;
     type State = QueryState<D, F>;
 
@@ -3131,18 +3147,18 @@ unsafe impl<D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> WorldQuery
 }
 
 // SAFETY:
-// `Self::ReadOnly` accesses `D::ReadOnly`, which is a subset of the data accessed by `D`
-// `IS_READ_ONLY` iff `D::IS_READ_ONLY` iff `D: ReadOnlyQueryData` iff `Self: ReadOnlyQueryData`
-unsafe impl<D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> QueryData
-    for NestedQuery<D, F>
-{
+// - `Self::State` is a `QueryState<D, F>`, which can always be transmuted to a valid `QueryState<D::ReadOnly, F>`.
+// - `Self::ReadOnly` accesses `D::ReadOnly`, which is a subset of the data accessed by `D`.
+// - `NestedQuery` always matches all entities.
+// - `IS_READ_ONLY` iff `D::IS_READ_ONLY` iff `D: ReadOnlyQueryData` iff `Self: ReadOnlyQueryData`
+unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> QueryData for NestedQuery<D, F> {
     const IS_READ_ONLY: bool = D::IS_READ_ONLY;
     // Nested queries are always archetypal because `fetch` always returns `Some`.
     // If `D::IS_ARCHETYPAL == false` or `F::IS_ARCHETYPAL == false`,
     // then the nested query may filter out some entities that *it* matches,
     // but it will not filter the outer query.
     const IS_ARCHETYPAL: bool = true;
-    type ReadOnly = NestedQuery<D, F>;
+    type ReadOnly = NestedQuery<D::ReadOnly, F>;
     type Item<'w, 's> = Query<'w, 's, D, F>;
 
     fn shrink<'wlong: 'wshort, 'wshort, 's>(
@@ -3191,7 +3207,7 @@ unsafe impl<D: ReadOnlyQueryData, F: QueryFilter> IterQueryData for NestedQuery<
 // If `D::IS_ARCHETYPAL == false` or `F::IS_ARCHETYPAL == false`,
 // then the nested query may filter out some entities that *it* matches,
 // but it will never filter the outer query.
-impl<D: ReadOnlyQueryData, F: QueryFilter> ArchetypeQueryData for NestedQuery<D, F> {}
+impl<D: QueryData, F: QueryFilter> ArchetypeQueryData for NestedQuery<D, F> {}
 
 #[doc(hidden)]
 pub struct OptionFetch<'w, T: WorldQuery> {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -122,9 +122,10 @@ impl<D: QueryData, F: QueryFilter> FromWorld for QueryState<D, F> {
 impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// Converts this `QueryState` reference to a `QueryState` that does not access anything mutably.
     pub fn as_readonly(&self) -> &QueryState<D::ReadOnly, F> {
-        // SAFETY: invariant on `WorldQuery` trait upholds that `D::ReadOnly` and `F::ReadOnly`
-        // have a subset of the access, and match the exact same archetypes/tables as `D`/`F` respectively.
-        unsafe { self.as_transmuted_state::<D::ReadOnly, F>() }
+        // SAFETY: `WorldQuery` trait ensures `D::State` may be transmuted to
+        // `D::ReadOnly::State` and that the resulting `QueryData`
+        // has a subset of the access and matches the exact same archetypes/tables as `D`.
+        unsafe { self.as_transmuted_state::<D::ReadOnly>() }
     }
 
     /// Converts this `QueryState` reference to a `QueryState` that does not return any data
@@ -133,9 +134,10 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// This doesn't use `NopWorldQuery` as it loses filter functionality, for example
     /// `NopWorldQuery<Changed<T>>` is functionally equivalent to `With<T>`.
     pub(crate) fn as_nop(&self) -> &QueryState<NopWorldQuery<D>, F> {
-        // SAFETY: `NopWorldQuery` doesn't have any accesses and defers to
+        // SAFETY: `NopWorldQuery<D>::State == D::State`,
+        // `NopWorldQuery` doesn't have any accesses and defers to
         // `D` for table/archetype matching
-        unsafe { self.as_transmuted_state::<NopWorldQuery<D>, F>() }
+        unsafe { self.as_transmuted_state::<NopWorldQuery<D>>() }
     }
 
     /// Converts this `QueryState` reference to any other `QueryState` with
@@ -145,15 +147,13 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     ///
     /// # Safety
     ///
-    /// `NewD` must have a subset of the access that `D` does and match the exact same archetypes/tables
-    /// `NewF` must have a subset of the access that `F` does and match the exact same archetypes/tables
-    pub(crate) unsafe fn as_transmuted_state<
-        NewD: ReadOnlyQueryData<State = D::State>,
-        NewF: QueryFilter<State = F::State>,
-    >(
+    /// It must be valid to transmute `D::State` to `NewD::State`,
+    /// and the resulting state must have a subset of the access that
+    /// `D` does and match the exact same archetypes/tables
+    pub(crate) unsafe fn as_transmuted_state<NewD: ReadOnlyQueryData>(
         &self,
-    ) -> &QueryState<NewD, NewF> {
-        &*ptr::from_ref(self).cast::<QueryState<NewD, NewF>>()
+    ) -> &QueryState<NewD, F> {
+        &*ptr::from_ref(self).cast::<QueryState<NewD, F>>()
     }
 
     /// Returns the components accessed by this query.

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -919,6 +919,33 @@ mod tests {
     }
 
     #[test]
+    #[should_panic = "error[B0001]"]
+    fn mut_nested_query_conflicts_with_main_query() {
+        fn sys(_: Query<(&A, NestedQuery<&mut A>)>) {}
+
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
+    #[should_panic = "error[B0001]"]
+    fn mut_nested_query_conflicts_with_earlier_query() {
+        fn sys(_: Query<&A>, _: Query<NestedQuery<&mut A>>) {}
+
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
+    #[should_panic = "error[B0001]"]
+    fn mut_nested_query_conflicts_with_later_query() {
+        fn sys(_: Query<NestedQuery<&mut A>>, _: Query<&A>) {}
+
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
     fn query_set_system() {
         fn sys(mut _set: ParamSet<(Query<&mut A>, Query<&A>)>) {}
         let mut world = World::default();

--- a/crates/bevy_extract/src/sync_world.rs
+++ b/crates/bevy_extract/src/sync_world.rs
@@ -375,8 +375,7 @@ mod sub_entities_world_query_impls {
         fn update_archetypes(_state: &mut Self::State, _world: UnsafeWorldCell) {}
     }
 
-    // SAFETY: Component access of Self::ReadOnly is a subset of Self.
-    // Self::ReadOnly matches exactly the same archetypes/tables as Self.
+    // SAFETY: `Self` is the same as `Self::ReadOnly`
     unsafe impl<L: AppLabel + Clone + Copy + Eq> QueryData for SubEntity<L> {
         const IS_READ_ONLY: bool = true;
         const IS_ARCHETYPAL: bool = <&MainEntity as QueryData>::IS_ARCHETYPAL;
@@ -506,8 +505,7 @@ mod sub_entities_world_query_impls {
         fn update_archetypes(_state: &mut Self::State, _world: UnsafeWorldCell) {}
     }
 
-    // SAFETY: Component access of Self::ReadOnly is a subset of Self.
-    // Self::ReadOnly matches exactly the same archetypes/tables as Self.
+    // SAFETY: `Self` is the same as `Self::ReadOnly`
     unsafe impl QueryData for MainEntity {
         const IS_READ_ONLY: bool = true;
         const IS_ARCHETYPAL: bool = <&MainEntity as QueryData>::IS_ARCHETYPAL;


### PR DESCRIPTION
# Objective

Support mutable queries using `NestedQuery`.  

The reason this was not supported in the initial version is that we want `NestedQuery<D, F>::ReadOnly == NestedQuery<D::ReadOnly, F>`, but that doesn't satisfy the `ReadOnly::State == State` constraint since `QueryState<D::ReadOnly, F> != QueryState<D, F>`.  

## Solution

Remove the `ReadOnly::State == State` constraint, and replace it with a safety requirement.  `QueryState<D, F>` could always be *transmuted* to `QueryState<D::ReadOnly, F>`, so the outer transmute is still valid.  

Note that the type constraint was merely a lint here.  It was never enough for the states to be the same *type*, they also had to have compatible *values*!  For example, `<&T>::State == ComponentId`, but any value other than the `ComponentId` of `T` would be unsound.  Make this requirement explicit, and update the safety comments of mutable query types to show that they satisfy it.  

See also #25642 for an alternative approach.