### PR TITLE
BSN: #{} entity syntax

### DIFF
--- a/benches/benches/bevy_scene/spawn.rs
+++ b/benches/benches/bevy_scene/spawn.rs
@@ -145,18 +145,16 @@ struct Reference(Entity);
 fn named_passing() -> impl Scene {
     bsn! {
         #Name
-        Children [
-            (#Name0 Reference(#Name) Reference(#Name0)),
-            (#Name1 Reference(#Name) Reference(#Name1)),
-            (#Name2 Reference(#Name) Reference(#Name2)),
-            (#Name3 Reference(#Name) Reference(#Name3)),
-            (#Name4 Reference(#Name) Reference(#Name4)),
-            (#Name5 Reference(#Name) Reference(#Name5)),
-            (#Name6 Reference(#Name) Reference(#Name6)),
-            (#Name7 Reference(#Name) Reference(#Name7)),
-            (#Name8 Reference(#Name) Reference(#Name8)),
-            (#Name9 Reference(#Name) Reference(#Name9)),
-        ]
+        #Name0 { Reference(#Name) Reference(#Name0) }
+        #Name1 { Reference(#Name) Reference(#Name1) }
+        #Name2 { Reference(#Name) Reference(#Name2) }
+        #Name3 { Reference(#Name) Reference(#Name3) }
+        #Name4 { Reference(#Name) Reference(#Name4) }
+        #Name5 { Reference(#Name) Reference(#Name5) }
+        #Name6 { Reference(#Name) Reference(#Name6) }
+        #Name7 { Reference(#Name) Reference(#Name7) }
+        #Name8 { Reference(#Name) Reference(#Name8) }
+        #Name9 { Reference(#Name) Reference(#Name9) }
     }
 }
 
@@ -174,7 +172,7 @@ fn asset_value_scene() -> impl Scene {
         })
         .collect::<Vec<_>>();
     bsn! {
-        Children [{children}]
+        #{{ children }}
     }
 }
 
@@ -186,43 +184,39 @@ fn asset_handle_scene(mut handles: Vec<Handle<EmptyAsset>>) -> impl Scene {
         })
         .collect::<Vec<_>>();
     bsn! {
-        Children [{children}]
+        #{{ children }}
     }
 }
 
 fn ui() -> impl Scene {
     bsn! {
         Node
-        Children [
-            (@button() Node { width: Val::Px(200.) }),
-            (@button() Node { width: Val::Px(200.) }),
-            (@button() Node { width: Val::Px(200.) }),
-            (@button() Node { width: Val::Px(200.) }),
-            (@button() Node { width: Val::Px(200.) }),
-            (@button() Node { width: Val::Px(200.) }),
-            (@button() Node { width: Val::Px(200.) }),
-            (@button() Node { width: Val::Px(200.) }),
-            (@button() Node { width: Val::Px(200.) }),
-            (@button() Node { width: Val::Px(200.) }),
-        ]
+        #{ @button() Node { width: Val::Px(200.) } }
+        #{ @button() Node { width: Val::Px(200.) } }
+        #{ @button() Node { width: Val::Px(200.) } }
+        #{ @button() Node { width: Val::Px(200.) } }
+        #{ @button() Node { width: Val::Px(200.) } }
+        #{ @button() Node { width: Val::Px(200.) } }
+        #{ @button() Node { width: Val::Px(200.) } }
+        #{ @button() Node { width: Val::Px(200.) } }
+        #{ @button() Node { width: Val::Px(200.) } }
+        #{ @button() Node { width: Val::Px(200.) } }
     }
 }
 
 fn ui_loaded_asset() -> impl Scene {
     bsn! {
         Node
-        Children [
-            (:"button.bsn" Node { width: Val::Px(200.) }),
-            (:"button.bsn" Node { width: Val::Px(200.) }),
-            (:"button.bsn" Node { width: Val::Px(200.) }),
-            (:"button.bsn" Node { width: Val::Px(200.) }),
-            (:"button.bsn" Node { width: Val::Px(200.) }),
-            (:"button.bsn" Node { width: Val::Px(200.) }),
-            (:"button.bsn" Node { width: Val::Px(200.) }),
-            (:"button.bsn" Node { width: Val::Px(200.) }),
-            (:"button.bsn" Node { width: Val::Px(200.) }),
-            (:"button.bsn" Node { width: Val::Px(200.) }),
-        ]
+            #{ :"button.bsn" Node { width: Val::Px(200.) } }
+            #{ :"button.bsn" Node { width: Val::Px(200.) } }
+            #{ :"button.bsn" Node { width: Val::Px(200.) } }
+            #{ :"button.bsn" Node { width: Val::Px(200.) } }
+            #{ :"button.bsn" Node { width: Val::Px(200.) } }
+            #{ :"button.bsn" Node { width: Val::Px(200.) } }
+            #{ :"button.bsn" Node { width: Val::Px(200.) } }
+            #{ :"button.bsn" Node { width: Val::Px(200.) } }
+            #{ :"button.bsn" Node { width: Val::Px(200.) } }
+            #{ :"button.bsn" Node { width: Val::Px(200.) } }
     }
 }
 
@@ -250,18 +244,16 @@ fn button() -> impl Scene {
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
         }
-        Children [
-            (Text("Text") Marker Marker1 Marker2 Marker3),
-            (Text("Text") Marker Marker1 Marker2 Marker3),
-            (Text("Text") Marker Marker1 Marker2 Marker3),
-            (Text("Text") Marker Marker1 Marker2 Marker3),
-            (Text("Text") Marker Marker1 Marker2 Marker3),
-            (Text("Text") Marker Marker1 Marker2 Marker3),
-            (Text("Text") Marker Marker1 Marker2 Marker3),
-            (Text("Text") Marker Marker1 Marker2 Marker3),
-            (Text("Text") Marker Marker1 Marker2 Marker3),
-            (Text("Text") Marker Marker1 Marker2 Marker3),
-        ]
+        #{ Text("Text") Marker Marker1 Marker2 Marker3 }
+        #{ Text("Text") Marker Marker1 Marker2 Marker3 }
+        #{ Text("Text") Marker Marker1 Marker2 Marker3 }
+        #{ Text("Text") Marker Marker1 Marker2 Marker3 }
+        #{ Text("Text") Marker Marker1 Marker2 Marker3 }
+        #{ Text("Text") Marker Marker1 Marker2 Marker3 }
+        #{ Text("Text") Marker Marker1 Marker2 Marker3 }
+        #{ Text("Text") Marker Marker1 Marker2 Marker3 }
+        #{ Text("Text") Marker Marker1 Marker2 Marker3 }
+        #{ Text("Text") Marker Marker1 Marker2 Marker3 }
     }
 }
 

--- a/crates/bevy_feathers/src/containers/pane.rs
+++ b/crates/bevy_feathers/src/containers/pane.rs
@@ -1,5 +1,4 @@
 use bevy_app::Propagate;
-use bevy_ecs::hierarchy::Children;
 use bevy_scene::{bsn, Scene};
 use bevy_text::FontWeight;
 use bevy_ui::{
@@ -65,7 +64,7 @@ pub fn pane_header_divider() -> impl Scene {
             width: px(1),
             align_self: AlignSelf::Stretch,
         }
-        Children [(
+        #{
             // Because we want to extend the divider into the header padding area, we'll use
             // an absolutely-positioned child.
             Node {
@@ -76,7 +75,7 @@ pub fn pane_header_divider() -> impl Scene {
                 bottom: px(-6),
             }
             ThemeBackgroundColor(tokens::PANE_HEADER_DIVIDER)
-        )]
+        }
     }
 }
 

--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -2,7 +2,6 @@ use bevy_app::{Plugin, PreUpdate};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    hierarchy::Children,
     lifecycle::RemovedComponents,
     query::{Added, Changed, Has, Or},
     reflect::ReflectComponent,
@@ -113,9 +112,7 @@ impl FeathersButton {
                 font_size: size::MEDIUM_FONT,
                 weight: FontWeight::NORMAL,
             }
-            Children [
-                {props.caption}
-            ]
+            #{{props.caption}}
         }
     }
 }
@@ -142,7 +139,7 @@ impl FeathersToolButton {
             @FeathersButton {
                 @caption: {props.caption},
                 @variant: {props.variant},
-                @corners: {props.corners}
+                @corners: {props.corners},
             }
             Node {
                 padding: UiRect::horizontal(px(4)),

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -84,7 +84,7 @@ impl FeathersCheckbox {
                 font_size: size::MEDIUM_FONT,
                 weight: FontWeight::NORMAL,
             }
-            Children [(
+            #{
                 Node {
                     width: size::CHECKBOX_SIZE,
                     height: size::CHECKBOX_SIZE,
@@ -95,7 +95,7 @@ impl FeathersCheckbox {
                 ThemeBackgroundColor(tokens::CHECKBOX_BG)
                 ThemeBorderColor(tokens::CHECKBOX_BORDER)
                 FocusIndicator
-                Children [(
+                #{
                     // Cheesy checkmark: rotated node with L-shaped border.
                     Node {
                         position_type: PositionType::Absolute,
@@ -111,9 +111,9 @@ impl FeathersCheckbox {
                     UiTransform::from_rotation(Rot2::FRAC_PI_4)
                     CheckboxMark
                     ThemeBorderColor(tokens::CHECKBOX_MARK)
-                )]),
-                {props.caption}
-            ]
+                }
+            }
+            #{{props.caption}}
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/color_input.rs
+++ b/crates/bevy_feathers/src/controls/color_input.rs
@@ -311,27 +311,23 @@ impl FeathersColorInput {
             @FeathersLazyMenu { popup }
             ButtonEntityRefs(#swatch)
             ColorInputState
-            Children [
-                (
-                    @FeathersMenuToolButton {
-                        @caption: bsn! {
-                            #swatch
-                            @FeathersColorSwatch {
-                                @opaque_color_percentage: {props.opaque_color_percentage},
-                                @corners: RoundedCorners::None,
-                            }
-                            Node {
-                                width: px(18),
-                                min_width: px(18),
-                                height: px(18),
-                                flex_grow: 0.0,
-                                align_self: AlignSelf::Center,
-                                justify_self: JustifySelf::Start,
-                            }
-                         }
+            # @FeathersMenuToolButton {
+                @caption: bsn! {
+                    #swatch
+                    @FeathersColorSwatch {
+                        @opaque_color_percentage: {props.opaque_color_percentage},
+                        @corners: RoundedCorners::None,
                     }
-                )
-            ]
+                    Node {
+                        width: px(18),
+                        min_width: px(18),
+                        height: px(18),
+                        flex_grow: 0.0,
+                        align_self: AlignSelf::Center,
+                        justify_self: JustifySelf::Start,
+                    }
+                }
+            }
         }
     }
 }
@@ -415,69 +411,59 @@ fn color_input_popup() -> Box<dyn Scene> {
             ],
             window_margin: 10.0,
         }
-        Children [
-            (
-                Node {
-                    display: Display::Flex,
-                    flex_direction: FlexDirection::Row,
-                    column_gap: px(1),
+        #{
+            Node {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                column_gap: px(1),
+            }
+            #mode_rgb {
+                @FeathersButton {
+                    @caption: bsn! { @caption("RGB") },
+                    @corners: RoundedCorners::Left,
                 }
-                Children [
-                    (
-                        #mode_rgb
-                        @FeathersButton {
-                            @caption: bsn! { @caption("RGB") },
-                            @corners: RoundedCorners::Left,
-                        }
-                        Node {
-                            flex_grow: 1.0,
-                        }
-                        ActivateOnPress
-                        AccessibleLabel("RGB")
-                        on(|_activate: On<Activate>, mut settings: ResMut<ColorInputSettings>| {
-                            settings.mode = ColorInputMode::RGPlane;
-                        })
-                        AutoFocus
-                    ),
-                    (
-                        #mode_hsl
-                        @FeathersButton {
-                            @caption: bsn! { @caption("HSL") },
-                            @corners: RoundedCorners::Right,
-                        }
-                        Node {
-                            flex_grow: 1.0,
-                        }
-                        ActivateOnPress
-                        AccessibleLabel("HSL")
-                        on(|_activate: On<Activate>, mut settings: ResMut<ColorInputSettings>| {
-                            settings.mode = ColorInputMode::HSPlane;
-                        })
-                    ),
-                ]
-            ),
-
-            (
-                #rg_plane
-                @FeathersColorPlane::RedGreen
                 Node {
-                    width: px(256 + 8),
-                    height: px(256 + 8),
+                    flex_grow: 1.0,
                 }
-                on(rg_color_plane_value_change)
-            ),
-
-            (
-                #hs_plane
-                @FeathersColorPlane::HueSaturation
+                ActivateOnPress
+                AccessibleLabel("RGB")
+                on(|_activate: On<Activate>, mut settings: ResMut<ColorInputSettings>| {
+                    settings.mode = ColorInputMode::RGPlane;
+                })
+                AutoFocus
+            }
+            #mode_hsl {
+                @FeathersButton {
+                    @caption: bsn! { @caption("HSL") },
+                    @corners: RoundedCorners::Right,
+                }
                 Node {
-                    width: px(256 + 8),
-                    height: px(256 + 8),
+                    flex_grow: 1.0,
                 }
-                on(hs_color_plane_value_change)
-            ),
-
-            #rgb_group
+                ActivateOnPress
+                AccessibleLabel("HSL")
+                on(|_activate: On<Activate>, mut settings: ResMut<ColorInputSettings>| {
+                    settings.mode = ColorInputMode::HSPlane;
+                })
+            }
+        }
+        #rg_plane {
+            @FeathersColorPlane::RedGreen
+            Node {
+                width: px(256 + 8),
+                height: px(256 + 8),
+            }
+            on(rg_color_plane_value_change)
+        }
+        #hs_plane {
+            @FeathersColorPlane::HueSaturation
+            Node {
+                width: px(256 + 8),
+                height: px(256 + 8),
+            }
+            on(hs_color_plane_value_change)
+        }
+        #rgb_group {
             Node {
                 display: Display::Grid,
                 column_gap: px(4),
@@ -490,70 +476,63 @@ fn color_input_popup() -> Box<dyn Scene> {
                 grid_auto_rows: vec![GridTrack::auto()],
                 align_items: AlignItems::Center,
             }
-            Children [
-                @label("R"),
-                (
-                    #r_slider
-                    @FeathersColorSlider {
-                        @value: 0.5,
-                        @channel: ColorChannel::Red
-                    }
-                    AccessibleLabel("Red Channel")
-                    on(color_slider_value_change)
-                ),
-                (
-                    #r_input
-                    @FeathersNumberInput
-                    NumberInputValue::F32(0.0)
-                    HardLimit(NumberInputRange::F32(0.0..=255.0))
-                    NumberInputPrecision(1)
-                    NumberInputStep(20.0)
-                    NumberInputChannel(ColorChannel::Red)
-                    on(number_input_value_change)
-                ),
-                @label("G"),
-                (
-                    #g_slider
-                    @FeathersColorSlider {
-                        @value: 0.5,
-                        @channel: ColorChannel::Green
-                    }
-                    AccessibleLabel("Green Channel")
-                    on(color_slider_value_change)
-                ),
-                (
-                    #g_input
-                    @FeathersNumberInput
-                    NumberInputValue::F32(0.0)
-                    HardLimit(NumberInputRange::F32(0.0..=255.0))
-                    NumberInputPrecision(1)
-                    NumberInputStep(20.0)
-                    NumberInputChannel(ColorChannel::Green)
-                    on(number_input_value_change)
-                ),
-                @label("B"),
-                (
-                    #b_slider
-                    @FeathersColorSlider {
-                        @value: 0.5,
-                        @channel: ColorChannel::Blue
-                    }
-                    AccessibleLabel("Blue Channel")
-                    on(color_slider_value_change)
-                ),
-                (
-                    #b_input
-                    @FeathersNumberInput
-                    NumberInputValue::F32(0.0)
-                    HardLimit(NumberInputRange::F32(0.0..=255.0))
-                    NumberInputPrecision(1)
-                    NumberInputStep(20.0)
-                    NumberInputChannel(ColorChannel::Blue)
-                    on(number_input_value_change)
-                ),
-            ],
-
-            #hsl_group
+            # @label("R")
+            #r_slider {
+                #r_slider
+                @FeathersColorSlider {
+                    @value: 0.5,
+                    @channel: ColorChannel::Red
+                }
+                AccessibleLabel("Red Channel")
+                on(color_slider_value_change)
+            }
+            #r_input {
+                @FeathersNumberInput
+                NumberInputValue::F32(0.0)
+                HardLimit(NumberInputRange::F32(0.0..=255.0))
+                NumberInputPrecision(1)
+                NumberInputStep(20.0)
+                NumberInputChannel(ColorChannel::Red)
+                on(number_input_value_change)
+            }
+            # @label("G")
+            #g_slider {
+                @FeathersColorSlider {
+                    @value: 0.5,
+                    @channel: ColorChannel::Green
+                }
+                AccessibleLabel("Green Channel")
+                on(color_slider_value_change)
+            }
+            #g_input {
+                @FeathersNumberInput
+                NumberInputValue::F32(0.0)
+                HardLimit(NumberInputRange::F32(0.0..=255.0))
+                NumberInputPrecision(1)
+                NumberInputStep(20.0)
+                NumberInputChannel(ColorChannel::Green)
+                on(number_input_value_change)
+            }
+            # @label("B")
+            #b_slider {
+                @FeathersColorSlider {
+                    @value: 0.5,
+                    @channel: ColorChannel::Blue
+                }
+                AccessibleLabel("Blue Channel")
+                on(color_slider_value_change)
+            }
+            #b_input {
+                @FeathersNumberInput
+                NumberInputValue::F32(0.0)
+                HardLimit(NumberInputRange::F32(0.0..=255.0))
+                NumberInputPrecision(1)
+                NumberInputStep(20.0)
+                NumberInputChannel(ColorChannel::Blue)
+                on(number_input_value_change)
+            }
+        }
+        #hsl_group {
             Node {
                 display: Display::Grid,
                 column_gap: px(4),
@@ -566,78 +545,71 @@ fn color_input_popup() -> Box<dyn Scene> {
                 grid_auto_rows: vec![GridTrack::auto()],
                 align_items: AlignItems::Center,
             }
-            Children [
-                @label("H"),
-                (
-                    #h_slider
-                    @FeathersColorSlider {
-                        @value: 0.5,
-                        @channel: ColorChannel::HslHue
-                    }
-                    AccessibleLabel("Hue Channel")
-                    on(color_slider_value_change)
-                ),
-                (
-                    #h_input
-                    @FeathersNumberInput
-                    NumberInputValue::F32(0.0)
-                    HardLimit(NumberInputRange::F32(0.0..=360.0))
-                    NumberInputPrecision(1)
-                    NumberInputStep(30.0)
-                    NumberInputChannel(ColorChannel::HslHue)
-                    Node {
-                        flex_grow: 1.0,
-                    }
-                    on(number_input_value_change)
-                ),
-                @label("S"),
-                (
-                    #s_slider
-                    @FeathersColorSlider {
-                        @value: 0.5,
-                        @channel: ColorChannel::HslSaturation
-                    }
-                    AccessibleLabel("Saturation Channel")
-                    on(color_slider_value_change)
-                ),
-                (
-                    #s_input
-                    @FeathersNumberInput
-                    NumberInputValue::F32(0.0)
-                    HardLimit(NumberInputRange::F32(0.0..=100.0))
-                    NumberInputPrecision(1)
-                    NumberInputStep(10.0)
-                    NumberInputChannel(ColorChannel::HslSaturation)
-                    Node {
-                        flex_grow: 1.0,
-                    }
-                    on(number_input_value_change)
-                ),
-                @label("L"),
-                (
-                    #l_slider
-                    @FeathersColorSlider {
-                        @value: 0.5,
-                        @channel: ColorChannel::HslLightness
-                    }
-                    AccessibleLabel("Lightness Channel")
-                    on(color_slider_value_change)
-                ),
-                (
-                    #l_input
-                    @FeathersNumberInput
-                    NumberInputValue::F32(0.0)
-                    HardLimit(NumberInputRange::F32(0.0..=100.0))
-                    NumberInputPrecision(1)
-                    NumberInputStep(10.0)
-                    NumberInputChannel(ColorChannel::HslLightness)
-                    Node {
-                        flex_grow: 1.0,
-                    }
-                    on(number_input_value_change)
-                ),
-            ],
-
+            # @label("H")
+            #h_slider {
+                @FeathersColorSlider {
+                    @value: 0.5,
+                    @channel: ColorChannel::HslHue
+                }
+                AccessibleLabel("Hue Channel")
+                on(color_slider_value_change)
+            }
+            #h_input {
+                @FeathersNumberInput
+                NumberInputValue::F32(0.0)
+                HardLimit(NumberInputRange::F32(0.0..=360.0))
+                NumberInputPrecision(1)
+                NumberInputStep(30.0)
+                NumberInputChannel(ColorChannel::HslHue)
+                Node {
+                    flex_grow: 1.0,
+                }
+                on(number_input_value_change)
+            }
+            # @label("S")
+            #s_slider {
+                @FeathersColorSlider {
+                    @value: 0.5,
+                    @channel: ColorChannel::HslSaturation
+                }
+                AccessibleLabel("Saturation Channel")
+                on(color_slider_value_change)
+            }
+            #s_input {
+                @FeathersNumberInput
+                NumberInputValue::F32(0.0)
+                HardLimit(NumberInputRange::F32(0.0..=100.0))
+                NumberInputPrecision(1)
+                NumberInputStep(10.0)
+                NumberInputChannel(ColorChannel::HslSaturation)
+                Node {
+                    flex_grow: 1.0,
+                }
+                on(number_input_value_change)
+            }
+            # @label("L")
+            #l_slider {
+                @FeathersColorSlider {
+                    @value: 0.5,
+                    @channel: ColorChannel::HslLightness
+                }
+                AccessibleLabel("Lightness Channel")
+                on(color_slider_value_change)
+            }
+            #l_input {
+                @FeathersNumberInput
+                NumberInputValue::F32(0.0)
+                HardLimit(NumberInputRange::F32(0.0..=100.0))
+                NumberInputPrecision(1)
+                NumberInputStep(10.0)
+                NumberInputChannel(ColorChannel::HslLightness)
+                Node {
+                    flex_grow: 1.0,
+                }
+                on(number_input_value_change)
+            }
+        }
+        #{
             Node {
                 display: Display::Grid,
                 column_gap: px(4),
@@ -650,73 +622,64 @@ fn color_input_popup() -> Box<dyn Scene> {
                 grid_auto_rows: vec![GridTrack::auto()],
                 align_items: AlignItems::Center,
             }
-            Children [
-                @label("A"),
-                (
-                    #a_slider
-                    @FeathersColorSlider {
-                        @value: 0.5,
-                        @channel: ColorChannel::Alpha
+            # @label("A")
+            #a_slider {
+                @FeathersColorSlider {
+                    @value: 0.5,
+                    @channel: ColorChannel::Alpha
+                }
+                AccessibleLabel("Alpha Channel")
+                on(color_slider_value_change)
+            }
+            #a_input {
+                @FeathersNumberInput
+                NumberInputValue::F32(0.0)
+                HardLimit(NumberInputRange::F32(0.0..=255.0))
+                NumberInputPrecision(1)
+                NumberInputStep(10.0)
+                NumberInputChannel(ColorChannel::Alpha)
+                on(number_input_value_change)
+            }
+            #hex_input_container {
+                @FeathersTextInputContainer
+                Node {
+                    flex_grow: 0.
+                    padding: { px(4).left() },
+                    grid_column: GridPlacement::span(2),
+                }
+                #hex_input {
+                    @FeathersTextInput {
+                        @max_characters: 9usize,
                     }
-                    AccessibleLabel("Alpha Channel")
-                    on(color_slider_value_change)
-                ),
-                (
-                    #a_input
-                    @FeathersNumberInput
-                    NumberInputValue::F32(0.0)
-                    HardLimit(NumberInputRange::F32(0.0..=255.0))
-                    NumberInputPrecision(1)
-                    NumberInputStep(10.0)
-                    NumberInputChannel(ColorChannel::Alpha)
-                    on(number_input_value_change)
-                ),
-                (
-                    #hex_input_container
-                    @FeathersTextInputContainer
-                    Node {
-                        flex_grow: 0.
-                        padding: { px(4).left() },
-                        grid_column: GridPlacement::span(2),
+                    TextLayout {
+                        justify: Justify::Center,
                     }
-                    Children [
-                        (
-                            #hex_input
-                            @FeathersTextInput {
-                                @max_characters: 9usize,
-                            }
-                            TextLayout {
-                                justify: Justify::Center,
-                            }
-                            InheritableFont {
-                                font: fonts::MONO
-                            }
-                            LineHeight::Px(24.0) // TODO: Make const for this
-                            on(hex_input_on_enter_key)
-                            on(hex_input_on_focus_loss)
-                        )
-                    ]
-                ),
-                (
-                    #swatch
-                    @FeathersColorSwatch {
-                        @opaque_color_percentage: 50.0,
+                    InheritableFont {
+                        font: fonts::MONO
                     }
-                    Node {
-                        flex_grow: 0.0,
-                        align_self: AlignSelf::Stretch,
-                    }
-                )
-            ],
-
-            // Recent colors
-            #recent
+                    LineHeight::Px(24.0) // TODO: Make const for this
+                    on(hex_input_on_enter_key)
+                    on(hex_input_on_focus_loss)
+                }
+            }
+            #swatch {
+                @FeathersColorSwatch {
+                    @opaque_color_percentage: 50.0,
+                }
+                Node {
+                    flex_grow: 0.0,
+                    align_self: AlignSelf::Stretch,
+                }
+            }
+        }
+        // Recent colors
+        #recent {
             @FeathersColorSwatchGrid {
                 size: UVec2::new(RECENT_COLORS_COLUMNS, RECENT_COLORS_ROWS),
                 opaque_color_percentage: 50.0,
             }
             on(recent_color_selected)
-        ]
+        }
     ))
 }
 

--- a/crates/bevy_feathers/src/controls/color_plane.rs
+++ b/crates/bevy_feathers/src/controls/color_plane.rs
@@ -155,13 +155,13 @@ impl FeathersColorPlane {
             ColorPlaneValue
             ThemeBackgroundColor(tokens::COLOR_PLANE_BG)
             EntityCursor::System(bevy_window::SystemCursorIcon::Crosshair)
-            Children [(
+            #{
                 Node {
                     align_self: AlignSelf::Stretch,
                     flex_grow: 1.0,
                 }
                 ColorPlaneInner
-                Children [(
+                #{
                     Node {
                         position_type: PositionType::Absolute,
                         left: percent(0),
@@ -180,8 +180,8 @@ impl FeathersColorPlane {
                     }
                     Pickable::IGNORE
                     UiTransform::from_translation(Val2::percent(-50., -50.),)
-                )]
-            )]
+                }
+            }
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/color_slider.rs
+++ b/crates/bevy_feathers/src/controls/color_slider.rs
@@ -248,81 +248,79 @@ impl FeathersColorSlider {
             EntityCursor::System(bevy_window::SystemCursorIcon::Pointer)
             TabIndex(0)
             FocusIndicator
-            Children [
-                // track
-                (
+            // track
+            #{
+                Node {
+                    grid_row: GridPlacement::start(1),
+                    grid_column: GridPlacement::start(1),
+                    margin: {UiRect::vertical(px(TRACK_PADDING))},
+                    border_radius: {RoundedCorners::All.to_border_radius(TRACK_RADIUS)},
+                }
+                ColorSliderTrack
+                AlphaPattern
+                MaterialNode::<AlphaPatternMaterial>
+            }
+            // gradient
+            #{
+                Node {
+                    grid_row: GridPlacement::start(1),
+                    grid_column: GridPlacement::start(1),
+                    margin: {UiRect::vertical(px(TRACK_PADDING))},
+                    border_radius: {RoundedCorners::All.to_border_radius(TRACK_RADIUS)},
+                }
+                BackgroundGradient(vec![
+                    Gradient::Linear(LinearGradient {
+                        angle: LinearGradient::TO_RIGHT,
+                        stops: vec![
+                            ColorStop::px(Color::NONE, 0),
+                            ColorStop::px(Color::NONE, THUMB_SIZE * 0.5),
+                            ColorStop::percent(Color::NONE, 50),
+                            ColorStop::percent(Color::NONE, 50),
+                            ColorStop::percent(Color::NONE, 100),
+                        ],
+                        color_space: InterpolationColorSpace::Srgba,
+                    }),
+                    Gradient::Linear(LinearGradient {
+                        angle: LinearGradient::TO_LEFT,
+                        stops: vec![
+                            ColorStop::px(Color::NONE, 0),
+                            ColorStop::px(Color::NONE, THUMB_SIZE * 0.5),
+                            ColorStop::percent(Color::NONE, 50),
+                            ColorStop::percent(Color::NONE, 50),
+                            ColorStop::percent(Color::NONE, 100),
+                        ],
+                        color_space: InterpolationColorSpace::Srgba,
+                    }),
+                ])
+            }
+            // thumb
+            #{
+                Node {
+                    grid_row: GridPlacement::start(1),
+                    grid_column: GridPlacement::start(1),
+                    margin: {UiRect::horizontal(px(THUMB_SIZE * 0.5))},
+                }
+                #{
                     Node {
-                        grid_row: GridPlacement::start(1),
-                        grid_column: GridPlacement::start(1),
-                        margin: {UiRect::vertical(px(TRACK_PADDING))},
-                        border_radius: {RoundedCorners::All.to_border_radius(TRACK_RADIUS)},
+                        position_type: PositionType::Absolute,
+                        left: percent(0),
+                        top: percent(50),
+                        width: px(THUMB_SIZE),
+                        height: px(THUMB_SIZE),
+                        border: px(2),
+                        border_radius: BorderRadius::MAX,
                     }
-                    ColorSliderTrack
-                    AlphaPattern
-                    MaterialNode::<AlphaPatternMaterial>
-                ),
-                // gradient
-                (
-                    Node {
-                        grid_row: GridPlacement::start(1),
-                        grid_column: GridPlacement::start(1),
-                        margin: {UiRect::vertical(px(TRACK_PADDING))},
-                        border_radius: {RoundedCorners::All.to_border_radius(TRACK_RADIUS)},
+                    SliderThumb
+                    ColorSliderThumb
+                    BorderColor::all(palette::WHITE)
+                    Outline {
+                        width: px(1),
+                        offset: px(0),
+                        color: palette::BLACK
                     }
-                    BackgroundGradient(vec![
-                        Gradient::Linear(LinearGradient {
-                            angle: LinearGradient::TO_RIGHT,
-                            stops: vec![
-                                ColorStop::px(Color::NONE, 0),
-                                ColorStop::px(Color::NONE, THUMB_SIZE * 0.5),
-                                ColorStop::percent(Color::NONE, 50),
-                                ColorStop::percent(Color::NONE, 50),
-                                ColorStop::percent(Color::NONE, 100),
-                            ],
-                            color_space: InterpolationColorSpace::Srgba,
-                        }),
-                        Gradient::Linear(LinearGradient {
-                            angle: LinearGradient::TO_LEFT,
-                            stops: vec![
-                                ColorStop::px(Color::NONE, 0),
-                                ColorStop::px(Color::NONE, THUMB_SIZE * 0.5),
-                                ColorStop::percent(Color::NONE, 50),
-                                ColorStop::percent(Color::NONE, 50),
-                                ColorStop::percent(Color::NONE, 100),
-                            ],
-                            color_space: InterpolationColorSpace::Srgba,
-                        }),
-                    ])
-                ),
-                // thumb
-                (
-                    Node {
-                        grid_row: GridPlacement::start(1),
-                        grid_column: GridPlacement::start(1),
-                        margin: {UiRect::horizontal(px(THUMB_SIZE * 0.5))},
-                    }
-                    Children [(
-                        Node {
-                            position_type: PositionType::Absolute,
-                            left: percent(0),
-                            top: percent(50),
-                            width: px(THUMB_SIZE),
-                            height: px(THUMB_SIZE),
-                            border: px(2),
-                            border_radius: BorderRadius::MAX,
-                        }
-                        SliderThumb
-                        ColorSliderThumb
-                        BorderColor::all(palette::WHITE)
-                        Outline {
-                            width: px(1),
-                            offset: px(0),
-                            color: palette::BLACK
-                        }
-                        UiTransform::from_translation(Val2::percent(-50., -50.))
-                    )]
-                )
-            ]
+                    UiTransform::from_translation(Val2::percent(-50., -50.))
+                }
+            }
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/color_swatch.rs
+++ b/crates/bevy_feathers/src/controls/color_swatch.rs
@@ -90,21 +90,19 @@ impl FeathersColorSwatch {
             ColorSwatchValue
             AlphaPattern
             MaterialNode::<AlphaPatternMaterial>
-            Children [
-                (
-                    Node {
-                        position_type: PositionType::Absolute,
-                        left: px(0),
-                        top: px(0),
-                        bottom: px(0),
-                        right: px(0),
-                        border_radius: {props.corners.to_border_radius(props.border_radius)},
-                    }
-                    ColorSwatchFg
-                    BackgroundColor({palette::ACCENT.with_alpha(0.5)})
-                ),
-                @{non_alpha_fg}
-            ]
+            #{
+                Node {
+                    position_type: PositionType::Absolute,
+                    left: px(0),
+                    top: px(0),
+                    bottom: px(0),
+                    right: px(0),
+                    border_radius: {props.corners.to_border_radius(props.border_radius)},
+                }
+                ColorSwatchFg
+                BackgroundColor({palette::ACCENT.with_alpha(0.5)})
+            }
+            # @{non_alpha_fg}
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/color_swatch_grid.rs
+++ b/crates/bevy_feathers/src/controls/color_swatch_grid.rs
@@ -95,9 +95,7 @@ impl FeathersColorSwatchGridCell {
                 display: Display::Flex,
             }
             RadioButton
-            Children [(
-                @ColorSwatchGridCellRing
-            )]
+            # @ColorSwatchGridCellRing
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/dialog.rs
+++ b/crates/bevy_feathers/src/controls/dialog.rs
@@ -1,9 +1,6 @@
 use bevy_app::Propagate;
 use bevy_color::{Alpha, Srgba};
-use bevy_ecs::{
-    event::EntityEvent, hierarchy::Children, observer::On, reflect::ReflectComponent,
-    system::Commands,
-};
+use bevy_ecs::{event::EntityEvent, observer::On, reflect::ReflectComponent, system::Commands};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
 use bevy_scene::{bsn, bsn_list, on, Scene, SceneComponent, SceneList};
 use bevy_text::FontWeight;
@@ -69,7 +66,7 @@ impl FeathersDialog {
             FixedNode
             OverrideClip
             GlobalZIndex(99) // One less than menu layer
-            Children [
+            #{
                 Node {
                     display: Display::Flex,
                     flex_direction: FlexDirection::Column,
@@ -91,10 +88,8 @@ impl FeathersDialog {
                     px(1),
                     px(4),
                 )
-                Children [
-                    {props.contents}
-                ]
-            ]
+                #{{props.contents}}
+            }
         }
     }
 }
