### PR TITLE
Cleanup observer system input: `Trigger` reborrowing

### DIFF
--- a/crates/bevy_animation/macros/src/animation_event.rs
+++ b/crates/bevy_animation/macros/src/animation_event.rs
@@ -18,7 +18,7 @@ pub fn derive_animation_event(input: TokenStream) -> TokenStream {
 
     quote! {
         impl #impl_generics #bevy_ecs::event::Event for #struct_name #type_generics #where_clause {
-            type Trigger<'a> = #bevy_animation::AnimationEventTrigger;
+            type Trigger = #bevy_animation::AnimationEventTrigger;
         }
 
         impl #impl_generics #bevy_animation::AnimationEvent for #struct_name #type_generics #where_clause {

--- a/crates/bevy_animation/src/animation_event.rs
+++ b/crates/bevy_animation/src/animation_event.rs
@@ -13,7 +13,7 @@ use bevy_ecs::{
 /// - If you used [`AnimationClip::add_event_to_target`](crate::AnimationClip::add_event_to_target), this will be triggered by the [`AnimationTargetId`](crate::AnimationTargetId).
 ///
 /// This trait can be derived.
-pub trait AnimationEvent: Clone + for<'a> Event<Trigger<'a> = AnimationEventTrigger> {}
+pub trait AnimationEvent: Clone + Event<Trigger = AnimationEventTrigger> {}
 
 /// The [`Trigger`] implementation for [`AnimationEvent`]. This passes in either the [`AnimationPlayer`](crate::AnimationPlayer) or the [`AnimationTargetId`](crate::AnimationTargetId)
 /// context, and uses that to run any observers that target that entity. See [`AnimationEvent`] for when which entity is used.
@@ -28,20 +28,27 @@ pub struct AnimationEventTrigger {
     unsafe_code,
     reason = "We must implement this trait to define a custom Trigger, which is required to be unsafe due to safety considerations within bevy_ecs."
 )]
-// SAFETY:
-// - `E`'s [`Event::Trigger`] is constrained to [`AnimationEventTrigger`]
-// - The implementation abides by the other safety constraints defined in [`Trigger`]
-unsafe impl<E: AnimationEvent + for<'a> Event<Trigger<'a> = AnimationEventTrigger>> Trigger<E>
+// SAFETY: `AnimationEventTrigger` has no lifetimes.
+unsafe impl<E: AnimationEvent + Event<Trigger = AnimationEventTrigger>> Trigger<E>
     for AnimationEventTrigger
 {
+    type State<'input> = AnimationEventTrigger;
+    type View<'input> = AnimationEventTrigger;
+
+    fn reborrow<'input>(state: &'input mut Self::State<'_>) -> Self::View<'input> {
+        AnimationEventTrigger {
+            target: state.target,
+        }
+    }
+
     unsafe fn trigger(
-        &mut self,
+        state: &mut Self::State<'_>,
         world: DeferredWorld,
         observers: &CachedObservers,
         trigger_context: &TriggerContext,
         event: &mut E,
     ) {
-        let target = self.target;
+        let target = state.target;
         // SAFETY:
         // - `observers` come from `world` and match the event type `E`, enforced by the call to `trigger`
         // - the passed in event pointer comes from `event`, which is an `Event`
@@ -53,7 +60,7 @@ unsafe impl<E: AnimationEvent + for<'a> Event<Trigger<'a> = AnimationEventTrigge
                 world,
                 observers,
                 event.into(),
-                self.into(),
+                state.into(),
                 target,
                 trigger_context,
             );

--- a/crates/bevy_animation/src/animation_event.rs
+++ b/crates/bevy_animation/src/animation_event.rs
@@ -24,12 +24,7 @@ pub struct AnimationEventTrigger {
     pub target: Entity,
 }
 
-#[expect(
-    unsafe_code,
-    reason = "We must implement this trait to define a custom Trigger, which is required to be unsafe due to safety considerations within bevy_ecs."
-)]
-// SAFETY: `AnimationEventTrigger` has no lifetimes.
-unsafe impl<E: AnimationEvent + Event<Trigger = AnimationEventTrigger>> Trigger<E>
+impl<E: AnimationEvent + Event<Trigger = AnimationEventTrigger>> Trigger<E>
     for AnimationEventTrigger
 {
     type State<'input> = AnimationEventTrigger;
@@ -41,6 +36,10 @@ unsafe impl<E: AnimationEvent + Event<Trigger = AnimationEventTrigger>> Trigger<
         }
     }
 
+    #[expect(
+        unsafe_code,
+        reason = "We must implement this function to define a custom Trigger, which is required to be unsafe due to safety considerations within bevy_ecs."
+    )]
     unsafe fn trigger(
         state: &mut Self::State<'_>,
         world: DeferredWorld,

--- a/crates/bevy_ecs/macros/src/event.rs
+++ b/crates/bevy_ecs/macros/src/event.rs
@@ -53,7 +53,7 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {
-            type Trigger<'a> = #trigger;
+            type Trigger = #trigger;
         }
     })
 }
@@ -150,7 +150,7 @@ pub fn derive_entity_event(input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {
-            type Trigger<'a> = #trigger;
+            type Trigger = #trigger;
         }
 
         impl #impl_generics #bevy_ecs_path::event::EntityEvent for #struct_name #type_generics #where_clause {

--- a/crates/bevy_ecs/src/event/mod.rs
+++ b/crates/bevy_ecs/src/event/mod.rs
@@ -88,7 +88,7 @@ use core::marker::PhantomData;
 )]
 pub trait Event: Send + Sync + Sized + 'static {
     /// Defines which observers will run, what data will be passed to them, and the order they will be run in. See [`Trigger`] for more info.
