### PR TITLE
Fix scene_viewer setup retry when mesh AABBs are missing

### DIFF
--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -181,7 +181,6 @@ fn setup_scene_after_load(
     meshes: Query<(&GlobalTransform, Option<&Aabb>), With<Mesh3d>>,
 ) {
     if scene_handle.is_loaded && !*setup {
-        *setup = true;
         // Find an approximate bounding box of the scene from its meshes
         if meshes.iter().any(|(_, maybe_aabb)| maybe_aabb.is_none()) {
             return;
@@ -290,5 +289,7 @@ fn setup_scene_after_load(
 
             scene_handle.has_light = true;
         }
+
+        *setup = true;
     }
 }


### PR DESCRIPTION
# Objective

Ensure that `scene_viewer` initializes its controllable camera and default light even when loaded scene meshes do not have `Aabb` components on the first setup attempt.

When `SceneHandle::is_loaded` becomes true, mesh bounds may still be pending. The setup system currently marks its local setup state before checking for missing `Aabb` components. If any mesh is missing an `Aabb`, the system returns and permanently skips the camera and light initialization.


## Solution

Set the local setup flag only after the scene bounds have been calculated and the camera and light initialization logic has completed.

This allows the system to retry on subsequent frames while any mesh is still waiting for its `Aabb`.


## Testing

- `cargo +nightly-2026-09-01 check --example scene_viewer --features free_camera,bevy_dev_tools`
- `rustfmt --edition 2024 --check examples/tools/scene_viewer/main.rs`
- `git diff --check`

---

## Showcase

> This section is optional. If this PR does not include a visual change or does not add a new feature, you can delete this section.

- Help others understand the result of this PR by showcasing your awesome work!
- If this PR adds a new feature or public API, consider adding a brief pseudo-code snippet of it in action
- If this PR includes a visual change, consider adding a screenshot, GIF, or video
  - If you want, you could even include a before/after comparison!
- If the Migration Guide adequately covers the changes, you can delete this section

While a showcase should aim to be brief and digestible, you can use a toggleable section to save space on longer showcases:

<details>
  <summary>Click to view showcase</summary>

```rust
println!("My super cool code.");
```

</details>