@@ -161,37 +156,31 @@ impl FeathersFloatingDialog {
             on(|close: On<RequestClose>, mut commands: Commands| {
                 commands.entity(close.event_target()).despawn();
             })
-            Children [
-                // Title bar; dragging it moves the window.
-                (
-                    Node {
-                        display: Display::Flex,
-                        flex_direction: FlexDirection::Row,
-                        align_items: AlignItems::Center,
-                        justify_content: JustifyContent::SpaceBetween,
-                        padding: UiRect::all(px(6.0)),
-                    }
-                    DialogDragHandle
-                    InheritableThemeTextColor(tokens::DIALOG_HEADER_TEXT)
-                    ThemeBackgroundColor(tokens::DIALOG_HEADER_BG)
-                    Propagate::<ThemeContext>(ThemeContext(SurfaceLevel::Higher))
-                    InheritableFont {
-                        font: fonts::REGULAR,
-                        font_size: size::HEADER_FONT,
-                        weight: FontWeight::BOLD,
-                    }
-                    Children [
-                        (Text({props.title}) ThemedText),
-                        @FeathersDialogClose
-                    ]
-                ),
-                (
-                    @FeathersDialogBody
-                    Children [
-                        {props.contents}
-                    ]
-                )
-            ]
+            // Title bar; dragging it moves the window.
+            #{
+                Node {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Row,
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::SpaceBetween,
+                    padding: UiRect::all(px(6.0)),
+                }
+                DialogDragHandle
+                InheritableThemeTextColor(tokens::DIALOG_HEADER_TEXT)
+                ThemeBackgroundColor(tokens::DIALOG_HEADER_BG)
+                Propagate::<ThemeContext>(ThemeContext(SurfaceLevel::Higher))
+                InheritableFont {
+                    font: fonts::REGULAR,
+                    font_size: size::HEADER_FONT,
+                    weight: FontWeight::BOLD,
+                }
+                #{ Text({props.title}) ThemedText }
+                # @FeathersDialogClose
+            }
+            #{
+                @FeathersDialogBody
+                #{{props.contents}}
+            }
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/disclosure_toggle.rs
+++ b/crates/bevy_feathers/src/controls/disclosure_toggle.rs
@@ -1,7 +1,6 @@
 use bevy_app::{App, Plugin, PreUpdate};
 use bevy_ecs::{
     entity::Entity,
-    hierarchy::Children,
     lifecycle::RemovedComponents,
     query::{Added, Has, Or, With},
     reflect::ReflectComponent,
@@ -52,9 +51,7 @@ impl FeathersDisclosureToggle {
             FocusIndicator
             InheritableThemeTextColor(tokens::BUTTON_TEXT)
             TabIndex(0)
-            Children [
-                @icon(icons::CHEVRON_RIGHT)
-            ]
+            # @icon(icons::CHEVRON_RIGHT)
         )
     }
 }

--- a/crates/bevy_feathers/src/controls/listview.rs
+++ b/crates/bevy_feathers/src/controls/listview.rs
@@ -78,8 +78,7 @@ impl FeathersListView {
             TabIndex(0)
             Children [
                 // Inner part that scrolls
-                (
-                    #inner
+                #inner {
                     Node {
                         display: Display::Flex,
                         flex_direction: FlexDirection::Column,
@@ -88,21 +87,20 @@ impl FeathersListView {
                         overflow: Overflow::scroll_y(),
                     }
                     ScrollArea
-                    Children [
-                        {props.rows}
-                    ]
-                ),
-
-                @FeathersScrollbar {
-                    @target: #inner,
-                    @orientation: {ControlOrientation::Vertical}
+                    #{{props.rows}}
                 }
-                Node {
-                    position_type: PositionType::Absolute,
-                    right: px(4),
-                    top: px(0),
-                    bottom: px(0),
-                    width: px(6),
+                #{
+                    @FeathersScrollbar {
+                        @target: #inner,
+                        @orientation: {ControlOrientation::Vertical}
+                    }
+                    Node {
+                        position_type: PositionType::Absolute,
+                        right: px(4),
+                        top: px(0),
+                        bottom: px(0),
+                        width: px(6),
+                    }
                 }
             ]
         }

--- a/crates/bevy_feathers/src/controls/menu.rs
+++ b/crates/bevy_feathers/src/controls/menu.rs
@@ -290,16 +290,12 @@ impl FeathersMenuButton {
             MenuButton
             FeathersMenuButton
             // Additional children for menu chevron
-            Children [
-                {
-                    props.arrow.then(|| bsn_list!(
-                        Node {
-                            flex_grow: 1.0,
-                        },
-                        @icon(icons::CHEVRON_DOWN),
-                    ))
-                }
-            ]
+            #{{
+                props.arrow.then(|| bsn_list!(
+                    #{ Node { flex_grow: 1.0 } }
+                    #{ @icon(icons::CHEVRON_DOWN) }
+                ))
+            }}
         }
     }
 }
@@ -326,14 +322,12 @@ impl FeathersMenuToolButton {
             MenuButton
             FeathersMenuButton
             // Additional children for menu chevron
-            Children [
-                {
-                    props.arrow.then(|| bsn_list!(
-                        Node { min_width: px(2) },
-                        @icon(icons::CHEVRON_DOWN),
-                    ))
-                }
-            ]
+            #{{
+                props.arrow.then(|| bsn_list!(
+                    #{ Node { min_width: px(2) } }
+                    #{ @icon(icons::CHEVRON_DOWN) }
+                ))
+            }}
         }
     }
 }
@@ -435,9 +429,7 @@ impl FeathersMenuItem {
                 font_size: size::MEDIUM_FONT,
                 weight: FontWeight::NORMAL,
             }
-            Children [
-                {props.caption}
-            ]
+            #{{ props.caption }}
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -147,122 +147,115 @@ impl FeathersNumberInput {
             on(number_input_on_insert_value)
             on(number_input_on_insert_disabled)
             on(number_input_on_remove_disabled)
-            Children [
-                {
-                    // Label section
-                    props.label_text.map(|text| {
-                        bsn_list!(
-                            Node {
-                                display: Display::Flex,
-                                align_items: AlignItems::Center,
-                                align_self: AlignSelf::Stretch,
-                                justify_content: JustifyContent::Center,
-                                padding: UiRect::axes(px(6), px(0)),
+            #{{
+                // Label section
+                props.label_text.map(|text| {
+                    bsn_list![#{
+                        Node {
+                            display: Display::Flex,
+                            align_items: AlignItems::Center,
+                            align_self: AlignSelf::Stretch,
+                            justify_content: JustifyContent::Center,
+                            padding: UiRect::axes(px(6), px(0)),
+                        }
+                        ThemeBackgroundColor(tokens::TEXT_INPUT_LABEL_BG)
+                        #{
+                            Text(text)
+                            TextFont {
+                                font: FontSourceTemplate::Handle(fonts::REGULAR),
+                                font_size: size::COMPACT_FONT,
                             }
-                            ThemeBackgroundColor(tokens::TEXT_INPUT_LABEL_BG)
-                            Children [
-                                Text(text)
-                                TextFont {
-                                    font: FontSourceTemplate::Handle(fonts::REGULAR),
-                                    font_size: size::COMPACT_FONT,
-                                }
-                                PropagateOver<TextFont>
-                                ThemeTextColor(tokens::TEXT_INPUT_TEXT)
-                            ]
-                        )
-                    })
-                },
-
-                (
-                    // The editable text entity
-                    @FeathersTextInput {
-                        @max_characters: 30usize, // 20 digits + units
-                    }
-                    DragState
+                            PropagateOver<TextFont>
+                            ThemeTextColor(tokens::TEXT_INPUT_TEXT)
+                        }
+                    }]
+                })
+            }}
+            #{
+                // The editable text entity
+                @FeathersTextInput {
+                    @max_characters: 30usize, // 20 digits + units
+                }
+                DragState
+                Node {
+                    flex_grow: 1.0,
+                    align_items: AlignItems::Center,
+                    align_self: AlignSelf::Stretch,
+                    border_radius: {
+                        if props.label_text.is_some() {
+                            RoundedCorners::Right.to_border_radius(4.0)
+                        } else {
+                            RoundedCorners::All.to_border_radius(4.0)
+                        }
+                    },
+                }
+                Hovered
+                LineHeight::Px(24.0) // TODO: Make const for this
+                TextLayout {
+                    justify: Justify::Center,
+                }
+                ThemeTextColor(tokens::TEXT_INPUT_TEXT)
+                // Use a gradient to draw the moving bar, this lets us round corners
+                BackgroundGradient(vec![Gradient::Linear(LinearGradient {
+                    angle: PI * 0.5,
+                    stops: vec![
+                        ColorStop::new(Color::NONE, percent(0)),
+                        ColorStop::new(Color::NONE, percent(50)),
+                        ColorStop::new(Color::NONE, percent(50)),
+                        ColorStop::new(Color::NONE, percent(100)),
+                    ],
+                    color_space: InterpolationColorSpace::Srgba,
+                })])
+                EntityCursor::System(bevy_window::SystemCursorIcon::ColResize)
+                on(number_input_init)
+                on(number_input_on_enter_key)
+                on(number_input_on_focus_gained)
+                on(number_input_on_focus_lost)
+                on(number_input_hovered)
+                on(update_chevron_visibility)
+                #{
+                    // Invisible child on top of input field which intercepts drag
+                    // events (conditionally) and handles scrubbing gestures.
                     Node {
-                        flex_grow: 1.0,
-                        align_items: AlignItems::Center,
-                        align_self: AlignSelf::Stretch,
-                        border_radius: {
-                            if props.label_text.is_some() {
-                                RoundedCorners::Right.to_border_radius(4.0)
-                            } else {
-                                RoundedCorners::All.to_border_radius(4.0)
-                            }
-                        },
+                        position_type: PositionType::Absolute,
+                        left: px(0),
+                        top: px(0),
+                        bottom: px(0),
+                        right: px(0),
                     }
-                    Hovered
-                    LineHeight::Px(24.0) // TODO: Make const for this
-                    TextLayout {
-                        justify: Justify::Center,
+                    on(scrubber_on_press)
+                    on(scrubber_on_release)
+                    on(scrubber_on_drag_start)
+                    on(scrubber_on_drag)
+                    on(scrubber_on_drag_end)
+                    on(scrubber_on_drag_cancel)
+                }
+                #{
+                    // The decrement chevron of a number input
+                    Node {
+                        position_type: PositionType::Absolute,
+                        display: Display::None,
+                        left: px(4),
                     }
-                    ThemeTextColor(tokens::TEXT_INPUT_TEXT)
-                    // Use a gradient to draw the moving bar, this lets us round corners
-                    BackgroundGradient(vec![Gradient::Linear(LinearGradient {
-                        angle: PI * 0.5,
-                        stops: vec![
-                            ColorStop::new(Color::NONE, percent(0)),
-                            ColorStop::new(Color::NONE, percent(50)),
-                            ColorStop::new(Color::NONE, percent(50)),
-                            ColorStop::new(Color::NONE, percent(100)),
-                        ],
-                        color_space: InterpolationColorSpace::Srgba,
-                    })])
-                    EntityCursor::System(bevy_window::SystemCursorIcon::ColResize)
-                    on(number_input_init)
-                    on(number_input_on_enter_key)
-                    on(number_input_on_focus_gained)
-                    on(number_input_on_focus_lost)
-                    on(number_input_hovered)
-                    on(update_chevron_visibility)
-                    Children [
-                        (
-                            // Invisible child on top of input field which intercepts drag
-                            // events (conditionally) and handles scrubbing gestures.
-                            Node {
-                                position_type: PositionType::Absolute,
-                                left: px(0),
-                                top: px(0),
-                                bottom: px(0),
-                                right: px(0),
-                            }
-                            on(scrubber_on_press)
-                            on(scrubber_on_release)
-                            on(scrubber_on_drag_start)
-                            on(scrubber_on_drag)
-                            on(scrubber_on_drag_end)
-                            on(scrubber_on_drag_cancel)
-                        ),
-                        (
-                            // The decrement chevron of a number input
-                            Node {
-                                position_type: PositionType::Absolute,
-                                display: Display::None,
-                                left: px(4),
-                            }
-                            NumberInputDecrement
-                            Children [
-                                @icon(icons::CHEVRON_DOWN)
-                                UiTransform {
-                                    rotation: Rot2::radians(std::f32::consts::FRAC_PI_2)
-                                }
-                            ]
-                        ),
-                        (
-                            // The increment chevron of a number input
-                            Node {
-                                position_type: PositionType::Absolute,
-                                display: Display::None,
-                                right: px(4),
-                            }
-                            NumberInputIncrement
-                            Children [
-                                @icon(icons::CHEVRON_RIGHT),
-                            ]
-                        ),
-                    ]
-                ),
-            ]
+                    NumberInputDecrement
+                    #{
+                        @icon(icons::CHEVRON_DOWN)
+                        UiTransform {
+                            rotation: Rot2::radians(std::f32::consts::FRAC_PI_2)
+                        }
+                    }
+                }
+                #{
+                    // The increment chevron of a number input
+                    Node {
+                        position_type: PositionType::Absolute,
+                        display: Display::None,
+                        right: px(4),
+                    }
+                    NumberInputIncrement
+                    # @icon(icons::CHEVRON_RIGHT)
+                }
+            }
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -82,7 +82,7 @@ impl FeathersRadio {
                 font_size: size::MEDIUM_FONT,
                 weight: FontWeight::NORMAL,
             }
-            Children [(
+            #{
                 Node {
                     display: Display::Flex,
                     align_items: AlignItems::Center,
@@ -96,7 +96,7 @@ impl FeathersRadio {
                 FocusIndicator
                 ThemeBorderColor(tokens::RADIO_BORDER)
                 ThemeBackgroundColor(tokens::RADIO_BG)
-                Children [(
+                #{
                     Node {
                         width: px(12),
                         height: px(12),
@@ -108,9 +108,9 @@ impl FeathersRadio {
                     }
                     RadioMark
                     ThemeBackgroundColor(tokens::RADIO_MARK)
-                )]),
-                {props.caption}
-            ]
+                }
+            }
+            #{{ props.caption }}
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/scrollbar.rs
+++ b/crates/bevy_feathers/src/controls/scrollbar.rs
@@ -3,7 +3,7 @@ use bevy_camera::visibility::Visibility;
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    hierarchy::{ChildOf, Children},
+    hierarchy::ChildOf,
     query::{Changed, Or, With},
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
@@ -76,7 +76,7 @@ impl FeathersScrollbar {
                 border_radius: BorderRadius::all(px(3))
             }
             ThemeBackgroundColor(tokens::SCROLLBAR_BG)
-            Children [(
+            #{
                 Hovered
                 ThemeBackgroundColor(tokens::SCROLLBAR_THUMB)
                 ScrollbarThumb {
@@ -84,7 +84,7 @@ impl FeathersScrollbar {
                 }
                 FeathersScrollbarThumb
                 EntityCursor::System(bevy_window::SystemCursorIcon::Pointer)
-            )]
+            }
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/select.rs
+++ b/crates/bevy_feathers/src/controls/select.rs
@@ -55,10 +55,9 @@ pub fn list_rows_from_strings(
             .map(|(i, label)| -> Box<dyn SceneList> {
                 let label: String = label.as_ref().into();
                 if Some(i) == selected {
-                    bsn! { @FeathersListRow Selected OptionIndex(i) Children [ @caption(label) ] }
-                        .into()
+                    bsn! { @FeathersListRow Selected OptionIndex(i) #{ @caption(label) } }.into()
                 } else {
-                    bsn! { @FeathersListRow OptionIndex(i) Children [ @caption(label) ] }.into()
+                    bsn! { @FeathersListRow OptionIndex(i) #{ @caption(label) } }.into()
                 }
             })
             .collect::<Vec<_>>(),
@@ -99,33 +98,29 @@ impl FeathersSelect {
         bsn! {
             @FeathersMenu
             FeathersSelect
-            Children [
-                (
-                    @FeathersMenuButton {
-                        @caption: bsn! { @caption("") SelectCaption },
-                        @corners: {props.corners},
+            #{
+                @FeathersMenuButton {
+                    @caption: bsn! { @caption("") SelectCaption },
+                    @corners: {props.corners},
+                }
+                Node {
+                    flex_grow: 1.0,
+                }
+            }
+            #{
+                @FeathersMenuPopup
+                #{
+                    @FeathersListView {
+                        @rows: {props.options}
                     }
                     Node {
-                        flex_grow: 1.0,
+                        max_height: {max_height},
                     }
-                ),
-                (
-                    @FeathersMenuPopup
-                    Children [
-                        (
-                            @FeathersListView {
-                                @rows: {props.options}
-                            }
-                            on(listbox_update_selection)
-                            on(re_emit_listbox_value)
-                            on(close_popup_on_reselect)
-                            Node {
-                                max_height: {max_height},
-                            }
-                        )
-                    ]
-                )
-            ]
+                    on(listbox_update_selection)
+                    on(re_emit_listbox_value)
+                    on(close_popup_on_reselect)
+                }
+            }
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/slider.rs
+++ b/crates/bevy_feathers/src/controls/slider.rs
@@ -103,7 +103,7 @@ impl FeathersSlider {
                 ],
                 color_space: InterpolationColorSpace::Srgba,
             })])
-            Children [(
+            #{
                 // Text container
                 Node {
                     display: Display::Flex,
@@ -117,8 +117,8 @@ impl FeathersSlider {
                     font_size: size::SMALL_FONT,
                     weight: FontWeight::NORMAL,
                 }
-                Children [(@caption("10.0") TextLayout::no_wrap() SliderValueText)]
-            )]
+                #{ @caption("10.0") TextLayout::no_wrap() SliderValueText }
+            }
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/text_input.rs
+++ b/crates/bevy_feathers/src/controls/text_input.rs
@@ -1,5 +1,4 @@
 use bevy_app::{Plugin, PreUpdate, PropagateOver};
-use bevy_asset::AssetServer;
 use bevy_ecs::{
     change_detection::DetectChanges,
     entity::Entity,
@@ -8,7 +7,6 @@ use bevy_ecs::{
     reflect::ReflectComponent,
     schedule::IntoScheduleConfigs,
     system::{Commands, Query, Res},
-    template::template,
 };
 use bevy_input_focus::tab_navigation::TabIndex;
 use bevy_picking::{cursor::EntityCursor, PickingSystems};
@@ -16,7 +14,7 @@ use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
 use bevy_scene::prelude::*;
 use bevy_text::{
-    EditableText, FontSource, FontWeight, LineBreak, TextCursorStyle, TextFont, TextLayout,
+    EditableText, FontSourceTemplate, FontWeight, LineBreak, TextCursorStyle, TextFont, TextLayout,
     TextReadWriteMode,
 };
 use bevy_ui::{
@@ -121,14 +119,11 @@ impl FeathersTextInput {
                 linebreak: LineBreak::NoWrap,
             }
             TabIndex(0)
-            template(|ctx| {
-                Ok(TextFont {
-                    font: FontSource::Handle(ctx.resource::<AssetServer>().load(fonts::REGULAR)),
-                    font_size: size::COMPACT_FONT,
-                    weight: FontWeight::NORMAL,
-                    ..Default::default()
-                })
-            })
+            TextFont {
+                font: FontSourceTemplate::Handle(fonts::REGULAR),
+                font_size: size::COMPACT_FONT,
+                weight: FontWeight::NORMAL,
+            }
             PropagateOver<TextFont>
             EntityCursor::System(bevy_window::SystemCursorIcon::Text)
             TextCursorStyle::default()

--- a/crates/bevy_feathers/src/controls/toggle_switch.rs
+++ b/crates/bevy_feathers/src/controls/toggle_switch.rs
@@ -60,7 +60,7 @@ impl FeathersToggleSwitch {
             EntityCursor::System(bevy_window::SystemCursorIcon::Pointer)
             TabIndex(0)
             FocusIndicator
-            Children [(
+            #{
                 Node {
                     position_type: PositionType::Absolute,
                     left: percent(0),
@@ -73,7 +73,7 @@ impl FeathersToggleSwitch {
                 ToggleSwitchSlide
                 ThemeBackgroundColor(tokens::SWITCH_SLIDE_BG)
                 ThemeBorderColor(tokens::SWITCH_SLIDE_BORDER)
-            )]
+            }
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/virtual_keyboard.rs
+++ b/crates/bevy_feathers/src/controls/virtual_keyboard.rs
@@ -59,9 +59,7 @@ impl<T: AsRef<str> + Clone + Send + Sync + 'static> VirtualKeyboard<T> {
                         });
                         Ok(())
                     })
-                    Children [
-                        Text::new(key_clone.as_ref())
-                    ]
+                    #{ Text::new(key_clone.as_ref()) }
                 }
             }));
             bsn! {
@@ -69,9 +67,7 @@ impl<T: AsRef<str> + Clone + Send + Sync + 'static> VirtualKeyboard<T> {
                     flex_direction: FlexDirection::Row,
                     column_gap: px(4),
                 }
-                Children [
-                    {key_row}
-                ]
+                #{{ key_row }}
             }
         }));
         bsn! {
@@ -80,9 +76,7 @@ impl<T: AsRef<str> + Clone + Send + Sync + 'static> VirtualKeyboard<T> {
                 row_gap: px(4),
             }
             TabGroup::new(0)
-            Children [
-                {keys}
-            ]
+            #{{ keys }}
         }
     }
 }

--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -1,7 +1,7 @@
 use crate::_bsn::types::{
     Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnFnCall, BsnListRoot,
     BsnNamedField, BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn, BsnSceneListItem,
-    BsnSceneListItems, BsnStructUpdate, BsnType, BsnUnnamedField, BsnValue,
+    BsnSceneListItems, BsnStructUpdate, BsnType, BsnUnnamedField, BsnValue, SceneListExpression,
 };
 use bevy_macro_utils::{fq_std::FQDefault, path_to_string};
 use proc_macro2::TokenStream;
