### PR TITLE
Animated gizmos

### DIFF
--- a/crates/bevy_gizmos/src/arrows.rs
+++ b/crates/bevy_gizmos/src/arrows.rs
@@ -68,8 +68,16 @@ where
         if !self.gizmos.enabled {
             return;
         }
-        // first, draw the body of the arrow
-        self.gizmos.line(self.start, self.end, self.color);
+
+        // first, draw the body (main line) of the arrow
+        if self.double_ended {
+            let center = (self.start + self.end) / 2.0;
+            // drawing two lines for double ended arrows looks better for animated gizmos
+            self.gizmos.line(center, self.start, self.color);
+            self.gizmos.line(center, self.end, self.color);
+        } else {
+            self.gizmos.line(self.start, self.end, self.color);
+        }
         // now the hard part is to draw the head in a sensible way
         // put us in a coordinate system where the arrow is pointing towards +x and ends at the origin
         let pointing_end = (self.end - self.start).normalize();

--- a/crates/bevy_gizmos/src/config.rs
+++ b/crates/bevy_gizmos/src/config.rs
@@ -262,6 +262,12 @@ pub struct GizmoLineConfig {
     pub style: GizmoLineStyle,
     /// Describe how lines should join.
     pub joints: GizmoLineJoint,
+    /// This only applies to [`GizmoLineStyle::Dotted`] and [`GizmoLineStyle::Dashed`] and
+    /// determines how fast these dots or dashes move along the lines from start to end in a cyclic
+    /// way to indicate a direction.
+    ///
+    /// Defaults to `0.0` which means no movement.
+    pub animation_speed: f32,
 }
 
 impl Default for GizmoLineConfig {
@@ -271,6 +277,7 @@ impl Default for GizmoLineConfig {
             perspective: false,
             style: GizmoLineStyle::Solid,
             joints: GizmoLineJoint::None,
+            animation_speed: 0.0,
         }
     }
 }

--- a/crates/bevy_gizmos/src/config.rs
+++ b/crates/bevy_gizmos/src/config.rs
@@ -263,11 +263,11 @@ pub struct GizmoLineConfig {
     /// Describe how lines should join.
     pub joints: GizmoLineJoint,
     /// This only applies to [`GizmoLineStyle::Dotted`] and [`GizmoLineStyle::Dashed`] and
-    /// determines how fast these dots or dashes move along the lines from start to end in a cyclic
-    /// way to indicate a direction.
+    /// determines how far the dots/dashes are offset from their original position. This can be used
+    /// to create animations.
     ///
-    /// Defaults to `0.0` which means no movement.
-    pub animation_speed: f32,
+    /// Defaults to `0.0`.
+    pub animation_offset: f32,
 }
 
 impl Default for GizmoLineConfig {
@@ -277,7 +277,7 @@ impl Default for GizmoLineConfig {
             perspective: false,
             style: GizmoLineStyle::Solid,
             joints: GizmoLineJoint::None,
-            animation_speed: 0.0,
+            animation_offset: 0.0,
         }
     }
 }

