### PR TITLE
Ergonomic observer queries: `SystemInput`-taking `SystemParam` edition

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -372,6 +372,8 @@ fn derive_system_param_impl(
 
     let fields_alias =
         ensure_no_collision(format_ident!("__StructFieldsAlias"), token_stream.clone());
+    let system_input_ident =
+        ensure_no_collision(format_ident!("__SystemInput"), token_stream.clone());
 
     let struct_name = &ast.ident;
     let state_struct_visibility = &ast.vis;
@@ -467,18 +469,23 @@ fn derive_system_param_impl(
                 fn queue(state: &mut Self::State, system_meta: &#path::system::SystemMeta, world: #path::world::DeferredWorld) {
                     <#fields_alias::<'_, '_, #punctuated_generic_idents> as #path::system::SystemParam>::queue(&mut state.state, system_meta, world);
                 }
+            }
 
+            unsafe impl<#system_input_ident: #path::system::SystemInput, #punctuated_generics> #path::system::SystemParamFetch<#system_input_ident> for
+                #struct_name <#(#shadowed_lifetimes,)* #punctuated_generic_idents> #where_clause
+            {
                 #[inline]
                 unsafe fn get_param<'w, 's>(
                     state: &'s mut Self::State,
                     system_meta: &#path::system::SystemMeta,
                     world: #path::world::unsafe_world_cell::UnsafeWorldCell<'w>,
                     change_tick: #path::change_detection::Tick,
+                    input: &#system_input_ident::Inner<'_>,
                 ) -> #FQResult<Self::Item<'w, 's>, #path::system::SystemParamValidationError> {
                     let (#(#tuple_patterns,)*) = &mut state.state;
                     #(
                         let #field_locals = unsafe {
-                            <#field_types as #path::system::SystemParam>::get_param(#field_locals, system_meta, world, change_tick)
+                            <#field_types as #path::system::SystemParamFetch<#system_input_ident>>::get_param(#field_locals, system_meta, world, change_tick, input)
                         }.map_err(|err| #path::system::SystemParamValidationError::new::<Self>(err.skipped, #field_validation_messages, #field_validation_names))?;
                     )*
                     #FQResult::Ok(#struct_name {

--- a/crates/bevy_ecs/src/lifecycle.rs
+++ b/crates/bevy_ecs/src/lifecycle.rs
@@ -62,8 +62,8 @@ use crate::{
     relationship::RelationshipHookMode,
     storage::SparseSet,
     system::{
-        Local, ReadOnlySystemParam, SystemAccess, SystemMeta, SystemParam,
-        SystemParamValidationError,
+        Local, ReadOnlySystemParam, SystemAccess, SystemInput, SystemMeta, SystemParam,
+        SystemParamFetch, SystemParamValidationError,
     },
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
 };
@@ -692,7 +692,7 @@ impl<'w, 's, T: Component> RemovedComponents<'w, 's, T> {
 // SAFETY: Only reads World removed component messages
 unsafe impl<'a> ReadOnlySystemParam for &'a RemovedComponentMessages {}
 
-// SAFETY: no component value access.
+// SAFETY: World metadata is registered and accessed.
 unsafe impl<'a> SystemParam for &'a RemovedComponentMessages {
     type State = ();
     type Item<'w, 's> = &'w RemovedComponentMessages;
@@ -707,13 +707,17 @@ unsafe impl<'a> SystemParam for &'a RemovedComponentMessages {
     ) {
         system_access.require_shared_access::<Self>(system_meta);
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput> SystemParamFetch<I> for &'_ RemovedComponentMessages {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         Ok(world.removed_components())
     }

--- a/crates/bevy_ecs/src/message/message_reader.rs
+++ b/crates/bevy_ecs/src/message/message_reader.rs
@@ -2,7 +2,7 @@
 use crate::message::MessageParIter;
 use crate::{
     message::{Message, MessageCursor, MessageIterator, MessageIteratorWithId, Messages},
-    system::{Local, Res, SystemParam, SystemParamValidationError},
+    system::{Local, Res, SystemInput, SystemParam, SystemParamFetch, SystemParamValidationError},
 };
 
 /// Reads [`Message`]s of type `T` in order and tracks which messages have already been read.
@@ -171,15 +171,27 @@ unsafe impl<'w, 's, M: Message> SystemParam for PopulatedMessageReader<'w, 's, M
     ) {
         MessageReader::<M>::init_access(state, system_meta, system_access, world);
     }
+}
 
+// SAFETY: relies on MessageReader to uphold soundness requirements
+unsafe impl<I: SystemInput, M: Message> SystemParamFetch<I> for PopulatedMessageReader<'_, '_, M> {
     unsafe fn get_param<'world, 'state>(
         state: &'state mut Self::State,
         system_meta: &crate::system::SystemMeta,
         world: crate::world::unsafe_world_cell::UnsafeWorldCell<'world>,
         change_tick: crate::change_detection::Tick,
+        input: &I::Inner<'_>,
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
         // SAFETY: requirements are upheld by MessageReader's implementation
-        let reader = unsafe { MessageReader::get_param(state, system_meta, world, change_tick)? };
+        let reader = unsafe {
+            <MessageReader<'_, '_, M> as SystemParamFetch<I>>::get_param(
+                state,
+                system_meta,
+                world,
+                change_tick,
+                input,
+            )?
+        };
         if reader.is_empty() {
             Err(SystemParamValidationError::skipped::<Self>(
                 "message queue is empty",

--- a/crates/bevy_ecs/src/observer/mod.rs
+++ b/crates/bevy_ecs/src/observer/mod.rs
@@ -482,6 +482,7 @@ mod tests {
         lifecycle::RemoveEvent,
         observer::{Discard, ObservedBy, Observer},
         prelude::*,
+        system::Target,
         world::DeferredWorld,
     };
 
@@ -1924,5 +1925,19 @@ mod tests {
         world.entity_mut(observer).despawn();
 
         assert!(!world.entity(target).contains::<ObservedBy>());
+    }
+
+    #[test]
+    fn observer_target_query() {
+        let mut world = World::new();
+        let e1 = world.spawn_empty().id();
+        let e2 = world.spawn(ChildOf(e1)).id();
+
+        world.add_observer(move |_: On<EntityEventA>, target: Target<&ChildOf>| {
+            assert_eq!(target.0, e1);
+        });
+        world.flush();
+
+        world.trigger(EntityEventA(e2));
     }
 }

--- a/crates/bevy_ecs/src/observer/system_param.rs
+++ b/crates/bevy_ecs/src/observer/system_param.rs
@@ -4,6 +4,7 @@ use crate::{
     change_detection::MaybeLocation,
     event::{Event, EventKey, EventPattern, EventPatternTrigger, PropagateEntityTrigger},
     prelude::*,
+    system::TargetEntity,
     traversal::Traversal,
 };
 use bevy_ptr::Ptr;
@@ -172,6 +173,12 @@ impl<'w, 't, E: EventPattern> Deref for On<'w, 't, E> {
 impl<'w, 't, E: EventPattern> DerefMut for On<'w, 't, E> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.event
+    }
+}
+
+impl<E: EventPattern<Event: EntityEvent>> TargetEntity for On<'_, '_, E> {
+    fn target(&self) -> Entity {
+        self.event().event_target()
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -586,8 +586,8 @@ mod validation_tests {
         schedule::{MultiThreadedExecutor, SingleThreadedExecutor},
         system::{
             DynParamBuilder, DynSystemParam, Local, ParamBuilder, ParamSet, Query, Res, ResMut,
-            RunSystemError, RunSystemOnce, Single, SystemAccess, SystemMeta, SystemParam,
-            SystemParamBuilder, SystemParamValidationError,
+            RunSystemError, RunSystemOnce, Single, SystemAccess, SystemInput, SystemMeta,
+            SystemParam, SystemParamBuilder, SystemParamFetch, SystemParamValidationError,
         },
         world::World,
     };
@@ -619,12 +619,16 @@ mod validation_tests {
             _world: &mut World,
         ) {
         }
+    }
 
+    // SAFETY: No world data is accessed.
+    unsafe impl<I: SystemInput> SystemParamFetch<I> for AlwaysInvalid {
         unsafe fn get_param<'world, 'state>(
             _state: &'state mut Self::State,
             _system_meta: &SystemMeta,
             _world: crate::world::unsafe_world_cell::UnsafeWorldCell<'world>,
             _change_tick: crate::change_detection::Tick,
+            _input: &I::Inner<'_>,
         ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
             Err(SystemParamValidationError::invalid::<Self>(
                 "always invalid",

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -911,7 +911,8 @@ mod tests {
         prelude::Resource,
         schedule::{IntoScheduleConfigs, MultiThreadedExecutor, Schedule},
         system::{
-            Commands, NonSendMut, SystemAccess, SystemMeta, SystemParam, SystemParamValidationError,
+            Commands, NonSendMut, SystemAccess, SystemInput, SystemMeta, SystemParam,
+            SystemParamFetch, SystemParamValidationError,
         },
         world::{unsafe_world_cell::UnsafeWorldCell, World},
     };
@@ -936,12 +937,16 @@ mod tests {
         ) {
             system_access.require_exclusive_access::<Self>(system_meta);
         }
+    }
 
+    // SAFETY: No world data is accessed.
+    unsafe impl<I: SystemInput> SystemParamFetch<I> for ExclusiveMarker {
         unsafe fn get_param<'world, 'state>(
             _state: &'state mut Self::State,
             _system_meta: &SystemMeta,
             _world: UnsafeWorldCell<'world>,
             _change_tick: Tick,
+            _input: &I::Inner<'_>,
         ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
             Ok(ExclusiveMarker)
         }

--- a/crates/bevy_ecs/src/system/builder.rs
+++ b/crates/bevy_ecs/src/system/builder.rs
@@ -13,7 +13,7 @@ use crate::{
     system::{
         DynSystemParam, DynSystemParamState, FromInput, FunctionSystem, If, IntoResult, IntoSystem,
         Local, ParamSet, Query, ReadOnlySystem, System, SystemAccess, SystemInput, SystemMeta,
-        SystemParam, SystemParamFunction, SystemParamValidationError,
+        SystemParam, SystemParamFetch, SystemParamFunction, SystemParamValidationError,
     },
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, FromWorld, World},
 };
@@ -754,7 +754,9 @@ pub struct DynParamBuilder<'a>(Box<dyn FnOnce(&mut World) -> DynSystemParamState
 impl<'a> DynParamBuilder<'a> {
     /// Creates a new [`DynParamBuilder`] by wrapping a [`SystemParamBuilder`] of any type.
     /// The built [`DynSystemParam`] can be downcast to `T`.
-    pub fn new<T: SystemParam + 'static>(builder: impl SystemParamBuilder<T> + 'a) -> Self {
+    pub fn new<T: SystemParamFetch<()> + 'static>(
+        builder: impl SystemParamBuilder<T> + 'a,
+    ) -> Self {
         Self(Box::new(|world| {
             DynSystemParamState::new::<T>(builder.build(world))
         }))

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -6,7 +6,7 @@ use crate::{
     schedule::{InternedSystemSet, SystemSet},
     system::{
         check_system_change_tick, FromInput, ReadOnlySystemParam, System, SystemAccess, SystemIn,
-        SystemInput, SystemParam, SystemParamItem,
+        SystemInput, SystemParam, SystemParamFetch, SystemParamItem,
     },
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World, WorldId},
 };
@@ -260,6 +260,8 @@ macro_rules! impl_build_system {
                 self,
                 func: F,
             ) -> FunctionSystem<Marker, (), Out, F>
+            where
+                $($param: SystemParamFetch<()>,)*
             {
                 self.build_any_system(func)
             }
@@ -280,7 +282,10 @@ macro_rules! impl_build_system {
             (
                 self,
                 func: F,
-            ) -> FunctionSystem<Marker, In, Out, F> {
+            ) -> FunctionSystem<Marker, In, Out, F>
+            where
+                $($param: SystemParamFetch<InnerIn>,)*
+            {
                 self.build_any_system(func)
             }
         }
@@ -369,7 +374,7 @@ impl<Param: SystemParam> SystemState<Param> {
         world: &'w World,
     ) -> Result<SystemParamItem<'w, 's, Param>, SystemParamValidationError>
     where
-        Param: ReadOnlySystemParam,
+        Param: ReadOnlySystemParam + SystemParamFetch<()>,
     {
         self.validate_world(world.id());
         // SAFETY: Param is read-only and doesn't allow mutable access to World.
@@ -385,7 +390,10 @@ impl<Param: SystemParam> SystemState<Param> {
     pub fn get_mut<'w, 's>(
         &'s mut self,
         world: &'w mut World,
-    ) -> Result<SystemParamItem<'w, 's, Param>, SystemParamValidationError> {
+    ) -> Result<SystemParamItem<'w, 's, Param>, SystemParamValidationError>
+    where
+        Param: SystemParamFetch<()>,
+    {
         self.validate_world(world.id());
         // SAFETY: World is uniquely borrowed and matches the World this SystemState was created with.
         unsafe { self.get_unchecked(world.as_unsafe_world_cell()) }
@@ -422,6 +430,88 @@ impl<Param: SystemParam> SystemState<Param> {
         }
     }
 
+    /// Retrieve the [`SystemParam`] values. This can only be called when all parameters are read-only.
+    ///
+    /// Returns an error if system parameter validation fails.
+    #[inline]
+    pub fn get_with<'w, 's, I: SystemInput>(
+        &'s mut self,
+        world: &'w World,
+        input: &I::Inner<'_>,
+    ) -> Result<SystemParamItem<'w, 's, Param>, SystemParamValidationError>
+    where
+        Param: ReadOnlySystemParam + SystemParamFetch<I>,
+    {
+        self.validate_world(world.id());
+        // SAFETY: Param is read-only and doesn't allow mutable access to World.
+        // It also matches the World this SystemState was created with.
+        unsafe { self.get_unchecked_with(world.as_unsafe_world_cell_readonly(), input) }
+    }
+
+    /// Retrieve the mutable [`SystemParam`] values.
+    ///
+    /// Returns an error if system parameter validation fails.
+    #[inline]
+    #[track_caller]
+    pub fn get_mut_with<'w, 's, I: SystemInput>(
+        &'s mut self,
+        world: &'w mut World,
+        input: &I::Inner<'_>,
+    ) -> Result<SystemParamItem<'w, 's, Param>, SystemParamValidationError>
+    where
+        Param: SystemParamFetch<I>,
+    {
+        self.validate_world(world.id());
+        // SAFETY: World is uniquely borrowed and matches the World this SystemState was created with.
+        unsafe { self.get_unchecked_with(world.as_unsafe_world_cell(), input) }
+    }
+
+    /// Retrieve the [`SystemParam`] values.
+    ///
+    /// Returns an error if system parameter validation fails.
+    ///
+    /// # Safety
+    /// This call might access any of the input parameters in a way that violates Rust's mutability rules. Make sure the data
+    /// access is safe in the context of global [`World`] access. The passed-in [`World`] _must_ be the [`World`] the [`SystemState`] was
+    /// created with.
+    #[inline]
+    #[track_caller]
+    pub unsafe fn get_unchecked_with<'w, 's, I: SystemInput>(
+        &'s mut self,
+        world: UnsafeWorldCell<'w>,
+        input: &I::Inner<'_>,
+    ) -> Result<SystemParamItem<'w, 's, Param>, SystemParamValidationError>
+    where
+        Param: SystemParamFetch<I>,
+    {
+        let change_tick = world.increment_change_tick();
+        // SAFETY: The invariants are upheld by the caller.
+        unsafe { self.fetch_with(world, change_tick, input) }
+    }
+
+    /// # Safety
+    /// This call might access any of the input parameters in a way that violates Rust's mutability rules. Make sure the data
+    /// access is safe in the context of global [`World`] access. The passed-in [`World`] _must_ be the [`World`] the [`SystemState`] was
+    /// created with.
+    #[inline]
+    #[track_caller]
+    unsafe fn fetch_with<'w, 's, I: SystemInput>(
+        &'s mut self,
+        world: UnsafeWorldCell<'w>,
+        change_tick: Tick,
+        input: &I::Inner<'_>,
+    ) -> Result<SystemParamItem<'w, 's, Param>, SystemParamValidationError>
+    where
+        Param: SystemParamFetch<I>,
+    {
+        // SAFETY: The invariants are upheld by the caller.
+        let param = unsafe {
+            Param::get_param(&mut self.param_state, &self.meta, world, change_tick, input)
+        }?;
+        self.meta.last_run = change_tick;
+        Ok(param)
+    }
+
     /// Retrieve the [`SystemParam`] values.
     ///
     /// Returns an error if system parameter validation fails.
@@ -435,7 +525,10 @@ impl<Param: SystemParam> SystemState<Param> {
     pub unsafe fn get_unchecked<'w, 's>(
         &'s mut self,
         world: UnsafeWorldCell<'w>,
-    ) -> Result<SystemParamItem<'w, 's, Param>, SystemParamValidationError> {
+    ) -> Result<SystemParamItem<'w, 's, Param>, SystemParamValidationError>
+    where
+        Param: SystemParamFetch<()>,
+    {
         let change_tick = world.increment_change_tick();
         // SAFETY: The invariants are upheld by the caller.
         unsafe { self.fetch(world, change_tick) }
@@ -451,10 +544,14 @@ impl<Param: SystemParam> SystemState<Param> {
         &'s mut self,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
-    ) -> Result<SystemParamItem<'w, 's, Param>, SystemParamValidationError> {
+    ) -> Result<SystemParamItem<'w, 's, Param>, SystemParamValidationError>
+    where
+        Param: SystemParamFetch<()>,
+    {
         // SAFETY: The invariants are upheld by the caller.
-        let param =
-            unsafe { Param::get_param(&mut self.param_state, &self.meta, world, change_tick) }?;
+        let param = unsafe {
+            Param::get_param(&mut self.param_state, &self.meta, world, change_tick, &())
+        }?;
         self.meta.last_run = change_tick;
         Ok(param)
     }
@@ -672,7 +769,13 @@ where
         // - All world accesses used by `F::Param` have been registered, so the caller
         //   will ensure that there are no data access conflicts.
         let params = unsafe {
-            F::Param::get_param(&mut state.param, &self.system_meta, world, change_tick)
+            F::Param::get_param(
+                &mut state.param,
+                &self.system_meta,
+                world,
+                change_tick,
+                &input,
+            )
         }?;
 
         #[cfg(feature = "hotpatching")]
@@ -851,7 +954,7 @@ pub trait SystemParamFunction<Marker>: Send + Sync + 'static {
     type Out;
 
     /// The [`SystemParam`]/s used by this system to access the [`World`].
-    type Param: SystemParam;
+    type Param: SystemParamFetch<Self::In>;
 
     /// Executes this system once. See [`System::run`] or [`System::run_unsafe`].
     fn run(
@@ -875,7 +978,7 @@ macro_rules! impl_system_function {
             non_snake_case,
             reason = "Certain variable names are provided by the caller, not by us."
         )]
-        impl<Out, Func, $($param: SystemParam),*> SystemParamFunction<fn($($param,)*) -> Out> for Func
+        impl<Out, Func, $($param: SystemParamFetch<()>),*> SystemParamFunction<fn($($param,)*) -> Out> for Func
         where
             Func: Send + Sync + 'static,
             for <'a> &'a mut Func:
@@ -910,7 +1013,7 @@ macro_rules! impl_system_function {
             non_snake_case,
             reason = "Certain variable names are provided by the caller, not by us."
         )]
-        impl<In, Out, Func, $($param: SystemParam),*> SystemParamFunction<(HasSystemInput, fn(In, $($param,)*) -> Out)> for Func
+        impl<In, Out, Func, $($param: SystemParamFetch<In>),*> SystemParamFunction<(HasSystemInput, fn(In, $($param,)*) -> Out)> for Func
         where
             Func: Send + Sync + 'static,
             for <'a> &'a mut Func:

--- a/crates/bevy_ecs/src/system/input.rs
+++ b/crates/bevy_ecs/src/system/input.rs
@@ -2,7 +2,7 @@ use core::ops::{Deref, DerefMut};
 
 use variadics_please::all_tuples;
 
-use crate::{event::EventPattern, prelude::On, system::System};
+use crate::{entity::Entity, event::EventPattern, prelude::On, system::System};
 
 /// Trait for types that can be used as input to [`System`]s.
 ///
@@ -324,6 +324,17 @@ all_tuples!(
     8,
     I
 );
+
+/// [`SystemInput`] types that target a specific entity may implement this in
+/// order to support [`SystemParam`]s that require access to the target entity,
+/// such as [`Target<D, F>`].
+///
+/// [`SystemParam`]: crate::system::SystemParam
+/// [`Target<D, F>`]: crate::system::Target
+pub trait TargetEntity {
+    /// Returns the [`Entity`] that the system input is targeting.
+    fn target(&self) -> Entity;
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -3089,6 +3089,106 @@ impl<'a, 'w, 's, D: IterQueryData, F: QueryFilter> IntoIterator
     }
 }
 
+/// [System parameter] that provides access to the target entity's components.
+/// This type acts like a [`Query`], but it only contains the fetched components
+/// of the target entity.
+///
+/// This type [`Deref`]s into the queried components.
+///
+/// To fetch components for multiple entities, use [`Query`] instead.
+/// To fetch components for a singleton entity, use [`Single`] instead.
+///
+/// # Usage Notes
+///
+/// This type can **ONLY** be used as a system parameter for systems
+/// that take a [`SystemInput`] that implements [`TargetEntity`], like an
+/// [`Observer`].
+///
+/// If this type is added to a function that doesn't take any input,
+/// or whose input doesn't implement [`TargetEntity`], the function cannot be
+/// used as a system.
+///
+/// # Examples
+///
+/// ## Simple
+///
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// #[derive(Component)]
+/// struct Health(i32);
+///
+/// # let mut world = World::new();
+/// world.add_observer(|_: On<Add<Health>>, health: Target<&Health>| {
+///     // You can access the target entity's Health directly:
+///     let health: i32 = health.0;
+///     # assert_eq!(health, 100);
+/// });
+/// # world.flush();
+///
+/// // ...
+/// world.spawn(Health(100));
+/// # world.flush();
+/// ```
+///
+/// ## Optional
+///
+/// If the target entity might not have the fetched components, use
+/// [`Option<Target<D, F>>`] instead.
+///
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// #[derive(Component)]
+/// struct Health(i32);
+/// #[derive(Component)]
+/// struct Mana(i32);
+///
+/// # let mut world = World::new();
+/// world.add_observer(|_: On<Add<Health>>, health: Option<Target<(&Health, &Mana)>>| {
+///     // Make sure to handle where the target entity doesn't have both components.
+///     let Some((Health(health), Mana(mana))) = health.map(|h| h.into_inner()) else {
+///         return;
+///     };
+///     // Use the components...
+///     # assert_eq!(*health, 100);
+///     # assert_eq!(*mana, 50);
+/// });
+/// # world.flush();
+///
+/// // ...
+/// world.spawn(Health(100));
+/// world.spawn((Health(100), Mana(50)));
+/// # world.flush();
+/// ```
+///
+/// [System parameter]: crate::system::SystemParam
+/// [`SystemInput`]: crate::system::SystemInput
+/// [`Observer`]: crate::observer::Observer
+pub struct Target<'w, 's, D: QueryData, F: QueryFilter = ()> {
+    pub(crate) item: D::Item<'w, 's>,
+    pub(crate) _filter: PhantomData<F>,
+}
+
+impl<'w, 's, D: QueryData, F: QueryFilter> Deref for Target<'w, 's, D, F> {
+    type Target = D::Item<'w, 's>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.item
+    }
+}
+
+impl<'w, 's, D: QueryData, F: QueryFilter> DerefMut for Target<'w, 's, D, F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.item
+    }
+}
+
+impl<'w, 's, D: QueryData, F: QueryFilter> Target<'w, 's, D, F> {
+    /// Returns the inner item with ownership.
+    pub fn into_inner(self) -> D::Item<'w, 's> {
+        self.item
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{prelude::*, query::QueryEntityError};

--- a/crates/bevy_ecs/src/system/system_name.rs
+++ b/crates/bevy_ecs/src/system/system_name.rs
@@ -2,7 +2,8 @@ use crate::{
     change_detection::Tick,
     prelude::World,
     system::{
-        ReadOnlySystemParam, SystemAccess, SystemMeta, SystemParam, SystemParamValidationError,
+        ReadOnlySystemParam, SystemAccess, SystemInput, SystemMeta, SystemParam, SystemParamFetch,
+        SystemParamValidationError,
     },
     world::unsafe_world_cell::UnsafeWorldCell,
 };
@@ -50,7 +51,7 @@ impl SystemName {
     }
 }
 
-// SAFETY: no component value access
+// SAFETY: No world access is required.
 unsafe impl SystemParam for SystemName {
     type State = ();
     type Item<'w, 's> = SystemName;
@@ -64,13 +65,17 @@ unsafe impl SystemParam for SystemName {
         _world: &mut World,
     ) {
     }
+}
 
+// SAFETY: No world access is required.
+unsafe impl<I: SystemInput> SystemParamFetch<I> for SystemName {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
         system_meta: &SystemMeta,
         _world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         Ok(SystemName(system_meta.name.clone()))
     }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -15,14 +15,16 @@ use crate::{
         QueryState, ReadOnlyQueryData,
     },
     resource::{Resource, ResourceEntities, IS_RESOURCE},
-    system::{Query, Single, SystemAccess, SystemInput, SystemMeta, SystemState},
+    system::{
+        Query, Single, SystemAccess, SystemInput, SystemMeta, SystemState, Target, TargetEntity,
+    },
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, FromWorld, World},
 };
 
 #[expect(deprecated, reason = "`FilteredResources` will be removed.")]
 use crate::world::{FilteredResources, FilteredResourcesMut};
 
-use alloc::{borrow::Cow, boxed::Box, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, string::ToString, vec::Vec};
 pub use bevy_ecs_macros::SystemParam;
 use bevy_platform::cell::SyncCell;
 use bevy_ptr::UnsafeCellDeref;
@@ -267,6 +269,11 @@ pub unsafe trait SystemParam: Sized {
 
 /// A [`SystemParam`] that can be constructed with a given [`SystemInput`].
 ///
+/// This trait enables system params to fetch their data based on the input
+/// provided to the system, in a compile-time checked manner. For example,
+/// [`Target<D, F>`] provides ergonomic access to query data for an entity that
+/// is passed in as a system input.
+///
 /// See [`SystemParam`] for more information.
 ///
 /// # Note for implementors
@@ -297,9 +304,14 @@ pub unsafe trait SystemParam: Sized {
 /// }
 /// ```
 ///
+/// See [`Target<D, F>`] for an example of a [`SystemParam`]
+/// that is implemented for a specific [`SystemInput`] type.
+///
 /// # Safety
 ///
 /// [`SystemParamFetch::get_param`] must only access things registered in [`SystemParam::init_access`].
+///
+/// [`Target<D, F>`]: crate::system::Target
 pub unsafe trait SystemParamFetch<I: SystemInput>: SystemParam {
     /// Creates a parameter to be passed into a [`SystemParamFunction`](super::SystemParamFunction).
     ///
@@ -506,6 +518,60 @@ unsafe impl<I: SystemInput, D: IterQueryData + 'static, F: QueryFilter + 'static
 // SAFETY: QueryState is constrained to read-only fetches, so it only reads World.
 unsafe impl<'w, 's, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> ReadOnlySystemParam
     for Populated<'w, 's, D, F>
+{
+}
+
+// SAFETY: Relevant query ComponentId access is applied to SystemMeta. If
+// this Query conflicts with any prior access, a panic will occur.
+unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Target<'_, '_, D, F> {
+    type State = QueryState<D, F>;
+    type Item<'w, 's> = Target<'w, 's, D, F>;
+
+    fn init_state(world: &mut World) -> Self::State {
+        Query::init_state(world)
+    }
+
+    fn init_access(
+        state: &Self::State,
+        system_meta: &mut SystemMeta,
+        system_access: &mut SystemAccess,
+        world: &mut World,
+    ) {
+        Query::init_access(state, system_meta, system_access, world);
+    }
+}
+
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I, D, F> SystemParamFetch<I> for Target<'_, '_, D, F>
+where
+    I: for<'i> SystemInput<Inner<'i>: TargetEntity>,
+    D: IterQueryData + 'static,
+    F: QueryFilter + 'static,
+{
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        change_tick: Tick,
+        input: &I::Inner<'_>,
+    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
+        let target = input.target();
+        // SAFETY: State ensures that the components it accesses are not accessible somewhere elsewhere.
+        // The caller ensures the world matches the one used in init_state.
+        let query =
+            unsafe { state.query_unchecked_with_ticks(world, system_meta.last_run, change_tick) };
+        Ok(Target {
+            item: query
+                .get_inner(target)
+                .map_err(|e| SystemParamValidationError::skipped::<Self>(e.to_string()))?,
+            _filter: PhantomData,
+        })
+    }
+}
+
+// SAFETY: QueryState is constrained to read-only fetches, so it only reads World.
+unsafe impl<D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> ReadOnlySystemParam
+    for Target<'_, '_, D, F>
 {
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -15,7 +15,7 @@ use crate::{
         QueryState, ReadOnlyQueryData,
     },
     resource::{Resource, ResourceEntities, IS_RESOURCE},
-    system::{Query, Single, SystemAccess, SystemMeta, SystemState},
+    system::{Query, Single, SystemAccess, SystemInput, SystemMeta, SystemState},
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, FromWorld, World},
 };
 
@@ -40,6 +40,11 @@ use super::Populated;
 use variadics_please::{all_tuples, all_tuples_enumerated};
 
 /// A parameter that can be used in a [`System`](super::System).
+///
+/// In order to fetch data from the [`World`], a system parameter must also
+/// implement [`SystemParamFetch<I>`] for some [`SystemInput`] `I` (usually for any `I`).
+///
+/// See [`SystemParamFetch`] for more information.
 ///
 /// # Derive
 ///
@@ -258,7 +263,44 @@ pub unsafe trait SystemParam: Sized {
         reason = "The parameters here are intentionally unused by the default implementation; however, putting underscores here will result in the underscores being copied by rust-analyzer's tab completion."
     )]
     fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {}
+}
 
+/// A [`SystemParam`] that can be constructed with a given [`SystemInput`].
+///
+/// See [`SystemParam`] for more information.
+///
+/// # Note for implementors
+///
+/// In addition to implementing [`SystemParam`], you must also implement this trait
+/// for the same type and for the [`SystemInput`] types you want to support.
+/// If you want to support any [`SystemInput`] type, or don't need system input at all,
+/// you can implement it like so:
+///
+/// ```rust,no_run
+/// # use bevy_ecs::system::{SystemParam, SystemInput, SystemParamFetch};
+/// pub struct MySystemParam;
+///
+/// impl SystemParam for MySystemParam {
+///     // ...
+/// }
+///
+/// // This allows your system param to be used with any system input type,
+/// // including `()` (i.e. no input).
+/// impl<I: SystemInput> SystemParamFetch<I> for MySystemParam {
+///     // ...
+/// }
+///
+/// // You SHOULD NOT do the following, as it will prevent your system param
+/// // from being used in other system types, like observers:
+/// impl SystemParamFetch<()> for MySystemParam {
+///     // ...
+/// }
+/// ```
+///
+/// # Safety
+///
+/// [`SystemParamFetch::get_param`] must only access things registered in [`SystemParam::init_access`].
+pub unsafe trait SystemParamFetch<I: SystemInput>: SystemParam {
     /// Creates a parameter to be passed into a [`SystemParamFunction`](super::SystemParamFunction).
     ///
     /// This method also validates that the param can be acquired. If validation fails,
@@ -285,6 +327,7 @@ pub unsafe trait SystemParam: Sized {
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'world>,
         change_tick: Tick,
+        input: &I::Inner<'_>,
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError>;
 }
 
@@ -325,13 +368,19 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
         let component_access_set = system_access.require_shared_access::<Self>(system_meta);
         state.init_access(Some(system_meta.name()), component_access_set, world.into());
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, D: QueryData + 'static, F: QueryFilter + 'static> SystemParamFetch<I>
+    for Query<'_, '_, D, F>
+{
     #[inline]
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         // SAFETY: We have registered all of the query's world accesses,
         // so the caller ensures that `world` has permission to access any
@@ -361,13 +410,19 @@ unsafe impl<'a, 'b, D: IterQueryData + 'static, F: QueryFilter + 'static> System
     ) {
         Query::init_access(state, system_meta, system_access, world);
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, D: IterQueryData + 'static, F: QueryFilter + 'static>
+    SystemParamFetch<I> for Single<'_, '_, D, F>
+{
     #[inline]
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         // SAFETY: State ensures that the components it accesses are not accessible somewhere elsewhere.
         // The caller ensures the world matches the one used in init_state.
@@ -414,16 +469,30 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
     ) {
         Query::init_access(state, system_meta, system_access, world);
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, D: IterQueryData + 'static, F: QueryFilter + 'static>
+    SystemParamFetch<I> for Populated<'_, '_, D, F>
+{
     #[inline]
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
+        input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         // SAFETY: Delegate to existing `SystemParam` implementations.
-        let query = unsafe { Query::get_param(state, system_meta, world, change_tick) }?;
+        let query = unsafe {
+            <Query<D, F> as SystemParamFetch<I>>::get_param(
+                state,
+                system_meta,
+                world,
+                change_tick,
+                input,
+            )
+        }?;
         if query.is_empty() {
             Err(SystemParamValidationError::skipped::<Self>(
                 "No matching entities",
@@ -620,12 +689,18 @@ macro_rules! impl_param_set {
                 <($($param,)*) as SystemParam>::queue(state, system_meta, world.reborrow());
             }
 
+        }
+
+        // SAFETY: `get_param` only accesses things registered in `init_access`.
+        unsafe impl<I: SystemInput, $($param: SystemParamFetch<I>,)*> SystemParamFetch<I> for ParamSet<'_, '_, ($($param,)*)>
+        {
             #[inline]
             unsafe fn get_param<'w, 's>(
                 state: &'s mut Self::State,
                 system_meta: &SystemMeta,
                 world: UnsafeWorldCell<'w>,
                 change_tick: Tick,
+                input: &I::Inner<'_>,
             ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
                 // Validate each sub-param eagerly so that the system is correctly
                 // skipped by the executor when any sub-param is unavailable.
@@ -634,7 +709,7 @@ macro_rules! impl_param_set {
                 // validate_param + get_param pattern.
                 $(
                     // SAFETY: Upheld by caller.
-                    drop(unsafe { $param::get_param(&mut state.$index, system_meta, world, change_tick) }?);
+                    drop(unsafe { $param::get_param(&mut state.$index, system_meta, world, change_tick, input) }?);
                 )*
 
                 Ok(ParamSet {
@@ -646,7 +721,7 @@ macro_rules! impl_param_set {
             }
         }
 
-        impl<'w, 's, $($param: SystemParam,)*> ParamSet<'w, 's, ($($param,)*)>
+        impl<'w, 's, $($param: SystemParamFetch<()>,)*> ParamSet<'w, 's, ($($param,)*)>
         {
             $(
                 /// Gets exclusive access to the parameter at index
@@ -658,7 +733,7 @@ macro_rules! impl_param_set {
                     // Conflicting params in ParamSet are not accessible at the same time
                     // ParamSets are guaranteed to not conflict with other SystemParams
                     unsafe {
-                        $param::get_param(&mut self.param_states.$index, &self.system_meta, self.world, self.change_tick)
+                        $param::get_param(&mut self.param_states.$index, &self.system_meta, self.world, self.change_tick, &())
                     }
                     .unwrap_or_else(|err| panic!("ParamSet parameter validation failed: {err}"))
                 }
@@ -701,13 +776,17 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
             panic!("error[B0002]: Res<{}> in system {} conflicts with a previous system parameter. Consider removing the duplicate access using `Without<IsResource>` to create disjoint Queries or merging conflicting Queries into a `ParamSet`. See: https://bevy.org/learn/errors/b0002", DebugName::type_name::<T>(), system_meta.name);
         }
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, T: Resource> SystemParamFetch<I> for Res<'_, T> {
     #[inline]
     unsafe fn get_param<'w, 's>(
         &mut component_id: &'s mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         let (ptr, ticks) = world.get_resource_with_ticks(component_id).ok_or_else(|| {
             SystemParamValidationError::invalid::<Self>("Resource does not exist")
@@ -754,13 +833,19 @@ unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T>
             panic!("error[B0002]: ResMut<{}> in system {} conflicts with a previous system parameter. Consider removing the duplicate access or using `Without<IsResource>` to create disjoint Queries or merging conflicting Queries into a `ParamSet`. See: https://bevy.org/learn/errors/b0002", DebugName::type_name::<T>(), system_meta.name);
         }
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, T: Resource<Mutability = Mutable>> SystemParamFetch<I>
+    for ResMut<'_, T>
+{
     #[inline]
     unsafe fn get_param<'w, 's>(
         &mut component_id: &'s mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         let value = world.get_resource_mut_by_id(component_id).ok_or_else(|| {
             SystemParamValidationError::invalid::<Self>("Resource does not exist")
@@ -805,13 +890,17 @@ unsafe impl SystemParam for &'_ World {
             );
         }
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput> SystemParamFetch<I> for &'_ World {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         // SAFETY: Read-only access to the entire world was registered in `init_access`.
         Ok(unsafe { world.world() })
@@ -836,13 +925,17 @@ unsafe impl SystemParam for &'_ mut World {
 
         system_access.require_exclusive_access::<Self>(system_meta);
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput> SystemParamFetch<I> for &'_ mut World {
     #[inline]
     unsafe fn get_param<'world, 'state>(
         _state: &'state mut Self::State,
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'world>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
         // SAFETY: Write access to the entire world was registered in `init_access`.
         Ok(unsafe { world.world_mut() })
@@ -872,12 +965,17 @@ unsafe impl<'w> SystemParam for DeferredWorld<'w> {
             );
         }
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput> SystemParamFetch<I> for DeferredWorld<'_> {
+    #[inline]
     unsafe fn get_param<'world, 'state>(
         _state: &'state mut Self::State,
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'world>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
         // SAFETY: Write access to the entire world was registered in `init_access`
         Ok(unsafe { world.into_deferred() })
@@ -1062,13 +1160,17 @@ unsafe impl<'a, T: FromWorld + Send + 'static> SystemParam for Local<'a, T> {
         _world: &mut World,
     ) {
     }
+}
 
+// SAFETY: only local state is accessed
+unsafe impl<I: SystemInput, T: FromWorld + Send + 'static> SystemParamFetch<I> for Local<'_, T> {
     #[inline]
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
         _system_meta: &SystemMeta,
         _world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         Ok(Local(state.get()))
     }
@@ -1266,13 +1368,17 @@ unsafe impl<T: SystemBuffer> SystemParam for Deferred<'_, T> {
     fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
         state.get().queue(system_meta, world);
     }
+}
 
+// SAFETY: Only local state is accessed.
+unsafe impl<I: SystemInput, T: SystemBuffer> SystemParamFetch<I> for Deferred<'_, T> {
     #[inline]
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
         _system_meta: &SystemMeta,
         _world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         Ok(Deferred(state.get()))
     }
@@ -1297,13 +1403,17 @@ unsafe impl SystemParam for NonSendMarker {
     ) {
         system_meta.set_non_send();
     }
+}
 
+// SAFETY: No world access.
+unsafe impl<I: SystemInput> SystemParamFetch<I> for NonSendMarker {
     #[inline]
     unsafe fn get_param<'world, 'state>(
         _state: &'state mut Self::State,
         _system_meta: &SystemMeta,
         _world: UnsafeWorldCell<'world>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
         Ok(Self(PhantomData))
     }
@@ -1343,13 +1453,17 @@ unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
             );
         }
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, T: 'static> SystemParamFetch<I> for NonSend<'_, T> {
     #[inline]
     unsafe fn get_param<'w, 's>(
         &mut component_id: &'s mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         let (ptr, ticks) = world.get_non_send_with_ticks(component_id).ok_or_else(|| {
             SystemParamValidationError::invalid::<Self>("Non-send data not found")
@@ -1389,13 +1503,17 @@ unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
             );
         }
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, T: 'static> SystemParamFetch<I> for NonSendMut<'_, T> {
     #[inline]
     unsafe fn get_param<'w, 's>(
         &mut component_id: &'s mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         let (ptr, ticks) = world.get_non_send_with_ticks(component_id).ok_or_else(|| {
             SystemParamValidationError::invalid::<Self>("Non-send data not found")
@@ -1425,13 +1543,17 @@ unsafe impl<'a> SystemParam for &'a Archetypes {
     ) {
         system_access.require_shared_access::<Self>(system_meta);
     }
+}
 
+// SAFETY: no component value access
+unsafe impl<'a, I: SystemInput> SystemParamFetch<I> for &'a Archetypes {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         Ok(world.archetypes())
     }
@@ -1455,13 +1577,17 @@ unsafe impl<'a> SystemParam for &'a ResourceEntities {
     ) {
         system_access.require_shared_access::<Self>(system_meta);
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<'a, I: SystemInput> SystemParamFetch<I> for &'a ResourceEntities {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         Ok(world.resource_entities())
     }
@@ -1485,13 +1611,17 @@ unsafe impl<'a> SystemParam for &'a Components {
     ) {
         system_access.require_shared_access::<Self>(system_meta);
     }
+}
 
+// SAFETY: no component value access
+unsafe impl<'a, I: SystemInput> SystemParamFetch<I> for &'a Components {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         Ok(world.components())
     }
@@ -1515,13 +1645,17 @@ unsafe impl<'a> SystemParam for &'a Entities {
     ) {
         system_access.require_shared_access::<Self>(system_meta);
     }
+}
 
+// SAFETY: no component value access
+unsafe impl<'a, I: SystemInput> SystemParamFetch<I> for &'a Entities {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         Ok(world.entities())
     }
@@ -1545,13 +1679,17 @@ unsafe impl<'a> SystemParam for &'a EntityAllocator {
     ) {
         system_access.require_shared_access::<Self>(system_meta);
     }
+}
 
+// SAFETY: no component value access
+unsafe impl<'a, I: SystemInput> SystemParamFetch<I> for &'a EntityAllocator {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         Ok(world.entity_allocator())
     }
@@ -1575,13 +1713,17 @@ unsafe impl<'a> SystemParam for &'a Bundles {
     ) {
         system_access.require_shared_access::<Self>(system_meta);
     }
+}
 
+// SAFETY: no component value access
+unsafe impl<'a, I: SystemInput> SystemParamFetch<I> for &'a Bundles {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         Ok(world.bundles())
     }
@@ -1633,13 +1775,17 @@ unsafe impl SystemParam for SystemChangeTick {
         _world: &mut World,
     ) {
     }
+}
 
+// SAFETY: `SystemChangeTick` doesn't require any world access
+unsafe impl<I: SystemInput> SystemParamFetch<I> for SystemChangeTick {
     #[inline]
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
         system_meta: &SystemMeta,
         _world: UnsafeWorldCell<'w>,
         change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         Ok(SystemChangeTick {
             last_run: system_meta.last_run,
@@ -1667,23 +1813,27 @@ unsafe impl<T: SystemParam> SystemParam for Option<T> {
         T::init_access(state, system_meta, system_access, world);
     }
 
-    #[inline]
-    unsafe fn get_param<'world, 'state>(
-        state: &'state mut Self::State,
-        system_meta: &SystemMeta,
-        world: UnsafeWorldCell<'world>,
-        change_tick: Tick,
-    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
-        // SAFETY: Upheld by caller
-        Ok(unsafe { T::get_param(state, system_meta, world, change_tick) }.ok())
-    }
-
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
         T::apply(state, system_meta, world);
     }
 
     fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
         T::queue(state, system_meta, world);
+    }
+}
+
+// SAFETY: Delegates to `T`, which ensures the safety requirements are met
+unsafe impl<I: SystemInput, T: SystemParamFetch<I>> SystemParamFetch<I> for Option<T> {
+    #[inline]
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        change_tick: Tick,
+        input: &I::Inner<'_>,
+    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
+        // SAFETY: Upheld by caller
+        Ok(unsafe { T::get_param(state, system_meta, world, change_tick, input) }.ok())
     }
 }
 
@@ -1709,23 +1859,29 @@ unsafe impl<T: SystemParam> SystemParam for Result<T, SystemParamValidationError
         T::init_access(state, system_meta, system_access, world);
     }
 
-    #[inline]
-    unsafe fn get_param<'world, 'state>(
-        state: &'state mut Self::State,
-        system_meta: &SystemMeta,
-        world: UnsafeWorldCell<'world>,
-        change_tick: Tick,
-    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
-        // SAFETY: Upheld by caller
-        Ok(unsafe { T::get_param(state, system_meta, world, change_tick) })
-    }
-
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
         T::apply(state, system_meta, world);
     }
 
     fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
         T::queue(state, system_meta, world);
+    }
+}
+
+// SAFETY: Delegates to `T`, which ensures the safety requirements are met
+unsafe impl<I: SystemInput, T: SystemParamFetch<I>> SystemParamFetch<I>
+    for Result<T, SystemParamValidationError>
+{
+    #[inline]
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        change_tick: Tick,
+        input: &I::Inner<'_>,
+    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
+        // SAFETY: Upheld by caller
+        Ok(unsafe { T::get_param(state, system_meta, world, change_tick, input) })
     }
 }
 
@@ -1804,28 +1960,32 @@ unsafe impl<T: SystemParam> SystemParam for If<T> {
         T::init_access(state, system_meta, system_access, world);
     }
 
-    #[inline]
-    unsafe fn get_param<'world, 'state>(
-        state: &'state mut Self::State,
-        system_meta: &SystemMeta,
-        world: UnsafeWorldCell<'world>,
-        change_tick: Tick,
-    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
-        // SAFETY: Upheld by caller.
-        unsafe { T::get_param(state, system_meta, world, change_tick) }
-            .map(If)
-            .map_err(|mut e| {
-                e.skipped = true;
-                e
-            })
-    }
-
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
         T::apply(state, system_meta, world);
     }
 
     fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
         T::queue(state, system_meta, world);
+    }
+}
+
+// SAFETY: Delegates to `T`, which ensures the safety requirements are met
+unsafe impl<I: SystemInput, T: SystemParamFetch<I>> SystemParamFetch<I> for If<T> {
+    #[inline]
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        change_tick: Tick,
+        input: &I::Inner<'_>,
+    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
+        // SAFETY: Upheld by caller.
+        unsafe { T::get_param(state, system_meta, world, change_tick, input) }
+            .map(If)
+            .map_err(|mut e| {
+                e.skipped = true;
+                e
+            })
     }
 }
 