@@ -73,11 +73,11 @@ impl<'a> BsnCodegenCtx<'a> {
 }
 
 pub trait BsnTokenStream: Parse {
-    fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream;
+    fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream;
 }
 
 impl BsnTokenStream for BsnRoot {
-    fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+    fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
         let tokens = self.0.to_tokens(ctx);
         let errors = ctx.errors.iter().map(|e| e.to_compile_error());
         let bevy_scene = ctx.bevy_scene;
@@ -108,7 +108,7 @@ impl BsnTokenStream for BsnRoot {
 }
 
 impl BsnTokenStream for BsnListRoot {
-    fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+    fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
         let tokens = self.0.to_tokens(ctx);
         let errors = ctx.errors.iter().map(|e| e.to_compile_error());
         let bevy_scene = ctx.bevy_scene;
@@ -141,13 +141,30 @@ impl BsnTokenStream for BsnListRoot {
 impl<const ALLOW_FLAT: bool> Bsn<ALLOW_FLAT> {
     /// Converts to tokens and performs validation checks.
     /// Accumulates errors in [`BsnCodegenCtx`].
-    pub fn try_to_tokens(&self, ctx: &mut BsnCodegenCtx) -> syn::Result<TokenStream> {
+    pub fn try_to_tokens(self, ctx: &mut BsnCodegenCtx) -> syn::Result<TokenStream> {
         let bevy_scene = ctx.bevy_scene;
         let mut combined_patches = Vec::new();
         let mut scene_impls = Vec::new();
-        for entry in &self.entries {
+        let mut child_scenes = Vec::new();
+
+        if let Some(name) = self.name {
+            let bevy_ecs = ctx.bevy_ecs;
+            let (name, index) = ctx.fixed_entity_ref(&name);
+            let invocation = ctx.invocation_index.clone();
+            combined_patches.push(quote! {
+                #bevy_scene::NameEntityReference { name: #bevy_ecs::name::Name(#name.into()), reference: #bevy_ecs::template::SceneEntityReference::new(#invocation, #index, _call_id,) }.resolve_inline(_context, _scene);
+            })
+        }
+
+        for entry in self.entries {
             match entry.try_to_tokens(ctx) {
                 Ok(EntryResult::CombinedSceneFunction(patch)) => combined_patches.push(patch),
+                Ok(EntryResult::ChildScene(scene)) => {
+                    child_scenes.push(BsnSceneListItem::Scene(scene))
+                }
+                Ok(EntryResult::ChildSceneListExpression(expression)) => {
+                    child_scenes.push(BsnSceneListItem::SceneListExpression(expression))
+                }
                 Ok(EntryResult::NewSceneImpl(scene_impl)) => {
                     if !combined_patches.is_empty() {
                         let patches = combined_patches.drain(..);
@@ -170,10 +187,18 @@ impl<const ALLOW_FLAT: bool> Bsn<ALLOW_FLAT> {
                 })
             });
         }
+        if !child_scenes.is_empty() {
+            let scenes = BsnSceneListItems(child_scenes).to_tokens(ctx);
+            let bevy_ecs = ctx.bevy_ecs;
+            scene_impls.push(quote! {
+                #bevy_scene::RelatedScenes::<<#bevy_ecs::hierarchy::Children as #bevy_ecs::relationship::RelationshipTarget>
+                ::Relationship, _>::new(#scenes)
+            });
+        }
         Ok(quote! { #bevy_scene::auto_nest_tuple!(#(#scene_impls),*) })
     }
 
-    pub fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+    pub fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
         self.try_to_tokens(ctx)
             .unwrap_or_else(|e| e.to_compile_error())
     }
@@ -182,10 +207,12 @@ impl<const ALLOW_FLAT: bool> Bsn<ALLOW_FLAT> {
 enum EntryResult {
     CombinedSceneFunction(TokenStream),
     NewSceneImpl(TokenStream),
+    ChildScene(Bsn<false>),
+    ChildSceneListExpression(SceneListExpression),
 }
 
 impl BsnEntry {
-    fn try_to_tokens(&self, ctx: &mut BsnCodegenCtx) -> syn::Result<EntryResult> {
+    fn try_to_tokens(self, ctx: &mut BsnCodegenCtx) -> syn::Result<EntryResult> {
         let (bevy_scene, bevy_ecs) = (ctx.bevy_scene, ctx.bevy_ecs);
 
         Ok(match self {
@@ -279,6 +306,10 @@ impl BsnEntry {
                     }
                 }
             }),
+            BsnEntry::ChildScene(bsn_scene) => EntryResult::ChildScene(bsn_scene),
+            BsnEntry::ChildSceneListExpression(expression) => {
+                EntryResult::ChildSceneListExpression(expression)
+            }
             BsnEntry::RelatedSceneList(BsnRelatedSceneList {
                 scene_list,
                 relationship_path,
@@ -291,13 +322,6 @@ impl BsnEntry {
             }
             BsnEntry::UncachedScene(s) => EntryResult::NewSceneImpl(s.to_tokens(ctx)?),
             BsnEntry::CachedScene(s) => EntryResult::NewSceneImpl(s.to_tokens(ctx)?),
-            BsnEntry::Name(ident) => {
-                let (name, index) = ctx.fixed_entity_ref(ident);
-                let invocation = ctx.invocation_index.clone();
-                EntryResult::CombinedSceneFunction(quote! {
-                    #bevy_scene::NameEntityReference { name: #bevy_ecs::name::Name(#name.into()), reference: #bevy_ecs::template::SceneEntityReference::new(#invocation, #index, _call_id,) }.resolve_inline(_context, _scene);
-                })
-            }
             BsnEntry::TemplateValue(token_stream) => EntryResult::CombinedSceneFunction(quote! {
                 _scene.insert_template(#token_stream);
             }),
@@ -312,7 +336,7 @@ impl BsnEntry {
 }
 
 impl BsnScene {
-    fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> syn::Result<TokenStream> {
+    fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> syn::Result<TokenStream> {
         let bevy_scene = ctx.bevy_scene;
         match self {
             BsnScene::Asset(lit) => Ok(quote! {
@@ -750,14 +774,14 @@ impl ToTokens for BsnStructUpdate {
 }
 
 impl BsnTokenStream for BsnSceneListItems {
-    fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+    fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
         let bevy_scene = ctx.bevy_scene;
-        let scenes = self.0.iter().map(|s| match s {
+        let scenes = self.0.into_iter().map(|s| match s {
             BsnSceneListItem::Scene(bsn) => {
                 let tokens = bsn.to_tokens(ctx);
                 quote! {#bevy_scene::EntityScene(#tokens)}
             }
-            BsnSceneListItem::Expression(tokens) => tokens.clone(),
+            BsnSceneListItem::SceneListExpression(expression) => expression.0,
         });
 
         quote! { #bevy_scene::auto_nest_tuple!(#(#scenes),*) }
@@ -765,7 +789,7 @@ impl BsnTokenStream for BsnSceneListItems {
 }
 
 impl BsnSceneFn {
-    fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+    fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
         let bevy_scene = ctx.bevy_scene;
         let args = self.args.to_tokens(ctx);
         let path = &self.path;
@@ -774,14 +798,14 @@ impl BsnSceneFn {
 }
 
 impl BsnTokenStream for BsnFnArgs {
-    fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
-        let args = self.0.iter().map(|a| a.to_tokens(ctx));
+    fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+        let args = self.0.into_iter().map(|a| a.to_tokens(ctx));
         quote! { (#(#args),*) }
     }
 }
 
 impl BsnTokenStream for BsnFnArg {
-    fn to_tokens(&self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+    fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
         let bevy_ecs = ctx.bevy_ecs;
         match self {
             BsnFnArg::EntityName(ident) => {
@@ -1085,7 +1109,10 @@ mod tests {
             proc_macro2::Span::call_site(),
             "Test Error",
         ));
-        let root = BsnRoot(Bsn::<true> { entries: vec![] });
+        let root = BsnRoot(Bsn::<true> {
+            name: None,
+            entries: vec![],
+        });
 
         // Act
         let res = root.to_tokens(&mut ctx).to_string();

--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -78,7 +78,7 @@ pub trait BsnTokenStream: Parse {
 
 impl BsnTokenStream for BsnRoot {
     fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
-        let tokens = self.0.to_tokens(ctx);
+        let tokens = self.0.into_tokens(ctx);
         let errors = ctx.errors.iter().map(|e| e.to_compile_error());
         let bevy_scene = ctx.bevy_scene;
         let hoisted_exprs = ctx.hoisted_expressions.expressions.drain(..);
@@ -198,7 +198,7 @@ impl<const ALLOW_FLAT: bool> Bsn<ALLOW_FLAT> {
         Ok(quote! { #bevy_scene::auto_nest_tuple!(#(#scene_impls),*) })
     }
 
-    pub fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+    pub fn into_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
         self.try_to_tokens(ctx)
             .unwrap_or_else(|e| e.to_compile_error())
     }
@@ -320,8 +320,8 @@ impl BsnEntry {
                     ::Relationship, _>::new(#scenes)
                 })
             }
-            BsnEntry::UncachedScene(s) => EntryResult::NewSceneImpl(s.to_tokens(ctx)?),
-            BsnEntry::CachedScene(s) => EntryResult::NewSceneImpl(s.to_tokens(ctx)?),
+            BsnEntry::UncachedScene(s) => EntryResult::NewSceneImpl(s.into_tokens(ctx)?),
+            BsnEntry::CachedScene(s) => EntryResult::NewSceneImpl(s.into_tokens(ctx)?),
             BsnEntry::TemplateValue(token_stream) => EntryResult::CombinedSceneFunction(quote! {
                 _scene.insert_template(#token_stream);
             }),
@@ -336,13 +336,13 @@ impl BsnEntry {
 }
 
 impl BsnScene {
-    fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> syn::Result<TokenStream> {
+    fn into_tokens(self, ctx: &mut BsnCodegenCtx) -> syn::Result<TokenStream> {
         let bevy_scene = ctx.bevy_scene;
         match self {
             BsnScene::Asset(lit) => Ok(quote! {
                 #bevy_scene::CachedSceneAsset::from(#lit)
             }),
-            BsnScene::Fn(func) => Ok(func.to_tokens(ctx)),
+            BsnScene::Fn(func) => Ok(func.into_tokens(ctx)),
             BsnScene::SceneComponent(bsn_type) => {
                 let props = format_ident!("__props");
                 let props_ref = format_ident!("__props_ref");
@@ -778,7 +778,7 @@ impl BsnTokenStream for BsnSceneListItems {
         let bevy_scene = ctx.bevy_scene;
         let scenes = self.0.into_iter().map(|s| match s {
             BsnSceneListItem::Scene(bsn) => {
-                let tokens = bsn.to_tokens(ctx);
+                let tokens = bsn.into_tokens(ctx);
                 quote! {#bevy_scene::EntityScene(#tokens)}
             }
             BsnSceneListItem::SceneListExpression(expression) => expression.0,
@@ -789,7 +789,7 @@ impl BsnTokenStream for BsnSceneListItems {
 }
 
 impl BsnSceneFn {
-    fn to_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+    fn into_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
         let bevy_scene = ctx.bevy_scene;
         let args = self.args.to_tokens(ctx);
         let path = &self.path;

--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -2,7 +2,7 @@ use crate::_bsn::types::{
     Bsn, BsnConstructor, BsnEntry, BsnFields, BsnFnArg, BsnFnArgs, BsnFnCall, BsnListRoot,
     BsnNamedField, BsnNamedFieldOrStructUpdate, BsnRelatedSceneList, BsnRoot, BsnScene, BsnSceneFn,
     BsnSceneList, BsnSceneListItem, BsnSceneListItems, BsnStructUpdate, BsnTuple, BsnType,
-    BsnUnnamedField, BsnValue,
+    BsnUnnamedField, BsnValue, SceneListExpression,
 };
 use bevy_macro_utils::{path_to_string, PathType};
 use proc_macro2::{Delimiter, TokenStream, TokenTree};
@@ -57,23 +57,26 @@ impl Parse for BsnListRoot {
     }
 }
 
-impl<const ALLOW_FLAT: bool> Parse for Bsn<ALLOW_FLAT> {
+impl<const IS_ROOT: bool> Parse for Bsn<IS_ROOT> {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut entries = Vec::new();
-        if input.peek(Paren) {
-            let content;
-            parenthesized![content in input];
-            while !content.is_empty() {
-                let entry = BsnEntry::parse(&content)?;
-                if matches!(entry, BsnEntry::CachedScene(_)) && !entries.is_empty() {
-                    return Err(syn::Error::new(
-                        content.span(),
-                        "Caching entries after the first is not supported, remove the ':' prefix or make this the first entry.",
-                    ));
+        Ok(if IS_ROOT {
+            let name = if input.peek(Token![#]) {
+                if input.peek2(Ident) && !input.peek3(Brace) {
+                    let _ = input.parse::<Token![#]>()?;
+                    Some(input.parse::<Ident>()?)
+                } else {
+                    entries.push(match input.parse::<ChildOrSceneList>()? {
+                        ChildOrSceneList::Child(bsn) => BsnEntry::ChildScene(bsn),
+                        ChildOrSceneList::SceneList(scene_list_expression) => {
+                            BsnEntry::ChildSceneListExpression(scene_list_expression)
+                        }
+                    });
+                    None
                 }
-                entries.push(entry);
-            }
-        } else if ALLOW_FLAT {
+            } else {
+                None
+            };
             while !input.is_empty() {
                 let entry = BsnEntry::parse(input)?;
                 if matches!(entry, BsnEntry::CachedScene(_)) && !entries.is_empty() {
@@ -83,21 +86,69 @@ impl<const ALLOW_FLAT: bool> Parse for Bsn<ALLOW_FLAT> {
                     ));
                 }
                 entries.push(entry);
-                if input.peek(Comma) {
-                    // Not ideal, but this anticipatory break allows us to parse non-parenthesized
-                    // flat Bsn entries in SceneLists
-                    break;
+            }
+            Bsn { name, entries }
+        } else {
+            let _ = input.parse::<Token![#]>()?;
+            if input.peek(At) {
+                let entry = input.parse::<BsnEntry>()?;
+                return Ok(Bsn {
+                    name: None,
+                    entries: vec![entry],
+                });
+            }
+            let name = if input.peek(Ident) {
+                Some(input.parse::<Ident>()?)
+            } else {
+                None
+            };
+
+            if input.peek(Brace) {
+                let content;
+                braced![content in input];
+                while !content.is_empty() {
+                    let entry = content.parse::<BsnEntry>()?;
+                    if matches!(entry, BsnEntry::CachedScene(_)) && !entries.is_empty() {
+                        return Err(syn::Error::new(
+                            content.span(),
+                            "Caching entries after the first is not supported, remove the ':' prefix or make this the first entry.",
+                        ));
+                    }
+                    entries.push(entry);
                 }
             }
-        } else {
-            entries.push(BsnEntry::parse(input)?);
-        }
 
-        Ok(Self { entries })
+            Bsn { name, entries }
+        })
     }
 }
 
-impl BsnEntry {
+enum ChildOrSceneList {
+    Child(Bsn<false>),
+    SceneList(SceneListExpression),
+}
+
+impl Parse for ChildOrSceneList {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(if input.peek2(Ident) && input.peek3(Brace) {
+            ChildOrSceneList::Child(input.parse::<Bsn<false>>()?)
+        } else {
+            let forked = input.fork();
+            forked.parse::<Token![#]>()?;
+            if let Ok(TokenTree::Group(group)) = forked.parse::<TokenTree>()
+                && group.delimiter() == Delimiter::Brace
+                && let Ok(TokenTree::Group(nested_group)) = syn::parse2::<TokenTree>(group.stream())
+                && nested_group.delimiter() == Delimiter::Brace
+            {
+                ChildOrSceneList::SceneList(input.parse::<SceneListExpression>()?)
+            } else {
+                ChildOrSceneList::Child(input.parse::<Bsn<false>>()?)
+            }
+        })
+    }
+}
+
+impl Parse for BsnEntry {
     fn parse(input: ParseStream) -> Result<Self> {
         Ok(if input.peek(Token![:]) && !input.peek(Token![::]) {
             let cached = input.parse::<Token![:]>()?;
@@ -110,8 +161,12 @@ impl BsnEntry {
             }
             BsnEntry::CachedScene(scene)
         } else if input.peek(Token![#]) {
-            input.parse::<Token![#]>()?;
-            BsnEntry::Name(input.parse::<Ident>()?)
+            match input.parse::<ChildOrSceneList>()? {
+                ChildOrSceneList::Child(bsn) => BsnEntry::ChildScene(bsn),
+                ChildOrSceneList::SceneList(scene_list_expression) => {
+                    BsnEntry::ChildSceneListExpression(scene_list_expression)
+                }
+            }
         } else if input.peek(At) {
             let _ = input.parse::<At>()?;
             BsnEntry::UncachedScene(BsnScene::parse(input)?)
@@ -222,19 +277,32 @@ impl Parse for BsnSceneList {
 impl Parse for BsnSceneListItems {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut scenes = Vec::new();
-        parse_punctuated_vec_autocomplete_friendly!(scenes, input, BsnSceneListItem, Comma);
+        while !input.is_empty() {
+            scenes.push(input.parse::<BsnSceneListItem>()?);
+        }
+
         Ok(BsnSceneListItems(scenes))
     }
 }
 
 impl Parse for BsnSceneListItem {
     fn parse(input: ParseStream) -> Result<Self> {
-        Ok(if input.peek(Brace) {
-            let tokens = braced_tokens(input)?;
-            BsnSceneListItem::Expression(tokens)
-        } else {
-            BsnSceneListItem::Scene(input.parse::<Bsn<true>>()?)
+        Ok(match input.parse::<ChildOrSceneList>()? {
+            ChildOrSceneList::Child(bsn) => BsnSceneListItem::Scene(bsn),
+            ChildOrSceneList::SceneList(scene_list_expression) => {
+                BsnSceneListItem::SceneListExpression(scene_list_expression)
+            }
         })
+    }
+}
+
+impl Parse for SceneListExpression {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let _ = input.parse::<Token![#]>()?;
+        let content;
+        braced![content in input];
+        let tokens = braced_tokens(&content)?;
+        Ok(SceneListExpression(tokens))
     }
 }
 

--- a/crates/bevy_scene/macros/src/bsn/types.rs
+++ b/crates/bevy_scene/macros/src/bsn/types.rs
@@ -9,12 +9,12 @@ pub struct BsnListRoot(pub BsnSceneListItems);
 
 #[derive(Debug)]
 pub struct Bsn<const ALLOW_FLAT: bool> {
+    pub name: Option<Ident>,
     pub entries: Vec<BsnEntry>,
 }
 
 #[derive(Debug)]
 pub enum BsnEntry {
-    Name(Ident),
     FromTemplatePatch(BsnType),
     FromTemplateConstructor {
         constructor: BsnConstructor,
@@ -30,6 +30,8 @@ pub enum BsnEntry {
     UncachedScene(BsnScene),
     CachedScene(BsnScene),
     RelatedSceneList(BsnRelatedSceneList),
+    ChildScene(Bsn<false>),
+    ChildSceneListExpression(SceneListExpression),
 }
 
 #[derive(Debug)]
@@ -58,9 +60,12 @@ pub struct BsnSceneListItems(pub Vec<BsnSceneListItem>);
 
 #[derive(Debug)]
 pub enum BsnSceneListItem {
-    Scene(Bsn<true>),
-    Expression(TokenStream),
+    Scene(Bsn<false>),
+    SceneListExpression(SceneListExpression),
 }
+
+#[derive(Debug)]
+pub struct SceneListExpression(pub TokenStream);
 
 #[derive(Debug)]
 pub struct BsnSceneFn {

--- a/crates/bevy_scene/macros/src/lib.rs
+++ b/crates/bevy_scene/macros/src/lib.rs
@@ -54,6 +54,10 @@ use syn::{parse_macro_input, DeriveInput};
 /// | **Observers**                              |                                                                                                                |
 /// | `on(\|ev: On<Ev>\| { … })`                 | Attaches an entity [`observer`] for the [`EntityEvent`] `Ev` to this entity. In this example, using a closure  |
 /// | `on(my_observer)`                          | Attaches an entity [`observer`] for the [`EntityEvent`] `Ev` to this entity. In this example, using a function |
+/// | **Entity Syntax**                          |                                                                                                                |
+/// | #{ CompA }                                 | Defines a new entity. If defined directly inside an entity, this is a "child" entity                           |
+/// | #Name { CompA }                            | Defines a new entity with a #Name. If defined directly inside an entity, this is a "child" entity              |
+/// | # @scene()                                 | Defines a new related scene. If defined directly inside an entity, this is a "child" entity                    |
 /// | **Relationships**                          |                                                                                                                |
 /// | `Children []`                              | Spawns each entry as a child of this entity, see **Scene Lists** below for details                             |
 /// | `ChildOf(entity)`                          | Makes **this** entity a child of `entity`, accepts an [`Entity`] or a `#Name` reference ([`EntityTemplate`])   |

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -61,14 +61,12 @@
 //! struct Shield;
 //!
 //! // #Player adds a `Name("Player")` component to the root entity.
-//! // Children spawns two child entities: one with Sword, one with Shield.
+//! // This also spawns two child entities: one with Sword, one with Shield.
 //! world.spawn_scene(bsn! {
 //!     #Player // This names the entity "Player"
-//!     Score(0)
-//!     Children [
-//!         Sword,
-//!         Shield,
-//!     ]
+//!     Score(0) // This is a component on the "Player" entity
+//!     #{ Sword } // First child
+//!     #{ Shield } // Second child
 //! });
 //! ```
 //!
@@ -110,65 +108,73 @@
 //!
 //! ## Entity Hierarchies and Relationships
 //!
-//! Use `Children [scene1, scene2]` inside [`bsn!`] to spawn child entities.
-//! [`Children`] (and entities within [`bsn_list!`]) are separated by commas;
-//! add multiple components to the same entity by listing them without a comma:
+//! Use `#{ SCENE_CONTENTS }` inside [`bsn!`] to spawn child entities.
+//! [`Children`] (and entities within [`bsn_list!`]) always start with `#`
 //!
 //! ```ignore
 //! // Spawns one child entity with components A, B and C
-//! bsn! { #Parent Children [A B C] }
+//! bsn! {
+//!     Root
+//!     #{ A B C }
+//! }
 //!
-//! // Spawns two child entities, one with A and B, the other with C, due to the added comma
-//! bsn! { #Parent Children [A B, C] }
+//! // Spawns two child entities, one with A and B, the other with C
+//! bsn! {
+//!     Root
+//!     #{ A B }
+//!     #{ C }
+//! }
+//! ```
 //!
-//! // Spawns two child entities, but more clearly separated due to parentheses.
-//! bsn! { #Parent Children [(A B), C] }
+//! "Child syntax" as seen above is actually just sugar for the following:
+//!
+//! ```ignore
+//! bsn! {
+//!     Root
+//!     Children [
+//!         #{ A B }
+//!         #{ C }
+//!     ]
+//! }
+//! ```
+//!
+//! This connects the children to the parent entity via the [`Children`] [`RelationshipTarget`].
+//! This syntax can be used with arbitrary [`RelationshipTarget`] types:
+//!
+//! ```ignore
+//! bsn! {
+//!     Player
+//!     Inventory [
+//!         #{ Sword }
+//!         #{ Apple }
+//!     ]
+//! }
+//! ```
+//!
+//! ```ignore
+//! // Children can be given names like this:
+//!
+//! bsn! {
+//!     Root
+//!     #Child1 { A B }
+//!     #Child2 { C }
+//! }
+//!
 //! ```
 //!
 //! These invocations can be nested to build deeper hierarchies.
 //!
 //! ```ignore
 //! bsn! {
-//!   #Parent
-//!   Children [
-//!     #Child1 SomeComponent,
-//!     #Child2
+//!   Parent
+//!   #Child1 { SomeComponent }
+//!   #Child2 {
 //!     SomeComponent
-//!     Children [
-//!        #GrandChild1 SomeComponent,
-//!        #GrandChild2
-//!     ]
-//!   ]
+//!     #GrandChild1 { SomeComponent }
+//!     #GrandChild2 {}
+//!   }
 //! }
 //! ```
-//!
-//! We can improve clarity at the cost of compactness through the careful use of newlines, parentheses and indentation:
-//!
-//! ```ignore
-//! bsn! {
-//!   #Parent
-//!   Children [
-//!      (
-//!        #Child1
-//!        SomeComponent
-//!      ),
-//!      (
-//!        #Child2
-//!        Children [
-//!           (
-//!             #GrandChild1
-//!             SomeComponent
-//!           ),
-//!           (
-//!             #GrandChild2
-//!           )
-//!        ]
-//!      ),
-//!   ]
-//! }
-//! ```
-//!
-//! This is fundamentally a stylistic choice: white space, Rust comments (`//` and `/* */`), and parentheses used in this way are ignored.
 //!
 //! The tools discussed here are not limited to [`Children`]: any [`RelationshipTarget`] type can be used the same way.
 //!
@@ -183,9 +189,7 @@
 //!     my_scene(#Name)
 //!     ComponentA(#Name)
 //!     ComponentB { entity: #Name }
-//!     Children [
-//!         ComponentC(#Name)
-//!     ]
+//!     #{ ComponentC(#Name) }
 //! }
 //! ```
 //!
@@ -195,9 +199,7 @@
 //! ```ignore
 //! bsn! {
 //!     #Root
-//!     Children [
-//!         Reference(#Root)
-//!     ]
+//!     #{ Reference(#Root) }
 //! }
 //! ```
 //!
@@ -229,8 +231,8 @@
 //! ```ignore
 //! fn linked_pair() -> impl SceneList {
 //!     bsn_list![
-//!         (#Left  Link(#Right)),
-//!         (#Right Link(#Left)),
+//!         #Left { Link(#Right) }
+//!         #Right { Link(#Left) }
 //!     ]
 //! }
 //! ```
@@ -245,9 +247,7 @@
 //! bsn! {
 //!   #Root
 //!   Name({format!("Entity {i}")})
-//!   Children [
-//!     Reference(#Root)
-//!   ]
+//!   #{ Reference(#Root) }
 //! }
 //! ```
 //! Adding `Name("desired name")` after the `#SomeName` reference will patch over the `Name` component created by the reference to give it a custom name.
@@ -482,11 +482,9 @@
 //!
 //! ```ignore
 //! fn enemy(hp: u32, name: &str) -> impl Scene {
-//!     let name_string = name.to_string();
 //!     bsn! {
-//!         #{name}
 //!         Health { current: {hp / 2}, max: hp }
-//!         Sprite { image: {name_string + ".png"} }
+//!         Sprite { image: {name.to_string() + ".png"} }
 //!     }
 //! }
 //!
@@ -544,21 +542,32 @@
 //! commands.spawn_scene(container(items));
 //! ```
 //!
-//! You can insert a [`SceneList`] in another Scene using curly-bracketed expressions inside of a relationship:
+//! You can insert a [`SceneList`] in another Scene using `#{{ scene_list }}`, wherever a single entity
+//! would be allowed:
 //!
 //! ```ignore
 //! fn container(contents: impl SceneList) -> impl Scene {
 //!     bsn! {
-//!         Children [
-//!             #Header,
-//!             {contents},
-//!             #Footer,
-//!         ]
+//!         #{ Header }
+//!         #{{ contents }}
+//!         #{ Footer }
 //!     }
 //! }
 //!
-//! let items = bsn_list![#A, #B, #C]; // or bsn! if container takes a `impl Scene`
+//! let items = bsn_list![#A #B #C]; // or bsn! if container takes a `impl Scene`
 //! commands.spawn_scene(container(items));
+//! ```
+//!
+//! This also works in "relationship syntax":
+//!
+//! ```ignore
+//! bsn! {
+//!     Player
+//!     Inventory [
+//!         #{ Apple }
+//!         #{{ list_of_items }}
+//!     ]
+//! }
 //! ```
 //!
 //! ### Conditional values
@@ -579,8 +588,8 @@
 //!         Box::new(bsn! {
 //!             Boss
 //!             Followers [ // the boss is followed by some grunts
-//!                 :unit(false, level - 1) #Grunt1,
-//!                 :unit(false, level - 2) #Grunt2
+//!                 #Grunt1 { :unit(false, level - 1) }
+//!                 #Grunt2 { :unit(false, level - 2) }
 //!             ]
 //!         })
 //!     } else {
@@ -588,7 +597,7 @@
 //!     };
 //!     bsn! {
 //!         Level(level)
-//!         {scene}
+//!         @{scene}
 //!     }
 //! }
 //! ```
@@ -615,10 +624,8 @@
 //!     fn scene() -> impl Scene {
 //!         bsn! {
 //!             #Player
-//!             Children [
-//!                 #RightHand Sword,
-//!                 #LeftHand Shield,
-//!             ]
+//!             #RightHand { Sword }
+//!             #LeftHand { Shield }
 //!         }
 //!     }
 //! }
@@ -755,9 +762,7 @@
 //!             .collect::<Vec<_>>();
 //!         bsn! {
 //!             Node
-//!             Children [
-//!                 {hellos}
-//!             ]
+//!             #{{ hellos }}
 //!         }
 //!     }
 //! }
@@ -1219,14 +1224,14 @@ mod tests {
             bsn! {
                 @a()
                 Position { x: 1. }
-                Children [ #Y ]
+                #Y {}
             }
         }
 
         fn a() -> impl Scene {
             bsn! {
                 Position { y: 2. }
-                Children [ #X ]
+                #X {}
             }
         }
 
@@ -1258,20 +1263,12 @@ mod tests {
         fn scene() -> impl Scene {
             bsn! {
                 #A
-                Children [
-                    (
-                        #B
-                        Children [
-                            #X
-                        ]
-                    ),
-                    (
-                        #C
-                        Children [
-                            #Y
-                        ]
-                    )
-                ]
+                #B {
+                    #X {}
+                }
+                #C {
+                    #Y {}
+                }
             }
         }
 
@@ -1342,20 +1339,20 @@ mod tests {
         fn a() -> impl Scene {
             bsn! {
                 #X
-                Children [
-                    (@b() Reference(#X))
-                ]
+                #{ @b() Reference(#X) }
             }
         }
 
         fn b() -> impl Scene {
-            let inline = bsn! {#Y Reference(#Y) Children [ Reference(#Y)] };
+            let inline = bsn! {
+                #Y
+                Reference(#Y)
+                #{ Reference(#Y) }
+            };
             bsn! {
                 #X
-                Children [
-                    Reference(#X),
-                    (@{inline} Reference(#X)),
-                ]
+                #{ Reference(#X) }
+                #{ @{inline} Reference(#X) }
             }
         }
 
@@ -1402,11 +1399,9 @@ mod tests {
         fn a() -> impl Scene {
             bsn! {
                 Reference(#Last)
-                Children [
-                    #First,
-                    #Second,
-                    #Last
-                ]
+                #First {}
+                #Second {}
+                #Last {}
             }
         }
         let id = world.spawn_scene(a()).unwrap().id();
@@ -1427,30 +1422,22 @@ mod tests {
         fn b() -> impl Scene {
             bsn! {
                 #Z
-                Children [
-                    Reference(#Z)
-                ]
+                #{ Reference(#Z) }
             }
         }
 
         fn a() -> impl SceneList {
             bsn_list![
-                (
-                    #X
+                #X {
                     Reference(#Y)
-                    Children [
-                        (#Z Reference(#X))
-                    ]
+                    #Z { Reference(#X) }
 
-                ),
-                (
-                    #Y
+                }
+                #Y {
                     Reference(#X)
-                    Children [
-                        Reference(#Y)
-                    ]
-                ),
-                (@b() #Z)
+                    #{ Reference(#Y) }
+                }
+                #Z { @b() }
             ]
         }
 
@@ -1670,8 +1657,8 @@ mod tests {
         let world = app.world_mut();
         let entities = world
             .spawn_scene_list(bsn_list! {
-                #A,
-                target(#A)
+                #A
+                #{ target(#A) }
             })
             .unwrap();
 
@@ -1961,17 +1948,15 @@ mod tests {
         fn container(items: impl SceneList) -> impl Scene {
             bsn! {
                 #Root
-                Children [
-                    #First,
-                    {items},
-                    #Last
-                ]
+                #First {}
+                #{{items}}
+                #Last {}
             }
         }
         let mut app = test_app();
         let world = app.world_mut();
         let items = bsn_list![
-            #Second,
+            #Second
             #Third
         ];
         let id = world.spawn_scene(container(items)).unwrap().id();
@@ -1987,11 +1972,9 @@ mod tests {
         fn container(item: impl Scene) -> impl Scene {
             bsn! {
                 #Root
-                Children [
-                    #First,
-                    @{item},
-                    #Last
-                ]
+                #First {}
+                #{ @{item} }
+                #Last {}
             }
         }
         let mut app = test_app();
@@ -2020,7 +2003,8 @@ mod tests {
             let scene: Box<dyn Scene> = if is_boss {
                 Box::new(bsn! {
                     Boss
-                    Children [ @unit(false, level - 1) #Grunt1, @unit(false, level - 1) #Grunt2]
+                    #Grunt1 { @unit(false, level - 1) }
+                    #Grunt2 { @unit(false, level - 1) }
                 })
             } else {
                 Box::new(bsn! { Grunt })
@@ -2209,9 +2193,9 @@ mod tests {
         let world = app.world_mut();
         let entities = world
             .spawn_scene_list(bsn_list! {
-                #A,
-                Foo::Entity(#A),
-                Bar { foo: FooTemplate::Entity(#A) }
+                #A
+                #{ Foo::Entity(#A) }
+                #{ Bar { foo: FooTemplate::Entity(#A) } }
             })
             .unwrap();
 
@@ -2363,8 +2347,8 @@ mod tests {
 
         fn scene(root: Entity) -> impl SceneList {
             bsn_list! {
-                ( #Child1 ChildOf(root) ),
-                ( #Child2 ChildOf(#Child1) ),
+                #Child1 { ChildOf(root) }
+                #Child2 { ChildOf(#Child1) }
             }
         }
 
@@ -2391,16 +2375,16 @@ mod tests {
         fn root(children: impl SceneList) -> impl Scene {
             bsn! {
                 Children [
-                    #A,
-                    {children},
+                    #A
+                    #{{children}}
                     #D
                 ]
             }
         }
 
         let children = bsn_list! [
-            #B,
-            #C,
+            #B
+            #C
         ];
 
         let id = world.spawn_scene(root(children)).unwrap().id();
@@ -2657,7 +2641,7 @@ mod tests {
                     .collect::<Vec<_>>();
                 bsn! {
                     Children [
-                        {children}
+                        #{{children}}
                     ]
                 }
             }
@@ -2733,9 +2717,7 @@ mod tests {
 
         let scene = bsn! {
             #Name
-            Children [
-                @Widget(#Name)
-            ]
+            #{ @Widget(#Name) }
         };
 
         let mut app = test_app();
@@ -2762,11 +2744,7 @@ mod tests {
 
         let scene = bsn! {
             #Name
-            Children [
-                @Widget{
-                    entity: #Name
-                }
-            ]
+            #{ @Widget { entity: #Name } }
         };
 
         let mut app = test_app();
@@ -2795,9 +2773,9 @@ mod tests {
 
         let pass_expr = bsn! {
             #Name
-            Children [
+            #{
                 @widget(placeholder_widget.into())
-            ]
+            }
         };
         let entity = world.spawn_scene(pass_expr).unwrap().id();
         let root = world.entity(entity);
@@ -2807,9 +2785,9 @@ mod tests {
 
         let pass_name = bsn! {
             #Name
-            Children [
+            #{
                 @widget(#Name)
-            ]
+            }
         };
         let entity = world.spawn_scene(pass_name).unwrap().id();
         let root = world.entity(entity);
@@ -2822,10 +2800,9 @@ mod tests {
         let pass_name_expr = bsn! {
             #Root
             Name({format!("Foo{i}")})
-            Children [
-                #Name
+            #Name {
                 @widget(#Root)
-            ]
+            }
         };
         let entity = world.spawn_scene(pass_name_expr).unwrap().id();
         let root = world.entity(entity);
@@ -2864,11 +2841,9 @@ mod tests {
         let placeholder_widget = world.spawn_empty().id();
 
         let prop_expr = bsn! {
-            Children [
-                @Widget {
-                    @entity: placeholder_widget
-                }
-            ]
+            # @Widget {
+                @entity: placeholder_widget
+            }
         };
         let entity = world.spawn_scene(prop_expr).unwrap().id();
         let root = world.entity(entity);
@@ -2877,11 +2852,9 @@ mod tests {
         assert_eq!(child_widget.0, placeholder_widget);
         let scene_prop = bsn! {
             #Name
-            Children [
-                @Widget {
-                    @entity: #Name
-                }
-            ]
+            # @Widget {
+                @entity: #Name
+            }
         };
         let entity = world.spawn_scene(scene_prop).unwrap().id();
         let root = world.entity(entity);
@@ -3096,29 +3069,31 @@ mod tests {
                 b.0 += evt.value;
             })
             Children [                   // spawning multiple related entities using a RelationshipTarget component
-                #Child1 ComponentA       // whitespace doesn't have to be newlines
-                ,                        // entities are comma-separated
-                (@other_scene() #Child3), // parentheses around a single entity are optional
-                Link(#SomeName),         // passing a entity reference to a component as `Entity`, component has to implement FromTemplate
+                #Child1 { ComponentA }   // whitespace doesn't have to be newlines
+                #Child2
+            ]                            // entities are comma-separated
+            #{ @other_scene() #Child3 } // Child entities can be defined without a `Children` wrapper
+            #{ Link(#SomeName) }         // passing a entity reference to a component as `Entity`, component has to implement FromTemplate
+            #{
                 @MySceneComponent {      // components which derive SceneComponent have scenes and can be inherited from
                     @some_prop: 3,       // props, look like fields prefixed with @ but end up passed to the components scene as arguments
                     normal_field: 5      // while normal fields are the actual fields of the component
-                },
-                (
-                    Node {
-                        width: some_var      // you can directly use variables without {}
+                }
+            }
+            #{
+                Node {
+                    width: some_var      // you can directly use variables without {}
+                }
+                ComponentB({some_var + 3.})  // values can be expressions, when wrapped in {}
+                @Container {
+                    @items: {
+                        bsn_list![                 // sometimes you may need to nest macro calls
+                            #Item1 { SomeComponent } // note: the name #Item1 here is in its own scope
+                            #Item2 { @some_scene() }
+                        ]
                     }
-                    ComponentB({some_var + 3.})  // values can be expressions, when wrapped in {}
-                    @Container {
-                        @items: {
-                            bsn_list![                // sometimes you may need to nest macro calls
-                                #item1 SomeComponent, // note: the name #item1 here is in its own scope
-                                @some_scene() #item2
-                            ]
-                        }
-                    }
-                )
-            ]
+                }
+            }
         };
         // just checking it spawns correctly
         let mut app = test_app();
@@ -3227,10 +3202,8 @@ mod tests {
 
         fn make_scene(config: &Config) -> impl Scene {
             bsn! {
-                Children [
-                    (FontSource::Handle { value: { config.value.clone() } }),
-                    (FontSource::Handle { value: { config.value.clone() } }),
-                ]
+                #{ FontSource::Handle { value: { config.value.clone() } } }
+                #{ FontSource::Handle { value: { config.value.clone() } } }
             }
         }
 
@@ -3344,9 +3317,7 @@ mod tests {
 
         let patch = bsn! {
             #patch
-            Children [
-                Ref(#patch)
-            ]
+            #{ Ref(#patch) }
         };
 
         let root = bsn! {
@@ -3374,14 +3345,14 @@ mod tests {
         struct Ref(Entity);
 
         let patch = bsn! {
-            #patch
-            Children [
-                Ref(#patch)
-            ]
+            #Patch
+            #{
+                Ref(#Patch)
+            }
         };
 
         let root = bsn_list! {
-            #root @{patch}
+            #Root { @{patch} }
         };
 
         let expected_id = Some(world.spawn_scene_list(root).unwrap()[0]);
@@ -3403,14 +3374,15 @@ mod tests {
         fn root() -> impl Scene {
             bsn! {
                 Foo(0)
-                Children [ :"child.bsn" ]
+                #{ :"child.bsn" }
             }
         }
 
         fn child() -> impl Scene {
             bsn! {
                 Foo(1)
-                Children [ Foo(2), Foo(3) ]
+                #{ Foo(2) }
+                #{ Foo(3) }
             }
         }
 

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -47,10 +47,8 @@ pub trait WorldSceneExt {
     /// world.spawn_scene(bsn! {
     ///     #Player
     ///     Score(0)
-    ///     Children [
-    ///         Sword,
-    ///         Shield,
-    ///     ]
+    ///     #{ Sword }
+    ///     #{ Shield }
     /// }).unwrap();
     /// ```
     fn spawn_scene<S: Scene>(&mut self, scene: S) -> Result<EntityWorldMut<'_>, SpawnSceneError>;
@@ -90,10 +88,8 @@ pub trait WorldSceneExt {
     ///     :"player.bsn"
     ///     #Player
     ///     Score(0)
-    ///     Children [
-    ///         Sword,
-    ///         Shield,
-    ///     ]
+    ///     #{ Sword }
+    ///     #{ Shield }
     /// });
     /// ```
     fn queue_spawn_scene<S: Scene>(&mut self, scene: S) -> EntityWorldMut<'_>;
@@ -129,14 +125,8 @@ pub trait WorldSceneExt {
     /// }
     ///
     /// world.spawn_scene_list(bsn_list! {
-    ///     (
-    ///         #Player1
-    ///         Team::Red
-    ///     ),
-    ///     (
-    ///         #Player2
-    ///         Team::Blue
-    ///     )
+    ///     #Player1 { Team::Red }
+    ///     #Player2 { Team::Blue }
     /// }).unwrap();
     /// ```
     // PERF: ideally this is an iterator
@@ -169,16 +159,14 @@ pub trait WorldSceneExt {
     /// // This scene list includes the "player.bsn" asset (note that the `.bsn` file format is not yet released). It will be spawned on the frame that "player.bsn"
     /// // is loaded.
     /// world.queue_spawn_scene_list(bsn_list! [
-    ///     (
+    ///     #Player1 {
     ///         :"player.bsn"
-    ///         #Player1
     ///         Team::Red
-    ///     ),
-    ///     (
+    ///     }
+    ///     #Player2 {
     ///         :"player.bsn"
-    ///         #Player2
     ///         Team::Blue
-    ///     )
+    ///     }
     /// ]);
     /// ```
     fn queue_spawn_scene_list<L: SceneList>(&mut self, scenes: L);
@@ -254,10 +242,8 @@ pub trait CommandsSceneExt {
     /// commands.spawn_scene(bsn! {
     ///     #Player
     ///     Score(0)
-    ///     Children [
-    ///         Sword,
-    ///         Shield,
-    ///     ]
+    ///     #{ Sword }
+    ///     #{ Shield }
     /// });
     /// ```
     fn spawn_scene<S: Scene>(&mut self, scene: S) -> EntityCommands<'_>;
@@ -289,10 +275,8 @@ pub trait CommandsSceneExt {
     ///     :"player.bsn"
     ///     #Player
     ///     Score(0)
-    ///     Children [
-    ///         Sword,
-    ///         Shield,
-    ///     ]
+    ///     #{ Sword }
+    ///     #{ Shield }
     /// });
     /// ```
     fn queue_spawn_scene<S: Scene>(&mut self, scene: S) -> EntityCommands<'_>;
@@ -320,16 +304,14 @@ pub trait CommandsSceneExt {
     ///
     /// // Note that the .bsn file format is not yet released.
     /// commands.spawn_scene_list(bsn_list! {
-    ///     (
+    ///     #Player1 {
     ///         :"player.bsn"
-    ///         #Player1
     ///         Team::Red
-    ///     ),
-    ///     (
+    ///     }
+    ///     #Player2 {
     ///         :"player.bsn"
-    ///         #Player2
     ///         Team::Blue
-    ///     )
+    ///     }
     /// });
     /// ```
     fn spawn_scene_list<L: SceneList>(&mut self, scenes: L);
@@ -354,16 +336,14 @@ pub trait CommandsSceneExt {
     /// // This scene list includes the "player.bsn" asset (note that the `.bsn` file format is not yet released). It will be spawned on the frame that "player.bsn"
     /// // is loaded.
     /// commands.queue_spawn_scene_list(bsn_list! [
-    ///     (
+    ///     #Player1 {
     ///         :"player.bsn"
-    ///         #Player1
     ///         Team::Red
-    ///     ),
-    ///     (
+    ///     }
+    ///     #Player2 {
     ///         :"player.bsn"
-    ///         #Player2
     ///         Team::Blue
-    ///     )
+    ///     }
     /// ]);
     /// ```
     fn queue_spawn_scene_list<L: SceneList>(&mut self, scenes: L);
@@ -439,14 +419,8 @@ pub trait EntityWorldMutSceneExt {
     /// }
     ///
     /// world.spawn_empty().queue_spawn_related_scenes::<Children>(bsn_list! {
-    ///     (
-    ///         #Player1
-    ///         Team::Red
-    ///     ),
-    ///     (
-    ///         #Player2
-    ///         Team::Blue
-    ///     )
+    ///     #Player1 { Team::Red }
+    ///     #Player2 { Team::Blue }
     /// });
     /// ```
     fn queue_spawn_related_scenes<T: RelationshipTarget>(self, scenes: impl SceneList) -> Self;
@@ -543,14 +517,8 @@ pub trait EntityCommandsSceneExt {
     /// }
     ///
     /// commands.spawn_empty().queue_spawn_related_scenes::<Children>(bsn_list! {
-    ///     (
-    ///         #Player1
-    ///         Team::Red
-    ///     ),
-    ///     (
-    ///         #Player2
-    ///         Team::Blue
-    ///     )
+    ///     #Player1 { Team::Red }
+    ///     #Player2 { Team::Blue }
     /// });
     /// ```
     fn queue_spawn_related_scenes<T: RelationshipTarget>(
@@ -906,7 +874,7 @@ mod tests {
         );
 
         let scene = bsn! {
-            Children [ #SceneChild SceneChild ]
+            #SceneChild { SceneChild }
         };
         world.entity_mut(root).apply_scene(scene).unwrap();
 

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -171,17 +171,13 @@ fn spawn_buttons(commands: &mut Commands) {
     if !cfg!(target_arch = "wasm32") {
         commands.spawn_scene(bsn! {
             @bottom_left_scene()
-            Children [
-                @feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
-                @feathers_option_checkbox("WIREFRAME", Some(CheckboxInput::Wireframe)),
-            ]
+            #{ @feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)) }
+            #{ @feathers_option_checkbox("WIREFRAME", Some(CheckboxInput::Wireframe)) }
         });
     } else {
         commands.spawn_scene(bsn! {
             @top_left_scene() // so the user can immediately see the control in browser w/o scrolling
-            Children [
-                @feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)),
-            ]
+            #{ @feathers_option_checkbox("ROTATE", Some(CheckboxInput::Rotation)) }
         });
     }
 }

--- a/examples/2d/dynamic_mip_generation.rs
+++ b/examples/2d/dynamic_mip_generation.rs
@@ -320,7 +320,7 @@ fn setup(
 fn spawn_ui(commands: &mut Commands) {
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-        Children [
+        #{
             // Spawn the "Regenerate Top Mip Level" button.
             @FeathersButton {
                 @caption: bsn! { @caption("Regenerate Top Mip Level") }
@@ -331,50 +331,48 @@ fn spawn_ui(commands: &mut Commands) {
                 align_items: AlignItems::Center,
             }
             BackgroundColor(Color::BLACK)
-            ,
-
-            // Spawn the "Mip Generation" switch that allows the user to toggle
-            // mip generation on and off.
-            @feathers_option_buttons(
-                "Mip Generation",
-                &[
-                    (
-                        EnableMipGeneration::On,
-                        "On"
-                    ),
-                    (
-                        EnableMipGeneration::Off,
-                        "Off"
-                    ),
-                ], 0
-            ),
-            // Spawn the "Image Width" control that allows the user to set the
-            // width of the image.
-            @feathers_option_buttons(
-                "Image Width",
-                &[
-                    (ImageSizeSetting::ImageWidth(ImageSize::Size240), "240"),
-                    (ImageSizeSetting::ImageWidth(ImageSize::Size480), "480"),
-                    (ImageSizeSetting::ImageWidth(ImageSize::Size640), "640"),
-                    (ImageSizeSetting::ImageWidth(ImageSize::Size1080), "1080"),
-                    (ImageSizeSetting::ImageWidth(ImageSize::Size1920), "1920"),
-                ],
-                2
-            ),
-            // Spawn the "Image Height" control that allows the user to set the
-            // height of the image.
-            @feathers_option_buttons(
-                "Image Height",
-                &[
-                    (ImageSizeSetting::ImageHeight(ImageSize::Size240), "240"),
-                    (ImageSizeSetting::ImageHeight(ImageSize::Size480), "480"),
-                    (ImageSizeSetting::ImageHeight(ImageSize::Size640), "640"),
-                    (ImageSizeSetting::ImageHeight(ImageSize::Size1080), "1080"),
-                    (ImageSizeSetting::ImageHeight(ImageSize::Size1920), "1920"),
-                ],
-                1
-            ),
-        ]
+        }
+        // Spawn the "Mip Generation" switch that allows the user to toggle
+        // mip generation on and off.
+        # @feathers_option_buttons(
+            "Mip Generation",
+            &[
+                (
+                    EnableMipGeneration::On,
+                    "On"
+                ),
+                (
+                    EnableMipGeneration::Off,
+                    "Off"
+                ),
+            ], 0
+        )
+        // Spawn the "Image Width" control that allows the user to set the
+        // width of the image.
+        # @feathers_option_buttons(
+            "Image Width",
+            &[
+                (ImageSizeSetting::ImageWidth(ImageSize::Size240), "240"),
+                (ImageSizeSetting::ImageWidth(ImageSize::Size480), "480"),
+                (ImageSizeSetting::ImageWidth(ImageSize::Size640), "640"),
+                (ImageSizeSetting::ImageWidth(ImageSize::Size1080), "1080"),
+                (ImageSizeSetting::ImageWidth(ImageSize::Size1920), "1920"),
+            ],
+            2
+        )
+        // Spawn the "Image Height" control that allows the user to set the
+        // height of the image.
+        # @feathers_option_buttons(
+            "Image Height",
+            &[
+                (ImageSizeSetting::ImageHeight(ImageSize::Size240), "240"),
+                (ImageSizeSetting::ImageHeight(ImageSize::Size480), "480"),
+                (ImageSizeSetting::ImageHeight(ImageSize::Size640), "640"),
+                (ImageSizeSetting::ImageHeight(ImageSize::Size1080), "1080"),
+                (ImageSizeSetting::ImageHeight(ImageSize::Size1920), "1920"),
+            ],
+            1
+        )
     });
 }
 

--- a/examples/2d/wireframe_2d.rs
+++ b/examples/2d/wireframe_2d.rs
@@ -110,29 +110,27 @@ fn setup(
 ) {
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-        Children [
-            (
-                @feathers_option_buttons("Toggle global",
-                    &[
-                        (GlobalWireframeSetting::On, "ON"),
-                        (GlobalWireframeSetting::Off, "OFF"),
-                    ], 0)
-            ),
-            (
-                @feathers_option_buttons("Change global color",
-                    &[
-                        (GlobalColorSetting::Red, "RED"),
-                        (GlobalColorSetting::White, "WHITE"),
-                    ], 1)
-            ),
-            (
-                @feathers_option_buttons("Change color of the circle wireframe",
-                    &[
-                        (ColorCircleWireframeSetting::Red, "RED"),
-                        (ColorCircleWireframeSetting::Green, "GREEN"),
-                    ], 1)
-            ),
-        ]
+        # @feathers_option_buttons("Toggle global",
+            &[
+                (GlobalWireframeSetting::On, "ON"),
+                (GlobalWireframeSetting::Off, "OFF"),
+            ],
+            0
+        )
+        # @feathers_option_buttons("Change global color",
+            &[
+                (GlobalColorSetting::Red, "RED"),
+                (GlobalColorSetting::White, "WHITE"),
+            ],
+            1
+        )
+        # @feathers_option_buttons("Change color of the circle wireframe",
+            &[
+                (ColorCircleWireframeSetting::Red, "RED"),
+                (ColorCircleWireframeSetting::Green, "GREEN"),
+            ],
+            1
+        )
     });
     // Triangle: Never renders a wireframe
     commands.spawn((

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -12,27 +12,25 @@ fn main() {
 /// set up a simple 3D scene
 fn scene() -> impl SceneList {
     bsn_list! [
-        (
-            #CircularBase
+        #CircularBase {
             Mesh3d(asset_value(Circle::new(4.0)))
             MeshMaterial3d::<StandardMaterial>(asset_value(Color::WHITE))
             Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2))
-        ),
-        (
-            #Cube
+        }
+        #Cube {
             Mesh3d(asset_value(Cuboid::new(1.0, 1.0, 1.0)))
             MeshMaterial3d::<StandardMaterial>(asset_value(Color::srgb_u8(124, 144, 255)))
             Transform::from_xyz(0.0, 0.5, 0.0)
-        ),
-        (
+        }
+        #{
             PointLight {
                 shadow_maps_enabled: true,
             }
             Transform::from_xyz(4.0, 8.0, 4.0)
-        ),
-        (
+        }
+        #{
             Camera3d
             Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y)
-        )
+        }
     ]
 }

--- a/examples/3d/clearcoat.rs
+++ b/examples/3d/clearcoat.rs
@@ -268,16 +268,14 @@ fn animate_spheres(mut spheres: Query<&mut Transform, With<ExampleSphere>>, time
 fn spawn_buttons(commands: &mut Commands, light_mode: Res<LightMode>) {
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-            Children [
-            @feathers_option_buttons(
-                "Toggle light type",
-                &[
-                    (LightMode::Directional, "Directional"),
-                    (LightMode::Point, "Point"),
-                ],
-                if *light_mode == LightMode::Directional { 0 } else { 1 },
-            )
-        ]
+        # @feathers_option_buttons(
+            "Toggle light type",
+            &[
+                (LightMode::Directional, "Directional"),
+                (LightMode::Point, "Point"),
+            ],
+            if *light_mode == LightMode::Directional { 0 } else { 1 },
+        )
     });
 }
 

--- a/examples/3d/clustered_decal_maps.rs
+++ b/examples/3d/clustered_decal_maps.rs
@@ -249,16 +249,14 @@ fn spawn_camera(commands: &mut Commands) {
 fn spawn_buttons(commands: &mut Commands) {
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-        Children [
-            @feathers_option_buttons(
-                "Emissive Decals",
-                &[
-                    (AppSetting::EmissiveDecals(false), "Off"),
-                    (AppSetting::EmissiveDecals(true), "On"),
-                ],
-                0,
-            ),
-        ]
+        # @feathers_option_buttons(
+            "Emissive Decals",
+            &[
+                (AppSetting::EmissiveDecals(false), "Off"),
+                (AppSetting::EmissiveDecals(true), "On"),
+            ],
+            0,
+        )
     });
 }
 

--- a/examples/3d/clustered_decals.rs
+++ b/examples/3d/clustered_decals.rs
@@ -232,24 +232,24 @@ fn spawn_buttons(commands: &mut Commands) {
     // aspects of clustered decals.
     commands.spawn_scene(bsn! {
         @radio::main_ui_node_scene()
-        Children [
-            @radio::feathers_option_buttons("Drag to Move",
+        # @radio::feathers_option_buttons("Drag to Move",
             &[
                 (Selection::Camera, "Camera"),
                 (Selection::DecalA, "Decal A"),
                 (Selection::DecalB, "Decal B"),
-            ], 0),
-
+            ],
+            0
+        )
+        #{
             // The number inputs start off hidden because Camera is selected first.
-            Visibility::Hidden
             @number_input_f32("Scale Multiplier", Some(AppNumberInput::Scale), 1.0, NumberInputPrecision(2), 0.05..=10.)
-            ,
-
+            Visibility::Hidden
+        }
+        #{
             Visibility::Hidden
             // + epsilon and next_down are used since roll recalculation likes to switch between -PI and PI upon recalculating roll.
             @number_input_f32("Roll (-π to π)", Some(AppNumberInput::Roll), 0.0, NumberInputPrecision(2), -PI + f32::EPSILON ..=PI.next_down())
-            ,
-        ]
+        }
     });
 }
 

--- a/examples/3d/color_grading.rs
+++ b/examples/3d/color_grading.rs
@@ -112,14 +112,12 @@ fn add_buttons(commands: &mut Commands, color_grading: &ColorGrading) {
             left: px(12),
             bottom: px(12),
         }
-        Children [
-            // Create the first pane, which contains the global controls.
-            @pane_for_global_controls(color_grading),
-            // Create the following panes for individual controls.
-            @pane_for_section(SectionColorGradingName::Highlights, color_grading),
-            @pane_for_section(SectionColorGradingName::Midtones, color_grading),
-            @pane_for_section(SectionColorGradingName::Shadows, color_grading),
-        ]
+        // Create the first pane, which contains the global controls.
+        # @pane_for_global_controls(color_grading)
+        // Create the following panes for individual controls.
+        # @pane_for_section(SectionColorGradingName::Highlights, color_grading)
+        # @pane_for_section(SectionColorGradingName::Midtones, color_grading)
+        # @pane_for_section(SectionColorGradingName::Shadows, color_grading)
     });
 }
 
@@ -131,28 +129,25 @@ fn pane_for_global_controls(color_grading: &ColorGrading) -> impl Scene {
 
     bsn! {
         @pane()
-        Children [
+        #{
             // Spawn the label ("Highlights", etc.)
             @pane_header()
-            Children[
+            #{
                 Node {
                     width: px(120)
                     align_self: AlignSelf::Start,
                 }
-                Children [
-                    @label("Global Settings")
-                ]
-            ],
-
+                # @label("Global Settings")
+            }
+        }
+        #{
             // Spawn the buttons
             @pane_body()
-            Children [
-                @make_button(GlobalColorGradingSetting::Exposure),
-                @make_button(GlobalColorGradingSetting::Temperature),
-                @make_button(GlobalColorGradingSetting::Tint),
-                @make_button(GlobalColorGradingSetting::Hue),
-            ]
-        ]
+            # @make_button(GlobalColorGradingSetting::Exposure)
+            # @make_button(GlobalColorGradingSetting::Temperature)
+            # @make_button(GlobalColorGradingSetting::Tint)
+            # @make_button(GlobalColorGradingSetting::Hue)
+        }
     }
 }
 
@@ -168,29 +163,26 @@ fn pane_for_section(section: SectionColorGradingName, color_grading: &ColorGradi
 
     bsn! {
         @pane()
-        Children [
-            // Spawn the label ("Highlights", etc.)
+        // Spawn the label ("Highlights", etc.)
+        #{
             @pane_header()
-            Children [
+            #{
                 Node {
                     width: px(120),
                     align_self: AlignSelf::Start,
                 }
-                Children [
-                    @label(section.to_string())
-                ],
-            ],
-
-            // Spawn the buttons.
+                # @label(section.to_string())
+            }
+        }
+        #{
             @pane_body()
-            Children[
-                @make_button(SectionColorGradingSetting::Saturation),
-                @make_button(SectionColorGradingSetting::Contrast),
-                @make_button(SectionColorGradingSetting::Gamma),
-                @make_button(SectionColorGradingSetting::Gain),
-                @make_button(SectionColorGradingSetting::Lift),
-            ]
-        ]
+            // Spawn the buttons.
+            # @make_button(SectionColorGradingSetting::Saturation)
+            # @make_button(SectionColorGradingSetting::Contrast)
+            # @make_button(SectionColorGradingSetting::Gamma)
+            # @make_button(SectionColorGradingSetting::Gain)
+            # @make_button(SectionColorGradingSetting::Lift)
+        }
     }
 }
 
@@ -209,14 +201,13 @@ fn number_input_for_value(
             justify_content: JustifyContent::Center,
             align_items: AlignItems::Center,
         }
-        Children [
+        #{
             Node {
                 width: px(120),
             }
-            Children[
-                @label(setting_label)
-            ],
-
+            # @label(setting_label)
+        }
+        #{
             Node {
                 align_items: AlignItems::Center,
                 width: px(50),
@@ -226,7 +217,7 @@ fn number_input_for_value(
             setting
             NumberInputPrecision(2)
             HardLimit::f32(0. ..=10.)
-        ]
+        }
     }
 }
 
@@ -454,10 +445,10 @@ fn add_help_text(commands: &mut Commands) {
             left: px(12),
             top: px(12),
         }
-        Children [
+        #{
             Text("Drag a setting's input value to change the scene.\n\
                 Click into an input field to change values via keyboard.\n\
                 Values must be between 0 and 10.")
-        ]
+        }
     });
 }

--- a/examples/3d/contact_shadows.rs
+++ b/examples/3d/contact_shadows.rs
@@ -285,101 +285,99 @@ fn rotate_light(
 fn spawn_buttons(commands: &mut Commands, app_status: &AppStatus) {
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-        Children [
-            @feathers_option_buttons(
-                "Contact Shadows",
-                &[
-                    (
-                        ExampleSetting::ContactShadows(ContactShadowState::Enabled),
-                        "On"
-                    ),
-                    (
-                        ExampleSetting::ContactShadows(ContactShadowState::Disabled),
-                        "Off"
-                    ),
-                ],
-                {
-                    if app_status.contact_shadows == ContactShadowState::Enabled {
-                        0
-                    }
-                    else {
-                        1
-                    }
-                },
-            ),
-            @feathers_option_buttons(
-                "Shadow Maps",
-                &[
-                    (ExampleSetting::ShadowMaps(ShadowMaps::Enabled), "On"),
-                    (ExampleSetting::ShadowMaps(ShadowMaps::Disabled), "Off"),
-                ],
-                {
-                    if app_status.shadow_maps == ShadowMaps::Enabled {
-                        0
-                    }
-                    else {
-                        1
-                    }
-                },
-            ),
-            @feathers_option_buttons(
-                "Light Rotation",
-                &[
-                    (ExampleSetting::LightRotation(LightRotation::Rotating), "On"),
-                    (
-                        ExampleSetting::LightRotation(LightRotation::Stationary),
-                        "Off"
-                    ),
-                ],
-                {
-                    if app_status.light_rotation == LightRotation::Rotating {
-                        0
-                    }
-                    else {
-                        1
-                    }
-                },
-            ),
-            @feathers_option_buttons(
-                "Light Type",
-                &[
-                    (
-                        ExampleSetting::LightType(LightType::Directional),
-                        "Directional"
-                    ),
-                    (ExampleSetting::LightType(LightType::Point), "Point"),
-                    (ExampleSetting::LightType(LightType::Spot), "Spot"),
-                ],
-                {
-                    match app_status.light_type {
-                        LightType::Directional => 0,
-                        LightType::Point => 1,
-                        LightType::Spot => 2,
-                    }
-                },
-            ),
-            @feathers_option_buttons(
-                "Receive Shadows",
-                &[
-                    (
-                        ExampleSetting::ReceiveShadows(ReceiveShadows::Enabled),
-                        "On"
-                    ),
-                    (
-                        ExampleSetting::ReceiveShadows(ReceiveShadows::Disabled),
-                        "Off"
-                    ),
-                ],
-                {
-                    if app_status.receive_shadows == ReceiveShadows::Enabled {
-                        0
-                    }
-                    else {
-                        1
-                    }
-                },
-            ),
-        ]
+        # @feathers_option_buttons(
+            "Contact Shadows",
+            &[
+                (
+                    ExampleSetting::ContactShadows(ContactShadowState::Enabled),
+                    "On"
+                ),
+                (
+                    ExampleSetting::ContactShadows(ContactShadowState::Disabled),
+                    "Off"
+                ),
+            ],
+            {
+                if app_status.contact_shadows == ContactShadowState::Enabled {
+                    0
+                }
+                else {
+                    1
+                }
+            },
+        )
+        # @feathers_option_buttons(
+            "Shadow Maps",
+            &[
+                (ExampleSetting::ShadowMaps(ShadowMaps::Enabled), "On"),
+                (ExampleSetting::ShadowMaps(ShadowMaps::Disabled), "Off"),
+            ],
+            {
+                if app_status.shadow_maps == ShadowMaps::Enabled {
+                    0
+                }
+                else {
+                    1
+                }
+            },
+        )
+        # @feathers_option_buttons(
+            "Light Rotation",
+            &[
+                (ExampleSetting::LightRotation(LightRotation::Rotating), "On"),
+                (
+                    ExampleSetting::LightRotation(LightRotation::Stationary),
+                    "Off"
+                ),
+            ],
+            {
+                if app_status.light_rotation == LightRotation::Rotating {
+                    0
+                }
+                else {
+                    1
+                }
+            },
+        )
+        # @feathers_option_buttons(
+            "Light Type",
+            &[
+                (
+                    ExampleSetting::LightType(LightType::Directional),
+                    "Directional"
+                ),
+                (ExampleSetting::LightType(LightType::Point), "Point"),
+                (ExampleSetting::LightType(LightType::Spot), "Spot"),
+            ],
+            {
+                match app_status.light_type {
+                    LightType::Directional => 0,
+                    LightType::Point => 1,
+                    LightType::Spot => 2,
+                }
+            },
+        )
+        # @feathers_option_buttons(
+            "Receive Shadows",
+            &[
+                (
+                    ExampleSetting::ReceiveShadows(ReceiveShadows::Enabled),
+                    "On"
+                ),
+                (
+                    ExampleSetting::ReceiveShadows(ReceiveShadows::Disabled),
+                    "Off"
+                ),
+            ],
+            {
+                if app_status.receive_shadows == ReceiveShadows::Enabled {
+                    0
+                }
+                else {
+                    1
+                }
+            },
+        )
     });
 }
 

--- a/examples/3d/light_probe_blending.rs
+++ b/examples/3d/light_probe_blending.rs
@@ -331,26 +331,24 @@ fn spawn_light_probes(commands: &mut Commands, asset_server: &AssetServer) {
 fn spawn_buttons(commands: &mut Commands) {
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-        Children [
-            @feathers_option_buttons(
-                "Gizmos",
-                &[(GizmosEnabled::On, "On"), (GizmosEnabled::Off, "Off"),],
-                0,
-            ),
-            @feathers_option_buttons(
-                "Object to Show",
-                &[
-                    (ObjectToShow::Sphere, "Sphere"),
-                    (ObjectToShow::Prism, "Prism"),
-                ],
-                0,
-            ),
-            @feathers_option_buttons(
-                "Camera Mode",
-                &[(CameraMode::Orbit, "Orbit"), (CameraMode::Free, "Free"),],
-                0,
-            ),
-        ]
+        # @feathers_option_buttons(
+            "Gizmos",
+            &[(GizmosEnabled::On, "On"), (GizmosEnabled::Off, "Off"),],
+            0,
+        )
+        # @feathers_option_buttons(
+            "Object to Show",
+            &[
+                (ObjectToShow::Sphere, "Sphere"),
+                (ObjectToShow::Prism, "Prism"),
+            ],
+            0,
+        )
+        # @feathers_option_buttons(
+            "Camera Mode",
+            &[(CameraMode::Orbit, "Orbit"), (CameraMode::Free, "Free"),],
+            0,
+        )
     });
 }
 

--- a/examples/3d/light_textures.rs
+++ b/examples/3d/light_textures.rs
@@ -274,20 +274,17 @@ fn spawn_light_textures(
 fn spawn_buttons(commands: &mut Commands) {
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-        Children [
-            @feathers_option_buttons(
-                "Drag to Move",
-                &[
-                    (Selection::Camera, "Camera"),
-                    (Selection::SpotLight, "Spotlight"),
-                    (Selection::PointLight, "Point Light"),
-                    (Selection::DirectionalLight, "Directional Light"),
-                ],
-                0,
-            ),
-
-            // Camera's visibility cannot be toggled.
-            Visibility::Hidden
+        # @feathers_option_buttons(
+            "Drag to Move",
+            &[
+                (Selection::Camera, "Camera"),
+                (Selection::SpotLight, "Spotlight"),
+                (Selection::PointLight, "Point Light"),
+                (Selection::DirectionalLight, "Directional Light"),
+            ],
+            0,
+        )
+        #{
             @feathers_option_buttons(
                 "Visibility",
                 &[
@@ -295,18 +292,20 @@ fn spawn_buttons(commands: &mut Commands) {
                     (Visibility::Hidden, "Hide"),
                 ],
                 0,
-            ),
-
+            )
+            // Camera's visibility cannot be toggled.
+            Visibility::Hidden
+        }
+        #{
+            @number_input_f32("Scale Multiplier", Some(AppNumberInput::Scale), 1.0, NumberInputPrecision(2), 0.01..=5.)
             // The number inputs start off hidden because Camera is selected first.
             Visibility::Hidden
-            @number_input_f32("Scale Multiplier", Some(AppNumberInput::Scale), 1.0, NumberInputPrecision(2), 0.01..=5.)
-            ,
-
-            Visibility::Hidden
+        }
+        #{
             // + epsilon and next_down are used since roll recalculation likes to switch between -PI and PI upon recalculating roll.
             @number_input_f32("Roll (-π to π)", Some(AppNumberInput::Roll), 0.0, NumberInputPrecision(2), -PI + f32::EPSILON ..=PI.next_down())
-            ,
-        ]
+            Visibility::Hidden
+        }
     });
 }
 

--- a/examples/3d/mirror.rs
+++ b/examples/3d/mirror.rs
@@ -325,14 +325,14 @@ fn spawn_buttons(commands: &mut Commands) {
     // control.
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-        Children [@feathers_option_buttons(
+        # @feathers_option_buttons(
             "Drag Action",
             &[
                 (DragAction::MoveCamera, "Move Camera"),
                 (DragAction::MoveFox, "Move Fox"),
             ],
             0,
-        )]
+        )
     });
 }
 

--- a/examples/3d/mixed_lighting.rs
+++ b/examples/3d/mixed_lighting.rs
@@ -193,8 +193,7 @@ fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
 fn spawn_buttons(commands: &mut Commands) {
     commands.spawn_scene(bsn! {
             @main_ui_node_scene()
-            Children [
-                @feathers_option_buttons(
+            # @feathers_option_buttons(
                 "Lighting",
                 &[
                     (LightingMode::Baked, "Baked"),
@@ -203,7 +202,7 @@ fn spawn_buttons(commands: &mut Commands) {
                     (LightingMode::RealTime, "Real-Time"),
                 ],
                 2 // Initially set to MixedIndirect
-            )]
+            )
     });
 }
 

--- a/examples/3d/occlusion_culling.rs
+++ b/examples/3d/occlusion_culling.rs
@@ -663,16 +663,14 @@ impl fmt::Display for OcclusionCullingSetting {
 fn spawn_buttons(commands: &mut Commands) {
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-        Children [
-            @feathers_option_buttons(
-                "Toggle occlusion culling",
-                &[
-                    (OcclusionCullingSetting::On, "ON"),
-                    (OcclusionCullingSetting::Off, "OFF"),
-                ],
-                0,
-            )
-        ]
+        # @feathers_option_buttons(
+            "Toggle occlusion culling",
+            &[
+                (OcclusionCullingSetting::On, "ON"),
+                (OcclusionCullingSetting::Off, "OFF"),
+            ],
+            0,
+        )
     });
 }
 

--- a/examples/3d/order_independent_transparency.rs
+++ b/examples/3d/order_independent_transparency.rs
@@ -268,7 +268,7 @@ fn spawn_ui(commands: &mut Commands, app_state: &AppState) {
         on (|mut event: On<PointerDrag>| {
             event.propagate(false);
         })
-        Children [
+        #{
             RadioGroupSetting::ChangeScene
             @feathers_option_buttons(
                 "Scene ([←] or [→])",
@@ -278,8 +278,9 @@ fn spawn_ui(commands: &mut Commands, app_state: &AppState) {
                     .map(|(i, scene)| (AppSetting::ChangeScene(i), scene.1))
                     .collect::<Vec<_>>()),
                 app_state.current_scene_id,
-            ),
-
+            )
+        }
+        #{
             RadioGroupSetting::EnableOIT
             @feathers_option_buttons(
                 "Order Independent [T]ransparency",
@@ -292,8 +293,9 @@ fn spawn_ui(commands: &mut Commands, app_state: &AppState) {
                 } else {
                     1
                 }
-            ),
-
+            )
+        }
+        #{
             RadioGroupSetting::UseDepthPrepass
             @feathers_option_buttons(
                 "[D]epth Prepass",
@@ -306,8 +308,8 @@ fn spawn_ui(commands: &mut Commands, app_state: &AppState) {
                 } else {
                     1
                 }
-            ),
-        ]
+            )
+        }
     });
 }
 

--- a/examples/3d/pccm.rs
+++ b/examples/3d/pccm.rs
@@ -157,16 +157,14 @@ fn spawn_reflection_probe(commands: &mut Commands, asset_server: &AssetServer) {
 fn spawn_buttons(commands: &mut Commands) {
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-        Children [
-            @feathers_option_buttons(
-                "Parallax Correction",
-                &[
-                    (PccmEnableStatus::Enabled, "On"),
-                    (PccmEnableStatus::Disabled, "Off"),
-                ],
-                0,
-            )
-        ]
+        # @feathers_option_buttons(
+            "Parallax Correction",
+            &[
+                (PccmEnableStatus::Enabled, "On"),
+                (PccmEnableStatus::Disabled, "Off"),
+            ],
+            0,
+        )
     });
 }
 

--- a/examples/3d/pcss.rs
+++ b/examples/3d/pcss.rs
@@ -201,36 +201,34 @@ fn spawn_gltf_scene(commands: &mut Commands, asset_server: &AssetServer) {
 fn spawn_buttons(commands: &mut Commands) {
     commands.spawn_scene(bsn! {
         @radio::main_ui_node_scene()
-        Children [
-            @radio::feathers_option_buttons(
-                "Light Type",
-                &[
-                    (LightType::Directional, "Directional"),
-                    (LightType::Point, "Point"),
-                    (LightType::Spot, "Spot"),
-                ],
-                0,
-            ),
-            @radio::feathers_option_buttons(
-                "Shadow Filter",
-                &[
-                    (
-                        ShadowFilter::NonTemporal,
-                        "Non-Temporal",
-                    ),
-                    (ShadowFilter::Temporal, "Temporal"),
-                ],
-                0,
-            ),
-            @radio::feathers_option_buttons(
-                "Soft Shadows",
-                &[
-                    (SoftShadows(true), "On"),
-                    (SoftShadows(false), "Off"),
-                ],
-                0,
-            ),
-        ]
+        # @radio::feathers_option_buttons(
+            "Light Type",
+            &[
+                (LightType::Directional, "Directional"),
+                (LightType::Point, "Point"),
+                (LightType::Spot, "Spot"),
+            ],
+            0,
+        )
+        # @radio::feathers_option_buttons(
+            "Shadow Filter",
+            &[
+                (
+                    ShadowFilter::NonTemporal,
+                    "Non-Temporal",
+                ),
+                (ShadowFilter::Temporal, "Temporal"),
+            ],
+            0,
+        )
+        # @radio::feathers_option_buttons(
+            "Soft Shadows",
+            &[
+                (SoftShadows(true), "On"),
+                (SoftShadows(false), "Off"),
+            ],
+            0,
+        )
     });
 }
 

--- a/examples/3d/specular_tint.rs
+++ b/examples/3d/specular_tint.rs
@@ -181,16 +181,14 @@ fn shift_hue(
 fn spawn_buttons(commands: &mut Commands) {
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-        Children [
-            @feathers_option_buttons(
-                "Toggle specular tint",
-                &[
-                    (TintType::Solid, "SOLID"),
-                    (TintType::Map,   "MAP"),
-                ],
-                0,
-            )
-        ]
+        # @feathers_option_buttons(
+            "Toggle specular tint",
+            &[
+                (TintType::Solid, "SOLID"),
+                (TintType::Map,   "MAP"),
+            ],
+            0,
+        )
     });
 }
 

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -124,10 +124,8 @@ fn setup(
                 align_items: AlignItems::Center,
                 padding: UiRect::all(px(20)),
             }
-            Children [
-                @rotate_button("<", Direction::Left),
-                @rotate_button(">", Direction::Right),
-            ]
+            # @rotate_button("<", Direction::Left)
+            # @rotate_button(">", Direction::Right)
         }
     }
 

--- a/examples/3d/ssr.rs
+++ b/examples/3d/ssr.rs
@@ -463,58 +463,56 @@ fn spawn_camera(commands: &mut Commands, asset_server: &AssetServer, app_setting
 fn spawn_buttons(commands: &mut Commands, app_settings: &AppSettings) {
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-        Children[
-            @feathers_option_buttons(
-                "SSR",
-                &[
-                    (SsrOn(true), "On"),
-                    (SsrOn(false), "Off"),
-                ],
-                0,
-            ),
-            @feathers_option_buttons(
-                "Model",
-                &[
-                    (DisplayedModel::Cube, "Cube"),
-                    (
-                        DisplayedModel::FlightHelmet,
-                        "Flight Helmet",
-                    ),
-                    (DisplayedModel::Capsules, "Capsules"),
-                ],
-                0,
-            ),
-            @feathers_option_buttons(
-                "Base",
-                &[
-                    (DisplayedBase::Water, "Water"),
-                    (DisplayedBase::Metallic, "Metallic"),
-                    (DisplayedBase::RedPlane, "Red Plane"),
-                ],
-                0,
-            ),
-            @range_row(
-                "Min Roughness",
-                app_settings.min_perceptual_roughness.start,
-                app_settings.min_perceptual_roughness.end,
-                AppNumberInput::MinRoughnessStart,
-                AppNumberInput::MinRoughnessEnd,
-            ),
-            @range_row(
-                "Max Roughness",
-                app_settings.max_perceptual_roughness.start,
-                app_settings.max_perceptual_roughness.end,
-                AppNumberInput::MaxRoughnessStart,
-                AppNumberInput::MaxRoughnessEnd,
-            ),
-            @range_row(
-                "Edge Fadeout",
-                app_settings.edge_fadeout.start,
-                app_settings.edge_fadeout.end,
-                AppNumberInput::EdgeFadeoutStart,
-                AppNumberInput::EdgeFadeoutEnd,
-            ),
-        ]
+        # @feathers_option_buttons(
+            "SSR",
+            &[
+                (SsrOn(true), "On"),
+                (SsrOn(false), "Off"),
+            ],
+            0,
+        )
+        # @feathers_option_buttons(
+            "Model",
+            &[
+                (DisplayedModel::Cube, "Cube"),
+                (
+                    DisplayedModel::FlightHelmet,
+                    "Flight Helmet",
+                ),
+                (DisplayedModel::Capsules, "Capsules"),
+            ],
+            0,
+        )
+        # @feathers_option_buttons(
+            "Base",
+            &[
+                (DisplayedBase::Water, "Water"),
+                (DisplayedBase::Metallic, "Metallic"),
+                (DisplayedBase::RedPlane, "Red Plane"),
+            ],
+            0,
+        )
+        # @range_row(
+            "Min Roughness",
+            app_settings.min_perceptual_roughness.start,
+            app_settings.min_perceptual_roughness.end,
+            AppNumberInput::MinRoughnessStart,
+            AppNumberInput::MinRoughnessEnd,
+        )
+        # @range_row(
+            "Max Roughness",
+            app_settings.max_perceptual_roughness.start,
+            app_settings.max_perceptual_roughness.end,
+            AppNumberInput::MaxRoughnessStart,
+            AppNumberInput::MaxRoughnessEnd,
+        )
+        # @range_row(
+            "Edge Fadeout",
+            app_settings.edge_fadeout.start,
+            app_settings.edge_fadeout.end,
+            AppNumberInput::EdgeFadeoutStart,
+            AppNumberInput::EdgeFadeoutEnd,
+        )
     });
 }
 
@@ -529,28 +527,23 @@ fn range_row(
         Node {
             align_items: AlignItems::Center,
         }
-        Children[
+        #{
             Node {
                 width: px(150),
             }
-            Children[
-                @label(title.to_string())
-            ],
-
-            @range_controls(
-                start_value,
-                start_number_input
-            ),
-
+            # @label(title.to_string())
+        }
+        # @range_controls(
+            start_value,
+            start_number_input
+        )
+        #{
             Node {
                 margin: UiRect::horizontal(px(10)),
             }
-            Children [
-                @label_small("to".to_string())
-            ],
-
-            @range_controls(end_value, end_number_input),
-        ]
+            # @label_small("to".to_string())
+        }
+        # @range_controls(end_value, end_number_input)
     }
 }
 

--- a/examples/animation/animation_graph.rs
+++ b/examples/animation/animation_graph.rs
@@ -307,10 +307,12 @@ fn setup_node_rects(commands: &mut Commands) {
             NodeType::Clip(clip) => {
                 commands.spawn_scene(bsn! {
                     @base_node_scene(node_rect)
-                    Children [
+                    #{
                         ZIndex(1)
-                            @number_input_f32(clip.text, Some(clip.clone()),
-                            ExampleAnimationWeights::default().weights[clip.index], NumberInputPrecision(2), 0. ..=1.),
+                        @number_input_f32(clip.text, Some(clip.clone()),
+                            ExampleAnimationWeights::default().weights[clip.index], NumberInputPrecision(2), 0. ..=1.)
+                    }
+                    #{
 
                         // The background node that fills up based on the number input value.
                         WeightBackground
@@ -322,16 +324,14 @@ fn setup_node_rects(commands: &mut Commands) {
                             height: px(node_rect.height),
                             width: px(node_rect.width),
                         }
-                        BackgroundColor({DARK_GREEN.with_alpha(0.5)}),
-                    ]
+                        BackgroundColor({DARK_GREEN.with_alpha(0.5)})
+                    }
                 });
             }
             NodeType::Blend(text) => {
                 commands.spawn_scene(bsn! {
                     @base_node_scene(node_rect)
-                    Children [
-                        @caption(*text)
-                    ]
+                    # @caption(*text)
                 });
             }
         };

--- a/examples/animation/animation_masks.rs
+++ b/examples/animation/animation_masks.rs
@@ -181,9 +181,7 @@ fn setup_ui(mut commands: Commands) {
             left: px(12),
             top: px(12),
         }
-        Children [
-            Text("Click on a button to toggle animations for its associated bones")
-        ]
+        #{ Text("Click on a button to toggle animations for its associated bones") }
     });
 
     // Add the buttons that allow the user to toggle mask groups on and off.
@@ -192,17 +190,15 @@ fn setup_ui(mut commands: Commands) {
         Node {
             align_items: AlignItems::Start,
         }
-        Children [
-            @feathers_option_buttons("Head", &make_animation_controls(MASK_GROUP_HEAD), 2),
-            @label("--"),
-            @feathers_option_buttons("Front Left Leg", &make_animation_controls(MASK_GROUP_LEFT_FRONT_LEG), 2),
-            @feathers_option_buttons("Front Right Leg", &make_animation_controls(MASK_GROUP_RIGHT_FRONT_LEG), 2),
-            @label("--"),
-            @feathers_option_buttons("Hind Left Leg", &make_animation_controls(MASK_GROUP_LEFT_HIND_LEG), 2),
-            @feathers_option_buttons("Hind Right Leg", &make_animation_controls(MASK_GROUP_RIGHT_HIND_LEG), 2),
-            @label("--"),
-            @feathers_option_buttons("Tail", &make_animation_controls(MASK_GROUP_TAIL), 2),
-        ]
+        # @feathers_option_buttons("Head", &make_animation_controls(MASK_GROUP_HEAD), 2)
+        # @label("--")
+        # @feathers_option_buttons("Front Left Leg", &make_animation_controls(MASK_GROUP_LEFT_FRONT_LEG), 2)
+        # @feathers_option_buttons("Front Right Leg", &make_animation_controls(MASK_GROUP_RIGHT_FRONT_LEG), 2)
+        # @label("--")
+        # @feathers_option_buttons("Hind Left Leg", &make_animation_controls(MASK_GROUP_LEFT_HIND_LEG), 2)
+        # @feathers_option_buttons("Hind Right Leg", &make_animation_controls(MASK_GROUP_RIGHT_HIND_LEG), 2)
+        # @label("--")
+        # @feathers_option_buttons("Tail", &make_animation_controls(MASK_GROUP_TAIL), 2)
     });
 }
 

--- a/examples/asset/compressed_image_saver.rs
+++ b/examples/asset/compressed_image_saver.rs
@@ -63,18 +63,18 @@ fn spawn_scene(
     );
 
     commands.spawn_scene_list(bsn_list! [
-        (
+        #{
             Mesh3d(floor_mesh)
             MeshMaterial3d::<StandardMaterial>(asset_value(Color::WHITE))
             Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2))
-        ),
-        (
+        }
+        #{
             Mesh3d(sphere_mesh)
             MeshMaterial3d::<StandardMaterial>(asset_value(sphere_material))
             Transform::from_xyz(0.0, 1.0, 0.0)
             Rotating
-        ),
-        (
+        }
+        #{
             DirectionalLight {
                 illuminance: 7300.0,
                 shadow_maps_enabled: true,
@@ -85,8 +85,8 @@ fn spawn_scene(
                 maximum_distance: 20.0,
                 ..default()
             }.build()
-        ),
-        (
+        }
+        #{
             Camera3d
             Hdr
             Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y)
@@ -95,7 +95,7 @@ fn spawn_scene(
                 specular_map: specular_env_map,
                 intensity: 1200.0,
             }
-        )
+        }
     ]);
 }
 

--- a/examples/gizmos/transform_gizmo.rs
+++ b/examples/gizmos/transform_gizmo.rs
@@ -48,48 +48,40 @@ fn setup(
 ) {
     commands.spawn_scene(bsn! {
         @main_ui_node_scene()
-        Children [
-            (
-                @label("Click an object to select it")
-            ),
-            (
-                @feathers_option_buttons("",
-                &[
-                    (TransformGizmoMode::Translate, "Translate"),
-                    (TransformGizmoMode::Rotate, "Rotate"),
-                    (TransformGizmoMode::Scale, "Scale"),
-                ], 0)
-            ),
-            (
-                @feathers_option_buttons("",
-                &[
-                    (TransformGizmoSpace::World, "World"),
-                    (TransformGizmoSpace::Local, "Local"),
-                ], 0)
-            ),
-            (
-                Node {
-                    align_items: AlignItems::Center,
-                    column_gap: px(4)
+        # @label("Click an object to select it")
+        # @feathers_option_buttons("",
+            &[
+                (TransformGizmoMode::Translate, "Translate"),
+                (TransformGizmoMode::Rotate, "Rotate"),
+                (TransformGizmoMode::Scale, "Scale"),
+            ],
+            0
+        )
+        # @feathers_option_buttons("",
+            &[
+                (TransformGizmoSpace::World, "World"),
+                (TransformGizmoSpace::Local, "Local"),
+            ],
+            0
+        )
+        #{
+            Node {
+                align_items: AlignItems::Center,
+                column_gap: px(4)
+            }
+            ScaleSensitivitySlider
+            # @label("Sensitivity")
+            #{
+                @FeathersSlider{
+                    @max: 2.0,
+                    @min: 0.1,
                 }
-                ScaleSensitivitySlider
-                Children [
-                    (
-                        @label("Sensitivity")
-                    ),
-                    (
-                        @FeathersSlider{
-                            @max: 2.0,
-                            @min: 0.1,
-                        }
-                        SliderValue(1.0)
-                        SliderPrecision(2)
-                        SliderStep(0.1)
-                        on(slider_update)
-                    )
-                ]
-            )
-        ]
+                SliderValue(1.0)
+                SliderPrecision(2)
+                SliderStep(0.1)
+                on(slider_update)
+            }
+        }
     });
 
     // Ground plane (not pickable)

--- a/examples/helpers/checkbox.rs
+++ b/examples/helpers/checkbox.rs
@@ -26,14 +26,14 @@ where
                 align_items: AlignItems::Center,
                 column_gap: px(5),
             }
-            Children [
+            #{
                 @FeathersCheckbox {
                     @caption: bsn! { @caption(option_name) }
                 }
                 Hovered
                 identifier
                 on(checkbox_self_update)
-            ]
+            }
         })
     } else {
         Box::new(bsn! {
@@ -41,13 +41,13 @@ where
                 align_items: AlignItems::Center,
                 column_gap: px(5),
             }
-            Children [
+            #{
                 @FeathersCheckbox {
                     @caption: bsn! { @caption(option_name) }
                 }
                 Hovered
                 on(checkbox_self_update)
-            ]
+            }
         })
     }
 }

--- a/examples/helpers/number_input_f32.rs
+++ b/examples/helpers/number_input_f32.rs
@@ -33,15 +33,14 @@ where
                 align_items: AlignItems::Center,
                 column_gap: px(5),
             }
-            Children [
+            #{
                 Node {
                     align_items: AlignItems::Center,
                     width: px(150),
                 }
-                Children [
-                    @label(name)
-                ],
-
+                # @label(name)
+            }
+            #{
                 identifier
                 @FeathersNumberInput
                 NumberInputValue::F32(value)
@@ -52,7 +51,7 @@ where
                     flex_grow: 1.0,
                     min_width: px(50),
                 }
-            ]
+            }
         })
     } else {
         Box::new(bsn! {
@@ -60,15 +59,14 @@ where
                 align_items: AlignItems::Center,
                 column_gap: px(5),
             }
-            Children [
+            #{
                 Node {
                     align_items: AlignItems::Center,
                     width: px(150),
                 }
-                Children [
-                    @label(name)
-                ],
-
+                # @label(name)
+            }
+            #{
                 @FeathersNumberInput
                 NumberInputValue::F32(value)
                 precision
@@ -78,7 +76,7 @@ where
                     flex_grow: 1.0,
                     min_width: px(50),
                 }
-            ]
+            }
         })
     }
 }

