### PR TITLE
bevy_render macro: ignore clippy in wasm

### DIFF
--- a/crates/bevy_render/src/renderer/wgpu_wrapper.rs
+++ b/crates/bevy_render/src/renderer/wgpu_wrapper.rs
@@ -71,6 +71,8 @@ macro_rules! wgpu_wrapper {
                     Self(send_wrapper::SendWrapper::new(t))
                 }
 
+                #[allow(clippy::allow_attributes, unused, reason = "This is not used on all wrappers.")]
+                /// Unwraps the value.
                 pub fn into_inner(self) -> $wgputy {
                     self.0.take()
                 }


### PR DESCRIPTION
# Objective

- #25512 introduced a macro with a function that's sometimes not used

## Solution

- Ignore clippy, like it's done in the other branch above

https://github.com/bevyengine/bevy/blob/7fecf1cd8b211ab16a3b9ad057ef56f967c3a400/crates/bevy_render/src/renderer/wgpu_wrapper.rs#L19-L24