-    type Trigger<'a>: Trigger<Self>;
+    type Trigger: Trigger<Self>;
 }
 
 /// Trait for types that can be 'matched' on by [`Observer`]s to register additional

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -1,9 +1,8 @@
-use crate::event::{EventPattern, SetEntityEventTarget};
 use crate::{
     archetype::Archetype,
     component::ComponentId,
     entity::Entity,
-    event::{EntityEvent, Event},
+    event::{EntityEvent, Event, SetEntityEventTarget},
     observer::{CachedObservers, TriggerContext},
     traversal::Traversal,
     world::DeferredWorld,
@@ -26,16 +25,27 @@ use core::{fmt, marker::PhantomData};
 ///
 /// # Safety
 ///
-/// Implementing this properly is _advanced_ soundness territory! Implementers must abide by the following:
-///
-/// - The `E`' [`Event::Trigger`] must be constrained to the implemented [`Trigger`] type, as part of the implementation.
-///   This prevents other [`Trigger`] implementations from directly deferring to your implementation, which is a very easy
-///   soundness misstep, as most [`Trigger`] implementations will invoke observers that are developed _for their specific [`Trigger`] type_.
-///   Without this constraint, something like [`GlobalTrigger`] could be called for _any_ [`Event`] type, even one that expects a different
-///   [`Trigger`] type. This would result in an unsound cast of [`GlobalTrigger`] reference.
-///   This is not expressed as an explicit type constraint,, as the `for<'a> Event::Trigger<'a>` lifetime can mismatch explicit lifetimes in
-///   some impls.
-pub unsafe trait Trigger<E: Event> {
+/// For any `'long: 'short`, `State<'long>` must have the same layout as
+/// `State<'short>` and must be valid to reinterpret as `State<'short>` for
+/// the duration of the shorter borrow.
+pub unsafe trait Trigger<E: Event<Trigger = Self>>: Sized + 'static {
+    /// The type that gets passed to [`World::trigger`] and [`Commands::trigger`]
+    /// that holds the state for an observer trigger.
+    ///
+    /// [`World::trigger`]: crate::world::World::trigger
+    /// [`Commands::trigger`]: crate::system::Commands::trigger
+    type State<'input>;
+
+    /// The type that gets passed to [`On`] which holds a mutable view of the
+    /// [`Trigger::State`] for the current observer trigger.
+    ///
+    /// [`On`]: crate::observer::On
+    type View<'input>;
+
+    /// Reborrows the [`Trigger::State`] into a [`Trigger::View`] for the current
+    /// observer trigger.
+    fn reborrow<'input>(state: &'input mut Self::State<'_>) -> Self::View<'input>;
+
     /// Trigger the given `event`, running every [`Observer`](crate::observer::Observer) that matches the `event`, as defined by this
     /// [`Trigger`] and the state stored on `self`.
     ///
@@ -47,7 +57,7 @@ pub unsafe trait Trigger<E: Event> {
     ///   unintuitively risky. _Do not use it directly unless you know what you are doing_. Importantly, this should only
     ///   be called for an `event` whose [`Event::Trigger`] matches this trigger.
     unsafe fn trigger(
-        &mut self,
+        state: &mut Self::State<'_>,
         world: DeferredWorld,
         observers: &CachedObservers,
         trigger_context: &TriggerContext,
@@ -55,8 +65,11 @@ pub unsafe trait Trigger<E: Event> {
     );
 }
 
-/// Shorthand for accessing an [`EventPattern`]s [`Trigger`] via its [`Event`].
-pub type EventPatternTrigger<'a, E> = <<E as EventPattern>::Event as Event>::Trigger<'a>;
+/// Shorthand for accessing an [`Event`]s [`Trigger::State`].
+pub type EventTriggerState<'a, E> = <<E as Event>::Trigger as Trigger<E>>::State<'a>;
+
+/// Shorthand for accessing an [`Event`]s [`Trigger::View`].
+pub type EventTriggerView<'a, E> = <<E as Event>::Trigger as Trigger<E>>::View<'a>;
 
 /// A [`Trigger`] that runs _every_ "global" [`Observer`](crate::observer::Observer) (ex: registered via [`World::add_observer`](crate::world::World::add_observer))
 /// that matches the given [`Event`].
@@ -65,12 +78,17 @@ pub type EventPatternTrigger<'a, E> = <<E as EventPattern>::Event as Event>::Tri
 #[derive(Default, Debug)]
 pub struct GlobalTrigger;
 
-// SAFETY:
-// - `E`'s [`Event::Trigger`] is constrained to [`GlobalTrigger`]
-// - The implementation abides by the other safety constraints defined in [`Trigger`]
-unsafe impl<E: for<'a> Event<Trigger<'a> = Self>> Trigger<E> for GlobalTrigger {
+// SAFETY: `GlobalTrigger` has no lifetimes.
+unsafe impl<E: Event<Trigger = Self>> Trigger<E> for GlobalTrigger {
+    type State<'input> = GlobalTrigger;
+    type View<'input> = GlobalTrigger;
+
+    fn reborrow<'input>(_: &'input mut Self::State<'_>) -> Self::View<'input> {
+        GlobalTrigger
+    }
+
     unsafe fn trigger(
-        &mut self,
+        state: &mut Self::State<'_>,
         world: DeferredWorld,
         observers: &CachedObservers,
         trigger_context: &TriggerContext,
@@ -82,7 +100,7 @@ unsafe impl<E: for<'a> Event<Trigger<'a> = Self>> Trigger<E> for GlobalTrigger {
         // - E: Event::Trigger is constrained to GlobalTrigger
         // - The caller of `trigger` ensures that `TriggerContext::event_key` matches `event`
         unsafe {
-            self.trigger_internal(world, observers, trigger_context, event.into());
+            state.trigger_internal(world, observers, trigger_context, event.into());
         }
     }
 }
@@ -135,12 +153,17 @@ impl GlobalTrigger {
 #[derive(Default, Debug)]
 pub struct EntityTrigger;
 
-// SAFETY:
-// - `E`'s [`Event::Trigger`] is constrained to [`EntityTrigger`]
-// - The implementation abides by the other safety constraints defined in [`Trigger`]
-unsafe impl<E: EntityEvent + for<'a> Event<Trigger<'a> = Self>> Trigger<E> for EntityTrigger {
+// SAFETY: `EntityTrigger` has no lifetimes.
+unsafe impl<E: EntityEvent<Trigger = Self>> Trigger<E> for EntityTrigger {
+    type State<'input> = EntityTrigger;
+    type View<'input> = EntityTrigger;
+
+    fn reborrow<'input>(_: &'input mut Self::State<'_>) -> Self::View<'input> {
+        EntityTrigger
+    }
+
     unsafe fn trigger(
-        &mut self,
+        state: &mut Self::State<'_>,
         world: DeferredWorld,
         observers: &CachedObservers,
         trigger_context: &TriggerContext,
@@ -157,7 +180,7 @@ unsafe impl<E: EntityEvent + for<'a> Event<Trigger<'a> = Self>> Trigger<E> for E
                 world,
                 observers,
                 event.into(),
-                self.into(),
+                state.into(),
                 entity,
                 trigger_context,
             );
@@ -233,7 +256,11 @@ pub unsafe fn trigger_entity_internal(
 /// [`EntityEvent`] type.
 ///
 /// If `AUTO_PROPAGATE` is `true`, [`PropagateEntityTrigger::propagate`] will default to `true`.
-pub struct PropagateEntityTrigger<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>> {
+pub struct PropagateEntityTrigger<const AUTO_PROPAGATE: bool, E, T>
+where
+    E: EntityEvent,
+    T: Traversal<E>,
+{
     /// The original [`Entity`] the [`Event`] was _first_ triggered for.
     pub original_event_target: Entity,
 
@@ -241,6 +268,20 @@ pub struct PropagateEntityTrigger<const AUTO_PROPAGATE: bool, E: EntityEvent, T:
     /// The [`Traversal`] will stop on the current entity.
     pub propagate: bool,
 
+    _marker: PhantomData<(E, T)>,
+}
+
+/// Mutable view of a [`PropagateEntityTrigger`] for the current observer trigger.
+pub struct PropagateEntityTriggerItem<'input, const AUTO_PROPAGATE: bool, E, T>
+where
+    E: EntityEvent,
+    T: Traversal<E>,
+{
+    /// The original [`Entity`] the [`Event`] was _first_ triggered for.
+    pub original_event_target: Entity,
+    /// Whether or not to continue propagating using the `T` [`Traversal`]. If this is false,
+    /// The [`Traversal`] will stop on the current entity.
+    pub propagate: &'input mut bool,
     _marker: PhantomData<(E, T)>,
 }
 
@@ -268,23 +309,33 @@ impl<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>> fmt::Debug
     }
 }
 
-// SAFETY:
-// - `E`'s [`Event::Trigger`] is constrained to [`PropagateEntityTrigger<E>`]
-unsafe impl<
-        const AUTO_PROPAGATE: bool,
-        E: EntityEvent + SetEntityEventTarget + for<'a> Event<Trigger<'a> = Self>,
-        T: Traversal<E>,
-    > Trigger<E> for PropagateEntityTrigger<AUTO_PROPAGATE, E, T>
+// SAFETY: `PropagateEntityTrigger` has no lifetimes.
+unsafe impl<const AUTO_PROPAGATE: bool, E, T> Trigger<E>
+    for PropagateEntityTrigger<AUTO_PROPAGATE, E, T>
+where
+    E: EntityEvent<Trigger = Self> + SetEntityEventTarget,
+    T: Traversal<E>,
 {
+    type State<'input> = PropagateEntityTrigger<AUTO_PROPAGATE, E, T>;
+    type View<'input> = PropagateEntityTriggerItem<'input, AUTO_PROPAGATE, E, T>;
+
+    fn reborrow<'input>(state: &'input mut Self::State<'_>) -> Self::View<'input> {
+        PropagateEntityTriggerItem {
+            original_event_target: state.original_event_target,
+            propagate: &mut state.propagate,
+            _marker: PhantomData,
+        }
+    }
+
     unsafe fn trigger(
-        &mut self,
+        state: &mut Self::State<'_>,
         mut world: DeferredWorld,
         observers: &CachedObservers,
         trigger_context: &TriggerContext,
         event: &mut E,
     ) {
         let mut current_entity = event.event_target();
-        self.original_event_target = current_entity;
+        state.original_event_target = current_entity;
         // SAFETY:
         // - `observers` come from `world` and match the event type `E`, enforced by the call to `trigger`
         // - the passed in event pointer comes from `event`, which is an `Event`
@@ -295,14 +346,14 @@ unsafe impl<
                 world.reborrow(),
                 observers,
                 event.into(),
-                self.into(),
+                state.into(),
                 current_entity,
                 trigger_context,
             );
         }
 
         loop {
-            if !self.propagate {
+            if !state.propagate {
                 return;
             }
             if let Ok(entity) = world.get_entity(current_entity)
@@ -325,7 +376,7 @@ unsafe impl<
                     world.reborrow(),
                     observers,
                     event.into(),
-                    self.into(),
+                    state.into(),
                     current_entity,
                     trigger_context,
                 );
@@ -425,13 +476,21 @@ pub struct EntityComponentsTrigger<'a> {
     pub new_archetype: Option<&'a Archetype>,
 }
 
-// SAFETY:
-// - `E`'s [`Event::Trigger`] is constrained to [`EntityComponentsTrigger`]
-unsafe impl<'a, E: EntityEvent + Event<Trigger<'a> = EntityComponentsTrigger<'a>>> Trigger<E>
-    for EntityComponentsTrigger<'a>
-{
+// SAFETY: `EntityComponentsTrigger<'a>` is covariant over `'a`.
+unsafe impl<E: EntityEvent<Trigger = Self>> Trigger<E> for EntityComponentsTrigger<'static> {
+    type State<'input> = EntityComponentsTrigger<'input>;
+    type View<'input> = EntityComponentsTrigger<'input>;
+
+    fn reborrow<'input>(state: &'input mut Self::State<'_>) -> Self::View<'input> {
+        EntityComponentsTrigger {
+            components: state.components,
+            old_archetype: state.old_archetype,
+            new_archetype: state.new_archetype,
+        }
+    }
+
     unsafe fn trigger(
-        &mut self,
+        state: &mut Self::State<'_>,
         world: DeferredWorld,
         observers: &CachedObservers,
         trigger_context: &TriggerContext,
@@ -443,7 +502,7 @@ unsafe impl<'a, E: EntityEvent + Event<Trigger<'a> = EntityComponentsTrigger<'a>
         // - the passed in event pointer comes from `event`, which is an `Event`
         // - `trigger_context`'s event_key matches `E`, enforced by the call to `trigger`
         unsafe {
-            self.trigger_internal(world, observers, event.into(), entity, trigger_context);
+            state.trigger_internal(world, observers, event.into(), entity, trigger_context);
         }
     }
 }

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -22,13 +22,7 @@ use core::{fmt, marker::PhantomData};
 /// - [`EntityTrigger`]: The [`EntityEvent`] derive defaults to using this
 /// - [`PropagateEntityTrigger`]: The [`EntityEvent`] derive uses this when propagation is enabled.
 /// - [`EntityComponentsTrigger`]: Used by Bevy's [component lifecycle events](crate::lifecycle).
-///
-/// # Safety
-///
-/// For any `'long: 'short`, `State<'long>` must have the same layout as
-/// `State<'short>` and must be valid to reinterpret as `State<'short>` for
-/// the duration of the shorter borrow.
-pub unsafe trait Trigger<E: Event<Trigger = Self>>: Sized + 'static {
+pub trait Trigger<E: Event<Trigger = Self>>: Sized + 'static {
     /// The type that gets passed to [`World::trigger`] and [`Commands::trigger`]
     /// that holds the state for an observer trigger.
     ///
@@ -78,8 +72,7 @@ pub type EventTriggerView<'a, E> = <<E as Event>::Trigger as Trigger<E>>::View<'
 #[derive(Default, Debug)]
 pub struct GlobalTrigger;
 
-// SAFETY: `GlobalTrigger` has no lifetimes.
-unsafe impl<E: Event<Trigger = Self>> Trigger<E> for GlobalTrigger {
+impl<E: Event<Trigger = Self>> Trigger<E> for GlobalTrigger {
     type State<'input> = GlobalTrigger;
     type View<'input> = GlobalTrigger;
 
@@ -153,8 +146,7 @@ impl GlobalTrigger {
 #[derive(Default, Debug)]
 pub struct EntityTrigger;
 
-// SAFETY: `EntityTrigger` has no lifetimes.
-unsafe impl<E: EntityEvent<Trigger = Self>> Trigger<E> for EntityTrigger {
+impl<E: EntityEvent<Trigger = Self>> Trigger<E> for EntityTrigger {
     type State<'input> = EntityTrigger;
     type View<'input> = EntityTrigger;
 
@@ -271,20 +263,6 @@ where
     _marker: PhantomData<(E, T)>,
 }
 
-/// Mutable view of a [`PropagateEntityTrigger`] for the current observer trigger.
-pub struct PropagateEntityTriggerItem<'input, const AUTO_PROPAGATE: bool, E, T>
-where
-    E: EntityEvent,
-    T: Traversal<E>,
-{
-    /// The original [`Entity`] the [`Event`] was _first_ triggered for.
-    pub original_event_target: Entity,
-    /// Whether or not to continue propagating using the `T` [`Traversal`]. If this is false,
-    /// The [`Traversal`] will stop on the current entity.
-    pub propagate: &'input mut bool,
-    _marker: PhantomData<(E, T)>,
-}
-
 impl<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>> Default
     for PropagateEntityTrigger<AUTO_PROPAGATE, E, T>
 {
@@ -309,22 +287,16 @@ impl<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>> fmt::Debug
     }
 }
 
-// SAFETY: `PropagateEntityTrigger` has no lifetimes.
-unsafe impl<const AUTO_PROPAGATE: bool, E, T> Trigger<E>
-    for PropagateEntityTrigger<AUTO_PROPAGATE, E, T>
+impl<const AUTO_PROPAGATE: bool, E, T> Trigger<E> for PropagateEntityTrigger<AUTO_PROPAGATE, E, T>
 where
     E: EntityEvent<Trigger = Self> + SetEntityEventTarget,
     T: Traversal<E>,
 {
     type State<'input> = PropagateEntityTrigger<AUTO_PROPAGATE, E, T>;
-    type View<'input> = PropagateEntityTriggerItem<'input, AUTO_PROPAGATE, E, T>;
+    type View<'input> = &'input mut PropagateEntityTrigger<AUTO_PROPAGATE, E, T>;
 
     fn reborrow<'input>(state: &'input mut Self::State<'_>) -> Self::View<'input> {
-        PropagateEntityTriggerItem {
-            original_event_target: state.original_event_target,
-            propagate: &mut state.propagate,
-            _marker: PhantomData,
-        }
+        state
     }
 
     unsafe fn trigger(
@@ -476,8 +448,7 @@ pub struct EntityComponentsTrigger<'a> {
     pub new_archetype: Option<&'a Archetype>,
 }
 
-// SAFETY: `EntityComponentsTrigger<'a>` is covariant over `'a`.
-unsafe impl<E: EntityEvent<Trigger = Self>> Trigger<E> for EntityComponentsTrigger<'static> {
+impl<E: EntityEvent<Trigger = Self>> Trigger<E> for EntityComponentsTrigger<'static> {
     type State<'input> = EntityComponentsTrigger<'input>;
     type View<'input> = EntityComponentsTrigger<'input>;
 

--- a/crates/bevy_ecs/src/event/trigger.rs
+++ b/crates/bevy_ecs/src/event/trigger.rs
@@ -248,11 +248,7 @@ pub unsafe fn trigger_entity_internal(
 /// [`EntityEvent`] type.
 ///
 /// If `AUTO_PROPAGATE` is `true`, [`PropagateEntityTrigger::propagate`] will default to `true`.
-pub struct PropagateEntityTrigger<const AUTO_PROPAGATE: bool, E, T>
-where
-    E: EntityEvent,
-    T: Traversal<E>,
-{
+pub struct PropagateEntityTrigger<const AUTO_PROPAGATE: bool, E: EntityEvent, T: Traversal<E>> {
     /// The original [`Entity`] the [`Event`] was _first_ triggered for.
     pub original_event_target: Entity,
 

--- a/crates/bevy_ecs/src/lifecycle.rs
+++ b/crates/bevy_ecs/src/lifecycle.rs
@@ -333,7 +333,7 @@ pub const DESPAWN: EventKey = EventKey(ComponentId::new(crate::component::DESPAW
 /// component. Runs before `Insert`.
 /// See [`ComponentHooks::on_add`](`crate::lifecycle::ComponentHooks::on_add`) for more information.
 #[derive(Debug, Clone, EntityEvent)]
-#[entity_event(trigger = EntityComponentsTrigger<'a>)]
+#[entity_event(trigger = EntityComponentsTrigger<'static>)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
 pub struct AddEvent {
@@ -360,7 +360,7 @@ impl<B: Bundle> EventPattern for Add<B> {
 /// had that component. Runs after `Add`, if it ran.
 /// See [`ComponentHooks::on_insert`](`crate::lifecycle::ComponentHooks::on_insert`) for more information.
 #[derive(Debug, Clone, EntityEvent)]
-#[entity_event(trigger = EntityComponentsTrigger<'a>)]
+#[entity_event(trigger = EntityComponentsTrigger<'static>)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
 pub struct InsertEvent {
@@ -389,7 +389,7 @@ impl<B: Bundle> EventPattern for Insert<B> {
 /// Runs before the value is replaced, so you can still access the original component data.
 /// See [`ComponentHooks::on_discard`](`crate::lifecycle::ComponentHooks::on_discard`) for more information.
 #[derive(Debug, Clone, EntityEvent)]
-#[entity_event(trigger = EntityComponentsTrigger<'a>)]
+#[entity_event(trigger = EntityComponentsTrigger<'static>)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
 
@@ -419,7 +419,7 @@ impl<B: Bundle> EventPattern for Discard<B> {
 /// removed, so you can still access the component data.
 /// See [`ComponentHooks::on_remove`](`crate::lifecycle::ComponentHooks::on_remove`) for more information.
 #[derive(Debug, Clone, EntityEvent)]
-#[entity_event(trigger = EntityComponentsTrigger<'a>)]
+#[entity_event(trigger = EntityComponentsTrigger<'static>)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
 pub struct RemoveEvent {
@@ -445,7 +445,7 @@ impl<B: Bundle> EventPattern for Remove<B> {
 /// [`EntityEvent`] emitted for each component on an entity when it is despawned.
 /// See [`ComponentHooks::on_despawn`](`crate::lifecycle::ComponentHooks::on_despawn`) for more information.
 #[derive(Debug, Clone, EntityEvent)]
-#[entity_event(trigger = EntityComponentsTrigger<'a>)]
+#[entity_event(trigger = EntityComponentsTrigger<'static>)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(feature = "bevy_reflect", reflect(Debug))]
 pub struct DespawnEvent {

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -18,7 +18,7 @@ pub use system_param::*;
 
 use crate::{
     change_detection::MaybeLocation,
-    event::Event,
+    event::{Event, EventTriggerState},
     prelude::*,
     world::{DeferredWorld, *},
 };
@@ -60,10 +60,13 @@ impl World {
     ///
     /// For a variant that borrows the `event` rather than consuming it, use [`World::trigger_ref`] instead.
     #[track_caller]
-    pub fn trigger<'a, E: Event<Trigger<'a>: Default>>(&mut self, mut event: E) {
+    pub fn trigger<E: Event>(&mut self, mut event: E)
+    where
+        for<'a> EventTriggerState<'a, E>: Default,
+    {
         self.trigger_ref_with_caller(
             &mut event,
-            &mut <E::Trigger<'a> as Default>::default(),
+            &mut EventTriggerState::<E>::default(),
             MaybeLocation::caller(),
         );
     }
@@ -72,7 +75,7 @@ impl World {
     ///
     /// For a variant that borrows the `event` rather than consuming it, use [`World::trigger_ref`] instead.
     #[track_caller]
-    pub fn trigger_with<'a, E: Event>(&mut self, mut event: E, mut trigger: E::Trigger<'a>) {
+    pub fn trigger_with<E: Event>(&mut self, mut event: E, mut trigger: EventTriggerState<'_, E>) {
         self.trigger_ref_with_caller(&mut event, &mut trigger, MaybeLocation::caller());
     }
 
@@ -81,10 +84,13 @@ impl World {
     /// Compared to [`World::trigger`], this method is most useful when it's necessary to check
     /// or use the event after it has been modified by observers.
     #[track_caller]
-    pub fn trigger_ref<'a, E: Event<Trigger<'a>: Default>>(&mut self, event: &mut E) {
+    pub fn trigger_ref<E: Event>(&mut self, event: &mut E)
+    where
+        for<'a> EventTriggerState<'a, E>: Default,
+    {
         self.trigger_ref_with_caller(
             event,
-            &mut <E::Trigger<'a> as Default>::default(),
+            &mut EventTriggerState::<E>::default(),
             MaybeLocation::caller(),
         );
     }
@@ -94,14 +100,18 @@ impl World {
     ///
     /// Compared to [`World::trigger`], this method is most useful when it's necessary to check
     /// or use the event after it has been modified by observers.
-    pub fn trigger_ref_with<'a, E: Event>(&mut self, event: &mut E, trigger: &mut E::Trigger<'a>) {
+    pub fn trigger_ref_with<E: Event>(
+        &mut self,
+        event: &mut E,
+        trigger: &mut EventTriggerState<'_, E>,
+    ) {
         self.trigger_ref_with_caller(event, trigger, MaybeLocation::caller());
     }
 
-    pub(crate) fn trigger_ref_with_caller<'a, E: Event>(
+    pub(crate) fn trigger_ref_with_caller<E: Event>(
         &mut self,
         event: &mut E,
-        trigger: &mut E::Trigger<'a>,
+        trigger: &mut EventTriggerState<'_, E>,
         caller: MaybeLocation,
     ) {
         let event_key = self.register_event_key::<E>();
@@ -502,7 +512,7 @@ mod tests {
     struct EntityEventA(Entity);
 
     #[derive(EntityEvent)]
-    #[entity_event(trigger = EntityComponentsTrigger<'a>)]
+    #[entity_event(trigger = EntityComponentsTrigger<'static>)]
     struct EntityComponentsEvent(Entity);
 
     struct EntityComponents<B: Bundle>(PhantomData<B>);
@@ -1831,8 +1841,7 @@ mod tests {
 
         fn observer<E>(e: On<E>, mut c: ResMut<Changes>)
         where
-            E: EventPattern,
-            E::Event: for<'a> Event<Trigger<'a> = EntityComponentsTrigger<'a>>,
+            E: EventPattern<Event: EntityEvent<Trigger = EntityComponentsTrigger<'static>>>,
         {
             c.0.push((
                 type_name::<E::Event>(),

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -62,7 +62,7 @@ impl World {
     #[track_caller]
     pub fn trigger<E: Event>(&mut self, mut event: E)
     where
-        for<'a> EventTriggerState<'a, E>: Default,
+        EventTriggerState<'static, E>: Default,
     {
         self.trigger_ref_with_caller(
             &mut event,
@@ -86,7 +86,7 @@ impl World {
     #[track_caller]
     pub fn trigger_ref<E: Event>(&mut self, event: &mut E)
     where
-        for<'a> EventTriggerState<'a, E>: Default,
+        EventTriggerState<'static, E>: Default,
     {
         self.trigger_ref_with_caller(
             event,

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -4,7 +4,7 @@ use core::any::Any;
 
 use crate::{
     error::ErrorContext,
-    event::{EventPattern, EventPatternTrigger},
+    event::{EventPattern, EventTriggerState, Trigger},
     observer::TriggerContext,
     prelude::*,
     query::DebugCheckedUnwrap,
@@ -67,20 +67,17 @@ pub(super) unsafe fn observer_system_runner<E: EventPattern, S: ObserverSystem<E
         return;
     }
 
-    // SAFETY: Caller ensures `trigger_ptr` is castable to `&mut E::Trigger<'_>`
-    // The soundness story here is complicated: This casts to &'a mut E::Trigger<'a> which notably
-    // casts the _arbitrary lifetimes_ of the passed in `trigger_ptr` (&'w E::Trigger<'t>, which are
-    // 'w and 't on On<'w, 't>) as the _same_ lifetime 'a, which is _local to this function call_.
-    // This becomes On<'a, 'a> in practice. This is why `On<'w, 't>` has the strict constraint that
-    // the 'w lifetime can never be exposed. To do so would make it possible to introduce use-after-free bugs.
-    // See this thread for more details: <https://github.com/bevyengine/bevy/pull/20731#discussion_r2311907935>
-    let trigger: &mut EventPatternTrigger<'_, E> = unsafe { trigger_ptr.deref_mut() };
+    // SAFETY: Caller ensures `trigger_ptr` is castable to `&mut E::Event::Trigger::State<'_>`.
+    // `Trigger`'s safety contract ensures that `Trigger::State<'long>` can be
+    // safely reborrowed as `Trigger::State<'short>` for any `'long: 'short`.
+    // Then, `Trigger::reborrow` ensures that the observer only receives the shorter lifetime.
+    let trigger: &mut EventTriggerState<'_, E::Event> = unsafe { trigger_ptr.deref_mut() };
 
     let on: On<E> = On::new(
         // SAFETY: Caller ensures `ptr` is castable to `&mut E`
         unsafe { event_ptr.deref_mut() },
         observer,
-        trigger,
+        <E::Event as Event>::Trigger::reborrow(trigger),
         trigger_context,
     );
 

--- a/crates/bevy_ecs/src/observer/runner.rs
+++ b/crates/bevy_ecs/src/observer/runner.rs
@@ -68,9 +68,8 @@ pub(super) unsafe fn observer_system_runner<E: EventPattern, S: ObserverSystem<E
     }
 
     // SAFETY: Caller ensures `trigger_ptr` is castable to `&mut E::Event::Trigger::State<'_>`.
-    // `Trigger`'s safety contract ensures that `Trigger::State<'long>` can be
-    // safely reborrowed as `Trigger::State<'short>` for any `'long: 'short`.
-    // Then, `Trigger::reborrow` ensures that the observer only receives the shorter lifetime.
+    // Because the `PtrMut` might contain arbitrary lifetimes, we must use `Trigger::reborrow`
+    // to ensure that the observer only witnesses the shortest lifetime of the trigger state.
     let trigger: &mut EventTriggerState<'_, E::Event> = unsafe { trigger_ptr.deref_mut() };
 
     let on: On<E> = On::new(

--- a/crates/bevy_ecs/src/observer/system_param.rs
+++ b/crates/bevy_ecs/src/observer/system_param.rs
@@ -2,7 +2,10 @@
 
 use crate::{
     change_detection::MaybeLocation,
-    event::{Event, EventKey, EventPattern, EventPatternTrigger, PropagateEntityTrigger},
+    event::{
+        Event, EventKey, EventPattern, EventTriggerView, PropagateEntityTrigger,
+        SetEntityEventTarget,
+    },
     prelude::*,
     traversal::Traversal,
 };
@@ -20,25 +23,25 @@ use core::{
 ///
 /// [system parameter]: crate::system::SystemParam
 // SAFETY WARNING!
-// this type must _never_ expose anything with the 'w lifetime
+// this type must _never_ expose anything with the 'i lifetime
 // See the safety discussion on `Trigger` for more details.
-pub struct On<'w, 't, E: EventPattern> {
+pub struct On<'i, E: EventPattern> {
     observer: Entity,
-    // SAFETY WARNING: never expose this 'w lifetime
-    event: &'w mut E::Event,
-    // SAFETY WARNING: never expose this 'w lifetime
-    trigger: &'w mut EventPatternTrigger<'t, E>,
-    // SAFETY WARNING: never expose this 'w lifetime
-    trigger_context: &'w TriggerContext,
+    // SAFETY WARNING: never expose this 'i lifetime
+    event: &'i mut E::Event,
+    // SAFETY WARNING: never expose this 'i lifetime
+    trigger: EventTriggerView<'i, E::Event>,
+    // SAFETY WARNING: never expose this 'i lifetime
+    trigger_context: &'i TriggerContext,
 }
 
-impl<'w, 't, E: EventPattern> On<'w, 't, E> {
+impl<'i, E: EventPattern> On<'i, E> {
     /// Creates a new instance of [`On`] for the given triggered event.
     pub fn new(
-        event: &'w mut E::Event,
+        event: &'i mut E::Event,
         observer: Entity,
-        trigger: &'w mut EventPatternTrigger<'t, E>,
-        trigger_context: &'w TriggerContext,
+        trigger: EventTriggerView<'i, E::Event>,
+        trigger_context: &'i TriggerContext,
     ) -> Self {
         Self {
             event,
@@ -69,13 +72,13 @@ impl<'w, 't, E: EventPattern> On<'w, 't, E> {
     }
 
     /// Returns the [`Trigger`](crate::event::Trigger) context for this event.
-    pub fn trigger(&self) -> &EventPatternTrigger<'t, E> {
-        self.trigger
+    pub fn trigger(&self) -> &EventTriggerView<'i, E::Event> {
+        &self.trigger
     }
 
     /// Returns the mutable [`Trigger`](crate::event::Trigger) context for this event.
-    pub fn trigger_mut(&mut self) -> &mut EventPatternTrigger<'t, E> {
-        self.trigger
+    pub fn trigger_mut(&mut self) -> &mut EventTriggerView<'i, E::Event> {
+        &mut self.trigger
     }
 
     /// Returns the [`Entity`] of the [`Observer`] of the triggered event.
@@ -110,10 +113,11 @@ impl<'w, 't, E: EventPattern> On<'w, 't, E> {
     }
 }
 
-impl<'w, 't, const AUTO_PROPAGATE: bool, E, T> On<'w, 't, E>
+impl<'i, const AUTO_PROPAGATE: bool, E, T> On<'i, E>
 where
     E: EventPattern<
-        Event: EntityEvent<Trigger<'t> = PropagateEntityTrigger<AUTO_PROPAGATE, E::Event, T>>,
+        Event: EntityEvent<Trigger = PropagateEntityTrigger<AUTO_PROPAGATE, E::Event, T>>
+                   + SetEntityEventTarget,
     >,
     T: Traversal<E::Event>,
 {
@@ -137,21 +141,22 @@ where
     ///
     /// [`Traversal`]: crate::traversal::Traversal
     pub fn propagate(&mut self, should_propagate: bool) {
-        self.trigger.propagate = should_propagate;
+        *self.trigger.propagate = should_propagate;
     }
 
     /// Returns the value of the flag that controls event propagation. See [`propagate`] for more information.
     ///
     /// [`propagate`]: On::propagate
     pub fn get_propagate(&self) -> bool {
-        self.trigger.propagate
+        *self.trigger.propagate
     }
 }
 
-impl<'w, 't, E> Debug for On<'w, 't, E>
+impl<'i, E> Debug for On<'i, E>
 where
     E: EventPattern,
-    E::Event: Event<Trigger<'t>: Debug> + Debug,
+    E::Event: Event + Debug,
+    for<'a> EventTriggerView<'a, E::Event>: Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("On")
@@ -161,7 +166,7 @@ where
     }
 }
 
-impl<'w, 't, E: EventPattern> Deref for On<'w, 't, E> {
+impl<'i, E: EventPattern> Deref for On<'i, E> {
     type Target = E::Event;
 
     fn deref(&self) -> &Self::Target {
@@ -169,7 +174,7 @@ impl<'w, 't, E: EventPattern> Deref for On<'w, 't, E> {
     }
 }
 
-impl<'w, 't, E: EventPattern> DerefMut for On<'w, 't, E> {
+impl<'i, E: EventPattern> DerefMut for On<'i, E> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.event
     }

--- a/crates/bevy_ecs/src/observer/system_param.rs
+++ b/crates/bevy_ecs/src/observer/system_param.rs
@@ -22,16 +22,10 @@ use core::{
 /// includes control over event propagation.
 ///
 /// [system parameter]: crate::system::SystemParam
-// SAFETY WARNING!
-// this type must _never_ expose anything with the 'i lifetime
-// See the safety discussion on `Trigger` for more details.
 pub struct On<'i, E: EventPattern> {
     observer: Entity,
-    // SAFETY WARNING: never expose this 'i lifetime
     event: &'i mut E::Event,
-    // SAFETY WARNING: never expose this 'i lifetime
     trigger: EventTriggerView<'i, E::Event>,
-    // SAFETY WARNING: never expose this 'i lifetime
     trigger_context: &'i TriggerContext,
 }
 
@@ -141,14 +135,14 @@ where
     ///
     /// [`Traversal`]: crate::traversal::Traversal
     pub fn propagate(&mut self, should_propagate: bool) {
-        *self.trigger.propagate = should_propagate;
+        self.trigger.propagate = should_propagate;
     }
 
     /// Returns the value of the flag that controls event propagation. See [`propagate`] for more information.
     ///
     /// [`propagate`]: On::propagate
     pub fn get_propagate(&self) -> bool {
-        *self.trigger.propagate
+        self.trigger.propagate
     }
 }
 
@@ -156,7 +150,7 @@ impl<'i, E> Debug for On<'i, E>
 where
     E: EventPattern,
     E::Event: Event + Debug,
-    for<'a> EventTriggerView<'a, E::Event>: Debug,
+    EventTriggerView<'i, E::Event>: Debug,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("On")

--- a/crates/bevy_ecs/src/reflect/event.rs
+++ b/crates/bevy_ecs/src/reflect/event.rs
@@ -8,7 +8,7 @@
 use alloc::boxed::Box;
 
 use crate::{
-    event::{Event, EventKey},
+    event::{Event, EventKey, EventTriggerState},
     observer::{Observer, On},
     reflect::from_reflect_with_fallback,
     world::{DeferredWorld, World},
@@ -56,11 +56,11 @@ impl ReflectEventFns {
     ///
     /// This is useful if you want to start with the default implementation
     /// before overriding some of the functions to create a custom implementation.
-    pub fn new<'a, T: Event + FromReflect + TypePath>() -> Self
+    pub fn new<E: Event + FromReflect + TypePath>() -> Self
     where
-        T::Trigger<'a>: Default,
+        for<'a> EventTriggerState<'a, E>: Default,
     {
-        <ReflectEvent as CreateTypeData<T>>::create_type_data(()).0
+        <ReflectEvent as CreateTypeData<E>>::create_type_data(()).0
     }
 }
 
@@ -122,9 +122,9 @@ impl ReflectEvent {
     }
 }
 
-impl<'a, E: Event + Reflect + TypePath> CreateTypeData<E> for ReflectEvent
+impl<E: Event + Reflect + TypePath> CreateTypeData<E> for ReflectEvent
 where
-    <E as Event>::Trigger<'a>: Default,
+    for<'a> EventTriggerState<'a, E>: Default,
 {
     fn create_type_data(_input: ()) -> Self {
         ReflectEvent(ReflectEventFns {

--- a/crates/bevy_ecs/src/reflect/event.rs
+++ b/crates/bevy_ecs/src/reflect/event.rs
@@ -58,7 +58,7 @@ impl ReflectEventFns {
     /// before overriding some of the functions to create a custom implementation.
     pub fn new<E: Event + FromReflect + TypePath>() -> Self
     where
-        for<'a> EventTriggerState<'a, E>: Default,
+        EventTriggerState<'static, E>: Default,
     {
         <ReflectEvent as CreateTypeData<E>>::create_type_data(()).0
     }
@@ -124,7 +124,7 @@ impl ReflectEvent {
 
 impl<E: Event + Reflect + TypePath> CreateTypeData<E> for ReflectEvent
 where
-    for<'a> EventTriggerState<'a, E>: Default,
+    EventTriggerState<'static, E>: Default,
 {
     fn create_type_data(_input: ()) -> Self {
         ReflectEvent(ReflectEventFns {

--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -283,7 +283,7 @@ pub fn run_schedule(label: impl ScheduleLabel) -> impl Command {
 #[track_caller]
 pub fn trigger<E: Event>(mut event: E) -> impl Command
 where
-    for<'a> EventTriggerState<'a, E>: Default,
+    EventTriggerState<'static, E>: Default,
 {
     let caller = MaybeLocation::caller();
     move |world: &mut World| {
@@ -301,7 +301,7 @@ pub fn trigger_with<E: Event>(
     mut trigger: EventTriggerState<'static, E>,
 ) -> impl Command
 where
-    for<'a> EventTriggerState<'a, E>: Send + Sync,
+    EventTriggerState<'static, E>: Send + Sync,
 {
     let caller = MaybeLocation::caller();
     move |world: &mut World| {

--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -11,7 +11,7 @@ use crate::{
     change_detection::MaybeLocation,
     entity::Entity,
     error::{BevyError, CommandOutput, ErrorContext, Result},
-    event::Event,
+    event::{Event, EventTriggerState},
     message::{Message, Messages},
     resource::Resource,
     schedule::ScheduleLabel,
@@ -281,14 +281,13 @@ pub fn run_schedule(label: impl ScheduleLabel) -> impl Command {
 ///
 /// [`Observer`]: crate::observer::Observer
 #[track_caller]
-pub fn trigger<'a, E: Event<Trigger<'a>: Default>>(mut event: E) -> impl Command {
+pub fn trigger<E: Event>(mut event: E) -> impl Command
+where
+    for<'a> EventTriggerState<'a, E>: Default,
+{
     let caller = MaybeLocation::caller();
     move |world: &mut World| {
-        world.trigger_ref_with_caller(
-            &mut event,
-            &mut <E::Trigger<'_> as Default>::default(),
-            caller,
-        );
+        world.trigger_ref_with_caller(&mut event, &mut EventTriggerState::<E>::default(), caller);
     }
 }
 
@@ -297,10 +296,13 @@ pub fn trigger<'a, E: Event<Trigger<'a>: Default>>(mut event: E) -> impl Command
 /// [`Trigger`]: crate::event::Trigger
 /// [`Observer`]: crate::observer::Observer
 #[track_caller]
-pub fn trigger_with<E: Event<Trigger<'static>: Send + Sync>>(
+pub fn trigger_with<E: Event>(
     mut event: E,
-    mut trigger: E::Trigger<'static>,
-) -> impl Command {
+    mut trigger: EventTriggerState<'static, E>,
+) -> impl Command
+where
+    for<'a> EventTriggerState<'a, E>: Send + Sync,
+{
     let caller = MaybeLocation::caller();
     move |world: &mut World| {
         world.trigger_ref_with_caller(&mut event, &mut trigger, caller);

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1096,7 +1096,7 @@ impl<'w, 's> Commands<'w, 's> {
     #[track_caller]
     pub fn trigger<E: Event>(&mut self, event: E)
     where
-        for<'a> EventTriggerState<'a, E>: Default,
+        EventTriggerState<'static, E>: Default,
     {
         self.queue(command::trigger(event));
     }
@@ -1108,7 +1108,7 @@ impl<'w, 's> Commands<'w, 's> {
     #[track_caller]
     pub fn trigger_with<E: Event>(&mut self, event: E, trigger: EventTriggerState<'static, E>)
     where
-        for<'a> EventTriggerState<'a, E>: Send + Sync,
+        EventTriggerState<'static, E>: Send + Sync,
     {
         self.queue(command::trigger_with(event, trigger));
     }
@@ -2287,7 +2287,7 @@ impl<'a> EntityCommands<'a> {
     #[track_caller]
     pub fn trigger<E: EntityEvent>(&mut self, event_fn: impl FnOnce(Entity) -> E) -> &mut Self
     where
-        for<'t> EventTriggerState<'t, E>: Default,
+        EventTriggerState<'static, E>: Default,
     {
         let event = (event_fn)(self.entity);
         self.commands.trigger(event);

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         InvalidEntityError, OptIn, OptOut,
     },
     error::{warn, BevyError, ErrorContext},
-    event::{EntityEvent, Event},
+    event::{EntityEvent, Event, EventTriggerState},
     message::Message,
     observer::{IntoEntityObserver, IntoObserver},
     relationship::RelationshipHookMode,
@@ -1094,7 +1094,10 @@ impl<'w, 's> Commands<'w, 's> {
     ///
     /// [`Observer`]: crate::observer::Observer
     #[track_caller]
-    pub fn trigger<'a>(&mut self, event: impl Event<Trigger<'a>: Default>) {
+    pub fn trigger<E: Event>(&mut self, event: E)
+    where
+        for<'a> EventTriggerState<'a, E>: Default,
+    {
         self.queue(command::trigger(event));
     }
 
@@ -1103,11 +1106,10 @@ impl<'w, 's> Commands<'w, 's> {
     /// [`Trigger`]: crate::event::Trigger
     /// [`Observer`]: crate::observer::Observer
     #[track_caller]
-    pub fn trigger_with<E: Event<Trigger<'static>: Send + Sync>>(
-        &mut self,
-        event: E,
-        trigger: E::Trigger<'static>,
-    ) {
+    pub fn trigger_with<E: Event>(&mut self, event: E, trigger: EventTriggerState<'static, E>)
+    where
+        for<'a> EventTriggerState<'a, E>: Send + Sync,
+    {
         self.queue(command::trigger_with(event, trigger));
     }
 
@@ -2283,10 +2285,10 @@ impl<'a> EntityCommands<'a> {
     /// }
     /// ```
     #[track_caller]
-    pub fn trigger<'t, E: EntityEvent<Trigger<'t>: Default>>(
-        &mut self,
-        event_fn: impl FnOnce(Entity) -> E,
-    ) -> &mut Self {
+    pub fn trigger<E: EntityEvent>(&mut self, event_fn: impl FnOnce(Entity) -> E) -> &mut Self
+    where
+        for<'t> EventTriggerState<'t, E>: Default,
+    {
         let event = (event_fn)(self.entity);
         self.commands.trigger(event);
         self

--- a/crates/bevy_ecs/src/system/input.rs
+++ b/crates/bevy_ecs/src/system/input.rs
@@ -247,13 +247,9 @@ impl<'i, T: ?Sized> DerefMut for InMut<'i, T> {
 /// Used for [`ObserverSystem`]s.
 ///
 /// [`ObserverSystem`]: crate::system::ObserverSystem
-impl<E: EventPattern> SystemInput for On<'_, '_, E> {
-    // Note: the fact that we must use a shared lifetime here is
-    // a key piece of the complicated safety story documented above
-    // the `&mut E::Trigger<'_>` cast in `observer_system_runner` and in
-    // the `On` implementation.
-    type Param<'i> = On<'i, 'i, E>;
-    type Inner<'i> = On<'i, 'i, E>;
+impl<E: EventPattern> SystemInput for On<'_, E> {
+    type Param<'i> = On<'i, E>;
+    type Inner<'i> = On<'i, E>;
 
     fn wrap(this: Self::Inner<'_>) -> Self::Param<'_> {
         this

--- a/crates/bevy_ecs/src/system/observer_system.rs
+++ b/crates/bevy_ecs/src/system/observer_system.rs
@@ -4,12 +4,12 @@ use super::IntoSystem;
 
 /// Implemented for [`System`]s that have [`On`] as the first argument.
 pub trait ObserverSystem<E: EventPattern, Out = ()>:
-    System<In = On<'static, 'static, E>, Out = Out> + Send + 'static
+    System<In = On<'static, E>, Out = Out> + Send + 'static
 {
 }
 
 impl<E: EventPattern, Out, T> ObserverSystem<E, Out> for T where
-    T: System<In = On<'static, 'static, E>, Out = Out> + Send + 'static
+    T: System<In = On<'static, E>, Out = Out> + Send + 'static
 {
 }
 
@@ -35,7 +35,7 @@ pub trait IntoObserverSystem<E: EventPattern, M, Out = ()>: Send + 'static {
 
 impl<E: EventPattern, M, Out, S> IntoObserverSystem<E, M, Out> for S
 where
-    S: IntoSystem<On<'static, 'static, E>, Out, M> + Send + 'static,
+    S: IntoSystem<On<'static, E>, Out, M> + Send + 'static,
     S::System: ObserverSystem<E, Out>,
     E: 'static,
 {

--- a/crates/bevy_ecs/src/traversal.rs
+++ b/crates/bevy_ecs/src/traversal.rs
@@ -26,7 +26,7 @@ use crate::{
 /// [observers]: crate::observer::Observer
 /// [`EntityEvent`]: crate::event::EntityEvent
 pub trait Traversal<D: ?Sized>:
-    ReadOnlyQueryData + ReleaseStateQueryData + SingleEntityQueryData
+    ReadOnlyQueryData + ReleaseStateQueryData + SingleEntityQueryData + 'static
 {
     /// Returns the next entity to visit.
     fn traverse(item: Self::Item<'_, '_>, data: &D) -> Option<Entity>;
@@ -45,7 +45,7 @@ impl<D> Traversal<D> for () {
 /// Traversing in a loop could result in infinite loops for relationship graphs with loops.
 ///
 /// [event propagation]: crate::observer::On::propagate
-impl<R: Relationship, D> Traversal<D> for &R {
+impl<R: Relationship, D> Traversal<D> for &'static R {
     fn traverse(item: Self::Item<'_, '_>, _data: &D) -> Option<Entity> {
         Some(item.get())
     }

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -789,7 +789,7 @@ impl<'w> DeferredWorld<'w> {
     #[track_caller]
     pub fn trigger<E: Event>(&mut self, event: E)
     where
-        for<'a> EventTriggerState<'a, E>: Default,
+        EventTriggerState<'static, E>: Default,
     {
         self.commands().trigger(event);
     }

--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -7,7 +7,7 @@ use crate::{
     change_detection::{MaybeLocation, MutUntyped, Tick},
     component::{ComponentId, Mutable},
     entity::Entity,
-    event::{EntityComponentsTrigger, Event, EventKey, Trigger},
+    event::{EntityComponentsTrigger, Event, EventKey, EventTriggerState, Trigger},
     lifecycle::{DiscardEvent, HookContext, InsertEvent, DISCARD, INSERT},
     message::{Message, MessageId, Messages, WriteBatchIds},
     observer::TriggerContext,
@@ -753,11 +753,11 @@ impl<'w> DeferredWorld<'w> {
     /// # Safety
     /// - Caller must ensure `E` is accessible as the type represented by `event_key`
     #[inline]
-    pub unsafe fn trigger_raw<'a, E: Event>(
+    pub unsafe fn trigger_raw<E: Event>(
         &mut self,
         event_key: EventKey,
         event: &mut E,
-        trigger: &mut E::Trigger<'a>,
+        trigger: &mut EventTriggerState<'_, E>,
         caller: MaybeLocation,
     ) {
         // SAFETY: You cannot get a mutable reference to `observers` from `DeferredWorld`
@@ -777,7 +777,7 @@ impl<'w> DeferredWorld<'w> {
         // - trigger_context contains the correct event_key for `event`, as enforced by the call to `trigger_raw`
         // - This method is being called for an `event` whose `Event::Trigger` matches, as the input trigger is E::Trigger.
         unsafe {
-            trigger.trigger(world.reborrow(), observers, &context, event);
+            E::Trigger::trigger(trigger, world.reborrow(), observers, &context, event);
         }
     }
 
@@ -787,7 +787,10 @@ impl<'w> DeferredWorld<'w> {
     ///
     /// [`Observer`]: crate::observer::Observer
     #[track_caller]
-    pub fn trigger<'a>(&mut self, event: impl Event<Trigger<'a>: Default>) {
+    pub fn trigger<E: Event>(&mut self, event: E)
+    where
+        for<'a> EventTriggerState<'a, E>: Default,
+    {
         self.commands().trigger(event);
     }
 

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -6,7 +6,7 @@ use crate::{
     change_detection::{ComponentTicks, MaybeLocation, MutUntyped, Tick},
     component::{Component, ComponentId, Components, Mutable, StorageType},
     entity::{Entity, EntityCloner, EntityClonerBuilder, EntityLocation, OptIn, OptOut},
-    event::{EntityComponentsTrigger, EntityEvent},
+    event::{EntityComponentsTrigger, EntityEvent, EventTriggerState},
     lifecycle::{DespawnEvent, DiscardEvent, RemoveEvent, DESPAWN, DISCARD, REMOVE},
     observer::IntoEntityObserver,
     query::{
@@ -2353,16 +2353,16 @@ impl<'w> EntityWorldMut<'w> {
     ///
     /// [`EntityCommands::trigger`]: crate::system::EntityCommands::trigger
     #[track_caller]
-    pub fn trigger<'t, E: EntityEvent<Trigger<'t>: Default>>(
-        &mut self,
-        event_fn: impl FnOnce(Entity) -> E,
-    ) -> &mut Self {
+    pub fn trigger<E: EntityEvent>(&mut self, event_fn: impl FnOnce(Entity) -> E) -> &mut Self
+    where
+        for<'t> EventTriggerState<'t, E>: Default,
+    {
         let mut event = (event_fn)(self.entity);
         let caller = MaybeLocation::caller();
         self.world_scope(|world| {
             world.trigger_ref_with_caller(
                 &mut event,
-                &mut <E::Trigger<'_> as Default>::default(),
+                &mut EventTriggerState::<E>::default(),
                 caller,
             );
         });

--- a/crates/bevy_ecs/src/world/entity_access/world_mut.rs
+++ b/crates/bevy_ecs/src/world/entity_access/world_mut.rs
@@ -2355,7 +2355,7 @@ impl<'w> EntityWorldMut<'w> {
     #[track_caller]
     pub fn trigger<E: EntityEvent>(&mut self, event_fn: impl FnOnce(Entity) -> E) -> &mut Self
     where
-        for<'t> EventTriggerState<'t, E>: Default,
+        EventTriggerState<'static, E>: Default,
     {
         let mut event = (event_fn)(self.entity);
         let caller = MaybeLocation::caller();

--- a/examples/usage/context_menu.rs
+++ b/examples/usage/context_menu.rs
@@ -2,10 +2,7 @@
 
 use bevy::{
     color::palettes::basic,
-    ecs::{
-        event::{PropagateEntityTrigger, SetEntityEventTarget},
-        system::ObserverSystem,
-    },
+    ecs::event::{PropagateEntityTrigger, SetEntityEventTarget},
     prelude::*,
     ui_widgets::{ListBox, ListItem, ValueChange},
 };
@@ -44,7 +41,9 @@ fn main() {
 }
 
 /// helper function to reduce code duplication when generating almost identical observers for the hover text color change effect
-fn text_color_on_hover<E>(color: Color) -> impl ObserverSystem<E>
+fn text_color_on_hover<E>(
+    color: Color,
+) -> impl FnMut(On<E>, Query<&mut TextColor, With<ContextMenuItemText>>, Query<&Children>)
 where
     E: PointerEvent<Trigger = PropagateEntityTrigger<true, E, PointerTraversal>>
         + SetEntityEventTarget,

--- a/examples/usage/context_menu.rs
+++ b/examples/usage/context_menu.rs
@@ -2,7 +2,10 @@
 
 use bevy::{
     color::palettes::basic,
-    ecs::event::PropagateEntityTrigger,
+    ecs::{
+        event::{PropagateEntityTrigger, SetEntityEventTarget},
+        system::ObserverSystem,
+    },
     prelude::*,
     ui_widgets::{ListBox, ListItem, ValueChange},
 };
@@ -41,11 +44,11 @@ fn main() {
 }
 
 /// helper function to reduce code duplication when generating almost identical observers for the hover text color change effect
-fn text_color_on_hover<
-    E: PointerEvent + for<'a> Event<Trigger<'a> = PropagateEntityTrigger<true, E, PointerTraversal>>,
->(
-    color: Color,
-) -> impl FnMut(On<E>, Query<&mut TextColor, With<ContextMenuItemText>>, Query<&Children>) {
+fn text_color_on_hover<E>(color: Color) -> impl ObserverSystem<E>
+where
+    E: PointerEvent<Trigger = PropagateEntityTrigger<true, E, PointerTraversal>>
+        + SetEntityEventTarget,
+{
     move |mut event: On<E>,
           mut text_color: Query<&mut TextColor, With<ContextMenuItemText>>,
           children: Query<&Children>| {


### PR DESCRIPTION
# Objective

Simplify the safety story of `On` and `Trigger`, and reduce the number of lifetimes on `On` from two to one.

This is a cleanup pass in preparation to support observer target queries, `On<'world, 'state, 'input, E: EventPattern, D: QueryData = (), F: QueryFilter = ()>`.

## Solution

Add and require support for `Trigger` reborrowing:

- Removed the lifetime from `Event::Trigger`
  - That lets us add the `E: Event<Trigger = Self>` requirement directly to `Trigger`'s trait, removing the `unsafe` requirement for it.
- Added `Trigger::State<'a>`, which is the type that's passed to `World::trigger` and `Commands::trigger`
- Added `Trigger::View<'a>`, which is the type passed into observer systems as a mutable view of the `Trigger::State`
  - This type currently only differs from `State` for `PropagateEntityTrigger`, in order to provide access to a `propagate: &mut bool`
- Added `Trigger::reborrow` to convert from a `&'a mut Trigger::State<'_>` to a `Trigger::View<'a>` (owned)
- Added `EventTriggerState` and `EventTriggerView` type aliases for ease of access (replacing `EventPatternTrigger`)

## Testing

No new tests were added, suggestions welcome.