--- a/examples/helpers/number_input_i32.rs
+++ b/examples/helpers/number_input_i32.rs
@@ -33,15 +33,14 @@ where
                 align_items: AlignItems::Center,
                 column_gap: px(5),
             }
-            Children [
+            #{
                 Node {
                     align_items: AlignItems::Center,
                     width: px(150),
                 }
-                Children [
-                    @label(name)
-                ],
-
+                # @label(name)
+            }
+            #{
                 identifier
                 @FeathersNumberInput
                 NumberInputValue::I32(value)
@@ -52,7 +51,7 @@ where
                     flex_grow: 1.0,
                     min_width: px(50),
                 }
-            ]
+            }
         })
     } else {
         Box::new(bsn! {
@@ -60,15 +59,14 @@ where
                 align_items: AlignItems::Center,
                 column_gap: px(5),
             }
-            Children [
+            #{
                 Node {
                     align_items: AlignItems::Center,
                     width: px(150),
                 }
-                Children [
-                    @label(name)
-                ],
-
+                # @label(name)
+            }
+            #{
                 @FeathersNumberInput
                 NumberInputValue::I32(value)
                 precision
@@ -78,7 +76,7 @@ where
                     flex_grow: 1.0,
                     min_width: px(50),
                 }
-            ]
+            }
         })
     }
 }

