### PR TITLE
Size the visibility range binding for the buffer type it was given

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -3,13 +3,13 @@ mod prepass_bindings;
 use crate::{
     alpha_mode_pipeline_key, binding_arrays_are_usable, buffer_layout,
     collect_meshes_for_gpu_building, init_material_pipeline, set_mesh_motion_vector_flags,
-    setup_morph_and_skinning_defs, skin, DeferredAlphaMaskDrawFunction, DeferredFragmentShader,
-    DeferredOpaqueDrawFunction, DeferredVertexShader, DrawMesh, MaterialPipeline,
-    MaterialPropertiesExt, MeshLayouts, MeshPipeline, MeshPipelineKey, PreparedMaterial,
-    PrepassAlphaMaskDrawFunction, PrepassFragmentShader, PrepassOpaqueDepthOnlyDrawFunction,
-    PrepassOpaqueDrawFunction, PrepassVertexShader, RenderLightmaps, RenderMaterialInstances,
-    RenderMeshInstanceFlags, RenderMeshInstances, SetMaterialBindGroup, SetMeshBindGroup,
-    ShadowView,
+    setup_morph_and_skinning_defs, skin, visibility_ranges_min_binding_size,
+    DeferredAlphaMaskDrawFunction, DeferredFragmentShader, DeferredOpaqueDrawFunction,
+    DeferredVertexShader, DrawMesh, MaterialPipeline, MaterialPropertiesExt, MeshLayouts,
+    MeshPipeline, MeshPipelineKey, PreparedMaterial, PrepassAlphaMaskDrawFunction,
+    PrepassFragmentShader, PrepassOpaqueDepthOnlyDrawFunction, PrepassOpaqueDrawFunction,
+    PrepassVertexShader, RenderLightmaps, RenderMaterialInstances, RenderMeshInstanceFlags,
+    RenderMeshInstances, SetMaterialBindGroup, SetMeshBindGroup, ShadowView,
 };
 use bevy_app::{App, Plugin, PreUpdate};
 use bevy_asset::{embedded_asset, load_embedded_asset, AssetServer, Handle};
@@ -26,7 +26,7 @@ use bevy_material::{
     key::{ErasedMaterialPipelineKey, ErasedMeshPipelineKey},
     AlphaMode, MaterialProperties, OpaqueRendererMethod, RenderPhaseType,
 };
-use bevy_math::{Affine3A, Mat4, Vec2, Vec4};
+use bevy_math::{Affine3A, Mat4, Vec2};
 use bevy_mesh::{Mesh, Mesh3d, MeshAttributeCompressionFlags, MeshVertexBufferLayoutRef};
 use bevy_render::{
     batching::gpu_preprocessing::GpuPreprocessingSupport,
@@ -300,7 +300,9 @@ pub fn init_prepass_pipeline(
                     buffer_layout(
                         visibility_ranges_buffer_binding_type,
                         false,
-                        Some(Vec4::min_size()),
+                        Some(visibility_ranges_min_binding_size(
+                            visibility_ranges_buffer_binding_type,
+                        )),
                     )
                     .visibility(ShaderStages::VERTEX),
                 ),
@@ -323,7 +325,9 @@ pub fn init_prepass_pipeline(
                     buffer_layout(
                         visibility_ranges_buffer_binding_type,
                         false,
-                        Some(Vec4::min_size()),
+                        Some(visibility_ranges_min_binding_size(
+                            visibility_ranges_buffer_binding_type,
+                        )),
                     )
                     .visibility(ShaderStages::VERTEX),
                 ),

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -32,7 +32,7 @@ use bevy_render::{
     texture::{FallbackImage, FallbackImageZero, GpuImage},
     view::{
         Msaa, RenderVisibilityRanges, ViewUniform, ViewUniformOffset, ViewUniforms,
-        VISIBILITY_RANGES_STORAGE_BUFFER_COUNT,
+        VISIBILITY_RANGES_STORAGE_BUFFER_COUNT, VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE,
     },
 };
 use core::fmt::Write;
@@ -350,7 +350,13 @@ fn layout_entries(
                 buffer_layout(
                     visibility_ranges_buffer_binding_type,
                     false,
-                    Some(Vec4::min_size()),
+                    Some(match visibility_ranges_buffer_binding_type {
+                        BufferBindingType::Uniform => Vec4::min_size().saturating_mul(
+                            NonZero::new(VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE as u64)
+                                .expect("the uniform array holds at least one element"),
+                        ),
+                        BufferBindingType::Storage { .. } => Vec4::min_size(),
+                    }),
                 )
                 .visibility(ShaderStages::VERTEX),
             ),

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -351,10 +351,9 @@ fn layout_entries(
                     visibility_ranges_buffer_binding_type,
                     false,
                     Some(match visibility_ranges_buffer_binding_type {
-                        BufferBindingType::Uniform => Vec4::min_size().saturating_mul(
-                            NonZero::new(VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE as u64)
-                                .expect("the uniform array holds at least one element"),
-                        ),
+                        BufferBindingType::Uniform => {
+                            <[Vec4; VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE]>::min_size()
+                        }
                         BufferBindingType::Storage { .. } => Vec4::min_size(),
                     }),
                 )

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -240,6 +240,17 @@ pub(crate) fn buffer_layout(
     }
 }
 
