### PR TITLE
turn more types into wgpu wrappers

### DIFF
--- a/crates/bevy_core_pipeline/src/schedule.rs
+++ b/crates/bevy_core_pipeline/src/schedule.rs
@@ -28,7 +28,7 @@ use bevy_render::{
         CommandEncoderDescriptor, LoadOp, Operations, RenderPassColorAttachment,
         RenderPassDescriptor, StoreOp,
     },
-    renderer::{CurrentView, PendingCommandBuffers, RenderDevice, RenderQueue},
+    renderer::{CurrentView, PendingCommandBuffers, RenderDevice, RenderQueue, WgpuCommandBuffer},
     sync_world::MainEntity,
     view::ExtractedWindow,
 };
@@ -279,7 +279,7 @@ pub(crate) fn submit_pending_command_buffers(
     if buffers.peek().is_some() {
         #[cfg(feature = "trace")]
         let _span = info_span!("queue_submit", count = buffer_count).entered();
-        queue.submit(buffers);
+        queue.submit(buffers.map(WgpuCommandBuffer::into_inner));
     }
 }
 
@@ -336,5 +336,5 @@ pub(crate) fn handle_uncovered_swap_chains(world: &mut World) {
         encoder.begin_render_pass(&pass_descriptor);
     }
 
-    render_queue.submit([encoder.finish()]);
+    render_queue.submit([encoder.into_inner().finish()]);
 }

--- a/crates/bevy_render/src/diagnostic/internal.rs
+++ b/crates/bevy_render/src/diagnostic/internal.rs
@@ -16,7 +16,9 @@ use wgpu::{
     RenderPass,
 };
 
-use crate::renderer::{wgpu_wrapper, RenderAdapterInfo, RenderDevice, RenderQueue};
+use crate::renderer::{
+    wgpu_wrapper, RenderAdapterInfo, RenderDevice, RenderQueue, WgpuCommandEncoder,
+};
 
 use super::RecordDiagnostics;
 
@@ -750,7 +752,7 @@ pub trait WriteTimestamp {
     fn write_timestamp(&mut self, query_set: &QuerySet, index: u32);
 }
 