--- a/examples/helpers/radio.rs
+++ b/examples/helpers/radio.rs
@@ -65,10 +65,8 @@ where
             column_gap: px(5),
         }
         RadioGroup
-        Children [
-            @label(title),
-            {buttons}
-        ]
+        # @label(title)
+        #{{ buttons }}
     }
 }
 

--- a/examples/large_scenes/bevy_city/src/main.rs
+++ b/examples/large_scenes/bevy_city/src/main.rs
@@ -133,7 +133,11 @@ fn main() {
 }
 
 fn scene() -> impl SceneList {
-    bsn_list![@camera(), @sun(), @loading_screen()]
+    bsn_list![
+        # @camera()
+        # @sun()
+        # @loading_screen()
+    ]
 }
 
 fn camera() -> impl Scene {
@@ -171,7 +175,7 @@ fn loading_screen() -> impl Scene {
             height: percent(100),
         }
         BackgroundColor(Color::BLACK)
-        Children [
+        #{
             Node {
                 position_type: PositionType::Absolute,
                 top: percent(50),
@@ -182,23 +186,21 @@ fn loading_screen() -> impl Scene {
                 align_items: AlignItems::FlexStart,
                 overflow: Overflow::scroll_y(),
             }
-            Children [
-                (
-                    LoadingText
-                    Text("Loading...")
-                    TextFont {
-                        font_size: FontSize::Px(24.0),
-                    }
-                ),
-                (
-                    LoadingPaths
-                    Text
-                    TextFont {
-                        font_size: FontSize::Px(14.0),
-                    }
-                ),
-            ]
-        ]
+            #{
+                LoadingText
+                Text("Loading...")
+                TextFont {
+                    font_size: FontSize::Px(24.0),
+                }
+            }
+            #{
+                LoadingPaths
+                Text
+                TextFont {
+                    font_size: FontSize::Px(14.0),
+                }
+            }
+        }
     }
 }
 

--- a/examples/large_scenes/bevy_city/src/settings.rs
+++ b/examples/large_scenes/bevy_city/src/settings.rs
@@ -53,7 +53,7 @@ pub fn settings_ui() -> impl Scene {
         on(|_: On<PointerOut>, mut free_camera_state: Single<&mut FreeCameraState>| {
             free_camera_state.enabled = true;
         })
-        Children [(
+        #{
             Node {
                 display: Display::Flex,
                 flex_direction: FlexDirection::Column,
@@ -61,111 +61,109 @@ pub fn settings_ui() -> impl Scene {
                 justify_content: JustifyContent::Start,
                 row_gap: px(8),
             }
-            Children [
-                Text("Settings"),
-                (
-                    @FeathersCheckbox {
-                        @caption: bsn! { @caption("Simulate Cars") }
-                    }
-                    Checked
-                    on(checkbox_self_update)
-                    on(|change: On<ValueChange<bool>>, mut settings: ResMut<Settings>| {
-                        settings.simulate_cars = change.value;
-                    })
-                ),
-                (
-                    @FeathersCheckbox {
-                        @caption: bsn! { @caption("Shadow maps enabled") }
-                    }
-                    Checked
-                    on(checkbox_self_update)
-                    on(
-                        |change: On<ValueChange<bool>>,
-                         mut settings: ResMut<Settings>,
-                         mut directional_lights: Query<&mut DirectionalLight>| {
-                            settings.shadow_maps_enabled = change.value;
-                            for mut light in &mut directional_lights {
-                                light.shadow_maps_enabled = change.value;
+            #{ Text("Settings") }
+            #{
+                @FeathersCheckbox {
+                    @caption: bsn! { @caption("Simulate Cars") }
+                }
+                Checked
+                on(checkbox_self_update)
+                on(|change: On<ValueChange<bool>>, mut settings: ResMut<Settings>| {
+                    settings.simulate_cars = change.value;
+                })
+            }
+            #{
+                @FeathersCheckbox {
+                    @caption: bsn! { @caption("Shadow maps enabled") }
+                }
+                Checked
+                on(checkbox_self_update)
+                on(
+                    |change: On<ValueChange<bool>>,
+                        mut settings: ResMut<Settings>,
+                        mut directional_lights: Query<&mut DirectionalLight>| {
+                        settings.shadow_maps_enabled = change.value;
+                        for mut light in &mut directional_lights {
+                            light.shadow_maps_enabled = change.value;
 
+                        }
+                    }
+                )
+            }
+            #{
+                @FeathersCheckbox {
+                    @caption: bsn! { @caption("Contact shadows enabled") }
+                }
+                Checked
+                on(checkbox_self_update)
+                on(
+                    |change: On<ValueChange<bool>>,
+                        mut settings: ResMut<Settings>,
+                        mut directional_lights: Query<&mut DirectionalLight>| {
+                        settings.contact_shadows_enabled = change.value;
+                        for mut light in &mut directional_lights {
+                            light.contact_shadows_enabled = change.value;
+
+                        }
+                    }
+                )
+            }
+            #{
+                @FeathersCheckbox {
+                    @caption: bsn! { @caption("Wireframe Enabled") }
+                }
+                on(checkbox_self_update)
+                on(
+                    |change: On<ValueChange<bool>>,
+                        mut settings: ResMut<Settings>,
+                        mut wireframe_config: ResMut<WireframeConfig>| {
+                        settings.wireframe_enabled = change.value;
+                        wireframe_config.global = change.value;
+                    }
+                )
+            }
+            #{
+                @FeathersCheckbox {
+                    @caption: bsn! { @caption("CPU culling") }
+                }
+                Checked
+                on(checkbox_self_update)
+                on(
+                    |change: On<ValueChange<bool>>,
+                        mut settings: ResMut<Settings>,
+                        mut commands: Commands,
+                        meshes: Query<Entity, With<Mesh3d>>| {
+                        settings.cpu_culling = change.value;
+
+                        for entity in meshes.iter() {
+                            if settings.cpu_culling {
+                                commands.entity(entity).remove::<NoCpuCulling>();
+                            } else {
+                                commands.entity(entity).insert(NoCpuCulling);
                             }
                         }
-                    )
-                ),
-                (
-                    @FeathersCheckbox {
-                        @caption: bsn! { @caption("Contact shadows enabled") }
                     }
-                    Checked
-                    on(checkbox_self_update)
-                    on(
-                        |change: On<ValueChange<bool>>,
-                         mut settings: ResMut<Settings>,
-                         mut directional_lights: Query<&mut DirectionalLight>| {
-                            settings.contact_shadows_enabled = change.value;
-                            for mut light in &mut directional_lights {
-                                light.contact_shadows_enabled = change.value;
+                )
+            }
+            #{
+                @FeathersButton {
+                    @caption: bsn! { @caption("Regenerate City") }
+                }
+                on(
+                    |_activate: On<Activate>,
+                        mut commands: Commands,
+                        city_root: Single<Entity, With<CityRoot>>,
+                        assets: Res<CityAssets>| {
+                        commands.entity(*city_root).despawn();
 
-                            }
-                        }
-                    )
-                ),
-                (
-                    @FeathersCheckbox {
-                        @caption: bsn! { @caption("Wireframe Enabled") }
+                        let mut rng = rand::rng();
+                        let seed = rng.random::<u64>();
+                        println!("new seed: {seed}");
+                        let mut stats = CityStats::default();
+                        spawn_city(&mut commands, &assets, seed, 32, 0.1, &mut stats);
                     }
-                    on(checkbox_self_update)
-                    on(
-                        |change: On<ValueChange<bool>>,
-                         mut settings: ResMut<Settings>,
-                         mut wireframe_config: ResMut<WireframeConfig>| {
-                            settings.wireframe_enabled = change.value;
-                            wireframe_config.global = change.value;
-                        }
-                    )
-                ),
-                (
-                    @FeathersCheckbox {
-                        @caption: bsn! { @caption("CPU culling") }
-                    }
-                    Checked
-                    on(checkbox_self_update)
-                    on(
-                        |change: On<ValueChange<bool>>,
-                         mut settings: ResMut<Settings>,
-                         mut commands: Commands,
-                         meshes: Query<Entity, With<Mesh3d>>| {
-                            settings.cpu_culling = change.value;
-
-                            for entity in meshes.iter() {
-                                if settings.cpu_culling {
-                                    commands.entity(entity).remove::<NoCpuCulling>();
-                                } else {
-                                    commands.entity(entity).insert(NoCpuCulling);
-                                }
-                            }
-                        }
-                    )
-                ),
-                (
-                    @FeathersButton {
-                        @caption: bsn! { @caption("Regenerate City") }
-                    }
-                    on(
-                        |_activate: On<Activate>,
-                         mut commands: Commands,
-                         city_root: Single<Entity, With<CityRoot>>,
-                         assets: Res<CityAssets>| {
-                            commands.entity(*city_root).despawn();
-
-                            let mut rng = rand::rng();
-                            let seed = rng.random::<u64>();
-                            println!("new seed: {seed}");
-                            let mut stats = CityStats::default();
-                            spawn_city(&mut commands, &assets, seed, 32, 0.1, &mut stats);
-                        }
-                    )
-                ),
-            ]
-        )]
+                )
+            }
+        }
     }
 }

--- a/examples/remote/app_under_test.rs
+++ b/examples/remote/app_under_test.rs
@@ -84,7 +84,7 @@ fn setup(mut commands: Commands, mut rng: ResMut<SeededRng>) {
             width: percent(100),
             height: percent(100),
         }
-        Children [
+        #{
             @FeathersButton {
                 @caption: bsn! { @caption("Button") }
             }
@@ -97,6 +97,6 @@ fn setup(mut commands: Commands, mut rng: ResMut<SeededRng>) {
             }
             BorderColor::all(Color::WHITE)
             on(on_button_click)
-        ]
+        }
     });
 }

--- a/examples/scene/bsn.rs
+++ b/examples/scene/bsn.rs
@@ -9,7 +9,10 @@ fn main() {
 }
 
 fn scene() -> impl SceneList {
-    bsn_list![Camera2d, @ui()]
+    bsn_list![
+        #{ Camera2d }
+        # @ui()
+    ]
 }
 
 fn ui() -> impl Scene {
@@ -21,17 +24,15 @@ fn ui() -> impl Scene {
             justify_content: JustifyContent::Center,
             column_gap: px(5),
         }
-        Children [
-            (
-                @button("Ok")
-                on(|_event: On<PointerPress>| println!("Ok pressed!"))
-            ),
-            (
-                @button("Cancel")
-                on(|_event: On<PointerPress>| println!("Cancel pressed!"))
-                BackgroundColor(Color::srgb(0.4, 0.15, 0.15))
-            ),
-        ]
+        #{
+            @button("Ok")
+            on(|_event: On<PointerPress>| println!("Ok pressed!"))
+        }
+        #{
+            @button("Cancel")
+            on(|_event: On<PointerPress>| println!("Cancel pressed!"))
+            BackgroundColor(Color::srgb(0.4, 0.15, 0.15))
+        }
     }
 }
 
@@ -48,7 +49,7 @@ fn button(label: &str) -> impl Scene {
         }
         BorderColor::from(Color::BLACK)
         BackgroundColor(Color::srgb(0.15, 0.15, 0.15))
-        Children [(
+        #{
             Text(label)
             TextFont {
                 font: FontSourceTemplate::Handle("fonts/FiraSans-Bold.ttf"),
@@ -56,6 +57,6 @@ fn button(label: &str) -> impl Scene {
             }
             TextColor(Color::srgb(0.9, 0.9, 0.9))
             TextShadow
-        )]
+        }
     }
 }

--- a/examples/state/custom_transitions.rs
+++ b/examples/state/custom_transitions.rs
@@ -226,16 +226,15 @@ fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
             width: percent(100),
             height: percent(100),
         }
-        Children [
+        #{
             Node {
                 position_type: PositionType::Absolute,
                 left: px(10),
                 top: px(10),
             }
-            Children [
-                Text("Move with arrow keys.")
-            ],
-
+            #{ Text("Move with arrow keys.") }
+        }
+        #{
             Node {
                 position_type: PositionType::Absolute,
                 left: px(10),
@@ -245,7 +244,7 @@ fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
                 align_items: AlignItems::Center,
             }
             Button
-            Hovered::default()
+            Hovered
             BackgroundColor(NORMAL_BUTTON)
             on(|event: On<Add<Pressed>>,
                 mut commands: Commands| {
@@ -260,14 +259,14 @@ fn setup_game(mut commands: Commands, asset_server: Res<AssetServer>) {
                         commands.entity(event.entity).insert(BackgroundColor(NORMAL_BUTTON));
                     }
             })
-            Children [
+            #{
                 Text("Restart Game")
                 TextFont {
                         font_size: FontSize::Px(33.0),
                 }
-                TextColor(Color::srgb(0.9, 0.9, 0.9)),
-            ],
-        ]
+                TextColor(Color::srgb(0.9, 0.9, 0.9))
+            }
+        }
     });
     info!("Setup game");
 }

--- a/examples/ui/layout/display_and_visibility.rs
+++ b/examples/ui/layout/display_and_visibility.rs
@@ -203,116 +203,86 @@ fn panels(palette: &[Color; 4]) -> impl Scene {
         Node {
             width: percent(100)
         }
-        Children [
-            #LeftPanel
+        #LeftPanel {
             Node {
                 width: percent(50),
                 height: px(520),
                 justify_content: JustifyContent::Center,
             }
-            Children [
+            #{
                 Node {
                     padding: UiRect::all(px(10)),
                 }
                 BackgroundColor(Color::WHITE)
-                Children [
+                #{
                     Node
                     BackgroundColor(Color::BLACK)
-                    Children [
-                        #LeftGrandParent
+                    #LeftGrandParent {
                         @left_panel_node_base(500, 0)
                         Outline {
                             width: px(4),
                             color: DARK_CYAN,
                             offset: px(10),
                         }
-                        Children [
-                            Node {
-                                width: px(100),
-                                height: px(500),
-                            },
-
-                            #LeftParent
+                        #{ Node { width: px(100), height: px(500) } }
+                        #LeftParent {
                             @left_panel_node_base(400, 1)
-                            Children [
-                                Node {
-                                    width: px(100),
-                                    height: px(400),
-                                },
-
-                                #LeftChild
+                            #{ Node { width: px(100), height: px(400) } }
+                            #LeftChild {
                                 @left_panel_node_base(300, 2)
-                                Children [
-                                    Node {
-                                        width: px(100),
-                                        height: px(300),
-                                    },
-
-                                    #LeftGrandChild
+                                #{ Node { width: px(100), height: px(300) } }
+                                #LeftGrandChild {
                                     Node {
                                         width: px(200),
                                         height: px(200),
 
                                     }
                                     BackgroundColor(palette[3])
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
-            ],
-
-            #RightPanel
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        #RightPanel {
             Node {
                 width: percent(50),
                 justify_content: JustifyContent::Center,
             }
-            Children [
+            #{
                 Node {
                     padding: UiRect::all(px(10)),
                 }
                 BackgroundColor(Color::WHITE)
-                Children [
-                    #RightGrandParent
+                #RightGrandParent {
                     @right_panel_node_base(500, 0)
                     Outline {
                         width: px(4),
                         color: DARK_CYAN,
                         offset: px(10),
                     }
-                    Children [
-                        @feathers_select_display(#LeftGrandParent),
-                        @feathers_select_visibility(#LeftGrandParent),
-
-                        #RightParent
+                    # @feathers_select_display(#LeftGrandParent)
+                    # @feathers_select_visibility(#LeftGrandParent)
+                    #RightParent {
                         @right_panel_node_base(400, 1)
-                        Children [
-                            @feathers_select_display(#LeftParent),
-                            @feathers_select_visibility(#LeftParent),
-
-                            #RightChild
+                        # @feathers_select_display(#LeftParent)
+                        # @feathers_select_visibility(#LeftParent)
+                        #RightChild {
                             @right_panel_node_base(300, 2)
-                            Children [
-                                @feathers_select_display(#LeftChild),
-                                @feathers_select_visibility(#LeftChild),
-
-                                #RightGrandChild
+                            # @feathers_select_display(#LeftChild)
+                            # @feathers_select_visibility(#LeftChild)
+                            #RightGrandChild {
                                 @right_panel_node_base(200, 3)
-                                Children [
-                                    @feathers_select_display(#LeftGrandChild),
-                                    @feathers_select_visibility(#LeftGrandChild),
-
-                                    Node {
-                                        width: px(100),
-                                        height: px(100),
-                                    }
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
-            ],
-        ]
+                                # @feathers_select_display(#LeftGrandChild)
+                                # @feathers_select_visibility(#LeftGrandChild)
+                                #{ Node { width: px(100), height: px(100) } }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -324,8 +294,14 @@ fn feathers_select_display(target: EntityTemplate) -> impl Scene {
         @FeathersSelect {
             @options: {
                 bsn_list! {
-                    @FeathersListRow Selected OptionIndex(0) NodeDisplaySetting::Flex Children[@caption(format!("Display::{:?}", Display::Flex))],
-                    @FeathersListRow OptionIndex(1) NodeDisplaySetting::None Children[@caption(format!("Display::{:?}", Display::None))],
+                    #{
+                        @FeathersListRow Selected OptionIndex(0) NodeDisplaySetting::Flex
+                        # @caption(format!("Display::{:?}", Display::Flex))
+                    }
+                    #{
+                        @FeathersListRow OptionIndex(1) NodeDisplaySetting::None
+                        # @caption(format!("Display::{:?}", Display::None))
+                    }
                 }
             }
         }
@@ -340,9 +316,19 @@ fn feathers_select_visibility(target: EntityTemplate) -> impl Scene {
         @FeathersSelect {
             @options: {
                 bsn_list! {
-                    @FeathersListRow Selected OptionIndex(0) NodeVisibilitySetting::Inherited Children[@caption(format!("Visibility::{:?}", Visibility::Inherited))],
-                    @FeathersListRow OptionIndex(1) NodeVisibilitySetting::Visible Children[@caption(format!("Visibility::{:?}", Visibility::Visible))],
-                    @FeathersListRow OptionIndex(2) NodeVisibilitySetting::Hidden Children[@caption(format!("Visibility::{:?}", Visibility::Hidden))],
+                    #{
+                        @FeathersListRow Selected OptionIndex(0) NodeVisibilitySetting::Inherited
+                        # @caption(format!("Visibility::{:?}", Visibility::Inherited))
+                    }
+                    #{
+                        @FeathersListRow OptionIndex(1) NodeVisibilitySetting::Visible
+                        # @caption(format!("Visibility::{:?}", Visibility::Visible))
+                    }
+                    #{
+
+                        @FeathersListRow OptionIndex(2) NodeVisibilitySetting::Hidden
+                        # @caption(format!("Visibility::{:?}", Visibility::Hidden))
+                    }
                 }
             }
         }

--- a/examples/ui/layout/ghost_nodes.rs
+++ b/examples/ui/layout/ghost_nodes.rs
@@ -27,17 +27,21 @@ fn main() {
 struct Counter(i32);
 
 fn scene() -> impl SceneList {
-    bsn_list![Camera2d, @ghost_root(), @normal_root()]
+    bsn_list![
+        #{ Camera2d }
+        # @ghost_root()
+        # @normal_root()
+    ]
 }
 
 /// Ghost UI root
 fn ghost_root() -> impl Scene {
     bsn! {
         GhostNode
-        Children [(
+        #{
             Node
-            Children [ @label("This text node is rendered under a ghost root") ]
-        )]
+            # @label("This text node is rendered under a ghost root")
+        }
     }
 }
 
@@ -50,20 +54,19 @@ fn normal_root() -> impl Scene {
             align_items: AlignItems::Center,
             justify_content: JustifyContent::Center,
         }
-        Children [(
+        #{
             Node Counter(0)
-            Children [
-                // Ghost children using a separate counter state.
-                // These buttons are being treated as children of the layout parent
-                // in the context of UI, but they share the ghost node's counter.
-                (
-                    GhostNode Counter(0)
-                    Children [ @button(), @button() ]
-                ),
-                // A normal child using the layout parent counter
-                @button(),
-            ]
-        )]
+            // Ghost children using a separate counter state.
+            // These buttons are being treated as children of the layout parent
+            // in the context of UI, but they share the ghost node's counter.
+            #{
+                GhostNode Counter(0)
+                # @button()
+                # @button()
+            }
+            // A normal child using the layout parent counter
+            # @button()
+        }
     }
 }
 
@@ -113,7 +116,7 @@ fn button() -> impl Scene {
         }
         BorderColor::from(Color::BLACK)
         BackgroundColor(Color::srgb(0.15, 0.15, 0.15))
-        Children [ @label("0") ]
+        # @label("0")
     }
 }
 

--- a/examples/ui/layout/size_constraints.rs
+++ b/examples/ui/layout/size_constraints.rs
@@ -55,23 +55,23 @@ fn setup(mut commands: Commands) {
             align_items: AlignItems::Center,
         }
         BackgroundColor(Color::BLACK)
-        Children [
+        #{
             // Centered column that contains all the content of the example.
             Node {
                 flex_direction: FlexDirection::Column,
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
             }
-            Children [
+            #{
                 Text("Size Constraints Example")
                 @font_style_scene()
                 Node {
                     margin: UiRect::bottom(px(25)),
-                },
-
-                @bar_scene(),
-
-                // Controls (radio buttons)
+                }
+            }
+            # @bar_scene()
+            // Controls (radio buttons)
+            #{
                 Node {
                     flex_direction: FlexDirection::Column,
                     align_items: AlignItems::Stretch,
@@ -79,21 +79,19 @@ fn setup(mut commands: Commands) {
                     margin: UiRect::top(px(50)),
                 }
                 BackgroundColor(YELLOW)
-                Children [
-                    {
-                        [
-                            Constraint::MinWidth,
-                            Constraint::FlexBasis,
-                            Constraint::Width,
-                            Constraint::MaxWidth,
-                        ].into_iter().map(|constraint| {
-                            radio_group_scene(constraint)
-                        })
-                        .collect::<Vec<_>>()
-                    }
-                ]
-            ]
-        ]
+                #{{
+                    [
+                        Constraint::MinWidth,
+                        Constraint::FlexBasis,
+                        Constraint::Width,
+                        Constraint::MaxWidth,
+                    ].into_iter().map(|constraint| {
+                        radio_group_scene(constraint)
+                    })
+                    .collect::<Vec<_>>()
+                }}
+            }
+        }
     });
 }
 
@@ -115,7 +113,7 @@ fn bar_scene() -> impl Scene {
             padding: UiRect::all(px(10)),
         }
         BackgroundColor(YELLOW)
-        Children [
+        #{
             Node {
                 align_items: AlignItems::Stretch,
                 width: percent(100),
@@ -123,13 +121,13 @@ fn bar_scene() -> impl Scene {
                 padding: UiRect::all(px(4)),
             }
             BackgroundColor(Color::BLACK)
-            Children [
-                // This bar will grow and shrink as the constraints are tinkered with.
+            // This bar will grow and shrink as the constraints are tinkered with.
+            #{
                 Bar
                 Node
                 BackgroundColor(Color::WHITE)
-            ]
-        ]
+            }
+        }
     }
 }
 
@@ -148,50 +146,50 @@ fn radio_group_scene(constraint: Constraint) -> impl Scene {
             align_items: AlignItems::Stretch,
         }
         BackgroundColor(Color::BLACK)
-        Children [
+        #{
             Node {
                 flex_direction: FlexDirection::Row,
                 justify_content: JustifyContent::End,
                 padding: UiRect::all(px(2)),
             }
-            Children [
-                // Row Label
+            // Row Label
+            #{
                 Node {
                     min_width: px(200),
                     max_width: px(200),
                     justify_content: JustifyContent::Center,
                     align_items: AlignItems::Center,
                 }
-                Children [
+                #{
                     Text(label)
                     @font_style_scene()
-                ],
-
-                // Row Buttons
+                }
+            }
+            // Row Buttons
+            #{
                 Node
                 RadioGroup
-                Children [
-                    Checked
+                #{
                     @radio_button_scene(
                         constraint,
                         RadioButtonValue(auto()),
                         "Auto".to_string(),
                         true,
-                    ),
-
-                    {
-                        [0, 25, 50, 75, 100, 125].into_iter().map(|percent_value| {
-                            radio_button_scene(
-                                constraint,
-                                RadioButtonValue(percent(percent_value)),
-                                format!("{percent_value}%"),
-                                false,
-                            )
-                        }).collect::<Vec<_>>()
-                    },
-                ],
-            ]
-        ]
+                    )
+                    Checked
+                }
+                #{{
+                    [0, 25, 50, 75, 100, 125].into_iter().map(|percent_value| {
+                        radio_button_scene(
+                            constraint,
+                            RadioButtonValue(percent(percent_value)),
+                            format!("{percent_value}%"),
+                            false,
+                        )
+                    }).collect::<Vec<_>>()
+                }}
+            }
+        }
     }
 }
 
@@ -216,27 +214,6 @@ fn radio_button_scene(
         })
         constraint
         action
-        Children [
-            Node {
-                width: px(100),
-                justify_content: JustifyContent::Center,
-            }
-            BackgroundColor({if active {
-                ACTIVE_INNER_COLOR
-            } else {
-                INACTIVE_INNER_COLOR
-            }})
-            Children [
-                Text(label)
-                @font_style_scene()
-                TextColor({if active {
-                    ACTIVE_TEXT_COLOR
-                } else {
-                    UNHOVERED_TEXT_COLOR
-                }})
-                TextLayout::justify(Justify::Center)
-            ]
-        ]
         // Observers for updating text on hover/leave
         on(|event: On<PointerOver>,
             has_checked_query: Query<&Checked>,
@@ -262,6 +239,27 @@ fn radio_button_scene(
                 commands.entity(text_entity).insert(TextColor(UNHOVERED_TEXT_COLOR));
             }
         })
+        #{
+            Node {
+                width: px(100),
+                justify_content: JustifyContent::Center,
+            }
+            BackgroundColor({if active {
+                ACTIVE_INNER_COLOR
+            } else {
+                INACTIVE_INNER_COLOR
+            }})
+            #{
+                Text(label)
+                @font_style_scene()
+                TextColor({if active {
+                    ACTIVE_TEXT_COLOR
+                } else {
+                    UNHOVERED_TEXT_COLOR
+                }})
+                TextLayout::justify(Justify::Center)
+            }
+        }
     }
 }
 

--- a/examples/ui/navigation/directional_navigation.rs
+++ b/examples/ui/navigation/directional_navigation.rs
@@ -127,12 +127,10 @@ fn setup_scattered_ui(mut commands: Commands) {
             width: percent(100),
             height: percent(100),
         }
-        Children [
-            @instructions_scene(),
-            @focus_display_scene(),
-            @key_display_scene(),
-            { buttons_scene() },
-        ]
+        # @instructions_scene()
+        # @focus_display_scene()
+        # @key_display_scene()
+        #{{ buttons_scene() }}
     });
 }
 
@@ -157,7 +155,7 @@ fn instructions_scene() -> impl Scene {
             border_radius: BorderRadius::all(px(8)),
         }
         BackgroundColor(Color::srgba(0.1, 0.1, 0.1, 0.8))
-        Children [
+        #{
             Text(
                 "Directional Navigation Demo\n\n\
                  Use arrow keys or D-pad to navigate.\n\
@@ -165,7 +163,7 @@ fn instructions_scene() -> impl Scene {
                  Buttons are scattered irregularly,\n\
                  but navigation is automatic!",
             )
-        ]
+        }
     }
 }
 
@@ -180,13 +178,13 @@ fn focus_display_scene() -> impl Scene {
             border_radius: BorderRadius::all(px(8)),
         }
         BackgroundColor(Color::srgba(0.1, 0.5, 0.1, 0.8))
-        Children [
+        #{
             FocusDisplay
             Text("Focused: None")
             TextFont {
                 font_size: FontSize::Px(20.0),
             }
-        ]
+        }
     }
 }
 
@@ -201,13 +199,13 @@ fn key_display_scene() -> impl Scene {
             border_radius: BorderRadius::all(px(8)),
         }
         BackgroundColor(Color::srgba(0.5, 0.1, 0.5, 0.8))