+/// The minimum size of the visibility ranges binding: one element of the
+/// runtime-sized storage array, or the whole fixed-size uniform array.
+pub(crate) fn visibility_ranges_min_binding_size(
+    buffer_binding_type: BufferBindingType,
+) -> NonZero<u64> {
+    match buffer_binding_type {
+        BufferBindingType::Uniform => <[Vec4; VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE]>::min_size(),
+        BufferBindingType::Storage { .. } => Vec4::min_size(),
+    }
+}
+
 /// Returns the appropriate bind group layout vec based on the parameters
 fn layout_entries(
     layout_key: MeshPipelineViewLayoutKey,
@@ -350,12 +361,9 @@ fn layout_entries(
                 buffer_layout(
                     visibility_ranges_buffer_binding_type,
                     false,
-                    Some(match visibility_ranges_buffer_binding_type {
-                        BufferBindingType::Uniform => {
-                            <[Vec4; VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE]>::min_size()
-                        }
-                        BufferBindingType::Storage { .. } => Vec4::min_size(),
-                    }),
+                    Some(visibility_ranges_min_binding_size(
+                        visibility_ranges_buffer_binding_type,
+                    )),
                 )
                 .visibility(ShaderStages::VERTEX),
             ),

--- a/crates/bevy_render/src/view/visibility/range.rs
+++ b/crates/bevy_render/src/view/visibility/range.rs
@@ -36,7 +36,7 @@ pub const VISIBILITY_RANGES_STORAGE_BUFFER_COUNT: u32 = 4;
 /// The size of the visibility ranges buffer in elements (not bytes) when fewer
 /// than 6 storage buffers are available and we're forced to use a uniform
 /// buffer instead (most notably, on WebGL 2).
-const VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE: usize = 64;
+pub const VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE: usize = 64;
 
 /// A plugin that enables [`RenderVisibilityRanges`]s, which allow entities to be
 /// hidden or shown based on distance to the camera.


### PR DESCRIPTION
## Objective

On WebGL2, a mesh with a crossfading `VisibilityRange` gets a pipeline that fails validation:

```
In Device::create_render_pipeline, label = 'pbr_opaque_mesh_pipeline'
  Error matching ShaderStages(VERTEX) shader requirements against the pipeline
    Shader global ResourceBinding { group: 0, binding: 14 } is not available in the pipeline layout
      Buffer structure size 1024, added to one element of an unbound array, if it's the last
      field, ended up greater than the given `min_binding_size`, which is 16
```

Fixes #21309.

## Solution

Binding 14 is the visibility range buffer, and it is declared two ways depending on how many
storage buffers the device has. `mesh_view_bindings.wesl`:

```wgsl
const VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE: u32 = 64u;
@if(AVAILABLE_STORAGE_BUFFER_BINDINGS__GE_6)
@group(0) @binding(14) var<storage> visibility_ranges: array<vec4<f32>>;
@else
@group(0) @binding(14) var<uniform> visibility_ranges: array<vec4<f32>, VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE>;
```

`layout_entries` gave that binding `Some(Vec4::min_size())` — 16 bytes — whichever branch had
been taken. That is right only for the storage declaration, where the array is runtime-sized and
one element genuinely is the minimum the shader can be said to require. The uniform declaration
is fixed at `VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE` elements, so the shader requires all 1024
bytes, and a layout promising 16 is one a 16-byte buffer could satisfy.

Only the layout changes. The buffer bound there is already 1024 bytes, because
`write_render_visibility_ranges` pads it to exactly `VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE`
elements on this path, so the larger `min_binding_size` is one it already satisfies.

The size now follows the binding type. `VISIBILITY_RANGE_UNIFORM_BUFFER_SIZE` was private to
`bevy_render`, so this exports it rather than writing the number out again here.

## Testing

- The `visibility_range` example from #21309, built for `wasm32-unknown-unknown` with `webgl2` at this commit and at its parent: it fails on the parent and runs here.

## AI usage

The gap was found by Claude Opus 5, and the change and the verification runs above were drafted
and carried out with it.

I have read every line of this change and stand behind it.