-impl WriteTimestamp for CommandEncoder {
+impl WriteTimestamp for WgpuCommandEncoder {
     fn write_timestamp(&mut self, query_set: &QuerySet, index: u32) {
         if cfg!(target_os = "macos") {
             // When using tracy (and thus this function), rendering was flickering on macOS Tahoe.

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -5,7 +5,8 @@ mod render_device;
 mod wgpu_wrapper;
 
 pub use render_context::{
-    CurrentView, FlushCommands, PendingCommandBuffers, RenderContext, RenderContextState, ViewQuery,
+    CurrentView, FlushCommands, PendingCommandBuffers, RenderContext, RenderContextState,
+    ViewQuery, WgpuCommandBuffer, WgpuCommandEncoder,
 };
 pub use render_device::*;
 
@@ -103,7 +104,7 @@ pub fn render_system(
         crate::view::screenshot::submit_screenshot_commands(world, screenshot_state, &mut encoder);
         crate::gpu_readback::submit_readback_commands(world, &mut encoder);
 
-        render_queue.submit([encoder.finish()]);
+        render_queue.submit([encoder.into_inner().finish()]);
     }
 
     {

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -1,6 +1,6 @@
 use crate::diagnostic::internal::DiagnosticsRecorder;
 use crate::render_phase::TrackedRenderPass;
-use crate::render_resource::{CommandEncoder, RenderPassDescriptor};
+use crate::render_resource::RenderPassDescriptor;
 use crate::renderer::{wgpu_wrapper, RenderDevice};
 use alloc::borrow::Cow;
 use bevy_derive::{Deref, DerefMut};
@@ -19,17 +19,18 @@ use bevy_log::info_span;
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::ComputeTaskPool;
 use core::marker::PhantomData;
-use wgpu::CommandBuffer;
 
 #[derive(Default)]
 struct PendingCommandBuffersInner {
     commands: Vec<PendingCommandBuffer>,
 }
+wgpu_wrapper!(pub struct WgpuCommandBuffer(wgpu::CommandBuffer));
+wgpu_wrapper!(pub struct WgpuCommandEncoder(wgpu::CommandEncoder));
 
 enum PendingCommandBuffer {
-    Buffer(CommandBuffer),
+    Buffer(WgpuCommandBuffer),
     Encoder {
-        encoder: CommandEncoder,
+        encoder: WgpuCommandEncoder,
         #[cfg(feature = "trace")]
         name: Cow<'static, str>,
     },
@@ -50,7 +51,7 @@ impl Default for PendingCommandBuffers {
 }
 
 impl PendingCommandBuffers {
-    pub fn push(&mut self, buffers: impl IntoIterator<Item = CommandBuffer>) {
+    pub fn push(&mut self, buffers: impl IntoIterator<Item = WgpuCommandBuffer>) {
         self.0
             .commands
             .extend(buffers.into_iter().map(PendingCommandBuffer::Buffer));
@@ -60,7 +61,11 @@ impl PendingCommandBuffers {
         self.0.commands.append(commands);
     }
 
-    pub fn push_encoder(&mut self, encoder: CommandEncoder, name: impl Into<Cow<'static, str>>) {
+    pub fn push_encoder(
+        &mut self,
+        encoder: WgpuCommandEncoder,
+        name: impl Into<Cow<'static, str>>,
+    ) {
         #[cfg(not(feature = "trace"))]
         let _ = name;
 
@@ -71,7 +76,7 @@ impl PendingCommandBuffers {
         });
     }
 
-    pub fn finish(&mut self) -> impl Iterator<Item = CommandBuffer> {
+    pub fn finish(&mut self) -> impl Iterator<Item = WgpuCommandBuffer> {
         #[cfg(feature = "trace")]
         let _finish_command_buffers_span = info_span!("finish_command_buffers").entered();
 
@@ -104,7 +109,7 @@ impl PendingCommandBuffers {
 #[cfg(target_arch = "wasm32")]
 fn finish_sequential(
     commands: impl Iterator<Item = PendingCommandBuffer>,
-) -> impl Iterator<Item = CommandBuffer> {
+) -> impl Iterator<Item = WgpuCommandBuffer> {
     commands.into_iter().map(|command| match command {
         PendingCommandBuffer::Buffer(command_buffer) => command_buffer,
         PendingCommandBuffer::Encoder { encoder, .. } => encoder.finish(),
@@ -116,7 +121,7 @@ fn finish_sequential(
 #[cfg(not(target_arch = "wasm32"))]
 fn finish_parallel(
     commands: impl Iterator<Item = PendingCommandBuffer>,
-) -> impl Iterator<Item = CommandBuffer> {
+) -> impl Iterator<Item = WgpuCommandBuffer> {
     let mut command_buffers = Vec::with_capacity(commands.size_hint().0);
     let mut finished_encoders = ComputeTaskPool::get().scope(|scope| {
         for (index, command) in commands.into_iter().enumerate() {
@@ -133,7 +138,7 @@ fn finish_parallel(
                         #[cfg(feature = "trace")]
                         let _span =
                             info_span!("finish_command_buffer", system = name.as_ref()).entered();
-                        (index, encoder.finish())
+                        (index, WgpuCommandBuffer(encoder.0.finish()))
                     });
                 }
             }
@@ -149,7 +154,7 @@ fn finish_parallel(
 
 #[derive(Default)]
 struct RenderContextStateInner {
-    command_encoder: Option<CommandEncoder>,
+    command_encoder: Option<WgpuCommandEncoder>,
     commands: Vec<PendingCommandBuffer>,
     render_device: Option<RenderDevice>,
 }
@@ -187,7 +192,7 @@ impl RenderContextState {
         self.0.flush_encoder();
     }
 
-    fn command_encoder(&mut self, label: &str) -> &mut CommandEncoder {
+    fn command_encoder(&mut self, label: &str) -> &mut WgpuCommandEncoder {
         let render_device = self
             .0
             .render_device
@@ -256,7 +261,7 @@ impl<'w, 's> RenderContext<'w, 's> {
     }
 
     /// Returns the current command encoder, creating one if it does not already exist.
-    pub fn command_encoder(&mut self) -> &mut CommandEncoder {
+    pub fn command_encoder(&mut self) -> &mut WgpuCommandEncoder {
         self.ensure_device();
         self.state.command_encoder(self.system_name.as_str())
     }
@@ -280,7 +285,7 @@ impl<'w, 's> RenderContext<'w, 's> {
     }
 
     /// Adds a finished command buffer to be submitted later.
-    pub fn add_command_buffer(&mut self, command_buffer: CommandBuffer) {
+    pub fn add_command_buffer(&mut self, command_buffer: WgpuCommandBuffer) {
         self.state.flush_encoder();
         self.state
             .0
@@ -303,7 +308,7 @@ impl<'w> FlushCommands<'w> {
     pub fn flush(&mut self) {
         let mut buffers = self.pending.finish().peekable();
         if buffers.peek().is_some() {
-            self.queue.submit(buffers);
+            self.queue.submit(buffers.map(|buffer| buffer.0));
         }
     }
 }

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -131,13 +131,13 @@ impl RenderDevice {
         self.device.poll(maintain)
     }
 
-    /// Creates an empty [`CommandEncoder`](wgpu::CommandEncoder).
+    /// Creates an empty [`WgpuCommandEncoder`](super::WgpuCommandEncoder).
     #[inline]
     pub fn create_command_encoder(
         &self,
         desc: &wgpu::CommandEncoderDescriptor,
-    ) -> wgpu::CommandEncoder {
-        self.device.create_command_encoder(desc)
+    ) -> super::WgpuCommandEncoder {
+        super::WgpuCommandEncoder::new(self.device.create_command_encoder(desc))
     }
 
     /// Creates an empty [`RenderBundleEncoder`](wgpu::RenderBundleEncoder).

--- a/crates/bevy_render/src/renderer/wgpu_wrapper.rs
+++ b/crates/bevy_render/src/renderer/wgpu_wrapper.rs
@@ -5,12 +5,13 @@
 /// On other platforms the wrapper simply contains the wrapped value.
 #[cfg(not(all(target_arch = "wasm32", target_feature = "atomics")))]
 macro_rules! wgpu_wrapper {
-    ($( $(#[$($attrs:tt)*])* $vis:vis struct $name:ident ($wgputy:ty) );+ $(;)?) => {
+    ($( $(#[$($attrs:tt)*])* $vis:vis struct $name:ident $(<$lt:lifetime>)? ($wgputy:ty) );+ $(;)?) => {
         $(
             $( #[$($attrs)*] )*
-            $vis struct $name ($wgputy);
+            #[repr(transparent)]
+            $vis struct $name$(<$lt>)* ($wgputy);
 
-            impl $name {
+            impl$(<$lt>)* $name$(<$lt>)* {
                 /// Constructs a new instance of `WgpuWrapper` which will wrap the specified value.
                 pub fn new(t: $wgputy) -> Self {
                     Self(t)
@@ -23,7 +24,7 @@ macro_rules! wgpu_wrapper {
                 }
             }
 
-            impl ::core::ops::Deref for $name {
+            impl$(<$lt>)* ::core::ops::Deref for $name$(<$lt>)* {
                 type Target = $wgputy;
 
                 fn deref(&self) -> &Self::Target {
@@ -31,7 +32,7 @@ macro_rules! wgpu_wrapper {
                 }
             }
 
-            impl ::core::ops::DerefMut for $name {
+            impl$(<$lt>)* ::core::ops::DerefMut for $name$(<$lt>)* {
                 fn deref_mut(&mut self) -> &mut Self::Target {
                     &mut self.0
                 }
@@ -42,15 +43,18 @@ macro_rules! wgpu_wrapper {
             // this creates a short-circuit for the trait solver that reduces recursion depth
             // and substantially improves compile times.
             const _: () = {
-                const fn assert_sync_send<T: Sync + Send>() {}
-                assert_sync_send::<$wgputy>()
+                const fn assert_sync_send<T: ?Sized + Sync + Send>() {}
+                #[allow(clippy::allow_attributes, dead_code, clippy::extra_unused_lifetimes, reason = "Only used for its type-check side effect.")]
+                fn check $(<$lt>)? () {
+                    assert_sync_send::<$wgputy>();
+                }
             };
             // SAFETY: We just asserted that $wgputy is Send and Sync
             #[expect(unsafe_code, reason = "Blanket-impl Send requires unsafe.")]
-            unsafe impl Send for $name {}
+            unsafe impl$(<$lt>)* Send for $name$(<$lt>)* {}
             // SAFETY: We just asserted that $wgputy is Send and Sync
             #[expect(unsafe_code, reason = "Blanket-impl Send requires unsafe.")]
-            unsafe impl Sync for $name {}
+            unsafe impl$(<$lt>)* Sync for $name$(<$lt>)* {}
         )+
     };
 }

--- a/crates/bevy_render/src/slab_allocator.rs
+++ b/crates/bevy_render/src/slab_allocator.rs
@@ -907,7 +907,7 @@ where
             slab_to_grow.old_slot_capacity as u64 * slab.element_layout.slot_size(),
         );
 
-        let command_buffer = encoder.finish();
+        let command_buffer = encoder.into_inner().finish();
         render_queue.submit([command_buffer]);
     }
 

--- a/crates/bevy_render/src/storage.rs
+++ b/crates/bevy_render/src/storage.rs
@@ -339,7 +339,7 @@ impl RenderAsset for GpuShaderBuffer {
                         label: Some("copy_buffer_on_resize"),
                     });
                 encoder.copy_buffer_to_buffer(&previous.buffer, 0, &new_buffer, 0, copy_size);
-                render_queue.submit([encoder.finish()]);
+                render_queue.submit([encoder.into_inner().finish()]);
             }
             new_buffer
         };

--- a/crates/bevy_render/src/texture/gpu_image.rs
+++ b/crates/bevy_render/src/texture/gpu_image.rs
@@ -138,7 +138,7 @@ impl RenderAsset for GpuImage {
                         new_texture.as_image_copy(),
                         copy_size,
                     );
-                    render_queue.submit([command_encoder.finish()]);
+                    render_queue.submit([command_encoder.into_inner().finish()]);
                 } else {
                     warn!("No previous asset to copy from for image: {:?}", image);
                 }

--- a/crates/bevy_solari/src/scene/binder/tlas.rs
+++ b/crates/bevy_solari/src/scene/binder/tlas.rs
@@ -18,7 +18,7 @@ use bevy_render::{
         ComputePipelineDescriptor, CreateTlasDescriptor, PipelineCache, ShaderStages, Tlas,
         TlasInstance,
     },
-    renderer::{RenderContext, RenderDevice},
+    renderer::{RenderContext, RenderDevice, WgpuCommandBuffer},
 };
 use bevy_utils::{default, once};
 use tracing::{info_span, warn};
@@ -418,7 +418,9 @@ fn build_tlas_raw(
         bindings.instances.slots.high_water_mark(),
         scratch,
     );
-    render_context.add_command_buffer(command_encoder.finish());
+    render_context.add_command_buffer(WgpuCommandBuffer::new(
+        command_encoder.into_inner().finish(),
+    ));
 
     time_span.end(render_context.command_encoder());
     if !built {

--- a/crates/bevy_solari/src/scene/blas.rs
+++ b/crates/bevy_solari/src/scene/blas.rs
@@ -155,7 +155,7 @@ pub fn prepare_raytracing_blas(
     if let Some(time_span) = time_span {
         time_span.end(&mut command_encoder);
     }
-    render_queue.submit([command_encoder.finish()]);
+    render_queue.submit([command_encoder.into_inner().finish()]);
 }
 
 pub fn compact_raytracing_blas(

--- a/examples/app/headless_renderer.rs
+++ b/examples/app/headless_renderer.rs
@@ -370,7 +370,7 @@ fn image_copy_driver(
             src_image.texture_descriptor.size,
         );
 
-        render_queue.submit(std::iter::once(encoder.finish()));
+        render_queue.submit(std::iter::once(encoder.into_inner().finish()));
     }
 }
 

--- a/examples/app/render_recovery.rs
+++ b/examples/app/render_recovery.rs
@@ -208,7 +208,7 @@ fn cause_error(error: If<Res<RenderError>>, device: Res<RenderDevice>, queue: Re
                 cpass.dispatch_workgroups(1, 1, 1);
             }
             device.poll(PollType::wait_indefinitely()).unwrap();
-            queue.submit([encoder.finish()]);
+            queue.submit([encoder.into_inner().finish()]);
         }
     }
 }


### PR DESCRIPTION
Continuation of #25512

improves bevy_render compile times by another ~1s for me

## Testing

- check
- ran `pan_orbit_camera_cad` example