@@ -1854,22 +2014,6 @@ unsafe impl<T: SystemParam> SystemParam for Vec<T> {
         }
     }
 
-    #[inline]
-    unsafe fn get_param<'world, 'state>(
-        state: &'state mut Self::State,
-        system_meta: &SystemMeta,
-        world: UnsafeWorldCell<'world>,
-        change_tick: Tick,
-    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
-        state
-            .iter_mut()
-            // SAFETY:
-            // - We initialized the access for each parameter in `init_access`, so the caller ensures we have access to any world data needed by each param.
-            // - The caller ensures this was the world used to initialize our state, and we used that world to initialize parameter states
-            .map(|state| unsafe { T::get_param(state, system_meta, world, change_tick) })
-            .collect()
-    }
-
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
         for state in state {
             T::apply(state, system_meta, world);
@@ -1880,6 +2024,26 @@ unsafe impl<T: SystemParam> SystemParam for Vec<T> {
         for state in state {
             T::queue(state, system_meta, world.reborrow());
         }
+    }
+}
+
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, T: SystemParamFetch<I>> SystemParamFetch<I> for Vec<T> {
+    #[inline]
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        change_tick: Tick,
+        input: &I::Inner<'_>,
+    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
+        state
+            .iter_mut()
+            // SAFETY:
+            // - We initialized the access for each parameter in `init_access`, so the caller ensures we have access to any world data needed by each param.
+            // - The caller ensures this was the world used to initialize our state, and we used that world to initialize parameter states
+            .map(|state| unsafe { T::get_param(state, system_meta, world, change_tick, input) })
+            .collect()
     }
 }
 