-        Children [
+        #{
             KeyDisplay
             Text("Last Key: None")
             TextFont {
                 font_size: FontSize::Px(20.0),
             }
-        ]
+        }
     }
 }
 
@@ -266,12 +264,12 @@ fn buttons_scene() -> impl SceneList {
                 AutoDirectionalNavigation::default()
                 ResetTimer::default()
                 BackgroundColor::from(NORMAL_BUTTON)
-                Children [
+                #{
                     Text(format!("Button {}", i + 1))
                     TextLayout {
                         justify: Justify::Center,
                     }
-                ]
+                }
             })
         })
         .collect::<Vec<_>>()

--- a/examples/ui/navigation/directional_navigation_overrides.rs
+++ b/examples/ui/navigation/directional_navigation_overrides.rs
@@ -177,11 +177,9 @@ fn setup_paged_ui(
             width: percent(100),
             height: percent(100),
         }
-        Children [
-            @instructions_scene(),
-            @focus_display_scene(),
-            @key_display_scene(),
-        ]
+        # @instructions_scene()
+        # @focus_display_scene()
+        # @key_display_scene()
     });
 
     // Setup the pages with buttons and helper text
@@ -212,9 +210,7 @@ fn setup_paged_ui(
                             height: percent(100),
                         }
                         visibility
-                        Children [
-                            { triangle_page_text_entities_scene_list(page_num) }
-                        ]
+                        #{{ triangle_page_text_entities_scene_list(page_num) }}
                     })
                     .id()
             } else {
@@ -225,9 +221,7 @@ fn setup_paged_ui(
                             height: percent(100),
                         }
                         visibility
-                        Children [
-                            { grid_page_text_entities_scene_list(page_num) }
-                        ]
+                        #{{ grid_page_text_entities_scene_list(page_num) }}
                     })
                     .id()
             };
@@ -344,7 +338,7 @@ fn instructions_scene() -> impl Scene {
             border_radius: BorderRadius::all(px(8)),
         }
         BackgroundColor(Color::srgba(0.1, 0.1, 0.1, 0.8))
-        Children [
+        #{
             Text(
                 "Directional Navigation Overrides Demo\n\n\
                 Use arrow keys or D-pad to navigate.\n\
@@ -352,7 +346,7 @@ fn instructions_scene() -> impl Scene {
                 Navigation on each page is a combination of \
                 both automatic and manual navigation.",
             )
-        ]
+        }
     }
 }
 
@@ -368,13 +362,13 @@ fn focus_display_scene() -> impl Scene {
             border_radius: BorderRadius::all(px(8)),
         }
         BackgroundColor(Color::srgba(0.1, 0.5, 0.1, 0.8))
-        Children [
+        #{
             FocusDisplay
             Text("Focused: None")
             TextFont {
                 font_size: FontSize::Px(20.0),
             }
-        ]
+        }
     }
 }
 
@@ -390,13 +384,13 @@ fn key_display_scene() -> impl Scene {
             border_radius: BorderRadius::all(px(8)),
         }
         BackgroundColor(Color::srgba(0.5, 0.1, 0.5, 0.8))
-        Children [
+        #{
             KeyDisplay
             Text("Last Key: None")
             TextFont {
                 font_size: FontSize::Px(20.0)
             }
-        ]
+        }
     }
 }
 
@@ -439,36 +433,38 @@ fn grid_page_text_entities_scene_list(page_num: usize) -> impl SceneList {
     };
     bsn_list! {
         // Text describing current page
-        @helper_text_node_scene(format!("Currently on Page {}", page_num + 1), 650, 10, Justify::Center),
+        # @helper_text_node_scene(format!("Currently on Page {}", page_num + 1), 650, 10, Justify::Center)
 
         // Text describing direction to go to the previous page, placed left of the top-left button.
-        @helper_text_node_scene(format!("Page {} << ", previous_page), 310, 120, Justify::Right),
+        # @helper_text_node_scene(format!("Page {} << ", previous_page), 310, 120, Justify::Right)
 
         // Text describing direction to go to the next page, placed right of the bottom-right button.
-        @helper_text_node_scene(format!(">> Page {}", (page_num + 1) % 3 + 1), 1000, 525, Justify::Left),
+        # @helper_text_node_scene(format!(">> Page {}", (page_num + 1) % 3 + 1), 1000, 525, Justify::Left)
 
         // Texts describing that moving right wraps to the next row.
-        @helper_text_node_scene("> Btn 2-1".into(), 1000, 120, Justify::Left),
-        @helper_text_node_scene("> Btn 3-1".into(), 1000, 255, Justify::Left),
-        @helper_text_node_scene("> Btn 4-1".into(), 1000, 390, Justify::Left),
-        @helper_text_node_scene("Btn 1-3 < ".into(), 310, 255, Justify::Right),
-        @helper_text_node_scene("Btn 2-3 < ".into(), 310, 390, Justify::Right),
-        @helper_text_node_scene("Btn 3-3 < ".into(), 310, 525, Justify::Right),
+        # @helper_text_node_scene("> Btn 2-1".into(), 1000, 120, Justify::Left)
+        # @helper_text_node_scene("> Btn 3-1".into(), 1000, 255, Justify::Left)
+        # @helper_text_node_scene("> Btn 4-1".into(), 1000, 390, Justify::Left)
+        # @helper_text_node_scene("Btn 1-3 < ".into(), 310, 255, Justify::Right)
+        # @helper_text_node_scene("Btn 2-3 < ".into(), 310, 390, Justify::Right)
+        # @helper_text_node_scene("Btn 3-3 < ".into(), 310, 525, Justify::Right)
 
         // Footer Text
-        Node {
-            position_type: PositionType::Absolute,
-            left: px(450),
-            top: px(600),
-            width: px(540),
-            padding: UiRect::all(px(12)),
-        }
-        Children [
-            footer_text
-            TextFont {
-                font_size: FontSize::Px(20.0),
+        #{
+            Node {
+                position_type: PositionType::Absolute,
+                left: px(450),
+                top: px(600),
+                width: px(540),
+                padding: UiRect::all(px(12)),
             }
-        ]
+            #{
+                footer_text
+                TextFont {
+                    font_size: FontSize::Px(20.0),
+                }
+            }
+        }
     }
 }
 
@@ -497,25 +493,25 @@ fn triangle_page_text_entities_scene_list(page_num: usize) -> impl SceneList {
     let previous_page = if page_num == 0 { 3 } else { page_num };
     bsn_list! {
         // Text describing current page
-        @helper_text_node_scene(format!("Currently on Page {}", page_num + 1), 650, 20, Justify::Center),
+        # @helper_text_node_scene(format!("Currently on Page {}", page_num + 1), 650, 20, Justify::Center)
 
         // Text describing direction to go to the previous page, placed left of the top-left button.
-        @helper_text_node_scene(format!("Page {} << ", previous_page), 310, 120, Justify::Right),
+        # @helper_text_node_scene(format!("Page {} << ", previous_page), 310, 120, Justify::Right)
 
         // Direction to navigate from button 3 to button 4, placed below center button
-        @helper_text_node_scene("v\nBtn 4".into(), 575, 325, Justify::Center),
+        # @helper_text_node_scene("v\nBtn 4".into(), 575, 325, Justify::Center)
 
         // Direction to navigate from button 3 to button 4, placed right of center button
-        @helper_text_node_scene("> Btn 4".into(), 735, 255, Justify::Left),
+        # @helper_text_node_scene("> Btn 4".into(), 735, 255, Justify::Left)
 
         // Direction to navigate from button 4 to button 3, placed above bottom right button
-        @helper_text_node_scene("Btn 3\n^".into(), 1050, 300, Justify::Center),
+        # @helper_text_node_scene("Btn 3\n^".into(), 1050, 300, Justify::Center)
 
         // Direction to navigate from button 4 to button 3, placed left of bottom right button
-        @helper_text_node_scene("Btn 3 < ".into(), 910, 390, Justify::Right),
+        # @helper_text_node_scene("Btn 3 < ".into(), 910, 390, Justify::Right)
 
         // Direction to go to the next page, placed bottom of the bottom-right button.
-        @helper_text_node_scene(format!("V\nV\nPage {}", (page_num + 1) % 3 + 1), 1050, 460, Justify::Center),
+        # @helper_text_node_scene(format!("V\nV\nPage {}", (page_num + 1) % 3 + 1), 1050, 460, Justify::Center)
     }
 }
 
@@ -561,15 +557,15 @@ fn auto_nav_button_scene(text: String, left: &f64, top: &f64, page_num: usize) -
         Page(page_num)
         BackgroundColor({NORMAL_BUTTON_COLORS[page_num]})
         // Just add this component for automatic navigation
-        AutoDirectionalNavigation::default()
-        ResetTimer::default()
-        Name::new(text)
-        Children [
+        AutoDirectionalNavigation
+        ResetTimer
+        Name(text)
+        #{
             Text(text_clone)
             TextLayout {
                 justify: Justify::Center,
             }
-        ]
+        }
     }
 }
 
@@ -583,7 +579,7 @@ fn helper_text_node_scene(text: String, left: i32, top: i32, justify: Justify) -
             width: px(140),
             padding: UiRect::all(px(12)),
         }
-        Children [
+        #{
             Text(text)
             TextFont {
                 font_size: FontSize::Px(20.0),
@@ -591,7 +587,7 @@ fn helper_text_node_scene(text: String, left: i32, top: i32, justify: Justify) -
             TextLayout {
                 justify,
             }
-        ]
+        }
     }
 }
 

--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -192,32 +192,31 @@ fn setup(mut commands: Commands, app_settings: Res<AppSettings>) {
 
     commands.spawn_scene_list(bsn_list! {
         // Camera
-        Camera2d
-        BoxShadowSamples({app_settings.samples}),
-
+        #{ Camera2d BoxShadowSamples({app_settings.samples}) }
         // Centered shape with shadow
-        Node {
-            width: percent(100),
-            height: percent(100),
-            align_items: AlignItems::Center,
-            justify_content: JustifyContent::Center,
+        #{
+            Node {
+                width: percent(100),
+                height: percent(100),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+            }
+            BackgroundColor(GRAY)
+            #{
+                node
+                BorderColor::all(WHITE)
+                BackgroundColor(Color::srgb(0.21, 0.21, 0.21))
+                BoxShadow(vec![ShadowStyle {
+                    color: Color::BLACK.with_alpha(0.8),
+                    x_offset: px(app_settings.x_offset),
+                    y_offset: px(app_settings.y_offset),
+                    spread_radius: px(app_settings.spread),
+                    blur_radius: px(app_settings.blur),
+                }])
+                ShadowNode
+            }
         }
-        BackgroundColor(GRAY)
-        Children [
-            node
-            BorderColor::all(WHITE)
-            BackgroundColor(Color::srgb(0.21, 0.21, 0.21))
-            BoxShadow(vec![ShadowStyle {
-                color: Color::BLACK.with_alpha(0.8),
-                x_offset: px(app_settings.x_offset),
-                y_offset: px(app_settings.y_offset),
-                spread_radius: px(app_settings.spread),
-                blur_radius: px(app_settings.blur),
-            }])
-            ShadowNode
-        ],
-
-        @settings_panel_scene(&app_settings),
+        # @settings_panel_scene(&app_settings)
     });
 }
 
@@ -234,63 +233,63 @@ fn settings_panel_scene(app_settings: &AppSettings) -> impl Scene {
         ZIndex(10)
         @pane()
         @main_ui_node_scene()
-        Children [
+        #{
             @pane_body()
-            Children [
-                @feathers_option_buttons(
-                    "Shape",
-                    &SHAPE_OPTIONS,
-                    selected_shape_index,
-                ),
-                @number_input_f32(
-                    AppNumberInputF32::XOffset.label(),
-                    Some(AppNumberInputF32::XOffset),
-                    app_settings.x_offset,
-                    NumberInputPrecision(0),
-                    -200. ..=200.
-                ),
-                @number_input_f32(
-                    AppNumberInputF32::YOffset.label(),
-                    Some(AppNumberInputF32::YOffset),
-                    app_settings.y_offset,
-                    NumberInputPrecision(0),
-                    -200. ..=200.
-                ),
-                @number_input_f32(
-                    AppNumberInputF32::Blur.label(),
-                    Some(AppNumberInputF32::Blur),
-                    app_settings.blur,
-                    NumberInputPrecision(0),
-                    0. ..=100.
-                ),
-                @number_input_f32(
-                    AppNumberInputF32::Spread.label(),
-                    Some(AppNumberInputF32::Spread),
-                    app_settings.spread,
-                    NumberInputPrecision(0),
-                    -200. ..=200.
-                ),
-                @number_input_i32(
-                    AppNumberInputI32::Count.label(),
-                    Some(AppNumberInputI32::Count),
-                    app_settings.count as i32,
-                    NumberInputPrecision(0),
-                    1..=3
-                ),
-                @number_input_i32(
-                    AppNumberInputI32::Samples.label(),
-                    Some(AppNumberInputI32::Samples),
-                    app_settings.samples as i32,
-                    NumberInputPrecision(0),
-                    0..=15
-                ),
-                // Reset button
+            # @feathers_option_buttons(
+                "Shape",
+                &SHAPE_OPTIONS,
+                selected_shape_index,
+            )
+            # @number_input_f32(
+                AppNumberInputF32::XOffset.label(),
+                Some(AppNumberInputF32::XOffset),
+                app_settings.x_offset,
+                NumberInputPrecision(0),
+                -200. ..=200.
+            )
+            # @number_input_f32(
+                AppNumberInputF32::YOffset.label(),
+                Some(AppNumberInputF32::YOffset),
+                app_settings.y_offset,
+                NumberInputPrecision(0),
+                -200. ..=200.
+            )
+            # @number_input_f32(
+                AppNumberInputF32::Blur.label(),
+                Some(AppNumberInputF32::Blur),
+                app_settings.blur,
+                NumberInputPrecision(0),
+                0. ..=100.
+            )
+            # @number_input_f32(
+                AppNumberInputF32::Spread.label(),
+                Some(AppNumberInputF32::Spread),
+                app_settings.spread,
+                NumberInputPrecision(0),
+                -200. ..=200.
+            )
+            # @number_input_i32(
+                AppNumberInputI32::Count.label(),
+                Some(AppNumberInputI32::Count),
+                app_settings.count as i32,
+                NumberInputPrecision(0),
+                1..=3
+            )
+            # @number_input_i32(
+                AppNumberInputI32::Samples.label(),
+                Some(AppNumberInputI32::Samples),
+                app_settings.samples as i32,
+                NumberInputPrecision(0),
+                0..=15
+            )
+            // Reset button
+            #{
                 @FeathersButton {
                     @caption: bsn! { @caption("Reset") }
                 }
                 on(on_activate_reset)
-            ]
-        ]
+            }
+        }
     }
 }
 

--- a/examples/ui/styling/gradients.rs
+++ b/examples/ui/styling/gradients.rs
@@ -224,25 +224,27 @@ fn buttons_scene() -> impl Scene {
             justify_content: JustifyContent::Center,
             column_gap: px(20),
         }
-        Children [
+        #{
             Node {
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
             }
-            Children [
+            #{
                 CurrentColorSpaceLabel
                 template(|ctx| {
                     let current_index = ctx.resource::<AppSettings>().color_space_current_index;
                     Ok(Text(format!("Current Space\n{:?}", COLOR_SPACES[current_index])))
                 })
-            ],
-
+            }
+        }
+        #{
             PreviousButton
-            @button_node_scene("Previous"),
-
+            @button_node_scene("Previous")
+        }
+        #{
             NextButton
-            @button_node_scene("Next"),
-        ]
+            @button_node_scene("Next")
+        }
     }
 }
 
@@ -267,9 +269,7 @@ fn button_node_scene(caption: &'static str) -> impl Scene {
         on(|event: On<PointerOut>, mut border_query: Query<&mut BorderColor, With<Button>>| {
             *border_query.get_mut(event.entity).unwrap() = BorderColor::all(Color::WHITE);
         })
-        Children [
-            Text(caption)
-        ]
+        #{ Text(caption) }
     }
 }
 

--- a/examples/ui/widgets/feathers_counter.rs
+++ b/examples/ui/widgets/feathers_counter.rs
@@ -40,7 +40,10 @@ fn main() {
 }
 
 fn scene() -> impl SceneList {
-    bsn_list![Camera2d, @demo_root()]
+    bsn_list![
+        #{ Camera2d }
+        # @demo_root()
+    ]
 }
 
 fn demo_root() -> impl Scene {
@@ -52,34 +55,33 @@ fn demo_root() -> impl Scene {
             justify_content: JustifyContent::Center,
         }
         ThemeBackgroundColor(tokens::WINDOW_BG)
-        Children[(
+        #{
             Node {
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
             }
-            Children [
-                (
-                    @FeathersButton
-                    on(|_activate: On<Activate>, mut counter: ResMut<Counter>| {
-                        counter.0 -= 1;
-                    })
-                    Children [ @caption("-1") ]
-                ),
-                (
-                    Node {
-                        margin: UiRect::horizontal(px(10.0)),
-                    }
-                    @caption("0") CounterText
-                ),
-                (
-                    @FeathersButton
-                    on(|_activate: On<Activate>, mut counter: ResMut<Counter>| {
-                        counter.0 += 1;
-                    })
-                    Children [ @caption("+1") ]
-                )
-            ]
-        )]
+            #{
+                @FeathersButton
+                on(|_activate: On<Activate>, mut counter: ResMut<Counter>| {
+                    counter.0 -= 1;
+                })
+                # @caption("-1")
+            }
+            #{
+                Node {
+                    margin: UiRect::horizontal(px(10.0)),
+                }
+                @caption("0")
+                CounterText
+            }
+            #{
+                @FeathersButton
+                on(|_activate: On<Activate>, mut counter: ResMut<Counter>| {
+                    counter.0 += 1;
+                })
+                # @caption("+1")
+            }
+        }
     }
 }
 

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -84,7 +84,10 @@ fn main() {
 }
 
 fn scene() -> impl SceneList {
-    bsn_list![Camera2d, @demo_root()]
+    bsn_list![
+        #{ Camera2d }
+        # @demo_root()
+    ]
 }
 
 fn demo_root() -> Box<dyn Scene> {
@@ -100,11 +103,9 @@ fn demo_root() -> Box<dyn Scene> {
         }
         TabGroup
         ThemeBackgroundColor(tokens::WINDOW_BG)
-        Children[
-            @demo_column_1(),
-            @demo_column_2(),
-            @demo_column_3(),
-        ]
+        # @demo_column_1()
+        # @demo_column_2()
+        # @demo_column_3()
     })
 }
 
@@ -162,7 +163,7 @@ impl Months {
 fn demo_column_1() -> impl Scene {
     // Lazily-constructed menu popup
     let popup: Arc<dyn Fn() -> Box<dyn Scene> + Sync + Send> = Arc::new(|| {
-        Box::new(bsn!(
+        Box::new(bsn! {
             @FeathersMenuPopup
             // Override popover placement to right-align the popup
             Popover {
@@ -180,33 +181,31 @@ fn demo_column_1() -> impl Scene {
                 ],
                 window_margin: 10.0,
             }
-            Children [
-                (
-                    @FeathersMenuItem {
-                        @caption: bsn! { @caption("MenuItem 4") }
-                    }
-                    on(|_: On<Activate>| {
-                        info!("Menu item 4 clicked!");
-                    })
-                ),
-                (
-                    @FeathersMenuItem {
-                        @caption: bsn! { @caption("MenuItem 5") }
-                    }
-                    on(|_: On<Activate>| {
-                        info!("Menu item 5 clicked!");
-                    })
-                ),
-                (
-                    @FeathersMenuItem {
-                        @caption: bsn! { @caption("MenuItem 6") }
-                    }
-                    on(|_: On<Activate>| {
-                        info!("Menu item 6 clicked!");
-                    })
-                )
-            ]
-        ))
+            #{
+                @FeathersMenuItem {
+                    @caption: bsn! { @caption("MenuItem 4") }
+                }
+                on(|_: On<Activate>| {
+                    info!("Menu item 4 clicked!");
+                })
+            }
+            #{
+                @FeathersMenuItem {
+                    @caption: bsn! { @caption("MenuItem 5") }
+                }
+                on(|_: On<Activate>| {
+                    info!("Menu item 5 clicked!");
+                })
+            }
+            #{
+                @FeathersMenuItem {
+                    @caption: bsn! { @caption("MenuItem 6") }
+                }
+                on(|_: On<Activate>| {
+                    info!("Menu item 6 clicked!");
+                })
+            }
+        })
     });
 
     bsn! {
@@ -220,572 +219,523 @@ fn demo_column_1() -> impl Scene {
             width: percent(30),
             min_width: px(200),
         }
-        Children [
-            (
-                Node {
-                    display: Display::Flex,
-                    flex_direction: FlexDirection::Row,
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::Start,
-                    column_gap: px(8),
-                }
-                Children [
-                    (
-                        @FeathersButton {
-                            @caption: bsn! { @caption("Normal") }
-                        }
-                        Node {
-                            flex_grow: 1.0,
-                        }
-                        AccessibleLabel("Normal")
-                        on(|_activate: On<Activate>| {
-                            info!("Normal button clicked!");
-                        })
-                        AutoFocus
-                    ),
-                    (
-                        @FeathersButton {
-                            @caption: bsn! { @caption("Disabled") },
-                        }
-                        Node {
-                            flex_grow: 1.0,
-                        }
-                        AccessibleLabel("Disabled")
-                        InteractionDisabled
-                        DemoDisabledButton
-                        on(|_activate: On<Activate>| {
-                            info!("Disabled button clicked!");
-                        })
-                    ),
-                    (
-                        @FeathersButton {
-                            @caption: bsn! { @caption("Primary") },
-                            @variant: ButtonVariant::Primary,
-                        }
-                        AccessibleLabel("Primary")
-                        Node {
-                            flex_grow: 1.0,
-                        }
-                        on(|_activate: On<Activate>| {
-                            info!("Primary button clicked!");
-                        })
-                    ),
-                    (
-                        @FeathersMenu
-                        Children [
-                            (
-                                @FeathersMenuButton {
-                                    @caption: bsn! { @caption("Menu") }
-                                }
-                                AccessibleLabel("Menu Example")
-                                Node {
-                                    flex_grow: 1.0,
-                                }
-                            ),
-                            (
-                                @FeathersMenuPopup
-                                Children [
-                                    (
-                                        @FeathersMenuItem {
-                                            @caption: bsn! { @caption("MenuItem 1") }
-                                        }
-                                        on(|_: On<Activate>| {
-                                            info!("Menu item 1 clicked!");
-                                        })
-                                    ),
-                                    (
-                                        @FeathersMenuItem {
-                                            @caption: bsn! { @caption("MenuItem 2") }
-                                        }
-                                        on(|_: On<Activate>| {
-                                            info!("Menu item 2 clicked!");
-                                        })
-                                    ),
-                                    @FeathersMenuDivider,
-                                    (
-                                        @FeathersMenuItem {
-                                            @caption: bsn! { @caption("MenuItem 3") }
-                                        }
-                                        on(|_: On<Activate>| {
-                                            info!("Menu item 3 clicked!");
-                                        })
-                                    )
-                                ]
-                            )
-                        ]
-                    ),
-                    (
-                        @FeathersLazyMenu { popup }
-                        Children [
-                            (
-                                @FeathersMenuToolButton {
-                                    @caption: bsn! { @caption("\u{0398}") }
-                                }
-                                AccessibleLabel("Menu Example")
-                                Node {
-                                    flex_grow: 1.0,
-                                }
-                            )
-                        ]
-                    )
-                ]
-            ),
-            (
-                @FeathersSelect {
-                    @options: {list_rows_from_strings([
-                        "One",
-                        "Two",
-                        "Three",
-                    ], Some(0))},
+        #{
+            Node {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Start,
+                column_gap: px(8),
+            }
+            #{
+                @FeathersButton {
+                    @caption: bsn! { @caption("Normal") }
                 }
                 Node {
                     flex_grow: 1.0,
                 }
-                on(|change: On<ValueChange<Entity>>, q_options: Query<&OptionIndex>| {
-                    let Ok(option) = q_options.get(change.value) else {
-                        info!("Select changed, not sure");
-                        return;
-                    };
-                    info!("Select changed to index {}", option.0);
+                AccessibleLabel("Normal")
+                on(|_activate: On<Activate>| {
+                    info!("Normal button clicked!");
                 })
-            ),
-            (
-                @FeathersSelect {
-                    @options: {
-                        Box::new(
-                            Months::ALL
-                                .into_iter()
-                                .map(|m| -> Box<dyn SceneList> {
-                                    let label = m.to_str();
-                                    if m == Months::default() {
-                                        bsn! { @FeathersListRow Selected m Children [ @caption(label) ] }.into()
-                                    } else {
-                                        bsn! { @FeathersListRow m Children [ @caption(label) ] }.into()
-                                    }
-                                })
-                                .collect::<Vec<_>>(),
-                        ) as Box<dyn SceneList>
-                    },
-                    @max_visible: 6,
-                }
-                Node {
-                    flex_grow: 1.0,
-                }
-                on(|change: On<ValueChange<Entity>>, q_months: Query<&Months>| {
-                    let Ok(month) = q_months.get(change.value) else {
-                        return;
-                    };
-                    info!("Select changed to {:?}", month);
-                })
-            ),
-            (
-                Node {
-                    display: Display::Flex,
-                    flex_direction: FlexDirection::Row,
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::Start,
-                    column_gap: px(1),
-                }
-                Children [
-                    (
-                        @FeathersButton {
-                            @caption: bsn! { @caption("Left") },
-                            @corners: RoundedCorners::Left,
-                        }
-                        Node {
-                            flex_grow: 1.0,
-                        }
-                        AccessibleLabel("Left")
-                        on(|_activate: On<Activate>| {
-                            info!("Left button clicked!");
-                        })
-                    ),
-                    (
-                        @FeathersButton {
-                            @caption: bsn! { @caption("Center") },
-                            @corners: RoundedCorners::None,
-                        }
-                        Node {
-                            flex_grow: 1.0,
-                        }
-                        AccessibleLabel("Center")
-                        on(|_activate: On<Activate>| {
-                            info!("Center button clicked!");
-                        })
-                    ),
-                    (
-                        @FeathersButton {
-                            @caption: bsn! { @caption("Right") },
-                            @variant: ButtonVariant::Primary,
-                            @corners: RoundedCorners::Right,
-                        }
-                        Node {
-                            flex_grow: 1.0,
-                        }
-                        AccessibleLabel("Right")
-                        on(|_activate: On<Activate>| {
-                            info!("Right button clicked!");
-                        })
-                    ),
-                ]
-            ),
-            (
-                Node {
-                    display: Display::Flex,
-                    flex_direction: FlexDirection::Row,
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::Start,
-                    column_gap: px(8),
-                }
-                Children [
-                    (
-                        @FeathersButton {
-                            @caption: bsn! { @caption("Toggle override") },
-                        }
-                        Node {
-                            flex_grow: 1.0,
-                        }
-                        on(|_activate: On<Activate>, mut ovr: ResMut<OverrideCursor>| {
-                            ovr.0 = if ovr.0.is_some() {
-                                None
-                            } else {
-                                Some(EntityCursor::System(SystemCursorIcon::Wait))
-                            };
-                            info!("Override cursor button clicked!");
-                        })
-                    ),
-                    (
-                        @FeathersButton {
-                            @caption: bsn! { @caption("Quit\u{2026}") },
-                        }
-                        Node {
-                            flex_grow: 1.0,
-                        }
-                        on(spawn_quit_dialog)
-                    ),
-                ]
-            ),
-            (
-                Node {
-                    display: Display::Flex,
-                    flex_direction: FlexDirection::Row,
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::Start,
-                    column_gap: px(8),
-                }
-                Children [
-                    @label("Dialog:"),
-                    (
-                        @FeathersToggleSwitch
-                        DemoDialogToggle
-                        on(toggle_demo_dialog)
-                    ),
-                ]
-            ),
-            (
-                @FeathersCheckbox {
-                    @caption: bsn! { @caption("Checkbox") }
-                }
-                Checked
-                AccessibleLabel("Checkbox Example")
-                on(|change: On<ValueChange<bool>>, query: Query<Entity, With<DemoDisabledButton>>, mut commands: Commands| {
-                    info!("Checkbox clicked!");
-                    let mut button = commands.entity(query.single().unwrap());
-                    if change.value {
-                        button.insert(InteractionDisabled);
-                    } else {
-                        button.remove::<InteractionDisabled>();
-                    }
-                    let mut checkbox = commands.entity(change.source);
-                    if change.value {
-                        checkbox.insert(Checked);
-                    } else {
-                        checkbox.remove::<Checked>();
-                    }
-                })
-            ),
-            (
-                @FeathersCheckbox {
-                    @caption: bsn! { @caption("Fast Click Checkbox") }
-                }
-                ActivateOnPress
-                AccessibleLabel("Fast Click Checkbox Example")
-                on(|change: On<ValueChange<bool>>, mut commands: Commands| {
-                    info!("Checkbox clicked!");
-                    let mut checkbox = commands.entity(change.source);
-                    if change.value {
-                        checkbox.insert(Checked);
-                    } else {
-                        checkbox.remove::<Checked>();
-                    }
-                })
-            ),
-            (
-                @FeathersCheckbox {
+                AutoFocus
+            }
+            #{
+                @FeathersButton {
                     @caption: bsn! { @caption("Disabled") },
                 }
+                Node {
+                    flex_grow: 1.0,
+                }
+                AccessibleLabel("Disabled")
                 InteractionDisabled
-                AccessibleLabel("Disabled Checkbox Example")
-                on(|_change: On<ValueChange<bool>>| {
-                    warn!("Disabled checkbox clicked!");
+                DemoDisabledButton
+                on(|_activate: On<Activate>| {
+                    info!("Disabled button clicked!");
                 })
-            ),
-            (
-                @FeathersCheckbox {
-                    @caption: bsn! { @caption("Checked+Disabled") }
+            }
+            #{
+                @FeathersButton {
+                    @caption: bsn! { @caption("Primary") },
+                    @variant: ButtonVariant::Primary,
                 }
-                InteractionDisabled
-                Checked
-                AccessibleLabel("Disabled and Checked Checkbox Example")
-                on(|_change: On<ValueChange<bool>>| {
-                    warn!("Disabled checkbox clicked!");
-                })
-            ),
-            (
+                AccessibleLabel("Primary")
                 Node {
-                    display: Display::Flex,
-                    flex_direction: FlexDirection::Row,
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::Start,
-                    column_gap: px(8),
+                    flex_grow: 1.0,
                 }
-                Children [
-                    (
-                        Node {
-                            display: Display::Flex,
-                            flex_direction: FlexDirection::Column,
-                            row_gap: px(4),
+                on(|_activate: On<Activate>| {
+                    info!("Primary button clicked!");
+                })
+            }
+            #{
+                @FeathersMenu
+                #{
+                    @FeathersMenuButton {
+                        @caption: bsn! { @caption("Menu") }
+                    }
+                    AccessibleLabel("Menu Example")
+                    Node {
+                        flex_grow: 1.0,
+                    }
+                }
+                #{
+                    @FeathersMenuPopup
+                    #{
+                        @FeathersMenuItem {
+                            @caption: bsn! { @caption("MenuItem 1") }
                         }
-                        RadioGroup
-                        on(radio_self_update)
-                        Children [
-                            (
-                                @FeathersRadio {
-                                    @caption: bsn! { @caption("One") }
-                                }
-                                Checked
-                            ),
-                            @FeathersRadio {
-                                @caption: bsn! { @caption("Two") }
-                            },
-                            (
-                                @FeathersRadio {
-                                    @caption: bsn! { @caption("Fast Click") }
-                                }
-                                ActivateOnPress
-                            ),
-                            (
-                                @FeathersRadio {
-                                    @caption: bsn! { @caption("Disabled") }
-                                }
-                                InteractionDisabled
-                            ),
-                        ]
-                    )
-                ]
-            ),
-            (
-                Node {
-                    display: Display::Flex,
-                    flex_direction: FlexDirection::Row,
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::Start,
-                    column_gap: px(8),
-                }
-                Children [
-                    (@FeathersToggleSwitch on(checkbox_self_update)),
-                    (@FeathersToggleSwitch ActivateOnPress on(checkbox_self_update)),
-                    (@FeathersToggleSwitch InteractionDisabled on(checkbox_self_update)),
-                    (@FeathersToggleSwitch InteractionDisabled Checked on(checkbox_self_update)),
-                    (@FeathersDisclosureToggle on(checkbox_self_update)),
-                ]
-            ),
-            (
-                @FeathersSlider {
-                    @max: 100.0,
-                }
-                SliderValue(20.0)
-                SliderStep(10.)
-                SliderPrecision(2)
-                on(slider_self_update)
-            ),
-            (
-                Node {
-                    display: Display::Flex,
-                    flex_direction: FlexDirection::Row,
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::SpaceBetween,
-                    column_gap: px(4),
-                }
-                Children [
-                    @label("Srgba"),
-                    // Spacer
-                    @flex_spacer(),
-                    // Text input
-                    (
-                        @FeathersTextInputContainer
-                        Node {
-                            flex_grow: 0.
-                            padding: { px(4).left() },
+                        on(|_: On<Activate>| {
+                            info!("Menu item 1 clicked!");
+                        })
+                    }
+                    #{
+                        @FeathersMenuItem {
+                            @caption: bsn! { @caption("MenuItem 2") }
                         }
-                        Children [
-                            (
-                                @FeathersTextInput {
-                                    @visible_width: 10f32,
-                                    @max_characters: 9usize,
+                        on(|_: On<Activate>| {
+                            info!("Menu item 2 clicked!");
+                        })
+                    }
+                    #{ @FeathersMenuDivider }
+                    #{
+                        @FeathersMenuItem {
+                            @caption: bsn! { @caption("MenuItem 3") }
+                        }
+                        on(|_: On<Activate>| {
+                            info!("Menu item 3 clicked!");
+                        })
+                    }
+                }
+            }
+            #{
+                @FeathersLazyMenu { popup }
+                #{
+                    @FeathersMenuToolButton {
+                        @caption: bsn! { @caption("\u{0398}") }
+                    }
+                    AccessibleLabel("Menu Example")
+                    Node {
+                        flex_grow: 1.0,
+                    }
+                }
+            }
+        }
+        #{
+            @FeathersSelect {
+                @options: {list_rows_from_strings([
+                    "One",
+                    "Two",
+                    "Three",
+                ], Some(0))},
+            }
+            Node {
+                flex_grow: 1.0,
+            }
+            on(|change: On<ValueChange<Entity>>, q_options: Query<&OptionIndex>| {
+                let Ok(option) = q_options.get(change.value) else {
+                    info!("Select changed, not sure");
+                    return;
+                };
+                info!("Select changed to index {}", option.0);
+            })
+        }
+        #{
+            @FeathersSelect {
+                @options: {
+                    Box::new(
+                        Months::ALL
+                            .into_iter()
+                            .map(|m| -> Box<dyn SceneList> {
+                                let label = m.to_str();
+                                if m == Months::default() {
+                                    bsn! { @FeathersListRow Selected m #{ @caption(label) } }.into()
+                                } else {
+                                    bsn! { @FeathersListRow m #{ @caption(label)} }.into()
                                 }
-                                InheritableFont {
-                                    font: fonts::MONO
-                                }
-                                HexColorInput
-                                on(handle_hex_color_change)
-                            )
-                        ]
-                    )
-                    (@FeathersColorSwatch {
-                        @opaque_color_percentage: 30.0,
-                    } SwatchType::Rgb),
-                ]
-            ),
-            (
-                @FeathersColorPlane::RedBlue
-                on(|change: On<ValueChange<Vec2>>, mut color: ResMut<DemoWidgetStates>| {
-                    color.rgb_color.red = change.value.x;
-                    color.rgb_color.blue = change.value.y;
-                })
-            ),
-            (
-                @FeathersColorSlider {
-                    @value: 0.5,
-                    @channel: ColorChannel::Red
+                            })
+                            .collect::<Vec<_>>(),
+                    ) as Box<dyn SceneList>
+                },
+                @max_visible: 6,
+            }
+            Node {
+                flex_grow: 1.0,
+            }
+            on(|change: On<ValueChange<Entity>>, q_months: Query<&Months>| {
+                let Ok(month) = q_months.get(change.value) else {
+                    return;
+                };
+                info!("Select changed to {:?}", month);
+            })
+        }
+        #{
+            Node {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Start,
+                column_gap: px(1),
+            }
+            #{
+                @FeathersButton {
+                    @caption: bsn! { @caption("Left") },
+                    @corners: RoundedCorners::Left,
                 }
-                AccessibleLabel("Red Channel")
-                on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
-                    color.rgb_color.red = change.value;
-                })
-            ),
-            (
-                @FeathersColorSlider {
-                    @value: 0.5,
-                    @channel: ColorChannel::Green
+                Node {
+                    flex_grow: 1.0,
                 }
-                AccessibleLabel("Green Channel")
-                on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
-                    color.rgb_color.green = change.value;
+                AccessibleLabel("Left")
+                on(|_activate: On<Activate>| {
+                    info!("Left button clicked!");
                 })
-            ),
-            (
-                @FeathersColorSlider {
-                    @value: 0.5,
-                    @channel: ColorChannel::Blue
+            }
+            #{
+                @FeathersButton {
+                    @caption: bsn! { @caption("Center") },
+                    @corners: RoundedCorners::None,
                 }
-                AccessibleLabel("Blue Channel")
-                on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
-                    color.rgb_color.blue = change.value;
-                })
-            ),
-            (
-                @FeathersColorSlider {
-                    @value: 0.5,
-                    @channel: ColorChannel::Alpha
+                Node {
+                    flex_grow: 1.0,
                 }
-                AccessibleLabel("Alpha Channel")
-                on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
-                    color.rgb_color.alpha = change.value;
+                AccessibleLabel("Center")
+                on(|_activate: On<Activate>| {
+                    info!("Center button clicked!");
                 })
-            ),
-            (
+            }
+            #{
+                @FeathersButton {
+                    @caption: bsn! { @caption("Right") },
+                    @variant: ButtonVariant::Primary,
+                    @corners: RoundedCorners::Right,
+                }
+                Node {
+                    flex_grow: 1.0,
+                }
+                AccessibleLabel("Right")
+                on(|_activate: On<Activate>| {
+                    info!("Right button clicked!");
+                })
+            }
+        }
+        #{
+            Node {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Start,
+                column_gap: px(8),
+            }
+            #{
+                @FeathersButton {
+                    @caption: bsn! { @caption("Toggle override") },
+                }
+                Node {
+                    flex_grow: 1.0,
+                }
+                on(|_activate: On<Activate>, mut ovr: ResMut<OverrideCursor>| {
+                    ovr.0 = if ovr.0.is_some() {
+                        None
+                    } else {
+                        Some(EntityCursor::System(SystemCursorIcon::Wait))
+                    };
+                    info!("Override cursor button clicked!");
+                })
+            }
+            #{
+                @FeathersButton {
+                    @caption: bsn! { @caption("Quit\u{2026}") },
+                }
+                Node {
+                    flex_grow: 1.0,
+                }
+                on(spawn_quit_dialog)
+            }
+        }
+        #{
+            Node {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Start,
+                column_gap: px(8),
+            }
+            # @label("Dialog:")
+            #{
+                @FeathersToggleSwitch
+                DemoDialogToggle
+                on(toggle_demo_dialog)
+            }
+        }
+        #{
+            @FeathersCheckbox {
+                @caption: bsn! { @caption("Checkbox") }
+            }
+            Checked
+            AccessibleLabel("Checkbox Example")
+            on(|change: On<ValueChange<bool>>, query: Query<Entity, With<DemoDisabledButton>>, mut commands: Commands| {
+                info!("Checkbox clicked!");
+                let mut button = commands.entity(query.single().unwrap());
+                if change.value {
+                    button.insert(InteractionDisabled);
+                } else {
+                    button.remove::<InteractionDisabled>();
+                }
+                let mut checkbox = commands.entity(change.source);
+                if change.value {
+                    checkbox.insert(Checked);
+                } else {
+                    checkbox.remove::<Checked>();
+                }
+            })
+        }
+        #{
+            @FeathersCheckbox {
+                @caption: bsn! { @caption("Fast Click Checkbox") }
+            }
+            ActivateOnPress
+            AccessibleLabel("Fast Click Checkbox Example")
+            on(|change: On<ValueChange<bool>>, mut commands: Commands| {
+                info!("Checkbox clicked!");
+                let mut checkbox = commands.entity(change.source);
+                if change.value {
+                    checkbox.insert(Checked);
+                } else {
+                    checkbox.remove::<Checked>();
+                }
+            })
+        }
+        #{
+            @FeathersCheckbox {
+                @caption: bsn! { @caption("Disabled") },
+            }
+            InteractionDisabled
+            AccessibleLabel("Disabled Checkbox Example")
+            on(|_change: On<ValueChange<bool>>| {
+                warn!("Disabled checkbox clicked!");
+            })
+        }
+        #{
+            @FeathersCheckbox {
+                @caption: bsn! { @caption("Checked+Disabled") }
+            }
+            InteractionDisabled
+            Checked
+            AccessibleLabel("Disabled and Checked Checkbox Example")
+            on(|_change: On<ValueChange<bool>>| {
+                warn!("Disabled checkbox clicked!");
+            })
+        }
+        #{
+            Node {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Start,
+                column_gap: px(8),
+            }
+            #{
                 Node {
                     display: Display::Flex,
-                    align_items: AlignItems::Center,
-                    flex_direction: FlexDirection::Row,
-                    justify_content: JustifyContent::SpaceBetween,
+                    flex_direction: FlexDirection::Column,
+                    row_gap: px(4),
                 }
