### PR TITLE
OIT example: remove conflicting handling of arrow keys

### DIFF
--- a/examples/3d/order_independent_transparency.rs
+++ b/examples/3d/order_independent_transparency.rs
@@ -214,11 +214,11 @@ fn handle_keyboard_shortcuts(
     setting_q: Query<(Entity, &RadioButtonOptionValue<AppSetting>), With<RadioButton>>,
     mut commands: Commands,
 ) {
-    let new_setting = if keyboard_input.just_pressed(KeyCode::ArrowRight)
-        || keyboard_input.just_pressed(KeyCode::ArrowLeft)
+    let new_setting = if keyboard_input.just_pressed(KeyCode::BracketRight)
+        || keyboard_input.just_pressed(KeyCode::BracketLeft)
     {
         let n = app_state.current_scene_id + SCENES.len();
-        if keyboard_input.pressed(KeyCode::ArrowLeft) {
+        if keyboard_input.pressed(KeyCode::BracketLeft) {
             AppSetting::ChangeScene((n - 1) % SCENES.len())
         } else {
             AppSetting::ChangeScene((n + 1) % SCENES.len())
@@ -271,7 +271,7 @@ fn spawn_ui(commands: &mut Commands, app_state: &AppState) {
         Children [
             RadioGroupSetting::ChangeScene
             @feathers_option_buttons(
-                "Scene ([←] or [→])",
+                "Scene ([ [ ] or [ ] ])",
                 &(SCENES
                     .iter()
                     .enumerate()

--- a/examples/3d/order_independent_transparency.rs
+++ b/examples/3d/order_independent_transparency.rs
@@ -11,6 +11,7 @@ use bevy::{
     core_pipeline::{oit::OrderIndependentTransparencySettings, prepass::DepthPrepass},
     ecs::system::SystemParam,
     feathers::{dark_theme::create_dark_theme, theme::UiTheme, FeathersPlugins},
+    input_focus::AutoFocus,
     pbr::{ExtendedMaterial, MaterialExtension},
     picking::window::update_window_hits,
     prelude::*,
@@ -214,16 +215,7 @@ fn handle_keyboard_shortcuts(
     setting_q: Query<(Entity, &RadioButtonOptionValue<AppSetting>), With<RadioButton>>,
     mut commands: Commands,
 ) {
-    let new_setting = if keyboard_input.just_pressed(KeyCode::ArrowRight)
-        || keyboard_input.just_pressed(KeyCode::ArrowLeft)
-    {
-        let n = app_state.current_scene_id + SCENES.len();
-        if keyboard_input.pressed(KeyCode::ArrowLeft) {
-            AppSetting::ChangeScene((n - 1) % SCENES.len())
-        } else {
-            AppSetting::ChangeScene((n + 1) % SCENES.len())
-        }
-    } else if keyboard_input.just_pressed(KeyCode::KeyT) {
+    let new_setting = if keyboard_input.just_pressed(KeyCode::KeyT) {
         AppSetting::EnableOIT(!app_state.use_oit)
     } else if keyboard_input.just_pressed(KeyCode::KeyD) {
         AppSetting::UseDepthPrepass(!app_state.use_depth_prepass)
@@ -270,6 +262,7 @@ fn spawn_ui(commands: &mut Commands, app_state: &AppState) {
         })
         Children [
             RadioGroupSetting::ChangeScene
+            AutoFocus
             @feathers_option_buttons(
                 "Scene ([←] or [→])",
                 &(SCENES

--- a/examples/3d/order_independent_transparency.rs
+++ b/examples/3d/order_independent_transparency.rs
@@ -11,7 +11,6 @@ use bevy::{
     core_pipeline::{oit::OrderIndependentTransparencySettings, prepass::DepthPrepass},
     ecs::system::SystemParam,
     feathers::{dark_theme::create_dark_theme, theme::UiTheme, FeathersPlugins},
-    input_focus::AutoFocus,
     pbr::{ExtendedMaterial, MaterialExtension},
     picking::window::update_window_hits,
     prelude::*,
@@ -215,7 +214,16 @@ fn handle_keyboard_shortcuts(
     setting_q: Query<(Entity, &RadioButtonOptionValue<AppSetting>), With<RadioButton>>,
     mut commands: Commands,
 ) {
-    let new_setting = if keyboard_input.just_pressed(KeyCode::KeyT) {
+    let new_setting = if keyboard_input.just_pressed(KeyCode::ArrowRight)
+        || keyboard_input.just_pressed(KeyCode::ArrowLeft)
+    {
+        let n = app_state.current_scene_id + SCENES.len();
+        if keyboard_input.pressed(KeyCode::ArrowLeft) {
+            AppSetting::ChangeScene((n - 1) % SCENES.len())
+        } else {
+            AppSetting::ChangeScene((n + 1) % SCENES.len())
+        }
+    } else if keyboard_input.just_pressed(KeyCode::KeyT) {
         AppSetting::EnableOIT(!app_state.use_oit)
     } else if keyboard_input.just_pressed(KeyCode::KeyD) {
         AppSetting::UseDepthPrepass(!app_state.use_depth_prepass)
@@ -262,7 +270,6 @@ fn spawn_ui(commands: &mut Commands, app_state: &AppState) {
         })
         Children [
             RadioGroupSetting::ChangeScene
-            AutoFocus
             @feathers_option_buttons(
                 "Scene ([←] or [→])",
                 &(SCENES


### PR DESCRIPTION
# Objective

The Order Independent Transparency example listens for left/right arrow keys to switch between scenes. The UI was recently migrated to Feathers and its radio buttons, which also handle arrow keys for navigation between buttons in a group. The key handling from the example thus conflicts / is redundant with this navigation, and makes the UI behave strangely when one of the `RadioGroup` is focused. 

https://github.com/user-attachments/assets/3d64be1c-fcc0-431a-95bc-7bca36de2eb5

## Solution

- Remove the manual handling of the arrow keys, let `RadioGroup` do it.
- Have the scene selection radio group `AutoFocus` to retain the current behavior at startup.

## Testing

- Launched the OIT example to verify the improved behavior and that nothing else breaks