@@ -1915,31 +2079,6 @@ unsafe impl<T: SystemParam> SystemParam for ParamSet<'_, '_, Vec<T>> {
         }
     }
 
-    #[inline]
-    unsafe fn get_param<'world, 'state>(
-        state: &'state mut Self::State,
-        system_meta: &SystemMeta,
-        world: UnsafeWorldCell<'world>,
-        change_tick: Tick,
-    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
-        // Validate each sub-param eagerly so that the system is correctly
-        // skipped by the executor when any sub-param is unavailable.
-        // PERF: the sub-params will be fetched again lazily when accessed through
-        // the ParamSet, but this is no worse than the previous
-        // validate_param + get_param pattern.
-        for s in state.iter_mut() {
-            // SAFETY: Upheld by caller.
-            drop(unsafe { T::get_param(s, system_meta, world, change_tick) }?);
-        }
-
-        Ok(ParamSet {
-            param_states: state,
-            system_meta: system_meta.clone(),
-            world,
-            change_tick,
-        })
-    }
-
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
         for state in state {
             T::apply(state, system_meta, world);
@@ -1953,7 +2092,38 @@ unsafe impl<T: SystemParam> SystemParam for ParamSet<'_, '_, Vec<T>> {
     }
 }
 
-impl<T: SystemParam> ParamSet<'_, '_, Vec<T>> {
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, T: SystemParamFetch<I>> SystemParamFetch<I>
+    for ParamSet<'_, '_, Vec<T>>
+{
+    #[inline]
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        change_tick: Tick,
+        input: &I::Inner<'_>,
+    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
+        // Validate each sub-param eagerly so that the system is correctly
+        // skipped by the executor when any sub-param is unavailable.
+        // PERF: the sub-params will be fetched again lazily when accessed through
+        // the ParamSet, but this is no worse than the previous
+        // validate_param + get_param pattern.
+        for s in state.iter_mut() {
+            // SAFETY: Upheld by caller.
+            drop(unsafe { T::get_param(s, system_meta, world, change_tick, input) }?);
+        }
+
+        Ok(ParamSet {
+            param_states: state,
+            system_meta: system_meta.clone(),
+            world,
+            change_tick,
+        })
+    }
+}
+
+impl<T: SystemParamFetch<()>> ParamSet<'_, '_, Vec<T>> {
     /// Accesses the parameter at the given index.
     /// No other parameters may be accessed while this one is active.
     pub fn get_mut(&mut self, index: usize) -> T::Item<'_, '_> {
@@ -1967,6 +2137,7 @@ impl<T: SystemParam> ParamSet<'_, '_, Vec<T>> {
                 &self.system_meta,
                 self.world,
                 self.change_tick,
+                &(),
             )
             .unwrap()
         }
@@ -1980,8 +2151,10 @@ impl<T: SystemParam> ParamSet<'_, '_, Vec<T>> {
                 // - We initialized the access for each parameter, so the caller ensures we have access to any world data needed by any param.
                 //   We have mutable access to the ParamSet, so no other params in the set are active.
                 // - The caller of `get_param` ensured that this was the world used to initialize our state, and we used that world to initialize parameter states
-                unsafe { T::get_param(state, &self.system_meta, self.world, self.change_tick) }
-                    .unwrap_or_else(|err| panic!("ParamSet parameter validation failed: {err}")),
+                unsafe {
+                    T::get_param(state, &self.system_meta, self.world, self.change_tick, &())
+                }
+                .unwrap_or_else(|err| panic!("ParamSet parameter validation failed: {err}")),
             );
         });
     }