-                Children [
-                    @label("Hsl"),
-                    (@FeathersColorSwatch SwatchType::Hsl)
-                ]
-            ),
-            (
-                @FeathersColorSlider {
-                    @value: 0.5,
-                    @channel: ColorChannel::HslHue
-                }
-                AccessibleLabel("Hue Channel")
-                on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
-                    color.hsl_color.hue = change.value;
-                })
-            ),
-            (
-                @FeathersColorSlider {
-                    @value: 0.5,
-                    @channel: ColorChannel::HslSaturation
-                }
-                AccessibleLabel("Saturation Channel")
-                on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
-                    color.hsl_color.saturation = change.value;
-                })
-            ),
-            (
-                @FeathersColorSlider {
-                    @value: 0.5,
-                    @channel: ColorChannel::HslLightness
-                }
-                AccessibleLabel("Lightness Channel")
-                on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
-                    color.hsl_color.lightness = change.value;
-                })
-            ),
-            (
+                RadioGroup
+                on(radio_self_update)
+                #{ @FeathersRadio { @caption: bsn! { @caption("One") } } Checked }
+                #{ @FeathersRadio { @caption: bsn! { @caption("Two") } } }
+                #{ @FeathersRadio { @caption: bsn! { @caption("Fast Click") } } ActivateOnPress }
+                #{ @FeathersRadio { @caption: bsn! { @caption("Disabled") } } InteractionDisabled }
+            }
+        }
+        #{
+            Node {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Start,
+                column_gap: px(8),
+            }
+            #{ @FeathersToggleSwitch on(checkbox_self_update) }
+            #{ @FeathersToggleSwitch ActivateOnPress on(checkbox_self_update) }
+            #{ @FeathersToggleSwitch InteractionDisabled on(checkbox_self_update) }
+            #{ @FeathersToggleSwitch InteractionDisabled Checked on(checkbox_self_update) }
+            #{ @FeathersDisclosureToggle on(checkbox_self_update) }
+        }
+        #{
+            @FeathersSlider {
+                @max: 100.0,
+            }
+            SliderValue(20.0)
+            SliderStep(10.)
+            SliderPrecision(2)
+            on(slider_self_update)
+        }
+        #{
+            Node {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::SpaceBetween,
+                column_gap: px(4),
+            }
+            # @label("Srgba")
+            // Spacer
+            # @flex_spacer()
+            // Text input
+            #{
+                @FeathersTextInputContainer
                 Node {
-                    display: Display::Flex,
-                    align_items: AlignItems::Center,
-                    flex_direction: FlexDirection::Row,
-                    justify_content: JustifyContent::SpaceBetween,
+                    flex_grow: 0.
+                    padding: { px(4).left() },
                 }
-                Children [
-                    @label("Okhsl"),
-                    (@FeathersColorSwatch SwatchType::Okhsl)
-                ]
-            ),
-            (
-                @FeathersColorPlane::OkhslHueLightness
-                on(|change: On<ValueChange<Vec2>>, mut color: ResMut<DemoWidgetStates>| {
-                    color.okhsl_color.hue = change.value.x * 360.0;
-                    color.okhsl_color.lightness = change.value.y;
-                })
-            ),
-            (
-                @FeathersColorSlider {
-                    @value: 0.5,
-                    @channel: ColorChannel::OkhslHue
+                #{
+                    @FeathersTextInput {
+                        @visible_width: 10f32,
+                        @max_characters: 9usize,
+                    }
+                    InheritableFont {
+                        font: fonts::MONO
+                    }
+                    HexColorInput
+                    on(handle_hex_color_change)
                 }
-                AccessibleLabel("Okhsl Hue Channel")
-                on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
-                    color.okhsl_color.hue = change.value;
-                })
-            ),
-            (
-                @FeathersColorSlider {
-                    @value: 0.5,
-                    @channel: ColorChannel::OkhslSaturation
-                }
-                AccessibleLabel("Okhsl Saturation Channel")
-                on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
-                    color.okhsl_color.saturation = change.value;
-                })
-            ),
-            (
-                @FeathersColorSlider {
-                    @value: 0.5,
-                    @channel: ColorChannel::OkhslLightness
-                }
-                AccessibleLabel("Okhsl Lightness Channel")
-                on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
-                    color.okhsl_color.lightness = change.value;
-                })
-            )
-        ]
+            }
+            #{ @FeathersColorSwatch { @opaque_color_percentage: 30.0 } SwatchType::Rgb }
+        }
+        #{
+            @FeathersColorPlane::RedBlue
+            on(|change: On<ValueChange<Vec2>>, mut color: ResMut<DemoWidgetStates>| {
+                color.rgb_color.red = change.value.x;
+                color.rgb_color.blue = change.value.y;
+            })
+        }
+        #{
+            @FeathersColorSlider {
+                @value: 0.5,
+                @channel: ColorChannel::Red
+            }
+            AccessibleLabel("Red Channel")
+            on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
+                color.rgb_color.red = change.value;
+            })
+        }
+        #{
+            @FeathersColorSlider {
+                @value: 0.5,
+                @channel: ColorChannel::Green
+            }
+            AccessibleLabel("Green Channel")
+            on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
+                color.rgb_color.green = change.value;
+            })
+        }
+        #{
+            @FeathersColorSlider {
+                @value: 0.5,
+                @channel: ColorChannel::Blue
+            }
+            AccessibleLabel("Blue Channel")
+            on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
+                color.rgb_color.blue = change.value;
+            })
+        }
+        #{
+            @FeathersColorSlider {
+                @value: 0.5,
+                @channel: ColorChannel::Alpha
+            }
+            AccessibleLabel("Alpha Channel")
+            on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
+                color.rgb_color.alpha = change.value;
+            })
+        }
+        #{
+            Node {
+                display: Display::Flex,
+                align_items: AlignItems::Center,
+                flex_direction: FlexDirection::Row,
+                justify_content: JustifyContent::SpaceBetween,
+            }
+            # @label("Hsl")
+            #{ @FeathersColorSwatch SwatchType::Hsl }
+        }
+        #{
+            @FeathersColorSlider {
+                @value: 0.5,
+                @channel: ColorChannel::HslHue
+            }
+            AccessibleLabel("Hue Channel")
+            on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
+                color.hsl_color.hue = change.value;
+            })
+        }
+        #{
+            @FeathersColorSlider {
+                @value: 0.5,
+                @channel: ColorChannel::HslSaturation
+            }
+            AccessibleLabel("Saturation Channel")
+            on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
+                color.hsl_color.saturation = change.value;
+            })
+        }
+        #{
+            @FeathersColorSlider {
+                @value: 0.5,
+                @channel: ColorChannel::HslLightness
+            }
+            AccessibleLabel("Lightness Channel")
+            on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
+                color.hsl_color.lightness = change.value;
+            })
+        }
+        #{
+            Node {
+                display: Display::Flex,
+                align_items: AlignItems::Center,
+                flex_direction: FlexDirection::Row,
+                justify_content: JustifyContent::SpaceBetween,
+            }
+            # @label("Okhsl")
+            #{ @FeathersColorSwatch SwatchType::Okhsl }
+        }
+        #{
+            @FeathersColorPlane::OkhslHueLightness
+            on(|change: On<ValueChange<Vec2>>, mut color: ResMut<DemoWidgetStates>| {
+                color.okhsl_color.hue = change.value.x * 360.0;
+                color.okhsl_color.lightness = change.value.y;
+            })
+        }
+        #{
+            @FeathersColorSlider {
+                @value: 0.5,
+                @channel: ColorChannel::OkhslHue
+            }
+            AccessibleLabel("Okhsl Hue Channel")
+            on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
+                color.okhsl_color.hue = change.value;
+            })
+        }
+        #{
+            @FeathersColorSlider {
+                @value: 0.5,
+                @channel: ColorChannel::OkhslSaturation
+            }
+            AccessibleLabel("Okhsl Saturation Channel")
+            on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
+                color.okhsl_color.saturation = change.value;
+            })
+        }
+        #{
+            @FeathersColorSlider {
+                @value: 0.5,
+                @channel: ColorChannel::OkhslLightness
+            }
+            AccessibleLabel("Okhsl Lightness Channel")
+            on(|change: On<ValueChange<f32>>, mut color: ResMut<DemoWidgetStates>| {
+                color.okhsl_color.lightness = change.value;
+            })
+        }
     }
 }
 
@@ -801,232 +751,238 @@ fn demo_column_2() -> impl Scene {
             width: percent(30),
             min_width: px(200),
         }
-        Children [
-            (
-                @pane() Children [
-                    @pane_header() Children [
-                        @FeathersToolButton {
-                            @variant: ButtonVariant::Primary,
-                            @caption: bsn! { @caption("\u{0398}") }
-                        },
-                        @pane_header_divider(),
-                        @FeathersToolButton {
-                            @variant: ButtonVariant::Plain,
-                            @caption: bsn! { @caption("\u{00BC}") }
-                        },
-                        @FeathersToolButton {
-                            @variant: ButtonVariant::Plain,
-                            @caption: bsn! { @caption("\u{00BD}") }
-                        },
-                        @FeathersToolButton {
-                            @variant: ButtonVariant::Plain,
-                            @caption: bsn! { @caption("\u{00BE}") }
-                        },
-                        @pane_header_divider(),
-                        @FeathersToolButton {
-                            @variant: ButtonVariant::Plain,
-                            @caption: bsn! { @icon(icons::CHEVRON_DOWN) }
-                        },
-                        @flex_spacer(),
-                        @FeathersToolButton {
-                            @variant: ButtonVariant::Plain,
-                            @caption: bsn! { @icon(icons::X) }
-                        },
-                    ],
-                    (
-                        @pane_body() Children [
-                            @label_dim("A standard editor pane"),
-                            @subpane() Children [
-                                @subpane_header() Children [
-                                    @caption("Left"),
-                                    @caption("Center"),
-                                    @caption("Right")
-                                ],
-                                @subpane_body() Children [
-                                    @label_dim("A standard sub-pane"),
-                                    @group()
-                                    Children [
-                                        @group_header() Children [
-                                            @caption("Group"),
-                                        ],
-                                        @group_body()
-                                        Children [
-                                            @label("A standard group"),
-                                            @label_small("Scalar property"),
-                                            (
-                                                @FeathersNumberInput
-                                                DemoScalarField
-                                                NumberInputPrecision(2)
-                                                HardLimit::f32(0.0..=100.0)
-                                                Node {
-                                                    flex_grow: 1.0,
-                                                    max_width: px(100),
-                                                }
-                                                on(|value_change: On<ValueChange<f32>>, mut states: ResMut<DemoWidgetStates>| {
-                                                    states.scalar_prop = value_change.value;
-                                                })
-                                            ),
-                                            @label_small("Scalar property (copy)"),
-                                            (
-                                                @FeathersNumberInput
-                                                DemoScalarField
-                                                NumberInputPrecision(4)
-                                                Node {
-                                                    flex_grow: 1.0,
-                                                    max_width: px(100),
-                                                }
-                                                on(|value_change: On<ValueChange<f32>>, mut states: ResMut<DemoWidgetStates>| {
-                                                    states.scalar_prop = value_change.value;
-                                                })
-                                            ),
-                                            @label_small("Vec3 property"),
-                                            Node {
-                                                display: Display::Flex,
-                                                flex_direction: FlexDirection::Row,
-                                                column_gap: px(6),
-                                                align_items: AlignItems::Center,
-                                                justify_content: JustifyContent::SpaceBetween,
-                                            }
-                                            Children [
-                                                (
-                                                    @FeathersNumberInput {
-                                                        @sigil_color: tokens::TEXT_INPUT_X_AXIS,
-                                                        @label_text: "X",
-                                                    }
-                                                    NumberInputPrecision(2)
-                                                    DemoVec3Field::X
-                                                    Node {
-                                                        flex_grow: 1.0,
-                                                    }
-                                                    BorderColor::all(palette::X_AXIS)
-                                                    on(|value_change: On<ValueChange<f32>>, mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec3_prop.x = value_change.value;
-                                                    })
-                                                ),
-                                                (
-                                                    @FeathersNumberInput {
-                                                        @sigil_color: tokens::TEXT_INPUT_Y_AXIS,
-                                                        @label_text: "Y",
-                                                    }
-                                                    NumberInputPrecision(2)
-                                                    DemoVec3Field::Y
-                                                    Node {
-                                                        flex_grow: 1.0,
-                                                    }
-                                                    on(|value_change: On<ValueChange<f32>>, mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec3_prop.y = value_change.value;
-                                                    })
-                                                ),
-                                                (
-                                                    @FeathersNumberInput {
-                                                        @sigil_color: tokens::TEXT_INPUT_Z_AXIS,
-                                                        @label_text: "Z",
-                                                    }
-                                                    NumberInputPrecision(2)
-                                                    DemoVec3Field::Z
-                                                    Node {
-                                                        flex_grow: 1.0,
-                                                    }
-                                                    on(|value_change: On<ValueChange<f32>>, mut states: ResMut<DemoWidgetStates>| {
-                                                        states.vec3_prop.z = value_change.value;
-                                                    })
-                                                ),
-                                            ],
-                                            @label_small("Color property"),
-                                            Node {
-                                                display: Display::Flex,
-                                                flex_direction: FlexDirection::Row,
-                                                column_gap: px(6),
-                                                align_items: AlignItems::Center,
-                                                justify_content: JustifyContent::SpaceBetween,
-                                            }
-                                            Children [
-                                                (
-                                                    @FeathersNumberInput {
-                                                        @sigil_color: tokens::TEXT_INPUT_X_AXIS,
-                                                        @label_text: "R",
-                                                    }
-                                                    InteractionDisabled
-                                                    NumberInputPrecision(2)
-                                                    HardLimit(NumberInputRange::F32(0.0..=1.0))
-                                                    Node {
-                                                        flex_grow: 1.0,
-                                                    }
-                                                    BorderColor::all(palette::X_AXIS)
-                                                ),
-                                                (
-                                                    @FeathersNumberInput {
-                                                        @sigil_color: tokens::TEXT_INPUT_Y_AXIS,
-                                                        @label_text: "G",
-                                                    }
-                                                    InteractionDisabled
-                                                    NumberInputPrecision(2)
-                                                    HardLimit(NumberInputRange::F32(0.0..=1.0))
-                                                    Node {
-                                                        flex_grow: 1.0,
-                                                    }
-                                                ),
-                                                (
-                                                    @FeathersNumberInput {
-                                                        @sigil_color: tokens::TEXT_INPUT_Z_AXIS,
-                                                        @label_text: "B",
-                                                    }
-                                                    InteractionDisabled
-                                                    NumberInputPrecision(2)
-                                                    HardLimit(NumberInputRange::F32(0.0..=1.0))
-                                                    Node {
-                                                        flex_grow: 1.0,
-                                                    }
-                                                ),
-                                                (
-                                                    @FeathersNumberInput {
-                                                        @sigil_color: tokens::TEXT_INPUT_W_AXIS,
-                                                        @label_text: "A",
-                                                    }
-                                                    InteractionDisabled
-                                                    NumberInputPrecision(2)
-                                                    HardLimit(NumberInputRange::F32(0.0..=1.0))
-                                                    Node {
-                                                        flex_grow: 1.0,
-                                                    }
-                                                ),
-                                            ],
-                                        ],
-                                    ]
-                                ],
-                            ]
-                        ]
-                    ),
-                ]
-            ),
-            @subpane() Children [
-                @subpane_header() Children [
-                    @caption("List"),
-                ],
-                @subpane_body() Children [
+        #{
+            @pane()
+            #{
+                @pane_header()
+                # @FeathersToolButton {
+                    @variant: ButtonVariant::Primary,
+                    @caption: bsn! { @caption("\u{0398}") }
+                }
+                # @pane_header_divider()
+                # @FeathersToolButton {
+                    @variant: ButtonVariant::Plain,
+                    @caption: bsn! { @caption("\u{00BC}") }
+                }
+                # @FeathersToolButton {
+                    @variant: ButtonVariant::Plain,
+                    @caption: bsn! { @caption("\u{00BD}") }
+                }
+                # @FeathersToolButton {
+                    @variant: ButtonVariant::Plain,
+                    @caption: bsn! { @caption("\u{00BE}") }
+                }
+                # @pane_header_divider()
+                # @FeathersToolButton {
+                    @variant: ButtonVariant::Plain,
+                    @caption: bsn! { @icon(icons::CHEVRON_DOWN) }
+                }
+                # @flex_spacer()
+                # @FeathersToolButton {
+                    @variant: ButtonVariant::Plain,
+                    @caption: bsn! { @icon(icons::X) }
+                }
+            }
+            #{
+                @pane_body()
+                # @label_dim("A standard editor pane")
+                #{
+                    @subpane()
+                    #{
+                        @subpane_header()
+                        # @caption("Left")
+                        # @caption("Center")
+                        # @caption("Right")
+                    }
+                    #{
+                        @subpane_body()
+                        # @label_dim("A standard sub-pane")
+                        #{
+                            @group()
+                            #{
+                                @group_header()
+                                # @caption("Group")
+                            }
+                            #{
+                                @group_body()
+                                # @label("A standard group")
+                                # @label_small("Scalar property")
+                                #{
+                                    @FeathersNumberInput
+                                    DemoScalarField
+                                    NumberInputPrecision(2)
+                                    HardLimit::f32(0.0..=100.0)
+                                    Node {
+                                        flex_grow: 1.0,
+                                        max_width: px(100),
+                                    }
+                                    on(|value_change: On<ValueChange<f32>>, mut states: ResMut<DemoWidgetStates>| {
+                                        states.scalar_prop = value_change.value;
+                                    })
+                                }
+                                # @label_small("Scalar property (copy)")
+                                #{
+                                    @FeathersNumberInput
+                                    DemoScalarField
+                                    NumberInputPrecision(4)
+                                    Node {
+                                        flex_grow: 1.0,
+                                        max_width: px(100),
+                                    }
+                                    on(|value_change: On<ValueChange<f32>>, mut states: ResMut<DemoWidgetStates>| {
+                                        states.scalar_prop = value_change.value;
+                                    })
+                                }
+                                # @label_small("Vec3 property")
+                                #{
+                                    Node {
+                                        display: Display::Flex,
+                                        flex_direction: FlexDirection::Row,
+                                        column_gap: px(6),
+                                        align_items: AlignItems::Center,
+                                        justify_content: JustifyContent::SpaceBetween,
+                                    }
+                                    #{
+                                        @FeathersNumberInput {
+                                            @sigil_color: tokens::TEXT_INPUT_X_AXIS,
+                                            @label_text: "X",
+                                        }
+                                        NumberInputPrecision(2)
+                                        DemoVec3Field::X
+                                        Node {
+                                            flex_grow: 1.0,
+                                        }
+                                        BorderColor::all(palette::X_AXIS)
+                                        on(|value_change: On<ValueChange<f32>>, mut states: ResMut<DemoWidgetStates>| {
+                                            states.vec3_prop.x = value_change.value;
+                                        })
+                                    }
+                                    #{
+                                        @FeathersNumberInput {
+                                            @sigil_color: tokens::TEXT_INPUT_Y_AXIS,
+                                            @label_text: "Y",
+                                        }
+                                        NumberInputPrecision(2)
+                                        DemoVec3Field::Y
+                                        Node {
+                                            flex_grow: 1.0,
+                                        }
+                                        on(|value_change: On<ValueChange<f32>>, mut states: ResMut<DemoWidgetStates>| {
+                                            states.vec3_prop.y = value_change.value;
+                                        })
+                                    }
+                                    #{
+                                        @FeathersNumberInput {
+                                            @sigil_color: tokens::TEXT_INPUT_Z_AXIS,
+                                            @label_text: "Z",
+                                        }
+                                        NumberInputPrecision(2)
+                                        DemoVec3Field::Z
+                                        Node {
+                                            flex_grow: 1.0,
+                                        }
+                                        on(|value_change: On<ValueChange<f32>>, mut states: ResMut<DemoWidgetStates>| {
+                                            states.vec3_prop.z = value_change.value;
+                                        })
+                                    }
+                                }
+                                # @label_small("Color property")
+                                #{
+                                    Node {
+                                        display: Display::Flex,
+                                        flex_direction: FlexDirection::Row,
+                                        column_gap: px(6),
+                                        align_items: AlignItems::Center,
+                                        justify_content: JustifyContent::SpaceBetween,
+                                    }
+                                    #{
+                                        @FeathersNumberInput {
+                                            @sigil_color: tokens::TEXT_INPUT_X_AXIS,
+                                            @label_text: "R",
+                                        }
+                                        InteractionDisabled
+                                        NumberInputPrecision(2)
+                                        HardLimit(NumberInputRange::F32(0.0..=1.0))
+                                        Node {
+                                            flex_grow: 1.0,
+                                        }
+                                        BorderColor::all(palette::X_AXIS)
+                                    }
+                                    #{
+                                        @FeathersNumberInput {
+                                            @sigil_color: tokens::TEXT_INPUT_Y_AXIS,
+                                            @label_text: "G",
+                                        }
+                                        InteractionDisabled
+                                        NumberInputPrecision(2)
+                                        HardLimit(NumberInputRange::F32(0.0..=1.0))
+                                        Node {
+                                            flex_grow: 1.0,
+                                        }
+                                    }
+                                    #{
+                                        @FeathersNumberInput {
+                                            @sigil_color: tokens::TEXT_INPUT_Z_AXIS,
+                                            @label_text: "B",
+                                        }
+                                        InteractionDisabled
+                                        NumberInputPrecision(2)
+                                        HardLimit(NumberInputRange::F32(0.0..=1.0))
+                                        Node {
+                                            flex_grow: 1.0,
+                                        }
+                                    }
+                                    #{
+                                        @FeathersNumberInput {
+                                            @sigil_color: tokens::TEXT_INPUT_W_AXIS,
+                                            @label_text: "A",
+                                        }
+                                        InteractionDisabled
+                                        NumberInputPrecision(2)
+                                        HardLimit(NumberInputRange::F32(0.0..=1.0))
+                                        Node {
+                                            flex_grow: 1.0,
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        #{
+            @subpane()
+            #{
+                @subpane_header()
+                # @caption("List")
+            }
+            #{
+                @subpane_body()
+                #{
                     @FeathersListView {
                         @rows: {bsn_list![
-                            @FeathersListRow Children [@caption("First World")],
-                            @FeathersListRow Selected Children [@caption("Second Nature")],
-                            @FeathersListRow Children [@caption("Third Degree")],
-                            @FeathersListRow InteractionDisabled Children [@caption("Fourth Wall")],
-                            @FeathersListRow Children [@caption("Fifth Column")],
-                            @FeathersListRow Children [@caption("Sixth Sense")],
-                            @FeathersListRow Children [@caption("Seventh Heaven")],
-                            @FeathersListRow Children [@caption("Eighth Wonder")],
-                            @FeathersListRow Children [@caption("Ninth Inning")],
-                            @FeathersListRow Children [@caption("Tenth Amendment")],
-                            @FeathersListRow Children [@caption("Eleventh Hour")],
-                            @FeathersListRow Children [@caption("Twelfth Night")],
+                            #{ @FeathersListRow #{ @caption("First World") } }
+                            #{ @FeathersListRow Selected #{ @caption("Second Nature") } }
+                            #{ @FeathersListRow #{ @caption("Third Degree")} }
+                            #{ @FeathersListRow InteractionDisabled #{ @caption("Fourth Wall") } }
+                            #{ @FeathersListRow #{ @caption("Fifth Column") } }
+                            #{ @FeathersListRow #{ @caption("Sixth Sense") } }
+                            #{ @FeathersListRow #{ @caption("Seventh Heaven") } }
+                            #{ @FeathersListRow #{ @caption("Eighth Wonder") } }
+                            #{ @FeathersListRow #{ @caption("Ninth Inning") } }
+                            #{ @FeathersListRow #{ @caption("Tenth Amendment") } }
+                            #{ @FeathersListRow #{ @caption("Eleventh Hour") } }
+                            #{ @FeathersListRow #{ @caption("Twelfth Night") } }
                         ]}
                     }
                     Node {
                         max_height: px(130)
                     }
                     on(listbox_update_selection)
-                ],
-            ]
-        ]
+                }
+            }
+        }
     }
 }
 
@@ -1042,36 +998,34 @@ fn demo_column_3() -> impl Scene {
             width: percent(15),
             min_width: px(100),
         }
-        Children [
-            (
-                Node {
-                    display: Display::Flex,
-                    flex_direction: FlexDirection::Row,
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::SpaceBetween,
-                }
-                Children [
-                    @label("Armor Tint"),
-                    @FeathersColorInput
-                    ColorInputValue(palettes::tailwind::AMBER_600)
-                    on(color_input_self_update)
-                ]
-            ),
-            (
-                Node {
-                    display: Display::Flex,
-                    flex_direction: FlexDirection::Row,
-                    align_items: AlignItems::Center,
-                    justify_content: JustifyContent::SpaceBetween,
-                }
-                Children [
-                    @label("Skin Color"),
-                    @FeathersColorInput
-                    ColorInputValue(palettes::tailwind::BLUE_800)
-                    on(color_input_self_update)
-                ]
-            )
-        ]
+        #{
+            Node {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::SpaceBetween,
+            }
+            # @label("Armor Tint")
+            #{
+                @FeathersColorInput
+                ColorInputValue(palettes::tailwind::AMBER_600)
+                on(color_input_self_update)
+            }
+        }
+        #{
+            Node {
+                display: Display::Flex,
+                flex_direction: FlexDirection::Row,
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::SpaceBetween,
+            }
+            # @label("Skin Color")
+            #{
+                @FeathersColorInput
+                ColorInputValue(palettes::tailwind::BLUE_800)
+                on(color_input_self_update)
+            }
+        }
     }
 }
 