--- a/crates/bevy_gizmos_render/src/lib.rs
+++ b/crates/bevy_gizmos_render/src/lib.rs
@@ -70,6 +70,7 @@ use {
 
 use bevy_render::{
     extract_resource::{ExtractResource, ExtractResourcePlugin},
+    globals::{GlobalsBuffer, GlobalsUniform},
     render_resource::{BindGroupLayoutDescriptor, PipelineCache, VertexAttribute, VertexStepMode},
 };
 
@@ -129,9 +130,12 @@ impl Plugin for GizmoRenderPlugin {
 fn init_line_gizmo_uniform_bind_group_layout(mut commands: Commands) {
     let line_layout = BindGroupLayoutDescriptor::new(
         "LineGizmoUniform layout",
-        &BindGroupLayoutEntries::single(
-            ShaderStages::VERTEX,
-            uniform_buffer::<LineGizmoUniform>(true),
+        &BindGroupLayoutEntries::sequential(
+            ShaderStages::VERTEX_FRAGMENT,
+            (
+                uniform_buffer::<LineGizmoUniform>(true),
+                uniform_buffer::<GlobalsUniform>(false),
+            ),
         ),
     );
 
@@ -200,6 +204,7 @@ fn extract_gizmo_data(
                 joints_resolution,
                 gap_scale,
                 line_scale,
+                animation_speed: config.line.animation_speed,
                 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
                 _webgl2_padding: Default::default(),
             },
@@ -229,9 +234,10 @@ struct LineGizmoUniform {
     // Only used if the current configs `line_style` is set to `GizmoLineStyle::Dashed{_}`
     gap_scale: f32,
     line_scale: f32,
+    animation_speed: f32,
     /// WebGL2 structs must be 16 byte aligned.
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
-    _webgl2_padding: bevy_math::Vec3,
+    _webgl2_padding: bevy_math::Vec2,
 }
 
 #[cfg_attr(
@@ -319,16 +325,23 @@ fn prepare_line_gizmo_bind_group(
     render_device: Res<RenderDevice>,
     pipeline_cache: Res<PipelineCache>,
     line_gizmo_uniforms: Res<ComponentUniforms<LineGizmoUniform>>,
+    globals_buffer: Res<GlobalsBuffer>,
 ) {
-    if let Some(binding) = line_gizmo_uniforms.uniforms().binding() {
-        commands.insert_resource(LineGizmoUniformBindgroup {
-            bindgroup: render_device.create_bind_group(
-                "LineGizmoUniform bindgroup",
-                &pipeline_cache.get_bind_group_layout(&line_gizmo_uniform_layout.layout),
-                &BindGroupEntries::single(binding),
-            ),
-        });
-    }
+    let Some(line_gizmo_binding) = line_gizmo_uniforms.uniforms().binding() else {
+        return;
+    };
+
+    let Some(globals_binding) = globals_buffer.buffer.binding() else {
+        return;
+    };
+
+    commands.insert_resource(LineGizmoUniformBindgroup {
+        bindgroup: render_device.create_bind_group(
+            "LineGizmoUniform bindgroup",
+            &pipeline_cache.get_bind_group_layout(&line_gizmo_uniform_layout.layout),
+            &BindGroupEntries::with_indices(((0, line_gizmo_binding), (1, globals_binding))),
+        ),
+    });
 }
 
 #[cfg_attr(

--- a/crates/bevy_gizmos_render/src/lib.rs
+++ b/crates/bevy_gizmos_render/src/lib.rs
@@ -70,7 +70,6 @@ use {
 
 use bevy_render::{
     extract_resource::{ExtractResource, ExtractResourcePlugin},
-    globals::{GlobalsBuffer, GlobalsUniform},
     render_resource::{BindGroupLayoutDescriptor, PipelineCache, VertexAttribute, VertexStepMode},
 };
 
@@ -130,12 +129,9 @@ impl Plugin for GizmoRenderPlugin {
 fn init_line_gizmo_uniform_bind_group_layout(mut commands: Commands) {
     let line_layout = BindGroupLayoutDescriptor::new(
         "LineGizmoUniform layout",
-        &BindGroupLayoutEntries::sequential(
+        &BindGroupLayoutEntries::single(
             ShaderStages::VERTEX_FRAGMENT,
-            (
-                uniform_buffer::<LineGizmoUniform>(true),
-                uniform_buffer::<GlobalsUniform>(false),
-            ),
+            uniform_buffer::<LineGizmoUniform>(true),
         ),
     );
 
@@ -204,7 +200,7 @@ fn extract_gizmo_data(
                 joints_resolution,
                 gap_scale,
                 line_scale,
-                animation_speed: config.line.animation_speed,
+                animation_offset: config.line.animation_offset,
                 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
                 _webgl2_padding: Default::default(),
             },
@@ -234,7 +230,7 @@ struct LineGizmoUniform {
     // Only used if the current configs `line_style` is set to `GizmoLineStyle::Dashed{_}`
     gap_scale: f32,
     line_scale: f32,
-    animation_speed: f32,
+    animation_offset: f32,
     /// WebGL2 structs must be 16 byte aligned.
     #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
     _webgl2_padding: bevy_math::Vec2,
@@ -325,13 +321,8 @@ fn prepare_line_gizmo_bind_group(
     render_device: Res<RenderDevice>,
     pipeline_cache: Res<PipelineCache>,
     line_gizmo_uniforms: Res<ComponentUniforms<LineGizmoUniform>>,
-    globals_buffer: Res<GlobalsBuffer>,
 ) {
     let Some(line_gizmo_binding) = line_gizmo_uniforms.uniforms().binding() else {
-        return;
-    };
-
-    let Some(globals_binding) = globals_buffer.buffer.binding() else {
         return;
     };
 
@@ -339,7 +330,7 @@ fn prepare_line_gizmo_bind_group(
         bindgroup: render_device.create_bind_group(
             "LineGizmoUniform bindgroup",
             &pipeline_cache.get_bind_group_layout(&line_gizmo_uniform_layout.layout),
-            &BindGroupEntries::with_indices(((0, line_gizmo_binding), (1, globals_binding))),
+            &BindGroupEntries::single(line_gizmo_binding),
         ),
     });
 }

--- a/crates/bevy_gizmos_render/src/lines.wesl
+++ b/crates/bevy_gizmos_render/src/lines.wesl
@@ -1,8 +1,9 @@
 // TODO use common view binding
-import bevy_render::{view::View, maths::affine3_to_square};
+import bevy_render::view::View;
+import bevy_render::globals::Globals;
+import bevy_render::maths::affine3_to_square;
 
 @group(0) @binding(0) var<uniform> view: View;
-
 
 struct LineGizmoUniform {
     world_from_local: mat3x4<f32>,
@@ -11,12 +12,14 @@ struct LineGizmoUniform {
     _joints_resolution: u32,
     gap_scale: f32,
     line_scale: f32,
+    animation_speed: f32,
     @if(SIXTEEN_BYTE_ALIGNMENT)
     // WebGL2 structs must be 16 byte aligned.
-    _padding: vec3<f32>,
+    _padding: vec2<f32>,
 }
 
 @group(1) @binding(0) var<uniform> line_gizmo: LineGizmoUniform;
+@group(1) @binding(1) var<uniform> globals: Globals;
 
 struct VertexInput {
     @location(0) position_a: vec3<f32>,
@@ -160,28 +163,39 @@ struct FragmentOutput {
     @location(0) color: vec4<f32>,
 };
 
+fn non_solid_uv(in: FragmentInput) -> f32 {
+    @if(PERSPECTIVE)
+    let uv = in.uv;
+    @else
+    let uv = in.uv * in.position.w;
+
+    // subtract the animation offset here since otherwise the animation is
+    // running "backwards", e.g.
+    // - from the line end to the line start
+    // - from the arrow tip to the arrow start
+    let animated = uv - globals.time * line_gizmo.animation_speed;
+
+    const PERIOD: f32 = 2.0;
+    return animated - floor(animated / PERIOD) * PERIOD;
+}
+
 @fragment
 fn fragment_solid(in: FragmentInput) -> FragmentOutput {
     return FragmentOutput(in.color);
 }
+
 @fragment
 fn fragment_dotted(in: FragmentInput) -> FragmentOutput {
-    var alpha: f32;
-    @if(PERSPECTIVE)
-    alpha = 1 - floor(in.uv % 2.0);
-    @else
-    alpha = 1 - floor((in.uv * in.position.w) % 2.0);
-    
+    let uv = non_solid_uv(in);
+    let alpha = 1.0 - floor(uv);
+
     return FragmentOutput(vec4(in.color.xyz, in.color.w * alpha));
 }
 
 @fragment
 fn fragment_dashed(in: FragmentInput) -> FragmentOutput {
-    @if(PERSPECTIVE)
-    let uv = in.uv;
-    @else
-    let uv = in.uv * in.position.w;
-    let alpha = 1.0 - floor(min((uv % 2.0) / in.line_fraction, 1.0));
-    
+    let uv = non_solid_uv(in);
+    let alpha = 1.0 - floor(min(uv / in.line_fraction, 1.0));
+
     return FragmentOutput(vec4(in.color.xyz, in.color.w * alpha));
 }

--- a/crates/bevy_gizmos_render/src/lines.wesl
+++ b/crates/bevy_gizmos_render/src/lines.wesl
@@ -1,6 +1,5 @@
 // TODO use common view binding
 import bevy_render::view::View;
-import bevy_render::globals::Globals;
 import bevy_render::maths::affine3_to_square;
 
 @group(0) @binding(0) var<uniform> view: View;
@@ -12,14 +11,13 @@ struct LineGizmoUniform {
     _joints_resolution: u32,
     gap_scale: f32,
     line_scale: f32,
-    animation_speed: f32,
+    animation_offset: f32,
     @if(SIXTEEN_BYTE_ALIGNMENT)
     // WebGL2 structs must be 16 byte aligned.
     _padding: vec2<f32>,
 }
 
 @group(1) @binding(0) var<uniform> line_gizmo: LineGizmoUniform;
-@group(1) @binding(1) var<uniform> globals: Globals;
 
 struct VertexInput {
     @location(0) position_a: vec3<f32>,
@@ -173,7 +171,7 @@ fn non_solid_uv(in: FragmentInput) -> f32 {
     // running "backwards", e.g.
     // - from the line end to the line start
     // - from the arrow tip to the arrow start
-    let animated = uv - globals.time * line_gizmo.animation_speed;
+    let animated = uv - line_gizmo.animation_offset;
 
     const PERIOD: f32 = 2.0;
     return animated - floor(animated / PERIOD) * PERIOD;

--- a/crates/bevy_gizmos_render/src/retained.rs
+++ b/crates/bevy_gizmos_render/src/retained.rs
@@ -63,6 +63,7 @@ pub(crate) fn extract_linegizmos(
                 joints_resolution,
                 gap_scale,
                 line_scale,
+                animation_speed: gizmo.line_config.animation_speed,
                 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
                 _webgl2_padding: Default::default(),
             },

--- a/crates/bevy_gizmos_render/src/retained.rs
+++ b/crates/bevy_gizmos_render/src/retained.rs
@@ -63,7 +63,7 @@ pub(crate) fn extract_linegizmos(
                 joints_resolution,
                 gap_scale,
                 line_scale,
-                animation_speed: gizmo.line_config.animation_speed,
+                animation_offset: gizmo.line_config.animation_offset,
                 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
                 _webgl2_padding: Default::default(),
             },

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -2,14 +2,21 @@
 
 use std::f32::consts::{FRAC_PI_2, PI, TAU};
 
-use bevy::{color::palettes::css::*, input::mouse::MouseWheel, math::Isometry2d, prelude::*};
+use bevy::{color::palettes::css::*, math::Isometry2d, prelude::*};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .init_gizmo_group::<MyRoundGizmos>()
         .add_systems(Startup, setup)
-        .add_systems(Update, (draw_example_collection, update_config))
+        .add_systems(
+            Update,
+            (
+                draw_example_collection,
+                update_config,
+                drive_gizmos_animation,
+            ),
+        )
         .run();
 }
 
@@ -27,8 +34,8 @@ fn setup(mut commands: Commands) {
         Press '1' / '2' to toggle the visibility of straight / round gizmos\n\
         Press 'U' / 'I' to cycle through line styles\n\
         Press 'J' / 'K' to cycle through line joins\n\
-        Press 'Spacebar' to toggle pause\n\
-        Roll 'MouseWheel' to increase/decrease animation speed for dotted/dashed round gizmos",
+        Press 'L' to cycle through gizmos animations (only for dotted/dashed round gizmos)\n\
+        Press 'Spacebar' to toggle pause",
         ),
         Node {
             position_type: PositionType::Absolute,
@@ -129,7 +136,6 @@ fn draw_example_collection(
 fn update_config(
     mut config_store: ResMut<GizmoConfigStore>,
     keyboard: Res<ButtonInput<KeyCode>>,
-    mut mouse: MessageReader<MouseWheel>,
     real_time: Res<Time<Real>>,
     mut virtual_time: ResMut<Time<Virtual>>,
 ) {
@@ -213,11 +219,45 @@ fn update_config(
             GizmoLineJoint::None => GizmoLineJoint::Bevel,
         };
     }
-    for ev in mouse.read() {
-        my_config.line.animation_speed = (my_config.line.animation_speed + ev.y).clamp(-10.0, 10.0);
-    }
 
     if keyboard.just_pressed(KeyCode::Space) {
         virtual_time.toggle();
+    }
+}
+
+enum GizmosAnimationType {
+    Linear,
+    BackAndForth,
+    Stutter,
+}
+
+fn drive_gizmos_animation(
+    mut config_store: ResMut<GizmoConfigStore>,
+    virtual_time: ResMut<Time<Virtual>>,
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut animation_type: Local<Option<GizmosAnimationType>>,
+) {
+    if keyboard.just_pressed(KeyCode::KeyL) {
+        *animation_type = match *animation_type {
+            None => Some(GizmosAnimationType::Linear),
+            Some(GizmosAnimationType::Linear) => Some(GizmosAnimationType::BackAndForth),
+            Some(GizmosAnimationType::BackAndForth) => Some(GizmosAnimationType::Stutter),
+            Some(GizmosAnimationType::Stutter) => None,
+        };
+    }
+
+    if let Some(animation_type) = animation_type.as_ref() {
+        let (my_config, _) = config_store.config_mut::<MyRoundGizmos>();
+        match animation_type {
+            GizmosAnimationType::Linear => {
+                my_config.line.animation_offset = virtual_time.elapsed_secs() * 10.0;
+            }
+            GizmosAnimationType::BackAndForth => {
+                my_config.line.animation_offset = ops::sin(virtual_time.elapsed_secs()) * 10.0;
+            }
+            GizmosAnimationType::Stutter => {
+                my_config.line.animation_offset = (virtual_time.elapsed_secs() * 4.0).round();
+            }
+        }
     }
 }

--- a/examples/gizmos/2d_gizmos.rs
+++ b/examples/gizmos/2d_gizmos.rs
@@ -2,7 +2,7 @@
 
 use std::f32::consts::{FRAC_PI_2, PI, TAU};
 
-use bevy::{color::palettes::css::*, math::Isometry2d, prelude::*};
+use bevy::{color::palettes::css::*, input::mouse::MouseWheel, math::Isometry2d, prelude::*};
 
 fn main() {
     App::new()
@@ -27,7 +27,8 @@ fn setup(mut commands: Commands) {
         Press '1' / '2' to toggle the visibility of straight / round gizmos\n\
         Press 'U' / 'I' to cycle through line styles\n\
         Press 'J' / 'K' to cycle through line joins\n\
-        Press 'Spacebar' to toggle pause",
+        Press 'Spacebar' to toggle pause\n\
+        Roll 'MouseWheel' to increase/decrease animation speed for dotted/dashed round gizmos",
         ),
         Node {
             position_type: PositionType::Absolute,
@@ -121,11 +122,14 @@ fn draw_example_collection(
         )
         .with_double_end()
         .with_tip_length(10.);
+
+    my_gizmos.arc_2d(Isometry2d::default(), FRAC_PI_2, 210., OLD_LACE);
 }
 
 fn update_config(
     mut config_store: ResMut<GizmoConfigStore>,
     keyboard: Res<ButtonInput<KeyCode>>,
+    mut mouse: MessageReader<MouseWheel>,
     real_time: Res<Time<Real>>,
     mut virtual_time: ResMut<Time<Virtual>>,
 ) {
@@ -209,6 +213,10 @@ fn update_config(
             GizmoLineJoint::None => GizmoLineJoint::Bevel,
         };
     }
+    for ev in mouse.read() {
+        my_config.line.animation_speed = (my_config.line.animation_speed + ev.y).clamp(-10.0, 10.0);
+    }
+
     if keyboard.just_pressed(KeyCode::Space) {
         virtual_time.toggle();
     }

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -3,6 +3,7 @@
 use bevy::{
     camera_controller::free_camera::{FreeCamera, FreeCameraPlugin},
     color::palettes::css::*,
+    input::mouse::MouseWheel,
     prelude::*,
 };
 use std::f32::consts::PI;
@@ -85,7 +86,8 @@ fn setup(
             Press 'B' to show all AABB boxes\n\
             Press 'U' or 'I' to cycle through line styles for straight or round gizmos\n\
             Press 'J' or 'K' to cycle through line joins for straight or round gizmos\n\
-            Press 'Spacebar' to toggle pause",
+            Press 'Spacebar' to toggle pause\n\
+            Roll 'MouseWheel' to increase/decrease animation speed for dotted/dashed round gizmos",
         ),
         Node {
             position_type: PositionType::Absolute,
@@ -212,11 +214,18 @@ fn draw_example_collection(
         .arrow(Vec3::new(2., 0., 2.), Vec3::new(2., 2., 2.), ORANGE_RED)
         .with_double_end()
         .with_tip_length(0.5);
+
+    let from = Vec3::new(1.0, 2.0, 3.0);
+    let to = Vec3::new(3.0, 2.5, 4.0);
+    gizmos.rect(from, Vec2::ONE, RED);
+    my_gizmos.short_arc_3d_between((from + to) / 2.0, from, to, YELLOW_GREEN);
+    gizmos.rect(to, Vec2::ONE, RED);
 }
 
 fn update_config(
     mut config_store: ResMut<GizmoConfigStore>,
     keyboard: Res<ButtonInput<KeyCode>>,
+    mut mouse: MessageReader<MouseWheel>,
     real_time: Res<Time<Real>>,
     mut virtual_time: ResMut<Time<Virtual>>,
 ) {
@@ -294,6 +303,9 @@ fn update_config(
             GizmoLineJoint::Round(_) => GizmoLineJoint::None,
             GizmoLineJoint::None => GizmoLineJoint::Bevel,
         };
+    }
+    for ev in mouse.read() {
+        my_config.line.animation_speed = (my_config.line.animation_speed + ev.y).clamp(-10.0, 10.0);
     }
 
     if keyboard.just_pressed(KeyCode::KeyB) {

--- a/examples/gizmos/3d_gizmos.rs
+++ b/examples/gizmos/3d_gizmos.rs
@@ -3,7 +3,6 @@
 use bevy::{
     camera_controller::free_camera::{FreeCamera, FreeCameraPlugin},
     color::palettes::css::*,
-    input::mouse::MouseWheel,
     prelude::*,
 };
 use std::f32::consts::PI;
@@ -13,7 +12,14 @@ fn main() {
         .add_plugins((DefaultPlugins, FreeCameraPlugin))
         .init_gizmo_group::<MyRoundGizmos>()
         .add_systems(Startup, setup)
-        .add_systems(Update, (draw_example_collection, update_config))
+        .add_systems(
+            Update,
+            (
+                draw_example_collection,
+                update_config,
+                drive_gizmos_animation,
+            ),
+        )
         .run();
 }
 
@@ -86,8 +92,8 @@ fn setup(
             Press 'B' to show all AABB boxes\n\
             Press 'U' or 'I' to cycle through line styles for straight or round gizmos\n\
             Press 'J' or 'K' to cycle through line joins for straight or round gizmos\n\
-            Press 'Spacebar' to toggle pause\n\
-            Roll 'MouseWheel' to increase/decrease animation speed for dotted/dashed round gizmos",
+            Press 'L' to cycle through gizmos animations (only for dotted/dashed round gizmos)\n\
+            Press 'Spacebar' to toggle pause",
         ),
         Node {
             position_type: PositionType::Absolute,
@@ -225,7 +231,6 @@ fn draw_example_collection(
 fn update_config(
     mut config_store: ResMut<GizmoConfigStore>,
     keyboard: Res<ButtonInput<KeyCode>>,
-    mut mouse: MessageReader<MouseWheel>,
     real_time: Res<Time<Real>>,
     mut virtual_time: ResMut<Time<Virtual>>,
 ) {
@@ -304,9 +309,6 @@ fn update_config(
             GizmoLineJoint::None => GizmoLineJoint::Bevel,
         };
     }
-    for ev in mouse.read() {
-        my_config.line.animation_speed = (my_config.line.animation_speed + ev.y).clamp(-10.0, 10.0);
-    }
 
     if keyboard.just_pressed(KeyCode::KeyB) {
         // AABB gizmos are normally only drawn on entities with a ShowAabbGizmo component
@@ -315,5 +317,42 @@ fn update_config(
     }
     if keyboard.just_pressed(KeyCode::Space) {
         virtual_time.toggle();
+    }
+}
+
+enum GizmosAnimationType {
+    Linear,
+    BackAndForth,
+    Stutter,
+}
+
+fn drive_gizmos_animation(
+    mut config_store: ResMut<GizmoConfigStore>,
+    virtual_time: ResMut<Time<Virtual>>,
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut animation_type: Local<Option<GizmosAnimationType>>,
+) {
+    if keyboard.just_pressed(KeyCode::KeyL) {
+        *animation_type = match *animation_type {
+            None => Some(GizmosAnimationType::Linear),
+            Some(GizmosAnimationType::Linear) => Some(GizmosAnimationType::BackAndForth),
+            Some(GizmosAnimationType::BackAndForth) => Some(GizmosAnimationType::Stutter),
+            Some(GizmosAnimationType::Stutter) => None,
+        };
+    }
+
+    if let Some(animation_type) = animation_type.as_ref() {
+        let (my_config, _) = config_store.config_mut::<MyRoundGizmos>();
+        match animation_type {
+            GizmosAnimationType::Linear => {
+                my_config.line.animation_offset = virtual_time.elapsed_secs() * 10.0;
+            }
+            GizmosAnimationType::BackAndForth => {
+                my_config.line.animation_offset = ops::sin(virtual_time.elapsed_secs()) * 10.0;
+            }
+            GizmosAnimationType::Stutter => {
+                my_config.line.animation_offset = (virtual_time.elapsed_secs() * 4.0).round();
+            }
+        }
     }
 }


### PR DESCRIPTION
# Objective

Sometimes it's nice to have some kind of animation for gizmos. An example of such a situation can be seen below where a arc gizmo can be used to visualize a rotation/translation around a center. Without an animation, you would lose the sense of direction.

Prior attempts to implement this can be found here:

- #14645
- #18895

## Solution

In the mean time the gizmo rendering code has evolved quiet a bit. The solution proposal consists of some minor changes:

- The `GizmoLineConfig` gets a new `animation_speed` field. This fields defaults to the value `0.0_f32`. It is only used with dotted or dashed gizmo line styles. In these cases, it decides how fast the dots and dashes move along the lines from the start to the end
- In the render code we add the global uniforms to the gizmo shaders to have access to the global time values. They are then used to drive the animation

The trade-off is that we still pay for animated gizmos, which is like 1 (one!) line of code and two arithmetic operations in the shader effectively, even if we set the animation speed to `0.0_f32`. Maybe it's valid to specialize the render pipeline further somehow to prevent this, but this also kinda feels like premature optimization.

## Testing

- I ran both the `2d_gizmos` and the `3d_gizmos` examples and created animations there.
- I also ran the examples with the whole gizmos collection using the animations to check if other things look weird. To be honest I don't think that the animations are useful outside of lines, arrows and arcs but maybe it does make sense after all. I'm also open to restrict the animations further to only these use cases.

## Additional stuff

- For double headed arrows, the animation looks kind of weird, so I split the double arrow line up into two lines both starting from the center and running to either the start or the end of the arrow line. This looks more natural

---

## Showcase

### 2d example

<img width="500" height="491" alt="animated" src="https://github.com/user-attachments/assets/976e7608-02c5-4bcf-9438-6faafafcd509" />

### 3d example

<img width="500" height="359" alt="animated" src="https://github.com/user-attachments/assets/5f44eeb3-748d-45bd-b5aa-a67f9954e43c" />

```rs
    let from = Vec3::new(1.0, 2.0, 3.0);
    let to = Vec3::new(3.0, 2.5, 4.0);
    gizmos.rect(from, Vec2::ONE, RED);
    animated.short_arc_3d_between((from + to) / 2.0, from, to, YELLOW_GREEN);
    gizmos.rect(to, Vec2::ONE, RED);
```

### Showcase of the double headed arrow change

<img width="500" height="899" alt="animated" src="https://github.com/user-attachments/assets/7df868ee-e760-43bc-ac48-76fc388f48f6" />