@@ -2009,22 +2182,6 @@ unsafe impl<T: SystemParam, const N: usize> SystemParam for SmallVec<[T; N]> {
         }
     }
 
-    #[inline]
-    unsafe fn get_param<'world, 'state>(
-        state: &'state mut Self::State,
-        system_meta: &SystemMeta,
-        world: UnsafeWorldCell<'world>,
-        change_tick: Tick,
-    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
-        state
-            .iter_mut()
-            // SAFETY:
-            // - We initialized the access for each parameter in `init_access`, so the caller ensures we have access to any world data needed by each param.
-            // - The caller ensures this was the world used to initialize our state, and we used that world to initialize parameter states
-            .map(|state| unsafe { T::get_param(state, system_meta, world, change_tick) })
-            .collect()
-    }
-
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
         for state in state {
             T::apply(state, system_meta, world);
@@ -2035,6 +2192,28 @@ unsafe impl<T: SystemParam, const N: usize> SystemParam for SmallVec<[T; N]> {
         for state in state {
             T::queue(state, system_meta, world.reborrow());
         }
+    }
+}
+
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, T: SystemParamFetch<I>, const N: usize> SystemParamFetch<I>
+    for SmallVec<[T; N]>
+{
+    #[inline]
+    unsafe fn get_param<'world, 'state>(
+        state: &'state mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'world>,
+        change_tick: Tick,
+        input: &I::Inner<'_>,
+    ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
+        state
+            .iter_mut()
+            // SAFETY:
+            // - We initialized the access for each parameter in `init_access`, so the caller ensures we have access to any world data needed by each param.
+            // - The caller ensures this was the world used to initialize our state, and we used that world to initialize parameter states
+            .map(|state| unsafe { T::get_param(state, system_meta, world, change_tick, input) })
+            .collect()
     }
 }
 
