### PR TITLE
Fix the SerializedImage doc link when the serialize feature is off

### DIFF
--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -614,7 +614,14 @@ impl ToExtents for UVec3 {
 /// ## Remote Inspection
 ///
 /// To transmit an [`Image`] between two running Bevy apps, e.g. through BRP, use
-/// `SerializedImage`, which requires the `serialize` feature.
+#[cfg_attr(
+    feature = "serialize",
+    doc = "[`SerializedImage`](crate::SerializedImage)."
+)]
+#[cfg_attr(
+    not(feature = "serialize"),
+    doc = "`SerializedImage`, which requires the `serialize` feature."
+)]
 /// This type is only meant for short-term transmission between same versions and should not be stored anywhere.
 #[derive(Asset, Debug, Clone, PartialEq)]
 #[cfg_attr(

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -613,7 +613,8 @@ impl ToExtents for UVec3 {
 ///
 /// ## Remote Inspection
 ///
-/// To transmit an [`Image`] between two running Bevy apps, e.g. through BRP, use [`SerializedImage`](crate::SerializedImage).
+/// To transmit an [`Image`] between two running Bevy apps, e.g. through BRP, use
+/// `SerializedImage`, which requires the `serialize` feature.
 /// This type is only meant for short-term transmission between same versions and should not be stored anywhere.
 #[derive(Asset, Debug, Clone, PartialEq)]
 #[cfg_attr(


### PR DESCRIPTION
# Objective

- The `Image` rustdoc links to `SerializedImage`, which does not exist when the `serialize` feature is off, so the link is broken.

## Solution

- Fix it.

## Testing

- Verified it works both ways.

---

This PR was built by me with the assistance of Claude Code w/ Fable 5 / 5.1