@@ -1246,45 +1200,49 @@ fn handle_hex_color_change(
 fn spawn_quit_dialog(activate: On<Activate>, mut commands: Commands) {
     commands
         .entity(activate.event_target())
-        .queue_spawn_related_scenes::<Children>(bsn_list! (
-            @FeathersDialog {
-                @width: px(320),
-                @contents: bsn_list! {
-                    @FeathersDialogHeader Children [
-                        @caption("Quit Feathers Gallery"),
-                        @FeathersDialogClose
-                    ],
-                    @FeathersDialogBody Children [
-                        @caption("Are you really sure you want to quit? I mean, really, really sure?")
-                    ],
-                    @FeathersDialogFooter Children [
-                        (
-                            @FeathersButton {
-                                @caption: bsn! { @caption("Cancel") },
+        .queue_spawn_related_scenes::<Children>(bsn_list![
+            # {
+                @FeathersDialog {
+                    @width: px(320),
+                    @contents: bsn_list![
+                        #{
+                            @FeathersDialogHeader
+                            # @caption("Quit Feathers Gallery")
+                            # @FeathersDialogClose
+                        }
+                        #{
+                            @FeathersDialogBody
+                            # @caption("Are you really sure you want to quit? I mean, really, really sure?")
+                        }
+                        #{
+                            @FeathersDialogFooter
+                            #{
+                                @FeathersButton {
+                                    @caption: bsn! { @caption("Cancel") },
+                                }
+                                AccessibleLabel("Cancel")
+                                on(|activate: On<Activate>, mut commands: Commands| {
+                                    commands.trigger(RequestClose { source: activate.event_target() });
+                                })
                             }
-                            AccessibleLabel("Cancel")
-                            on(|activate: On<Activate>, mut commands: Commands| {
-                                commands.trigger(RequestClose { source: activate.event_target() });
-                            })
-                        ),
-                        (
-                            @FeathersButton {
-                                @caption: bsn! { @caption("Exit Application") },
-                                @variant: ButtonVariant::Primary,
+                            #{
+                                @FeathersButton {
+                                    @caption: bsn! { @caption("Exit Application") },
+                                    @variant: ButtonVariant::Primary,
+                                }
+                                AccessibleLabel("Exit Application")
+                                on(|_activate: On<Activate>, mut exit: MessageWriter<AppExit>| {
+                                    exit.write(AppExit::Success);
+                                })
                             }
-                            AccessibleLabel("Exit Application")
-                            on(|_activate: On<Activate>, mut exit: MessageWriter<AppExit>| {
-                                exit.write(AppExit::Success);
-                            })
-                        ),
-
-                    ],
+                        }
+                    ]
                 }
+                on(|close: On<RequestClose>, mut commands: Commands| {
+                    commands.entity(close.event_target()).despawn();
+                })
             }
-            on(|close: On<RequestClose>, mut commands: Commands| {
-                commands.entity(close.event_target()).despawn();
-            })
-        ));
+        ]);
 }
 
 fn toggle_demo_dialog(
@@ -1301,9 +1259,9 @@ fn toggle_demo_dialog(
             @FeathersFloatingDialog {
                 @title: {"Hello".to_string()},
                 @width: px(280),
-                @contents: bsn_list! {
-                    @caption("Close this dialog to unset the toggle.")
-                }
+                @contents: bsn_list![
+                    # @caption("Close this dialog to unset the toggle.")
+                ]
             }
             // The dialog despawns itself on close; this just clears the toggle.
             on(|_close: On<RequestClose>, mut commands: Commands, toggles: Query<Entity, With<DemoDialogToggle>>| {

--- a/examples/ui/widgets/feathers_number_input.rs
+++ b/examples/ui/widgets/feathers_number_input.rs
@@ -26,7 +26,10 @@ fn main() {
 }
 
 fn scene() -> impl SceneList {
-    bsn_list![Camera2d, @demo_root()]
+    bsn_list![
+        #{ Camera2d }
+        # @demo_root()
+    ]
 }
 
 fn demo_root() -> impl Scene {
@@ -44,62 +47,60 @@ fn demo_root() -> impl Scene {
         }
         TabGroup
         ThemeBackgroundColor(tokens::WINDOW_BG)
-        Children[
-            @demo_field_f32("none (bare)", 1.0, bsn!()),
-            @demo_field_f32("soft limit", 2.0, bsn!(
-                SoftLimit(NumberInputRange::F32(0.0..=10.0))
-            )),
-            @demo_field_f32("hard limit", 3.0, bsn!(
-                HardLimit(NumberInputRange::F32(-100.0..=100.0))
-            )),
-            @demo_field_f32("soft + hard", 4.0, bsn!(
-                SoftLimit(NumberInputRange::F32(0.0..=10.0))
-                HardLimit(NumberInputRange::F32(-100.0..=100.0))
-            )),
-            @demo_field_f32("precision(0)", 5.0, bsn!(
-                NumberInputPrecision(0)
-            )),
-            @demo_field_f32("precision(2)", 6.0, bsn!(
-                NumberInputPrecision(2)
-            )),
-            @demo_field_f32("precision(4)", 7.0, bsn!(
-                NumberInputPrecision(4)
-            )),
-            @demo_field_f32("step(1.0)", 8.0, bsn!(
-                NumberInputStep(1.0f64)
-            )),
-            @demo_field_f64("f64: soft limit", 1.0f64, bsn!(
-                SoftLimit(NumberInputRange::F64(0.0f64..=10.0f64))
-            )),
-            @demo_field_f64("f64: soft limit + precision(2)", 1.0f64, bsn!(
-                SoftLimit(NumberInputRange::F64(0.0f64..=10.0f64))
-                NumberInputPrecision(2)
-            )),
-            @demo_field_i32("i32: bare", 1, bsn!()),
-            @demo_field_i32("i32: soft limit", 1, bsn!(
-                SoftLimit(NumberInputRange::I32(0..=10))
-            )),
-            @demo_field_f32_with_sigil("precision(2) + sigil", 6.0, bsn!(
-                NumberInputPrecision(2)
-            )),
-            @demo_field_f32("soft limit + disabled", 2.0, bsn!(
-                InteractionDisabled
-                SoftLimit(NumberInputRange::F32(0.0..=10.0))
-            )),
-            @demo_field_f32("hard limit + wrap", 0.0, bsn!(
-                HardLimit(NumberInputRange::F32(-180.0..=180.0))
-                NumberInputWrap::Wrap
-            )),
-            @demo_field_f32("in meters", 2.0, bsn!(
-                NumberInputUnits::new(&LengthMeters)
-            )),
-            @demo_field_f32("in seconds", 2.0, bsn!(
-                NumberInputUnits::new(&TimeSeconds)
-            )),
-            @demo_field_f32("in degrees", PI, bsn!(
-                NumberInputUnits::new(&AngleDegrees)
-            )),
-        ]
+        # @demo_field_f32("none (bare)", 1.0, bsn!())
+        # @demo_field_f32("soft limit", 2.0, bsn!(
+            SoftLimit(NumberInputRange::F32(0.0..=10.0))
+        ))
+        # @demo_field_f32("hard limit", 3.0, bsn!(
+            HardLimit(NumberInputRange::F32(-100.0..=100.0))
+        ))
+        # @demo_field_f32("soft + hard", 4.0, bsn!(
+            SoftLimit(NumberInputRange::F32(0.0..=10.0))
+            HardLimit(NumberInputRange::F32(-100.0..=100.0))
+        ))
+        # @demo_field_f32("precision(0)", 5.0, bsn!(
+            NumberInputPrecision(0)
+        ))
+        # @demo_field_f32("precision(2)", 6.0, bsn!(
+            NumberInputPrecision(2)
+        ))
+        # @demo_field_f32("precision(4)", 7.0, bsn!(
+            NumberInputPrecision(4)
+        ))
+        # @demo_field_f32("step(1.0)", 8.0, bsn!(
+            NumberInputStep(1.0f64)
+        ))
+        # @demo_field_f64("f64: soft limit", 1.0f64, bsn!(
+            SoftLimit(NumberInputRange::F64(0.0f64..=10.0f64))
+        ))
+        # @demo_field_f64("f64: soft limit + precision(2)", 1.0f64, bsn!(
+            SoftLimit(NumberInputRange::F64(0.0f64..=10.0f64))
+            NumberInputPrecision(2)
+        ))
+        # @demo_field_i32("i32: bare", 1, bsn!())
+        # @demo_field_i32("i32: soft limit", 1, bsn!(
+            SoftLimit(NumberInputRange::I32(0..=10))
+        ))
+        # @demo_field_f32_with_sigil("precision(2) + sigil", 6.0, bsn!(
+            NumberInputPrecision(2)
+        ))
+        # @demo_field_f32("soft limit + disabled", 2.0, bsn!(
+            InteractionDisabled
+            SoftLimit(NumberInputRange::F32(0.0..=10.0))
+        ))
+        # @demo_field_f32("hard limit + wrap", 0.0, bsn!(
+            HardLimit(NumberInputRange::F32(-180.0..=180.0))
+            NumberInputWrap::Wrap
+        ))
+        # @demo_field_f32("in meters", 2.0, bsn!(
+            NumberInputUnits::new(&LengthMeters)
+        ))
+        # @demo_field_f32("in seconds", 2.0, bsn!(
+            NumberInputUnits::new(&TimeSeconds)
+        ))
+        # @demo_field_f32("in degrees", PI, bsn!(
+            NumberInputUnits::new(&AngleDegrees)
+        ))
     }
 }
 
@@ -112,8 +113,8 @@ fn demo_field_f32(label_text: &str, value: f32, options: impl Scene) -> impl Sce
             width: px(200),
             row_gap: px(4),
         }
-        Children [
-            @label(label_text),
+        # @label(label_text)
+        #{
             Node {
                 display: Display::Flex,
                 flex_direction: FlexDirection::Row,
@@ -121,27 +122,22 @@ fn demo_field_f32(label_text: &str, value: f32, options: impl Scene) -> impl Sce
                 align_self: AlignSelf::Stretch,
                 justify_content: JustifyContent::SpaceBetween,
             }
-            Children [
-                (
-                    @FeathersNumberInput
-                    NumberInputValue::F32(value)
-                    @{options}
-                    Node {
-                        flex_grow: 1.0,
-                        max_width: px(120),
-                    }
-                    on(
-                        |value_change: On<ValueChange<f32>>, mut commands: Commands| {
-                        commands.entity(value_change.event_target())
-                            .insert(NumberInputValue::F32(value_change.value));
-                    })
-                ),
-                (
-                    #Output
-                    @label("-")
-                )
-            ]
-        ]
+            #{
+                @FeathersNumberInput
+                NumberInputValue::F32(value)
+                @{options}
+                Node {
+                    flex_grow: 1.0,
+                    max_width: px(120),
+                }
+                on(
+                    |value_change: On<ValueChange<f32>>, mut commands: Commands| {
+                    commands.entity(value_change.event_target())
+                        .insert(NumberInputValue::F32(value_change.value));
+                })
+            }
+            #Output { @label("-") }
+        }
     }
 }
 
@@ -153,8 +149,8 @@ fn demo_field_f32_with_sigil(label_text: &str, value: f32, options: impl Scene) 
             align_items: AlignItems::Start,
             width: px(200),
         }
-        Children [
-            @label(label_text),
+        # @label(label_text)
+        #{
             Node {
                 display: Display::Flex,
                 flex_direction: FlexDirection::Row,
@@ -162,30 +158,27 @@ fn demo_field_f32_with_sigil(label_text: &str, value: f32, options: impl Scene) 
                 align_self: AlignSelf::Stretch,
                 justify_content: JustifyContent::SpaceBetween,
             }
-            Children [
-                (
-                    @FeathersNumberInput {
-                        @sigil_color: tokens::TEXT_INPUT_X_AXIS,
-                        @label_text: "X",
-                    }
-                    NumberInputValue::F32(value)
-                    @{options}
-                    Node {
-                        flex_grow: 1.0,
-                        max_width: px(120),
-                    }
-                    on(
-                        |value_change: On<ValueChange<f32>>, mut commands: Commands| {
-                        commands.entity(value_change.event_target())
-                            .insert(NumberInputValue::F32(value_change.value));
-                    })
-                ),
-                (
-                    #Output
-                    @label("-")
-                )
-            ]
-        ]
+            #{
+                @FeathersNumberInput {
+                    @sigil_color: tokens::TEXT_INPUT_X_AXIS,
+                    @label_text: "X",
+                }
+                NumberInputValue::F32(value)
+                @{options}
+                Node {
+                    flex_grow: 1.0,
+                    max_width: px(120),
+                }
+                on(
+                    |value_change: On<ValueChange<f32>>, mut commands: Commands| {
+                    commands.entity(value_change.event_target())
+                        .insert(NumberInputValue::F32(value_change.value));
+                })
+            }
+            #Output {
+                @label("-")
+            }
+        }
     }
 }
 
@@ -197,8 +190,8 @@ fn demo_field_f64(label_text: &str, value: f64, options: impl Scene) -> impl Sce
             align_items: AlignItems::Start,
             width: px(200),
         }
-        Children [
-            @label(label_text),
+        # @label(label_text)
+        #{
             Node {
                 display: Display::Flex,
                 flex_direction: FlexDirection::Row,
@@ -206,27 +199,22 @@ fn demo_field_f64(label_text: &str, value: f64, options: impl Scene) -> impl Sce
                 align_self: AlignSelf::Stretch,
                 justify_content: JustifyContent::SpaceBetween,
             }
-            Children [
-                (
-                    @FeathersNumberInput
-                    NumberInputValue::F64(value)
-                    @{options}
-                    Node {
-                        flex_grow: 1.0,
-                        max_width: px(120),
-                    }
-                    on(
-                        |value_change: On<ValueChange<f64>>, mut commands: Commands| {
-                        commands.entity(value_change.event_target())
-                            .insert(NumberInputValue::F64(value_change.value));
-                    })
-                ),
-                (
-                    #Output
-                    @label("-")
-                )
-            ]
-        ]
+            #{
+                @FeathersNumberInput
+                NumberInputValue::F64(value)
+                @{options}
+                Node {
+                    flex_grow: 1.0,
+                    max_width: px(120),
+                }
+                on(
+                    |value_change: On<ValueChange<f64>>, mut commands: Commands| {
+                    commands.entity(value_change.event_target())
+                        .insert(NumberInputValue::F64(value_change.value));
+                })
+            }
+            #Output { @label("-") }
+        }
     }
 }
 
@@ -238,8 +226,8 @@ fn demo_field_i32(label_text: &str, value: i32, options: impl Scene) -> impl Sce
             align_items: AlignItems::Start,
             width: px(200),
         }
-        Children [
-            @label(label_text),
+        # @label(label_text)
+        # {
             Node {
                 display: Display::Flex,
                 flex_direction: FlexDirection::Row,
@@ -247,26 +235,21 @@ fn demo_field_i32(label_text: &str, value: i32, options: impl Scene) -> impl Sce
                 align_self: AlignSelf::Stretch,
                 justify_content: JustifyContent::SpaceBetween,
             }
-            Children [
-                (
-                    @FeathersNumberInput
-                    NumberInputValue::I32(value)
-                    @{options}
-                    Node {
-                        flex_grow: 1.0,
-                        max_width: px(120),
-                    }
-                    on(
-                        |value_change: On<ValueChange<i32>>, mut commands: Commands| {
-                        commands.entity(value_change.event_target())
-                            .insert(NumberInputValue::I32(value_change.value));
-                    })
-                ),
-                (
-                    #Output
-                    @label("-")
-                )
-            ]
-        ]
+            #{
+                @FeathersNumberInput
+                NumberInputValue::I32(value)
+                @{options}
+                Node {
+                    flex_grow: 1.0,
+                    max_width: px(120),
+                }
+                on(
+                    |value_change: On<ValueChange<i32>>, mut commands: Commands| {
+                    commands.entity(value_change.event_target())
+                        .insert(NumberInputValue::I32(value_change.value));
+                })
+            }
+            #Output { @label("-") }
+        }
     }
 }

--- a/examples/ui/widgets/headless_tabs.rs
+++ b/examples/ui/widgets/headless_tabs.rs
@@ -32,8 +32,8 @@ fn main() {
 
 fn showcase() -> impl SceneList {
     bsn_list![
-        Camera2d,
-        (
+        #{ Camera2d }
+        #{
             Node {
                 width: percent(100),
                 height: percent(100),
@@ -46,78 +46,52 @@ fn showcase() -> impl SceneList {
             }
             BackgroundColor(Color::srgb(0.06, 0.07, 0.09))
             TabGroup
-            Children [
-                @section_label("Horizontal automatic - self-updating"),
-                (
-                    #automatic
-                    @tab_strip(ControlOrientation::Horizontal)
-                    TabList {
-                        orientation: ControlOrientation::Horizontal,
-                        activation: TabActivation::Automatic,
-                    }
-                    @selected_tab(#automatic_general)
-                    on(tablist_self_update)
-                    Children [
-                        (
-                            #automatic_general
-                            @tab_header("General")
-                        ),
-                        @tab_header("Rendering"),
-                        (
-                            @tab_header("Disabled")
-                            InteractionDisabled
-                        ),
-                    ]
-                ),
-                @section_label("Horizontal manual - focus and selection are separate"),
-                (
-                    @tab_strip(ControlOrientation::Horizontal)
-                    TabList::default()
-                    @selected_tab(#manual_scene)
-                    on(tablist_self_update)
-                    Children [
-                        (
-                            #manual_scene
-                            @tab_header("Scene")
-                        ),
-                        @tab_header("Assets"),
-                        @tab_header("Inspector"),
-                    ]
-                ),
-                @section_label("Vertical manual"),
-                (
-                    @tab_strip(ControlOrientation::Vertical)
-                    TabList {
-                        orientation: ControlOrientation::Vertical,
-                        activation: TabActivation::Manual,
-                    }
-                    @selected_tab(#vertical_transform)
-                    on(tablist_self_update)
-                    Children [
-                        (
-                            #vertical_transform
-                            @tab_header("Transform")
-                        ),
-                        @tab_header("Visibility"),
-                        @tab_header("Metadata"),
-                    ]
-                ),
-                @section_label("Controlled - observer updates external state"),
-                (
-                    @tab_strip(ControlOrientation::Horizontal)
-                    TabList::default()
-                    @selected_tab(#controlled_a)
-                    on(controlled_selection)
-                    Children [
-                        (
-                            #controlled_a
-                            @tab_header("External A")
-                        ),
-                        @tab_header("External B"),
-                    ]
-                ),
-            ]
-        )
+            # @section_label("Horizontal automatic - self-updating")
+            #automatic {
+                @tab_strip(ControlOrientation::Horizontal)
+                TabList {
+                    orientation: ControlOrientation::Horizontal,
+                    activation: TabActivation::Automatic,
+                }
+                @selected_tab(#automatic_general)
+                on(tablist_self_update)
+                #automatic_general { @tab_header("General") }
+                # @tab_header("Rendering")
+                #{ @tab_header("Disabled") InteractionDisabled }
+            }
+            # @section_label("Horizontal manual - focus and selection are separate")
+            #{
+                @tab_strip(ControlOrientation::Horizontal)
+                TabList::default()
+                @selected_tab(#manual_scene)
+                on(tablist_self_update)
+                #manual_scene { @tab_header("Scene") }
+                # @tab_header("Assets")
+                # @tab_header("Inspector")
+            }
+            # @section_label("Vertical manual")
+            #{
+                @tab_strip(ControlOrientation::Vertical)
+                TabList {
+                    orientation: ControlOrientation::Vertical,
+                    activation: TabActivation::Manual,
+                }
+                @selected_tab(#vertical_transform)
+                on(tablist_self_update)
+                #vertical_transform { @tab_header("Transform") }
+                # @tab_header("Visibility")
+                # @tab_header("Metadata")
+            }
+            # @section_label("Controlled - observer updates external state")
+            #{
+                @tab_strip(ControlOrientation::Horizontal)
+                TabList::default()
+                @selected_tab(#controlled_a)
+                on(controlled_selection)
+                #controlled_a { @tab_header("External A") }
+                # @tab_header("External B")
+            }
+        }
     ]
 }
 
@@ -151,13 +125,13 @@ fn tab_header(label: &'static str) -> impl Scene {
         }
         BackgroundColor(Color::srgb(0.13, 0.14, 0.18))
         BorderColor::all(Color::srgb(0.24, 0.25, 0.30))
-        Children [(
+        #{
             Text(label)
             TextFont {
                 font_size: FontSize::Px(16.0)
             }
             TextColor(Color::srgb(0.88, 0.89, 0.92))
-        )]
+        }
     }
 }
 

--- a/examples/ui/widgets/virtual_keyboard.rs
+++ b/examples/ui/widgets/virtual_keyboard.rs
@@ -51,7 +51,11 @@ fn on_virtual_key_pressed(
 }
 
 fn scene() -> impl SceneList {
-    bsn_list![Camera2d, @text_input(), @keyboard()]
+    bsn_list![
+        #{ Camera2d }
+        # @text_input()
+        # @keyboard()
+    ]
 }
 
 fn keyboard() -> impl Scene {
@@ -73,7 +77,7 @@ fn keyboard() -> impl Scene {
             align_items: AlignItems::Center,
             justify_content: JustifyContent::End,
         }
-        Children [(
+        #{
             Node {
                 flex_direction: FlexDirection::Column,
                 border: px(5),
@@ -85,14 +89,12 @@ fn keyboard() -> impl Scene {
             }
             BackgroundColor(NAVY)
             BorderColor::all(Color::WHITE)
-            Children [
-                Text("virtual keyboard"),
-                (
-                    @VirtualKeyboard::<&str> { @keys: keys }
-                    on(on_virtual_key_pressed)
-                )
-            ]
-        )]
+            #{ Text("virtual keyboard") }
+            #{
+                @VirtualKeyboard::<&str> { @keys: keys }
+                on(on_virtual_key_pressed)
+            }
+        }
     }
 }
 
@@ -106,7 +108,7 @@ fn text_input() -> impl Scene {
             justify_content: JustifyContent::Center,
         }
         TabGroup
-        Children [(
+        #{
             Node {
                 width: percent(80),
                 border: px(5),
@@ -129,6 +131,6 @@ fn text_input() -> impl Scene {
             }
             TabIndex(0)
             AutoFocus
-        )]
+        }
     }
 }

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -53,7 +53,7 @@ fn main() {
 
 fn setup(mut commands: Commands, character: Res<Character>) {
     commands.spawn_scene_list(bsn_list! {
-        Camera2d,
+        #{ Camera2d }
 
         // This scene will serve as one half of our "View"
         // and most of the "Controller" in our MVC design.
@@ -61,11 +61,11 @@ fn setup(mut commands: Commands, character: Res<Character>) {
         // via observers and systems. The observers and systems update the
         // state and also update the look of the UI widgets
         // (i.e. changing text color of a selected option, inserting an X).
-        @ui(&character),
+        # @ui(&character)
 
         // This scene will serve as the other half of our "View" in our MVC design.
         // The user will see the character they are creating.
-        @character_view(&character),
+        # @character_view(&character)
     });
 }
 
@@ -163,7 +163,7 @@ fn ui(character: &Character) -> impl Scene {
             height: percent(100)
             width: percent(50),
         }
-        Children [
+        #{
             // The character creation pane
             Node {
                 flex_direction: FlexDirection::Column,
@@ -176,18 +176,16 @@ fn ui(character: &Character) -> impl Scene {
                 row_gap: px(10),
             }
             BackgroundColor(palettes::basic::GRAY)
-            Children [
-                // Pane header
+            // Pane header
+            #{
                 Node
-                Children[
-                    Text("Character Creator")
-                ],
-                @name_text_input_row(character),
-                @age_slider_row(character),
-                @hat_type_radio_group_row(character),
-                @tint_yellow_checkbox_row(character),
-            ]
-        ]
+                #{ Text("Character Creator") }
+            }
+            # @name_text_input_row(character)
+            # @age_slider_row(character)
+            # @hat_type_radio_group_row(character)
+            # @tint_yellow_checkbox_row(character)
+        }
     }
 }
 
@@ -201,13 +199,10 @@ fn name_text_input_row(character: &Character) -> impl Scene {
             align_items: AlignItems::Center,
             justify_content: JustifyContent::SpaceBetween,
         }
-        Children [
-            Node
-            Children [
-                Text::new("Name: ")
-            ],
+        #{
             @name_text_input(character)
-        ]
+            #{ Text("Name: ") }
+        }
     }
 }
 
@@ -270,20 +265,20 @@ fn age_slider_row(character: &Character) -> impl Scene {
             justify_content: JustifyContent::SpaceBetween,
             column_gap: px(10),
         }
-        Children [
+        #{
             Node
-            Children [
-                Text::new("Age:")
-            ],
-            @age_slider(character),
+            #{ Text::new("Age:") }
+        }
+        # @age_slider(character)
+        #{
             Node {
                 width: px(30),
             }
-            Children [
+            #{
                 AgeSliderText
                 Text(format!("{}", age))
-            ],
-        ]
+            }
+        }
     }
 }
 
@@ -310,18 +305,20 @@ fn age_slider(character: &Character) -> impl Scene {
         on(on_pointer_drag_start_grabbing_cursor)
         on(on_pointer_drag_end_grab_cursor)
         on(on_pointer_out_default_cursor)
-        Children [
-            // Visible Slider Track
+        // Visible Slider Track
+        #{
+
             // It is 220px in width via its parent.
             Node {
                 height: px(5),
                 border_radius: BorderRadius::all(px(3)),
             }
-            BackgroundColor(Color::BLACK),
-
-            // Invisible shorter track (does not have background color) that the
-            // SliderThumb glides on. This is so that the thumb
-            // does not go past the left and right sides of the visible slider track.
+            BackgroundColor(Color::BLACK)
+        }
+        // Invisible shorter track (does not have background color) that the
+        // SliderThumb glides on. This is so that the thumb
+        // does not go past the left and right sides of the visible slider track.
+        #{
             Node {
                 display: Display::Flex,
                 position_type: PositionType::Absolute,
@@ -332,7 +329,7 @@ fn age_slider(character: &Character) -> impl Scene {
                 top: px(0),
                 bottom: px(0),
             }
-            Children [
+            #{
                 AgeSliderThumb
                 SliderThumb
                 Node {
@@ -348,8 +345,8 @@ fn age_slider(character: &Character) -> impl Scene {
                 on(on_pointer_out_default_cursor)
                 on(on_pointer_drag_start_grabbing_cursor)
                 on(on_pointer_drag_end_grab_cursor)
-            ]
-        ]
+            }
+        }
     }
 }
 
@@ -408,18 +405,15 @@ fn hat_type_radio_group_row(character: &Character) -> impl Scene {
         HatTypeRadioGroup
         // This observer is part of the Controller -- it reacts to the user's input!
         on(on_value_change_hat_type)
-        Children [
+        #{
             Node
-            Children [
-                Text("Hat: ")
-            ],
-
-            {
-                HAT_TYPES.iter()
-                    .map(|hat_type| hat_type_radio_button(*hat_type, character))
-                    .collect::<Vec<_>>()
-            }
-        ]
+            #{ Text("Hat: ") }
+        }
+        #{{
+            HAT_TYPES.iter()
+                .map(|hat_type| hat_type_radio_button(*hat_type, character))
+                .collect::<Vec<_>>()
+        }}
     }
 }
 
@@ -443,19 +437,19 @@ fn hat_type_radio_button(hat_type: HatType, character: &Character) -> Box<dyn Sc
             @base_radio_button()
             // The selected hat_type must have the `Checked` component.
             Checked
-            Children [
-                Text::new(format!("{hat_type:?}"))
+            #{
+                Text(format!("{hat_type:?}"))
                 // The selected hat_type's text is green as opposed to white.
                 TextColor(palettes::basic::GREEN)
-            ]
+            }
         })
     } else {
         Box::new(bsn! {
             @base_radio_button()
-            Children [
+            #{
                 Text(format!("{hat_type:?}"))
                 TextColor(palettes::basic::WHITE)
-            ]
+            }
         })
     }
 }
@@ -520,13 +514,11 @@ fn tint_yellow_checkbox_row(character: &Character) -> impl Scene {
             align_items: AlignItems::Center,
             justify_content: JustifyContent::SpaceBetween,
         }
-        Children [
+        #{
             Node
-            Children [
-                Text("Tint Yellow: ")
-            ],
-            @tint_yellow_checkbox(character)
-        ]
+            #{ Text("Tint Yellow: ") }
+        }
+        # @tint_yellow_checkbox(character)
     }
 }
 
@@ -550,18 +542,18 @@ fn tint_yellow_checkbox(character: &Character) -> Box<dyn Scene> {
         Box::new(bsn! {
             @base_checkbox()
             Checked
-            Children [
+            #{
                 Text("X")
                 TextColor(palettes::basic::GREEN)
-            ]
+            }
         })
     } else {
         Box::new(bsn! {
             @base_checkbox()
-            Children [
+            #{
                 Text(" ")
                 TextColor(palettes::basic::GREEN)
-            ]
+            }
         })
     }
 }
@@ -616,11 +608,9 @@ fn character_view(character: &Character) -> impl Scene {
         CharacterView
         Transform::from_xyz(320., 0., 0.)
         Visibility::Inherited
-        Children [
-            @character_sprite(&character),
-            @character_hat(&character),
-            @character_name_and_age(&character),
-        ]
+        # @character_sprite(&character)
+        # @character_hat(&character)
+        # @character_name_and_age(&character)
     }
 }
 
@@ -724,21 +714,23 @@ fn character_hat(character: &Character) -> Box<dyn Scene> {
             // 0.78 radians ~ PI / 4
             Transform::from_rotation(Quat::from_rotation_z(0.78))
             Visibility::Inherited
-            Children [
-                // bottom wider portion of the top hat.
+            // bottom wider portion of the top hat.
+            #{
                 Mesh2d(asset_value(Rectangle::new(
                     40., 10.
                 )))
                 MeshMaterial2d<ColorMaterial>(asset_value(ColorMaterial::from_color(Color::BLACK)))
-                Transform::from_xyz(55., 60., 1.),
+                Transform::from_xyz(55., 60., 1.)
+            }
+            // top longer portion of the top hat
+            #{
 
-                // top longer portion of the top hat
                 Mesh2d(asset_value(Rectangle::new(
                     20., 50.
                 )))
                 MeshMaterial2d<ColorMaterial>(asset_value(ColorMaterial::from_color(Color::BLACK)))
-                Transform::from_xyz(55., 85., 1.),
-            ]
+                Transform::from_xyz(55., 85., 1.)
+            }
         }),
         HatType::DunceCap => Box::new(bsn! {
             CharacterHat

--- a/examples/usage/context_menu.rs
+++ b/examples/usage/context_menu.rs
@@ -114,13 +114,6 @@ fn on_trigger_menu(event: On<OpenContextMenu>, mut commands: Commands) {
         BorderColor::all(Color::BLACK)
         BackgroundColor(Color::linear_rgb(0.1, 0.1, 0.1))
         ListBox
-        Children [
-            @context_item("fuchsia", basic::FUCHSIA),
-            @context_item("gray", basic::GRAY),
-            @context_item("maroon", basic::MAROON),
-            @context_item("purple", basic::PURPLE),
-            @context_item("teal", basic::TEAL),
-        ]
         on(|event: On<ValueChange<Entity>>,
             menu_items: Query<&ContextMenuItem, With<ListItem>>,
             mut clear_col: ResMut<ClearColor>,
@@ -134,6 +127,11 @@ fn on_trigger_menu(event: On<OpenContextMenu>, mut commands: Commands) {
                 // We do not set the `Selected` state of any of the items because the menu
                 // will be despawned.
         })
+        # @context_item("fuchsia", basic::FUCHSIA)
+        # @context_item("gray", basic::GRAY)
+        # @context_item("maroon", basic::MAROON)
+        # @context_item("purple", basic::PURPLE)
+        # @context_item("teal", basic::TEAL)
     });
 }
 
@@ -145,7 +143,7 @@ fn context_item(text: &'static str, col: Srgba) -> impl Scene {
         Node {
             padding: UiRect::all(px(5)),
         }
-        Children [
+        #{
             ContextMenuItemText
             Pickable::IGNORE
             Text(text)
@@ -153,7 +151,7 @@ fn context_item(text: &'static str, col: Srgba) -> impl Scene {
                 font_size: FontSize::Px(24.0),
             }
             TextColor(Color::WHITE)
-        ]
+        }
     }
 }
 
@@ -167,12 +165,12 @@ fn background() -> impl Scene {
             justify_content: JustifyContent::Center,
         }
         ZIndex({-10})
-        Children [
-            Text::new("Click anywhere to spawn a Context Menu.\nYour selection will change the background color.")
+        #{
+            Text("Click anywhere to spawn a Context Menu.\nYour selection will change the background color.")
             TextFont {
                 font_size: FontSize::Px(28.0),
             }
             TextColor(Color::WHITE)
-        ]
+        }
     }
 }

--- a/examples/usage/cooldown.rs
+++ b/examples/usage/cooldown.rs
@@ -37,9 +37,7 @@ fn setup(mut commands: Commands, mut texture_atlas_layouts: ResMut<Assets<Textur
             justify_content: JustifyContent::Center,
             column_gap: px(15),
         }
-        Children [
-            { food_items_scene_list(texture_atlas_layout) }
-        ]
+        #{{ food_items_scene_list(texture_atlas_layout) }}
     });
 
     // Status text
@@ -49,9 +47,7 @@ fn setup(mut commands: Commands, mut texture_atlas_layouts: ResMut<Assets<Textur
             top: px(12),
             left: px(12),
         }
-        Children [
-            Text("*Click some food to eat it*")
-        ]
+        #{ Text("*Click some food to eat it*") }
     });
 }
 
@@ -114,6 +110,7 @@ fn build_ability(
     // The child node's height will be animated to be at 100% at the beginning
     // of a cooldown, effectively graying out the whole button, and then getting smaller over time.
     bsn! {
+        Name(name)
         Node {
             width: px(80),
             height: px(80),
@@ -126,14 +123,13 @@ fn build_ability(
             texture_atlas: texture_atlas_template(layout, index),
         }
         Cooldown(Timer::from_seconds(cooldown, TimerMode::Once))
-        Name(name)
-        Children [
+        #{
             Node {
                 width: percent(100),
                 height: percent(0),
             }
             BackgroundColor({SLATE_50.with_alpha(0.5)})
-        ]
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

BSN currently encourages over-indentation (and line noise) if you want visible clarity between entities in a list:

```rust
bsn! {
    Node 
    Children [
        (
            #OkButton
            @button("Ok")
        ),
        (
            #CancelButton
            @button("Cancel")
        ),
    ]
}
```

It technically supports omitting the `()`, but it severely degrades clarity and makes it easy to make a mistake:

```rust
bsn! {
    Node 
    Children [
        #OkButton
        @button("Ok"),
        #CancelButton
        @button("Cancel"),
    ]
}
```

In general, regardless of the style chosen, it is very hard to see where entities "are". "Peer" entities do not necessarily look like they are peers:

```rust
bsn! {
    Node 
    Children [
        Button,
        #OkButton
        @button("Ok"),
        (
            #CancelButton
            @button("Cancel")
        ),
    ]
}
``` 

It would be nice to have both terseness and clarity!

## Solution

Embrace `#` as  "entity syntax":

```rust
bsn! {
    Node 
    #OkButton {
        @button("Ok")
    }
    #CancelButton {
        @button("Cancel")
    }
}
```

Entities defined this way _directly_ inside another entity are implicitly `Children`. But you can still define arbitrary relationships (including Children) like this:

```rust
bsn! {
    Player
    Children [
        #{ Item Sword }
        #{ Item Shield }
    ]
}
```

Notice that commas are no longer used as entity delimiters.

```rust
bsn! {
    Player
    #{ Item Sword }
    #{ Item Shield }
}
```

"Entity syntax" supports entity references / names, which are defined like this:

```rust
bsn! {
    Player
    #Sword { Item Sword }
    #Shield { Item Shield }
}
```

If defining a standalone scene (any single entry starting with `@` or `:`), you can omit the `{}` wrapper:

```rust
bsn! {
    Node
    # @button("Ok")
    # @MyButton {
        @label: "Cancel"
    }
}
```
Regardless of the syntax used, notice that _all_ child entities start with `#` , and that character is always "aligned".

`bsn_list!` also now employs this syntax:

```rust
bsn_list! [
    #{ Item Apple }
    #{ Item Sword }
]

bsn_list! [
    #A { Ref(#B) }
    #B { Ref(#A) }
]
```

Passing in a `SceneList` as children now looks like this:

```rust
bsn! {
    Node
    #{{ scene_list }}
}
```

In practice, this syntax is _extremely_ consistent and legible:

```rust
bsn! {
    Node 
    #OkButton {
        @button("Ok")
        BackgroundColor(GREEN)
    }
    #CancelButton {
        @button("Cancel")
        BackgroundColor(RED)
    }
}
```

See the diffs in this PR (and the final result of examples like `feathers_gallery`), as I think the "real world" use cases are the most convincing arguments here. This feels _clean_.

This syntax has a lot of things going for it:
- Visual consistency and clarity. If you see `#` thats the start of an entity! "Peer" entities are always vertically aligned starting with `#`. 
- Way less syntax noise in general
    - _Significantly_ less indentation
    - Fewer commas (only actual Rust types use commas now). The story is clearer... BSN syntax: no commas, Rust types and expressions: commas
- Missing or including a comma no longer accidentally changes the bound of an entity
- No more typing `Children []` ad-nauseam. People coming from other markup languages expect a certain level of "hierarchy" terseness, and the only way to get that is with implicit Children! 
- `#Name` labels can share a line with `{}`, reducing line noise when specifying multi-line entities
- More "refactor friendly", as child entities are already generally encapsulated in `{}`. Way less "I guess its time to wrap this in `()` now when adding components!


## Followup Work

I believe this syntax enables us to make BSN prop values a "first class" concept:
```rust
// Current
bsn! {
    @Widget {
        @scene: bsn! { Node }
    }
}

// Proposed
bsn! {
    @Widget {
        @scene: #{ Node }
    }
}
```

Notably, because these share a macro, we can share entity references across argument bounds:
```rust
bsn! {
    #Root
    @Widget {
        @scene: #{
            Node
            Reference(#Root)
        }
    }
}
```