@@ -2088,7 +2267,24 @@ macro_rules! impl_system_param_tuple {
             fn queue(($($param,)*): &mut Self::State, system_meta: &SystemMeta, mut world: DeferredWorld) {
                 $($param::queue($param, system_meta, world.reborrow());)*
             }
+        }
 
+        #[expect(
+            clippy::allow_attributes,
+            reason = "This is in a macro, and as such, the below lints may not always apply."
+        )]
+        #[allow(
+            non_snake_case,
+            reason = "Certain variable names are provided by the caller, not by us."
+        )]
+        #[allow(
+            unused_variables,
+            reason = "Zero-length tuples won't use some of the parameters."
+        )]
+        #[allow(clippy::unused_unit, reason = "Zero length tuple is unit.")]
+        $(#[$meta])*
+        // SAFETY: implementers of each `SystemParam` in the tuple have validated their impls
+        unsafe impl<I: SystemInput, $($param: SystemParamFetch<I>),*> SystemParamFetch<I> for ($($param,)*) {
             #[inline]
             #[track_caller]
             unsafe fn get_param<'w, 's>(
@@ -2096,6 +2292,7 @@ macro_rules! impl_system_param_tuple {
                 system_meta: &SystemMeta,
                 world: UnsafeWorldCell<'w>,
                 change_tick: Tick,
+                input: &I::Inner<'_>
             ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
                 let ($($param,)*) = state;
 
@@ -2109,7 +2306,7 @@ macro_rules! impl_system_param_tuple {
                         clippy::unused_unit,
                         reason = "Zero-length tuples won't have any params to get."
                     )]
-                    Ok(($($param::get_param($param, system_meta, world, change_tick)?,)*))
+                    Ok(($($param::get_param($param, system_meta, world, change_tick, input)?,)*))
                 }
             }
         }
