### PR TITLE
expose complex-scripts feature (#24094)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -618,6 +618,9 @@ default_font = ["bevy_internal/default_font"]
 # Allows for discovery of preloaded system fonts
 system_font_discovery = ["bevy_internal/system_font_discovery"]
 
+# Enables dictionary-based segmentation for complex scripts (CJK, Thai, Khmer, Lao, Myanmar), at the cost of a larger binary
+complex_script_segmentation = ["bevy_internal/complex_script_segmentation"]
+
 # Enable support for shaders in SPIR-V
 shader_format_spirv = ["bevy_internal/shader_format_spirv"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -302,6 +302,9 @@ default_font = ["bevy_text?/default_font"]
 # Allows for discovery of preloaded system fonts
 system_font_discovery = ["bevy_text?/system_font_discovery"]
 
+# Enables dictionary-based segmentation for complex scripts (CJK, Thai, Khmer, Lao, Myanmar), at the cost of a larger binary
+complex_script_segmentation = ["bevy_text?/complex_script_segmentation"]
+
 # Enables downloading assets from HTTP sources
 http = ["bevy_asset?/http"]
 

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["bevy"]
 default_font = []
 system_font_discovery = ["parley/system"]
 system_clipboard = ["bevy_clipboard/system_clipboard"]
+complex_script_segmentation = ["parley/complex-scripts"]
 
 [dependencies]
 # bevy

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -116,6 +116,7 @@ This is the complete `bevy` cargo feature list, without "profiles" or "collectio
 |bluenoise_texture|Include spatio-temporal blue noise KTX2 file used by generated environment maps, Solari and atmosphere|
 |bmp|BMP image format support|
 |clipboard_image|Enables image copy/paste via the system clipboard. Not supported on WASM.|
+|complex_script_segmentation|Enables dictionary-based segmentation for complex scripts (CJK, Thai, Khmer, Lao, Myanmar), at the cost of a larger binary|
 |compressed_image_saver|Texture compression asset processor (BCn for desktop, ASTC for mobile via env var)|
 |compressed_image_saver_universal|Texture compression asset processor (cross-platform, transcodes to any GPU format at load time)|
 |critical-section|`critical-section` provides the building blocks for synchronization primitives on all platforms, including `no_std`.|


### PR DESCRIPTION
# Objective
Fixes #24094

(Rebase of #24683, closed due to merge conflicts on `main`. Re-verified the fix still works on current `main`. That PR had received a community review approval.)

Text containing complex scripts that lack explicit word boundaries (CJK, Thai, Khmer, Lao, Myanmar) is segmented by parley's lightweight segmenter, which emits a data error per layout:
```text
ICU4X data error: No segmentation model for language: ja
```
parley added a `complex-scripts` Cargo feature that switches to dictionary-based segmentation, but it was not reachable from Bevy.

## Solution
- Add an opt-in `complex_script_segmentation` feature to `bevy_text` that forwards to `parley/complex-scripts`, propagated through `bevy_internal` and `bevy`. It is off by default because the bundled segmentation dictionary increases binary size (see below).

This supplies the segmentation data and enables dictionary-based word segmentation; it does not change CJK line-break positions, which ICU keeps permissive by design.

## Testing
- `cargo build -p bevy_text -p bevy_ui -p bevy_ui_widgets`, with default features and with `--features complex_script_segmentation`.
- `cargo tree -e features -i parley` confirms parley's `complex-scripts` feature is only enabled when `complex_script_segmentation` is requested (not pulled in by any default/collection feature).
- Ran a `Text2d` example with a Japanese string in a width-bounded box (`TextBounds`, `LineBreak::WordBoundary`) under `RUST_LOG=warn`:
    - default: the `No segmentation model for language: ja` error is logged.
    - `--features complex_script_segmentation`: the error is gone.
- `cargo run -p ci` (lints + compile + tests). One unrelated local failure: `bevy_ecs ... filtered_backtrace_test`, which also fails on main on my machine (an environment-dependent backtrace-symbolization test, unrelated to this PR).
- Tested on macOS (Apple Silicon).

## Binary size impact

Measured with a stripped release build of the `text_debug` example:

- without `complex_script_segmentation`: 57,018,696 bytes
- with `complex_script_segmentation`:    60,832,984 bytes
- delta: ~3.6 MiB / ~6.7%

It seems the feature should be an opt-in.