@@ -2256,16 +2453,23 @@ unsafe impl<P: SystemParam + 'static> SystemParam for StaticSystemParam<'_, '_, 
     fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
         P::queue(state, system_meta, world);
     }
+}
 
+// SAFETY: all methods are just delegated to `P`'s `SystemParam` implementation
+unsafe impl<I: SystemInput, P: SystemParamFetch<I> + 'static> SystemParamFetch<I>
+    for StaticSystemParam<'_, '_, P>
+{
     #[inline]
     unsafe fn get_param<'world, 'state>(
         state: &'state mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'world>,
         change_tick: Tick,
+        input: &I::Inner<'_>,
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
         // SAFETY: Defer to the safety of P::SystemParam
-        unsafe { P::get_param(state, system_meta, world, change_tick) }.map(StaticSystemParam)
+        unsafe { P::get_param(state, system_meta, world, change_tick, input) }
+            .map(StaticSystemParam)
     }
 }
 
@@ -2283,13 +2487,17 @@ unsafe impl<T: ?Sized> SystemParam for PhantomData<T> {
         _world: &mut World,
     ) {
     }
+}
 
+// SAFETY: No world access.
+unsafe impl<I: SystemInput, T: ?Sized> SystemParamFetch<I> for PhantomData<T> {
     #[inline]
     unsafe fn get_param<'world, 'state>(
         _state: &'state mut Self::State,
         _system_meta: &SystemMeta,
         _world: UnsafeWorldCell<'world>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
         Ok(PhantomData)
     }
@@ -2316,12 +2524,18 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         _world: &mut World,
     ) {
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, D: QueryData + 'static, F: QueryFilter + 'static> SystemParamFetch<I>
+    for &'_ mut QueryState<D, F>
+{
     unsafe fn get_param<'world, 'state>(
         state: &'state mut Self::State,
         _system_meta: &SystemMeta,
         _world: UnsafeWorldCell<'world>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
         Ok(state)
     }
@@ -2349,12 +2563,18 @@ unsafe impl<P: SystemParam + 'static> SystemParam for &'_ mut SystemState<P> {
         _world: &mut World,
     ) {
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, P: SystemParam + 'static> SystemParamFetch<I>
+    for &'_ mut SystemState<P>
+{
     unsafe fn get_param<'world, 'state>(
         state: &'state mut Self::State,
         _system_meta: &SystemMeta,
         _world: UnsafeWorldCell<'world>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
         Ok(state)
     }
@@ -2451,20 +2671,20 @@ impl<'w, 's> DynSystemParam<'w, 's> {
     }
 
     /// Returns `true` if the inner system param is the same as `T`.
-    pub fn is<T: SystemParam>(&self) -> bool
+    pub fn is<T: SystemParamFetch<()>>(&self) -> bool
     // See downcast() function for an explanation of the where clause
     where
-        T::Item<'static, 'static>: SystemParam<Item<'w, 's> = T> + 'static,
+        T::Item<'static, 'static>: SystemParamFetch<(), Item<'w, 's> = T> + 'static,
     {
         self.state.is::<ParamState<T::Item<'static, 'static>>>()
     }
 
     /// Returns the inner system param if it is the correct type.
     /// This consumes the dyn param, so the returned param can have its original world and state lifetimes.
-    pub fn downcast<T: SystemParam>(self) -> Option<T>
+    pub fn downcast<T: SystemParamFetch<()>>(self) -> Option<T>
     // See downcast() function for an explanation of the where clause
     where
-        T::Item<'static, 'static>: SystemParam<Item<'w, 's> = T> + 'static,
+        T::Item<'static, 'static>: SystemParamFetch<(), Item<'w, 's> = T> + 'static,
     {
         // SAFETY:
         // - `DynSystemParam::new()` ensures `state` is a `ParamState<T>`, that the world matches,
@@ -2475,10 +2695,10 @@ impl<'w, 's> DynSystemParam<'w, 's> {
 
     /// Returns the inner system parameter if it is the correct type.
     /// This borrows the dyn param, so the returned param is only valid for the duration of that borrow.
-    pub fn downcast_mut<'a, T: SystemParam>(&'a mut self) -> Option<T>
+    pub fn downcast_mut<'a, T: SystemParamFetch<()>>(&'a mut self) -> Option<T>
     // See downcast() function for an explanation of the where clause
     where
-        T::Item<'static, 'static>: SystemParam<Item<'a, 'a> = T> + 'static,
+        T::Item<'static, 'static>: SystemParamFetch<(), Item<'a, 'a> = T> + 'static,
     {
         // SAFETY:
         // - `DynSystemParam::new()` ensures `state` is a `ParamState<T>`, that the world matches,
@@ -2492,10 +2712,12 @@ impl<'w, 's> DynSystemParam<'w, 's> {
     /// but since it only performs read access it can keep the original world lifetime.
     /// This can be useful with methods like [`Query::iter_inner()`] or [`Res::into_inner()`]
     /// to obtain references with the original world lifetime.
-    pub fn downcast_mut_inner<'a, T: ReadOnlySystemParam>(&'a mut self) -> Option<T>
+    pub fn downcast_mut_inner<'a, T: ReadOnlySystemParam + SystemParamFetch<()>>(
+        &'a mut self,
+    ) -> Option<T>
     // See downcast() function for an explanation of the where clause
     where
-        T::Item<'static, 'static>: SystemParam<Item<'w, 'a> = T> + 'static,
+        T::Item<'static, 'static>: SystemParamFetch<(), Item<'w, 'a> = T> + 'static,
     {
         // SAFETY:
         // - `DynSystemParam::new()` ensures `state` is a `ParamState<T>`, that the world matches,
@@ -2511,7 +2733,7 @@ impl<'w, 's> DynSystemParam<'w, 's> {
 ///   in [`init_state`](SystemParam::init_state) for the inner system param.
 /// - `world` must be the same `World` that was used to initialize
 ///   [`state`](SystemParam::init_state) for the inner system param.
-unsafe fn downcast<'w, 's, T: SystemParam>(
+unsafe fn downcast<'w, 's, T: SystemParamFetch<()>>(
     state: &'s mut dyn Any,
     system_meta: &SystemMeta,
     world: UnsafeWorldCell<'w>,
@@ -2526,7 +2748,7 @@ unsafe fn downcast<'w, 's, T: SystemParam>(
 // Every actual `SystemParam` implementation has `T::Item == T` up to lifetimes,
 // so they should all work with this constraint.
 where
-    T::Item<'static, 'static>: SystemParam<Item<'w, 's> = T> + 'static,
+    T::Item<'static, 'static>: SystemParamFetch<(), Item<'w, 's> = T> + 'static,
 {
     state
         .downcast_mut::<ParamState<T::Item<'static, 'static>>>()
@@ -2535,7 +2757,7 @@ where
             // - The caller ensures the world has access for the underlying system param,
             //   and since the downcast succeeded, the underlying system param is T.
             // - The caller ensures the `world` matches.
-            unsafe { T::Item::get_param(&mut state.0, system_meta, world, change_tick) }.ok()
+            unsafe { T::Item::get_param(&mut state.0, system_meta, world, change_tick, &()) }.ok()
         })
 }
 
@@ -2543,7 +2765,7 @@ where
 pub struct DynSystemParamState(Box<dyn DynParamState>);
 
 impl DynSystemParamState {
-    pub(crate) fn new<T: SystemParam + 'static>(state: T::State) -> Self {
+    pub(crate) fn new<T: SystemParamFetch<()> + 'static>(state: T::State) -> Self {
         Self(Box::new(ParamState::<T>(state)))
     }
 }
@@ -2580,9 +2802,9 @@ trait DynParamState: Sync + Send + Any {
 }
 
 /// A wrapper around a [`SystemParam::State`] that can be used as a trait object in a [`DynSystemParam`].
-struct ParamState<T: SystemParam>(T::State);
+struct ParamState<T: SystemParamFetch<()>>(T::State);
 
-impl<T: SystemParam + 'static> DynParamState for ParamState<T> {
+impl<T: SystemParamFetch<()> + 'static> DynParamState for ParamState<T> {
     fn apply(&mut self, system_meta: &SystemMeta, world: &mut World) {
         T::apply(&mut self.0, system_meta, world);
     }
@@ -2607,7 +2829,7 @@ impl<T: SystemParam + 'static> DynParamState for ParamState<T> {
         change_tick: Tick,
     ) -> Result<(), SystemParamValidationError> {
         // SAFETY: Upheld by caller.
-        unsafe { T::get_param(&mut self.0, system_meta, world, change_tick) }.map(drop)
+        unsafe { T::get_param(&mut self.0, system_meta, world, change_tick, &()) }.map(drop)
     }
 }
 
@@ -2630,12 +2852,24 @@ unsafe impl SystemParam for DynSystemParam<'_, '_> {
         state.0.init_access(system_meta, system_access, world);
     }
 
+    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
+        state.0.apply(system_meta, world);
+    }
+
+    fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
+        state.0.queue(system_meta, world);
+    }
+}
+
+// SAFETY: Delegates to the wrapped parameter, which ensures the safety requirements are met
+unsafe impl SystemParamFetch<()> for DynSystemParam<'_, '_> {
     #[inline]
     unsafe fn get_param<'world, 'state>(
         state: &'state mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'world>,
         change_tick: Tick,
+        _input: &(),
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
         // Validate the inner parameter eagerly so that systems using DynSystemParam
         // are correctly skipped by the executor when the inner param is unavailable.
@@ -2649,14 +2883,6 @@ unsafe impl SystemParam for DynSystemParam<'_, '_> {
         Ok(unsafe {
             DynSystemParam::new(state.0.as_mut(), world, system_meta.clone(), change_tick)
         })
-    }
-
-    fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
-        state.0.apply(system_meta, world);
-    }
-
-    fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
-        state.0.queue(system_meta, world);
     }
 }
 
@@ -2688,12 +2914,17 @@ unsafe impl SystemParam for FilteredResources<'_, '_> {
             panic!("error[B0002]: FilteredResources in system {system_name} accesses resources(s){accesses} in a way that conflicts with a previous system parameter. Consider removing the duplicate access. See: https://bevy.org/learn/errors/b0002");
         }
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+#[expect(deprecated, reason = "`FilteredResources` will be removed.")]
+unsafe impl<I: SystemInput> SystemParamFetch<I> for FilteredResources<'_, '_> {
     unsafe fn get_param<'world, 'state>(
         state: &'state mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'world>,
         change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
         // SAFETY: The caller ensures that `world` has access to anything registered in `init_access`,
         // and we registered all resource access in `state``.
@@ -2733,12 +2964,17 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
             panic!("error[B0002]: FilteredResourcesMut in system {system_name} accesses resources(s){accesses} in a way that conflicts with a previous system parameter. Consider removing the duplicate access. See: https://bevy.org/learn/errors/b0002");
         }
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+#[expect(deprecated, reason = "`FilteredResourcesMut` will be removed.")]
+unsafe impl<I: SystemInput> SystemParamFetch<I> for FilteredResourcesMut<'_, '_> {
     unsafe fn get_param<'world, 'state>(
         state: &'state mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'world>,
         change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
         // SAFETY: The caller ensures that `world` has access to anything registered in `init_access`,
         // and we registered all resource access in `state``.

--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -1,7 +1,10 @@
 use crate::{
     change_detection::Tick,
     storage::SparseSetIndex,
-    system::{SystemAccess, SystemMeta, SystemParam, SystemParamValidationError},
+    system::{
+        SystemAccess, SystemInput, SystemMeta, SystemParam, SystemParamFetch,
+        SystemParamValidationError,
+    },
     world::{unsafe_world_cell::UnsafeWorldCell, FromWorld, World},
 };
 use bevy_platform::sync::atomic::{AtomicUsize, Ordering};
@@ -74,13 +77,17 @@ unsafe impl SystemParam for WorldId {
     ) {
         system_access.require_shared_access::<Self>(system_meta);
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput> SystemParamFetch<I> for WorldId {
     #[inline]
     unsafe fn get_param<'world, 'state>(
         _: &'state mut Self::State,
         _: &SystemMeta,
         world: UnsafeWorldCell<'world>,
         _: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
         Ok(world.id())
     }

--- a/crates/bevy_extract/src/extract_param.rs
+++ b/crates/bevy_extract/src/extract_param.rs
@@ -3,8 +3,8 @@ use bevy_ecs::{
     change_detection::Tick,
     prelude::*,
     system::{
-        ReadOnlySystemParam, SystemAccess, SystemMeta, SystemParam, SystemParamItem,
-        SystemParamValidationError, SystemState,
+        ReadOnlySystemParam, SystemAccess, SystemMeta, SystemParam, SystemParamFetch,
+        SystemParamItem, SystemParamValidationError, SystemState,
     },
     world::unsafe_world_cell::UnsafeWorldCell,
 };
@@ -89,26 +89,35 @@ where
     ) {
         Res::<MainWorld>::init_access(&state.main_world_state, system_meta, system_access, world);
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I, P> SystemParamFetch<I> for Extract<'_, '_, P>
+where
+    I: SystemInput,
+    P: ReadOnlySystemParam + SystemParamFetch<I>,
+{
     #[inline]
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
+        input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         // SAFETY:
         // - The caller ensures that `world` is the same one that `init_state` was called with.
         // - The caller ensures that no other `SystemParam`s will conflict with the accesses we have registered.
         let main_world = unsafe {
-            Res::<MainWorld>::get_param(
+            <Res<MainWorld> as SystemParamFetch<()>>::get_param(
                 &mut state.main_world_state,
                 system_meta,
                 world,
                 change_tick,
+                &(),
             )?
         };
-        let item = state.state.get(main_world.into_inner())?;
+        let item = state.state.get_with(main_world.into_inner(), input)?;
         Ok(Extract { item })
     }
 }

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -12,8 +12,8 @@ use bevy_ecs::{
     change_detection::Tick,
     resource::Resource,
     system::{
-        Deferred, ReadOnlySystemParam, Res, SystemAccess, SystemBuffer, SystemMeta, SystemParam,
-        SystemParamValidationError,
+        Deferred, ReadOnlySystemParam, Res, SystemAccess, SystemBuffer, SystemInput, SystemMeta,
+        SystemParam, SystemParamFetch, SystemParamValidationError,
     },
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
 };
@@ -222,21 +222,34 @@ where
     fn queue(state: &mut Self::State, system_meta: &SystemMeta, world: DeferredWorld) {
         GizmosState::<Config, Clear>::queue(&mut state.state, system_meta, world);
     }
+}
 
+#[expect(
+    unsafe_code,
+    reason = "We cannot implement SystemParam without using unsafe code."
+)]
+// SAFETY: All methods are delegated to existing `SystemParam` implementations
+unsafe impl<I: SystemInput, Config, Clear> SystemParamFetch<I> for Gizmos<'_, '_, Config, Clear>
+where
+    Config: GizmoConfigGroup,
+    Clear: 'static + Send + Sync,
+{
     #[inline]
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
         system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
+        input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         // SAFETY: Delegated to existing `SystemParam` implementations.
         let (mut f0, f1) = unsafe {
-            GizmosState::<Config, Clear>::get_param(
+            <GizmosState<Config, Clear> as SystemParamFetch<I>>::get_param(
                 &mut state.state,
                 system_meta,
                 world,
                 change_tick,
+                input,
             )?
         };
 

--- a/crates/bevy_render/src/batching/mod.rs
+++ b/crates/bevy_render/src/batching/mod.rs
@@ -1,7 +1,7 @@
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    system::{ResMut, SystemParam, SystemParamItem},
+    system::{ResMut, SystemParamFetch, SystemParamItem},
 };
 use gpu_preprocessing::UntypedPhaseIndirectParametersBuffers;
 use nonmax::NonMaxU32;
@@ -78,7 +78,7 @@ impl<T: PartialEq> BatchSetMeta<T> {
 pub trait GetBatchData {
     /// The system parameters [`GetBatchData::get_batch_data`] needs in
     /// order to compute the batch data.
-    type Param: SystemParam + 'static;
+    type Param: SystemParamFetch<()> + 'static;
     /// Data used for comparison between phase items to decide whether items can
     /// be batched.
     ///

--- a/crates/bevy_render/src/erased_render_asset.rs
+++ b/crates/bevy_render/src/erased_render_asset.rs
@@ -8,7 +8,7 @@ use bevy_asset::{Asset, AssetEvent, AssetId, Assets, UntypedAssetId};
 use bevy_ecs::{
     prelude::{Commands, IntoScheduleConfigs, Local, MessageReader, ResMut, Resource},
     schedule::{ScheduleConfigs, SystemSet},
-    system::{ScheduleSystem, StaticSystemParam, SystemParam, SystemParamItem, SystemState},
+    system::{ScheduleSystem, StaticSystemParam, SystemParamFetch, SystemParamItem, SystemState},
     world::{FromWorld, Mut},
 };
 use bevy_log::{debug, error};
@@ -45,7 +45,7 @@ pub trait ErasedRenderAsset: Send + Sync + 'static {
     /// Specifies all ECS data required by [`ErasedRenderAsset::prepare_asset`].
     ///
     /// For convenience use the [`lifetimeless`](bevy_ecs::system::lifetimeless) [`SystemParam`].
-    type Param: SystemParam;
+    type Param: SystemParamFetch<()>;
 
     /// Whether or not to unload the asset after extracting it to the render world.
     #[inline]

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -7,7 +7,7 @@ use bevy_asset::{Asset, AssetEvent, AssetId, Assets, RenderAssetUsages};
 use bevy_ecs::{
     prelude::{Commands, IntoScheduleConfigs, Local, MessageReader, ResMut, Resource},
     schedule::{ScheduleConfigs, SystemSet},
-    system::{ScheduleSystem, StaticSystemParam, SystemParam, SystemParamItem, SystemState},
+    system::{ScheduleSystem, StaticSystemParam, SystemParamFetch, SystemParamItem, SystemState},
     world::{FromWorld, Mut},
 };
 use bevy_log::{debug, error};
@@ -51,7 +51,7 @@ pub trait RenderAsset: Send + Sync + 'static + Sized {
     /// Specifies all ECS data required by [`RenderAsset::prepare_asset`].
     ///
     /// For convenience use the [`lifetimeless`](bevy_ecs::system::lifetimeless) [`SystemParam`].
-    type Param: SystemParam;
+    type Param: SystemParamFetch<()>;
 
     /// Whether or not to unload the asset after extracting it to the render world.
     #[inline]

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     entity::Entity,
     query::{QueryEntityError, QueryState, ROQueryItem, ReadOnlyQueryData},
     resource::Resource,
-    system::{ReadOnlySystemParam, SystemParam, SystemParamItem, SystemState},
+    system::{ReadOnlySystemParam, SystemParamFetch, SystemParamItem, SystemState},
     world::World,
 };
 use bevy_utils::TypeIdHashMap;
@@ -190,7 +190,7 @@ pub trait RenderCommand<P: PhaseItem> {
     ///
     /// [`SRes`]: bevy_ecs::system::lifetimeless::SRes
     /// [`SRes::into_inner`]: bevy_ecs::system::lifetimeless::SRes::into_inner
-    type Param: SystemParam + 'static;
+    type Param: SystemParamFetch<()> + 'static;
     /// Specifies the ECS data of the view entity required by [`RenderCommand::render`].
     ///
     /// The view entity refers to the camera, or shadow-casting light, etc. from which the phase

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use bevy_asset::Handle;
 use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::system::{SystemParam, SystemParamItem};
+use bevy_ecs::system::{SystemParamFetch, SystemParamItem};
 use bevy_material::descriptor::BindGroupLayoutDescriptor;
 pub use bevy_render_macros::AsBindGroup;
 use bevy_utils::define_atomic_id;
@@ -511,7 +511,7 @@ pub trait AsBindGroup {
     /// Data that will be stored alongside the "prepared" bind group.
     type Data: Send + Sync;
 
-    type Param: SystemParam + 'static;
+    type Param: SystemParamFetch<()> + 'static;
 
     /// The number of slots per bind group, if bindless mode is enabled.
     ///

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -9,7 +9,7 @@ use bevy_ecs::component::ComponentId;
 use bevy_ecs::prelude::*;
 use bevy_ecs::query::{QueryData, QueryFilter, QueryState};
 use bevy_ecs::system::{
-    Deferred, SystemAccess, SystemBuffer, SystemMeta, SystemName, SystemParam,
+    Deferred, SystemAccess, SystemBuffer, SystemMeta, SystemName, SystemParam, SystemParamFetch,
     SystemParamValidationError,
 };
 use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
@@ -370,13 +370,19 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
             world,
         );
     }
+}
 
+// SAFETY: `get_param` only accesses things registered in `init_access`.
+unsafe impl<I: SystemInput, D: QueryData + 'static, F: QueryFilter + 'static> SystemParamFetch<I>
+    for ViewQuery<'_, '_, D, F>
+{
     #[inline]
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
         _system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
+        _input: &I::Inner<'_>,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         // SAFETY: We have registered resource read access in init_access
         let current_view = unsafe { world.get_resource::<CurrentView>() };


### PR DESCRIPTION
# Objective

- Closes #15653 

## Solution

`SystemParam`s now take the `SystemInput` by reference when fetching the data for the system:

1. Add `trait SystemParamFetch<I: SystemInput>: SystemParam`, a new super trait of `SystemParam`.
2. Move `SystemParam::get_param` to `SystemParamFetch`, and add a new argument to it that accepts a reference to the `SystemInput`.
3. Implement `SystemParamFetch` for any `I: SystemInput` for all current `SystemParam` implementations, and move the `get_param` implementation over.
4. Add functions to `SystemState` to work with non-`()` system inputs.
5. Update `FunctionSystem` trait machinery from `P: SystemParam` to `P: SystemParamFetch<System::In>`.
6. Add `TargetEntity` trait and `Target<D, F>` query type. The latter is similar to `Single<D, F>`, but fetches the query data for the *target* entity rather than the *unique* entity that matches the query.
  a. `Target<D, F>` is bounded to only work with `SystemInput`s that take a type that implements `TargetEntity`.

Benefits of this approach:
- **Compile-time checked**: if you use `Target<D, F>` in a normal scheduled system (which has no input), you get an error when trying to register the system via `add_systems`.
- **No hidden state**: The target `Entity` used by `Target<D, F>` is the same data available via `On<E>`.
- **Extensible**: supports `SystemParam` fetching based on *any* `SystemInput`
  - Which means you could implement an `OriginalTarget<D, F>` for propagating events, for example.

Drawbacks of this approach:
- **Type complexity**: while custom `SystemParam` implementations are already in advanced territory, complicating the API surface further does have an impact.
  - This can be (and has partly been) remediated with documentation on good practices.

## Testing

Added a test for `Target<D, F>`.

---

## Showcase

Ergonomic target entity queries are here!

```rust
fn my_observer(on: On<Interact>, button: Target<&Name, With<Button>>) {
    // The observer's function only executes if the Target query matches the target entity
    let name = *button;
    println!("Button {name} was interacted with");
}

app.add_observer(my_observer);
```