### PR TITLE
use `///` for wesl doc comments

### DIFF
--- a/assets/shaders/bindless_material.wesl
+++ b/assets/shaders/bindless_material.wesl
@@ -6,8 +6,8 @@ struct Color {
     base_color: vec4<f32>,
 }
 
-// This structure is a mapping from bindless index to the index in the
-// appropriate slab
+/// This structure is a mapping from bindless index to the index in the
+/// appropriate slab
 struct MaterialBindings {
     material: u32,              // 0
     color_texture: u32,         // 1

--- a/assets/shaders/compute_mesh.wesl
+++ b/assets/shaders/compute_mesh.wesl
@@ -1,12 +1,12 @@
-// This shader is used for the compute_mesh example
-// The actual work it does is not important for the example and
-// has been hardcoded to return a cube mesh
+//! This shader is used for the compute_mesh example
+//! The actual work it does is not important for the example and
+//! has been hardcoded to return a cube mesh
 
-// `vertex_start` is the starting offset of the mesh data in the *vertex_data* storage buffer
-// `index_start` is the starting offset of the index data in the *index_data* storage buffer
 struct DataRanges {
+    /// the starting offset of the mesh data in the *vertex_data* storage buffer
     vertex_start: u32,
     vertex_end: u32,
+    /// the starting offset of the index data in the *index_data* storage buffer
     index_start: u32,
     index_end: u32,
 }
@@ -26,7 +26,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         // which allocates slabs that each can contain multiple meshes.
         // This buffer is one slab, and data_range.vertex_start is the
         // starting offset for the mesh we care about.
-        // So the 0 starting value in the for loop is added to 
+        // So the 0 starting value in the for loop is added to
         // data_range.vertex_start which means we start writing at the
         // correct offset.
         //
@@ -46,7 +46,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 }
 
 // hardcoded compute shader data.
-// half_size is half the size of the cube
+/// half the size of the cube
 const half_size = vec3(1.5);
 const min = -half_size;
 const max = half_size;

--- a/assets/shaders/custom_clustered_decal.wesl
+++ b/assets/shaders/custom_clustered_decal.wesl
@@ -1,5 +1,5 @@
-// This shader, a part of the `clustered_decals` example, shows how to use the
-// decal `tag` field to apply arbitrary decal effects.
+//! This shader, a part of the `clustered_decals` example, shows how to use the
+//! decal `tag` field to apply arbitrary decal effects.
 
 import bevy_pbr::{
     decal::clustered,
@@ -85,4 +85,3 @@ fn fragment(
 
     return out;
 }
-

--- a/assets/shaders/custom_material_2d_bindless.wesl
+++ b/assets/shaders/custom_material_2d_bindless.wesl
@@ -8,8 +8,8 @@ struct Color {
     base_color: vec4<f32>,
 }
 
-// This structure is a mapping from bindless index to the index in the
-// appropriate slab
+/// This structure is a mapping from bindless index to the index in the
+/// appropriate slab
 struct MaterialBindings {
     material: u32,              // 0
     color_texture: u32,         // 1

--- a/assets/shaders/custom_phase_item.wesl
+++ b/assets/shaders/custom_phase_item.wesl
@@ -1,25 +1,25 @@
-// `custom_phase_item.wesl`
-//
-// This shader goes with the `custom_phase_item` example. It demonstrates how to
-// enqueue custom rendering logic in a `RenderPhase`.
+//! `custom_phase_item.wesl`
+//!
+//! This shader goes with the `custom_phase_item` example. It demonstrates how to
+//! enqueue custom rendering logic in a `RenderPhase`.
 
-// The GPU-side vertex structure.
+/// The GPU-side vertex structure.
 struct Vertex {
-    // The world-space position of the vertex.
+    /// The world-space position of the vertex.
     @location(0) position: vec3<f32>,
-    // The color of the vertex.
+    /// The color of the vertex.
     @location(1) color: vec3<f32>,
 };
 
-// Information passed from the vertex shader to the fragment shader.
+/// Information passed from the vertex shader to the fragment shader.
 struct VertexOutput {
-    // The clip-space position of the vertex.
+    /// The clip-space position of the vertex.
     @builtin(position) clip_position: vec4<f32>,
-    // The color of the vertex.
+    /// The color of the vertex.
     @location(0) color: vec3<f32>,
 };
 
-// The vertex shader entry point.
+/// The vertex shader entry point.
 @vertex
 fn vertex(vertex: Vertex) -> VertexOutput {
     // Use an orthographic projection.
@@ -29,7 +29,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     return vertex_output;
 }
 
-// The fragment shader entry point.
+/// The fragment shader entry point.
 @fragment
 fn fragment(vertex_output: VertexOutput) -> @location(0) vec4<f32> {
     return vec4(vertex_output.color, 1.0);

--- a/assets/shaders/custom_stencil.wesl
+++ b/assets/shaders/custom_stencil.wesl
@@ -20,7 +20,7 @@ struct Vertex {
     @location(0) position: vec3<f32>,
 };
 
-// This is the output of the vertex shader and we also use it as the input for the fragment shader
+/// This is the output of the vertex shader and we also use it as the input for the fragment shader
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) world_position: vec4<f32>,

--- a/assets/shaders/custom_ui_material.wesl
+++ b/assets/shaders/custom_ui_material.wesl
@@ -1,4 +1,4 @@
-// Draws a progress bar with properties defined in CustomUiMaterial
+//! Draws a progress bar with properties defined in CustomUiMaterial
 import bevy_ui_render::ui_vertex_output::UiVertexOutput;
 
 @group(1) @binding(0) var<uniform> color: vec4<f32>;
@@ -31,8 +31,8 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     // distance along each axis from the corner
     let d = half_size - abs(p);
 
-    // if the distance to the edge from the current position on any axis 
-    // is less than the border width on that axis then the position is within 
+    // if the distance to the edge from the current position on any axis
+    // is less than the border width on that axis then the position is within
     // the border and we return the border color
     if d.x < b.x || d.y < b.y {
         // select radius for the nearest corner

--- a/assets/shaders/deferred_raymarch.wesl
+++ b/assets/shaders/deferred_raymarch.wesl
@@ -1,7 +1,7 @@
-// Raymarches a signed distance field and packs it into the deferred gbuffer exactly as
-// a `StandardMaterial` would (via `deferred_gbuffer_from_pbr_input`), so Bevy's deferred
-// PBR lighting shades it like any other geometry. This example assumes familiarity with
-// raymarching.
+//! Raymarches a signed distance field and packs it into the deferred gbuffer exactly as
+//! a `StandardMaterial` would (via `deferred_gbuffer_from_pbr_input`), so Bevy's deferred
+//! PBR lighting shades it like any other geometry. This example assumes familiarity with
+//! raymarching.
 
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
 import bevy_pbr::render::mesh_view_bindings::view;
@@ -88,9 +88,9 @@ fn depth_for_world_pos(world_pos: vec3<f32>) -> f32 {
     return view_z_to_depth_ndc(position_world_to_view(world_pos).z);
 }
 
-// Our render pass has two color targets, matching the deferred prepass:
-//   location 0: the packed gbuffer (Rgba32Uint)
-//   location 1: the deferred lighting pass id (R8Uint)
+/// Our render pass has two color targets, matching the deferred prepass:
+///   location 0: the packed gbuffer (Rgba32Uint)
+///   location 1: the deferred lighting pass id (R8Uint)
 struct GBufferOutput {
     @location(0) deferred: vec4<u32>,
     @location(1) deferred_lighting_pass_id: u32,
@@ -102,7 +102,7 @@ fn fragment(in: FullscreenVertexOutput) -> GBufferOutput {
     let ray = ray_for_uv(in.uv);
     let t = raymarch(ray.origin, ray.dir);
 
-    // discard so we leave the mesh gbuffer intact when we miss 
+    // discard so we leave the mesh gbuffer intact when we miss
     if t >= FAR {
         discard;
     }

--- a/assets/shaders/extended_material_bindless.wesl
+++ b/assets/shaders/extended_material_bindless.wesl
@@ -1,7 +1,7 @@
-// The shader that goes with `extended_material_bindless.rs`.
-//
-// This code demonstrates how to write shaders that are compatible with both
-// bindless and non-bindless mode. See the `@if(BINDLESS)` blocks.
+//! The shader that goes with `extended_material_bindless.rs`.
+//!
+//! This code demonstrates how to write shaders that are compatible with both
+//! bindless and non-bindless mode. See the `@if(BINDLESS)` blocks.
 
 import bevy_pbr::render::{
     forward_io::{FragmentOutput, VertexOutput},
@@ -16,33 +16,33 @@ import bevy_pbr::render::pbr_bindings::{material_array, material_indices};
 @else
 import bevy_pbr::render::pbr_bindings::material;
 
-// Stores the indices of the bindless resources in the bindless resource arrays,
-// for the `ExampleBindlessExtension` fields.
+/// Stores the indices of the bindless resources in the bindless resource arrays,
+/// for the `ExampleBindlessExtension` fields.
 struct ExampleBindlessExtendedMaterialIndices {
-    // The index of the `ExampleBindlessExtendedMaterial` data in
-    // `example_extended_material`.
+    /// The index of the `ExampleBindlessExtendedMaterial` data in
+    /// `example_extended_material`.
     material: u32,
-    // The index of the texture we're going to modulate the base color with in
-    // the `bindless_textures_2d` array.
+    /// The index of the texture we're going to modulate the base color with in
+    /// the `bindless_textures_2d` array.
     modulate_texture: u32,
-    // The index of the sampler we're going to sample the modulated texture with
-    // in the `bindless_samplers_filtering` array.
+    /// The index of the sampler we're going to sample the modulated texture with
+    /// in the `bindless_samplers_filtering` array.
     modulate_texture_sampler: u32,
 }
 
-// Plain data associated with this example material.
+/// Plain data associated with this example material.
 struct ExampleBindlessExtendedMaterial {
-    // The color that we multiply the base color, base color texture, and
-    // modulated texture with.
+    /// The color that we multiply the base color, base color texture, and
+    /// modulated texture with.
     modulate_color: vec4<f32>,
 }
 
-// The indices of the bindless resources in the bindless resource arrays, for
-// the `ExampleBindlessExtension` fields.
+/// The indices of the bindless resources in the bindless resource arrays, for
+/// the `ExampleBindlessExtension` fields.
 @if(BINDLESS) {
 @group(constants::MATERIAL_BIND_GROUP) @binding(100) var<storage> example_extended_material_indices: array<ExampleBindlessExtendedMaterialIndices>;
-// An array that holds the `ExampleBindlessExtendedMaterial` plain old data,
-// indexed by `ExampleBindlessExtendedMaterialIndices.material`.
+/// An array that holds the `ExampleBindlessExtendedMaterial` plain old data,
+/// indexed by `ExampleBindlessExtendedMaterialIndices.material`.
 @group(constants::MATERIAL_BIND_GROUP) @binding(101) var<storage> example_extended_material: array<ExampleBindlessExtendedMaterial>;
 }
 // In non-bindless mode, we simply use a uniform for the plain old data.

--- a/assets/shaders/fullscreen_effect.wesl
+++ b/assets/shaders/fullscreen_effect.wesl
@@ -1,4 +1,4 @@
-// This shader computes the chromatic aberration effect
+//! This shader computes the chromatic aberration effect
 
 // Since post processing is a fullscreen effect, we use the fullscreen vertex shader provided by bevy.
 // This will import a vertex shader that renders a single fullscreen triangle.
@@ -45,5 +45,3 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
         1.0
     );
 }
-
-

--- a/assets/shaders/gpu_component_array_buffer.wesl
+++ b/assets/shaders/gpu_component_array_buffer.wesl
@@ -1,37 +1,37 @@
 import bevy_pbr::render::{forward_io::VertexOutput, mesh_bindings::mesh};
 import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d};
 
-// The custom data that we extract from the ECS and expose to this shader.
+/// The custom data that we extract from the ECS and expose to this shader.
 struct CustomMaterialData {
-    // The tint color for the mesh.
+    /// The tint color for the mesh.
     color: vec3<f32>,
-    // Padding to pad this out to a multiple of 16 bytes.
+    /// Padding to pad this out to a multiple of 16 bytes.
     pad: u32,
 }
 
-// The array of material data that Bevy supplies.
-//
-// We need to declare this type because
-// `binding_array<array<CustomMaterialData>>` isn't currently accepted by Naga.
-// We have to factor the `array<CustomMaterialData>` out into a separate type.
+/// The array of material data that Bevy supplies.
+///
+/// We need to declare this type because
+/// `binding_array<array<CustomMaterialData>>` isn't currently accepted by Naga.
+/// We have to factor the `array<CustomMaterialData>` out into a separate type.
 struct CustomMaterialDataArray {
     data_array: array<CustomMaterialData>,
 }
 
 @if(BINDLESS) {
 
-// The bindings table for bindless mode.
-//
-// These are indexes into the various arrays.
+/// The bindings table for bindless mode.
+///
+/// These are indexes into the various arrays.
 struct CustomMaterialBindings {
     material: u32,              // 0
-    // The index of the data for this instance in the `CustomMaterialDataArray`.
+    /// The index of the data for this instance in the `CustomMaterialDataArray`.
     data: u32,                  // 1
-    // The index of the color texture for this instance in the
-    // `bindless_textures_2d`.
+    /// The index of the color texture for this instance in the
+    /// `bindless_textures_2d`.
     color_texture: u32,         // 2
-    // The index of the sampler for this instance in the
-    // `bindless_samplers_filtering`.
+    /// The index of the sampler for this instance in the
+    /// `bindless_samplers_filtering`.
     color_texture_sampler: u32, // 3
 }
 

--- a/assets/shaders/gpu_readback.wesl
+++ b/assets/shaders/gpu_readback.wesl
@@ -1,7 +1,7 @@
-// This shader is used for the gpu_readback example
-// The actual work it does is not important for the example
+//! This shader is used for the gpu_readback example
+//! The actual work it does is not important for the example
 
-// This is the data that lives in the gpu only buffer
+/// This is the data that lives in the gpu only buffer
 @group(0) @binding(0) var<storage, read_write> data: array<u32>;
 @group(0) @binding(1) var texture: texture_storage_2d<r32uint, write>;
 

--- a/assets/shaders/irradiance_volume_voxel_visualization.wesl
+++ b/assets/shaders/irradiance_volume_voxel_visualization.wesl
@@ -7,8 +7,8 @@ struct VoxelVisualizationIrradianceVolumeInfo {
     world_from_voxel: mat4x4<f32>,
     voxel_from_world: mat4x4<f32>,
     resolution: vec3<u32>,
-    // A scale factor that's applied to the diffuse and specular light from the
-    // light probe. This is in units of cd/m² (candela per square meter).
+    /// A scale factor that's applied to the diffuse and specular light from the
+    /// light probe. This is in units of cd/m² (candela per square meter).
     intensity: f32,
 }
 

--- a/assets/shaders/oit_compatible_extended_material.wesl
+++ b/assets/shaders/oit_compatible_extended_material.wesl
@@ -20,7 +20,7 @@ import bevy_pbr::render::pbr_types;
 @if(MATERIAL_OIT_ENABLED)
 import bevy_pbr::render::pbr_fragment::pbr_input_from_standard_material;
 
-// The material parameters
+/// The material parameters
 struct Colors {
     color1: vec4<f32>,
     color2: vec4<f32>,

--- a/assets/shaders/pipeline_constants.wesl
+++ b/assets/shaders/pipeline_constants.wesl
@@ -1,8 +1,8 @@
 import bevy_sprite_render::mesh2d::vertex_output::VertexOutput;
 
-// Pipeline-overridable constant: number of discrete color steps.
-// This value is substituted at pipeline compilation time by Bevy's pipeline cache
-// when the material's `specialize` method pushes it into `descriptor.constants`.
+/// Pipeline-overridable constant: number of discrete color steps.
+/// This value is substituted at pipeline compilation time by Bevy's pipeline cache
+/// when the material's `specialize` method pushes it into `descriptor.constants`.
 override LEVELS: f32 = 4.0;
 
 @fragment

--- a/assets/shaders/post_processing.wesl
+++ b/assets/shaders/post_processing.wesl
@@ -1,4 +1,4 @@
-// This shader computes the chromatic aberration effect
+//! This shader computes the chromatic aberration effect
 
 // Since post processing is a fullscreen effect, we use the fullscreen vertex shader provided by bevy.
 // This will import a vertex shader that renders a single fullscreen triangle.
@@ -43,4 +43,3 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
         1.0
     );
 }
-

--- a/assets/shaders/screen_space_texture_material.wesl
+++ b/assets/shaders/screen_space_texture_material.wesl
@@ -1,7 +1,7 @@
-// A shader that samples its emissive texture at screen space positions rather
-// than UVs.
-//
-// This is used for the mirror example: `examples/3d/mirror.rs`.
+//! A shader that samples its emissive texture at screen space positions rather
+//! than UVs.
+//!
+//! This is used for the mirror example: `examples/3d/mirror.rs`.
 
 import bevy_pbr::render::{
     forward_io::{VertexOutput, FragmentOutput},
@@ -10,11 +10,11 @@ import bevy_pbr::render::{
     pbr_functions::{alpha_discard, apply_pbr_lighting, main_pass_post_lighting_processing}
 };
 
-// This is unused, but it's here to satisfy `ExtendedMaterial` requirements.
-// See the comment in `ScreenSpaceTextureExtension` in `examples/3d/mirror.rs`
-// for more information.
+/// This is unused, but it's here to satisfy `ExtendedMaterial` requirements.
+/// See the comment in `ScreenSpaceTextureExtension` in `examples/3d/mirror.rs`
+/// for more information.
 struct ScreenSpaceTextureMaterial {
-    // An unused value.
+    /// An unused value.
     dummy: f32,
 }
 

--- a/assets/shaders/single_mip_level.wesl
+++ b/assets/shaders/single_mip_level.wesl
@@ -1,4 +1,4 @@
-// A shader that displays only one mip level of a texture.
+//! A shader that displays only one mip level of a texture.
 
 import bevy_sprite_render::mesh2d::vertex_output::VertexOutput;
 

--- a/assets/shaders/specialized_mesh_pipeline.wesl
+++ b/assets/shaders/specialized_mesh_pipeline.wesl
@@ -22,7 +22,7 @@ struct Vertex {
     @location(1) color: vec4<f32>,
 };
 
-// This is the output of the vertex shader and we also use it as the input for the fragment shader
+/// This is the output of the vertex shader and we also use it as the input for the fragment shader
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) world_position: vec4<f32>,

--- a/assets/shaders/sprite_material.wesl
+++ b/assets/shaders/sprite_material.wesl
@@ -44,10 +44,10 @@ fn fragment(input: VertexOutput) -> @location(0) vec4<f32> {
     return color;
 }
 
-// An implementation of the simplex noise algorithm to generate noise for the dissolve effect. Credit to <https://crates.io/crates/noisy_bevy>.
-//
-// Note that usually sampling the noise from a prebaked texture is better for performance.
-// However, to avoid increasing the size of the bevy git repository, we generate the noise in the shader.
+/// An implementation of the simplex noise algorithm to generate noise for the dissolve effect. Credit to <https://crates.io/crates/noisy_bevy>.
+///
+/// Note that usually sampling the noise from a prebaked texture is better for performance.
+/// However, to avoid increasing the size of the bevy git repository, we generate the noise in the shader.
 fn simplex_noise_2d(v: vec2<f32>) -> f32 {
     let C = vec4(
         0.211324865405187, // (3.0 - sqrt(3.0)) / 6.0
@@ -88,7 +88,7 @@ fn simplex_noise_2d(v: vec2<f32>) -> f32 {
     return (130. * dot(m, g) + 1.) / 2.;
 }
 
-// Fractional brownian motion using simplex noise. This approach makes the noise look more detailed.
+/// Fractional brownian motion using simplex noise. This approach makes the noise look more detailed.
 fn fbm_simplex_2d(pos: vec2<f32>) -> f32 {
     const octaves = 3;
     const lacunarity = 2.0;

--- a/assets/shaders/tonemapping_test_patterns.wesl
+++ b/assets/shaders/tonemapping_test_patterns.wesl
@@ -8,8 +8,8 @@ import bevy_render::maths::PI;
 @if(TONEMAP_IN_SHADER)
 import bevy_core_pipeline::tonemapping::tone_mapping;
 
-// Sweep across hues on y axis with value from 0.0 to +15EV across x axis
-// quantized into 24 steps for both axis.
+/// Sweep across hues on y axis with value from 0.0 to +15EV across x axis
+/// quantized into 24 steps for both axis.
 fn color_sweep(uv_input: vec2<f32>) -> vec3<f32> {
     var uv = uv_input;
     let steps = 24.0;
@@ -37,7 +37,7 @@ fn hsv_to_srgb(c: vec3<f32>) -> vec3<f32> {
     return c.z * mix(K.xxx, clamp(p - K.xxx, vec3(0.0), vec3(1.0)), c.y);
 }
 
-// Generates a continuous sRGB sweep.
+/// Generates a continuous sRGB sweep.
 fn continuous_hue(uv: vec2<f32>) -> vec3<f32> {
     return hsv_to_srgb(vec3(uv.x, 1.0, 1.0)) * max(0.0, exp2(uv.y * 9.0) - 1.0);
 }

--- a/assets/shaders/water_material.wesl
+++ b/assets/shaders/water_material.wesl
@@ -1,7 +1,7 @@
-// A shader that creates water ripples by overlaying 4 normal maps on top of one
-// another.
-//
-// This is used in the `ssr` example. It only supports deferred rendering.
+//! A shader that creates water ripples by overlaying 4 normal maps on top of one
+//! another.
+//!
+//! This is used in the `ssr` example. It only supports deferred rendering.
 
 import bevy_pbr::{
     deferred::functions::deferred_output,
@@ -10,14 +10,14 @@ import bevy_pbr::{
 };
 import bevy_render::globals::Globals;
 
-// Parameters to the water shader.
+/// Parameters to the water shader.
 struct WaterSettings {
-    // How much to displace each octave each frame, in the u and v directions.
-    // Two octaves are packed into each `vec4`.
+    /// How much to displace each octave each frame, in the u and v directions.
+    /// Two octaves are packed into each `vec4`.
     octave_vectors: array<vec4<f32>, 2>,
-    // How wide the waves are in each octave.
+    /// How wide the waves are in each octave.
     octave_scales: vec4<f32>,
-    // How high the waves are in each octave.
+    /// How high the waves are in each octave.
     octave_strengths: vec4<f32>,
 }
 
@@ -27,14 +27,14 @@ struct WaterSettings {
 @group(constants::MATERIAL_BIND_GROUP) @binding(101) var water_normals_sampler: sampler;
 @group(constants::MATERIAL_BIND_GROUP) @binding(102) var<uniform> water_settings: WaterSettings;
 
-// Samples a single octave of noise and returns the resulting normal.
+/// Samples a single octave of noise and returns the resulting normal.
 fn sample_noise_octave(uv: vec2<f32>, strength: f32) -> vec3<f32> {
     let N = textureSample(water_normals_texture, water_normals_sampler, uv).rbg * 2.0 - 1.0;
     // This isn't slerp, but it's good enough.
-    return normalize(mix(vec3(0.0, 1.0, 0.0), N, strength)); 
+    return normalize(mix(vec3(0.0, 1.0, 0.0), N, strength));
 }
 
-// Samples all four octaves of noise and returns the resulting normal.
+/// Samples all four octaves of noise and returns the resulting normal.
 fn sample_noise(uv: vec2<f32>, time: f32) -> vec3<f32> {
     let uv0 = uv * water_settings.octave_scales[0] + water_settings.octave_vectors[0].xy * time;
     let uv1 = uv * water_settings.octave_scales[1] + water_settings.octave_vectors[0].zw * time;

--- a/crates/bevy_anti_alias/src/contrast_adaptive_sharpening/robust_contrast_adaptive_sharpening.wesl
+++ b/crates/bevy_anti_alias/src/contrast_adaptive_sharpening/robust_contrast_adaptive_sharpening.wesl
@@ -32,30 +32,30 @@ const FSR_RCAS_LIMIT = 0.1875;
 // -4.0 instead of -1.0 to avoid issues with MSAA.
 const peakC = vec2<f32>(10.0, -40.0);
 
-// Robust Contrast Adaptive Sharpening (RCAS)
-// Based on the following implementation:
-// https://github.com/GPUOpen-Effects/FidelityFX-FSR2/blob/ea97a113b0f9cadf519fbcff315cc539915a3acd/src/ffx-fsr2-api/shaders/ffx_fsr1.h#L672
-// RCAS is based on the following logic.
-// RCAS uses a 5 tap filter in a cross pattern (same as CAS),
-//    W                b
-//  W 1 W  for taps  d e f 
-//    W                h
-// Where 'W' is the negative lobe weight.
-//  output = (W*(b+d+f+h)+e)/(4*W+1)
-// RCAS solves for 'W' by seeing where the signal might clip out of the {0 to 1} input range,
-//  0 == (W*(b+d+f+h)+e)/(4*W+1) -> W = -e/(b+d+f+h)
-//  1 == (W*(b+d+f+h)+e)/(4*W+1) -> W = (1-e)/(b+d+f+h-4)
-// Then chooses the 'W' which results in no clipping, limits 'W', and multiplies by the 'sharp' amount.
-// This solution above has issues with MSAA input as the steps along the gradient cause edge detection issues.
-// So RCAS uses 4x the maximum and 4x the minimum (depending on equation)in place of the individual taps.
-// As well as switching from 'e' to either the minimum or maximum (depending on side), to help in energy conservation.
-// This stabilizes RCAS.
-// RCAS does a simple highpass which is normalized against the local contrast then shaped,
-//       0.25
-//  0.25  -1  0.25
-//       0.25
-// This is used as a noise detection filter, to reduce the effect of RCAS on grain, and focus on real edges.
-// The CAS node runs after tonemapping, so the input will be in the range of 0 to 1.
+/// Robust Contrast Adaptive Sharpening (RCAS)
+/// Based on the following implementation:
+/// https://github.com/GPUOpen-Effects/FidelityFX-FSR2/blob/ea97a113b0f9cadf519fbcff315cc539915a3acd/src/ffx-fsr2-api/shaders/ffx_fsr1.h#L672
+/// RCAS is based on the following logic.
+/// RCAS uses a 5 tap filter in a cross pattern (same as CAS),
+///    W                b
+///  W 1 W  for taps  d e f
+///    W                h
+/// Where 'W' is the negative lobe weight.
+///  output = (W*(b+d+f+h)+e)/(4*W+1)
+/// RCAS solves for 'W' by seeing where the signal might clip out of the {0 to 1} input range,
+///  0 == (W*(b+d+f+h)+e)/(4*W+1) -> W = -e/(b+d+f+h)
+///  1 == (W*(b+d+f+h)+e)/(4*W+1) -> W = (1-e)/(b+d+f+h-4)
+/// Then chooses the 'W' which results in no clipping, limits 'W', and multiplies by the 'sharp' amount.
+/// This solution above has issues with MSAA input as the steps along the gradient cause edge detection issues.
+/// So RCAS uses 4x the maximum and 4x the minimum (depending on equation)in place of the individual taps.
+/// As well as switching from 'e' to either the minimum or maximum (depending on side), to help in energy conservation.
+/// This stabilizes RCAS.
+/// RCAS does a simple highpass which is normalized against the local contrast then shaped,
+///       0.25
+///  0.25  -1  0.25
+///       0.25
+/// This is used as a noise detection filter, to reduce the effect of RCAS on grain, and focus on real edges.
+/// The CAS node runs after tonemapping, so the input will be in the range of 0 to 1.
 @fragment
 fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     // Algorithm uses minimal 3x3 pixel neighborhood.

--- a/crates/bevy_anti_alias/src/fxaa/fxaa.wesl
+++ b/crates/bevy_anti_alias/src/fxaa/fxaa.wesl
@@ -11,7 +11,7 @@ import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
 @group(0) @binding(0) var screenTexture: texture_2d<f32>;
 @group(0) @binding(1) var samp: sampler;
 
-// Trims the algorithm from processing darks.
+/// Trims the algorithm from processing darks.
     @if(EDGE_THRESH_MIN_LOW)
     const EDGE_THRESHOLD_MIN: f32 = 0.0833;
 
@@ -27,7 +27,7 @@ import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
     @if(EDGE_THRESH_MIN_EXTREME)
     const EDGE_THRESHOLD_MIN: f32 = 0.0078;
 
-// The minimum amount of local contrast required to apply algorithm.
+/// The minimum amount of local contrast required to apply algorithm.
     @if(EDGE_THRESH_LOW)
     const EDGE_THRESHOLD_MAX: f32 = 0.250;
 
@@ -61,7 +61,7 @@ fn rgb2luma(rgb: vec3<f32>) -> f32 {
     return sqrt(dot(rgb, vec3<f32>(0.299, 0.587, 0.114)));
 }
 
-// Performs FXAA post-process anti-aliasing as described in the Nvidia FXAA white paper and the associated shader code.
+/// Performs FXAA post-process anti-aliasing as described in the Nvidia FXAA white paper and the associated shader code.
 @fragment
 fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let resolution = vec2<f32>(textureDimensions(screenTexture));
@@ -109,12 +109,12 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let lumaUpCorners = lumaUpRight + lumaUpLeft;
 
     // Compute an estimation of the gradient along the horizontal and vertical axis.
-    let edgeHorizontal = abs(-2.0 * lumaLeft   + lumaLeftCorners)  + 
-                         abs(-2.0 * lumaCenter + lumaDownUp) * 2.0 + 
+    let edgeHorizontal = abs(-2.0 * lumaLeft   + lumaLeftCorners)  +
+                         abs(-2.0 * lumaCenter + lumaDownUp) * 2.0 +
                          abs(-2.0 * lumaRight  + lumaRightCorners);
 
-    let edgeVertical =   abs(-2.0 * lumaUp     + lumaUpCorners)       + 
-                         abs(-2.0 * lumaCenter + lumaLeftRight) * 2.0 + 
+    let edgeVertical =   abs(-2.0 * lumaUp     + lumaUpCorners)       +
+                         abs(-2.0 * lumaCenter + lumaLeftRight) * 2.0 +
                          abs(-2.0 * lumaDown   + lumaDownCorners);
 
     // Is the local edge horizontal or vertical ?
@@ -182,12 +182,12 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     if (!reachedBoth) {
         for (var i: i32 = 2; i < ITERATIONS; i = i + 1) {
             // If needed, read luma in 1st direction, compute delta.
-            if (!reached1) { 
+            if (!reached1) {
                 lumaEnd1 = rgb2luma(textureSampleLevel(screenTexture, samp, uv1, 0.0).rgb);
                 lumaEnd1 = lumaEnd1 - lumaLocalAverage;
             }
             // If needed, read luma in opposite direction, compute delta.
-            if (!reached2) { 
+            if (!reached2) {
                 lumaEnd2 = rgb2luma(textureSampleLevel(screenTexture, samp, uv2, 0.0).rgb);
                 lumaEnd2 = lumaEnd2 - lumaLocalAverage;
             }
@@ -205,8 +205,8 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
             }
 
             // If both sides have been reached, stop the exploration.
-            if (reachedBoth) { 
-                break; 
+            if (reachedBoth) {
+                break;
             }
         }
     }

--- a/crates/bevy_anti_alias/src/smaa/smaa.wesl
+++ b/crates/bevy_anti_alias/src/smaa/smaa.wesl
@@ -459,23 +459,23 @@ const SMAA_CORNER_ROUNDING_NORM: f32 = f32(SMAA_CORNER_ROUNDING) / 100.0;
 //-----------------------------------------------------------------------------
 // WGSL-Specific Functions
 
-// This vertex shader produces the following, when drawn using indices 0..3:
-//
-//  1 |  0-----x.....2
-//  0 |  |  s  |  . ´
-// -1 |  x_____x´
-// -2 |  :  .´
-// -3 |  1´
-//    +---------------
-//      -1  0  1  2  3
-//
-// The axes are clip-space x and y. The region marked s is the visible region.
-// The digits in the corners of the right-angled triangle are the vertex
-// indices.
-//
-// The top-left has UV 0,0, the bottom-left has 0,2, and the top-right has 2,0.
-// This means that the UV gets interpolated to 1,1 at the bottom-right corner
-// of the clip-space rectangle that is at 1,-1 in clip space.
+/// This vertex shader produces the following, when drawn using indices 0..3:
+///
+///  1 |  0-----x.....2
+///  0 |  |  s  |  . ´
+/// -1 |  x_____x´
+/// -2 |  :  .´
+/// -3 |  1´
+///    +---------------
+///      -1  0  1  2  3
+///
+/// The axes are clip-space x and y. The region marked s is the visible region.
+/// The digits in the corners of the right-angled triangle are the vertex
+/// indices.
+///
+/// The top-left has UV 0,0, the bottom-left has 0,2, and the top-right has 2,0.
+/// This means that the UV gets interpolated to 1,1 at the bottom-right corner
+/// of the clip-space rectangle that is at 1,-1 in clip space.
 fn calculate_vertex_varyings(vertex_index: u32) -> VertexVaryings {
     // See the explanation above for how this works
     let uv = vec2<f32>(f32(vertex_index >> 1u), f32(vertex_index & 1u)) * 2.0;
@@ -489,9 +489,7 @@ fn calculate_vertex_varyings(vertex_index: u32) -> VertexVaryings {
 
 @if(SMAA_EDGE_DETECTION)
 
-/**
- * Edge Detection Vertex Shader
- */
+/// Edge Detection Vertex Shader
 @vertex
 fn edge_detection_vertex_main(@builtin(vertex_index) vertex_index: u32) -> EdgeDetectionVaryings {
     let varyings = calculate_vertex_varyings(vertex_index);
@@ -513,9 +511,7 @@ fn edge_detection_vertex_main(@builtin(vertex_index) vertex_index: u32) -> EdgeD
 
 @if(SMAA_BLENDING_WEIGHT_CALCULATION)
 
-/**
- * Blend Weight Calculation Vertex Shader
- */
+/// Blend Weight Calculation Vertex Shader
 @vertex
 fn blending_weight_calculation_vertex_main(@builtin(vertex_index) vertex_index: u32)
         -> BlendingWeightCalculationVaryings {
@@ -542,9 +538,7 @@ fn blending_weight_calculation_vertex_main(@builtin(vertex_index) vertex_index: 
 
 @if(SMAA_NEIGHBORHOOD_BLENDING)
 
-/**
- * Neighborhood Blending Vertex Shader
- */
+/// Neighborhood Blending Vertex Shader
 @vertex
 fn neighborhood_blending_vertex_main(@builtin(vertex_index) vertex_index: u32)
         -> NeighborhoodBlendingVaryings {
@@ -563,12 +557,10 @@ fn neighborhood_blending_vertex_main(@builtin(vertex_index) vertex_index: u32)
 
 @if(SMAA_EDGE_DETECTION)
 
-/**
- * Luma Edge Detection
- *
- * IMPORTANT NOTICE: luma edge detection requires gamma-corrected colors, and
- * thus 'color_texture' should be a non-sRGB texture.
- */
+/// Luma Edge Detection
+///
+/// IMPORTANT NOTICE: luma edge detection requires gamma-corrected colors, and
+/// thus 'color_texture' should be a non-sRGB texture.
 @fragment
 fn luma_edge_detection_fragment_main(in: EdgeDetectionVaryings) -> @location(0) vec4<f32> {
     // Calculate the threshold:
@@ -621,9 +613,7 @@ fn luma_edge_detection_fragment_main(in: EdgeDetectionVaryings) -> @location(0) 
 
 @if(SMAA_BLENDING_WEIGHT_CALCULATION && !SMAA_DISABLE_DIAG_DETECTION)
 
-/**
- * Allows to decode two binary values from a bilinear-filtered access.
- */
+/// Allows to decode two binary values from a bilinear-filtered access.
 fn decode_diag_bilinear_access_2(in_e: vec2<f32>) -> vec2<f32> {
     // Bilinear access for fetching 'e' have a 0.25 offset, and we are
     // interested in the R and G edges:
@@ -686,10 +676,8 @@ fn search_diag_2(tex_coord: vec2<f32>, dir: vec2<f32>, e: ptr<function, vec2<f32
     return coord.zw;
 }
 
-/**
- * Similar to SMAAArea, this calculates the area corresponding to a certain
- * diagonal distance and crossing edges 'e'.
- */
+/// Similar to SMAAArea, this calculates the area corresponding to a certain
+/// diagonal distance and crossing edges 'e'.
 @if(SMAA_BLENDING_WEIGHT_CALCULATION && !SMAA_DISABLE_DIAG_DETECTION)
 fn area_diag(dist: vec2<f32>, e: vec2<f32>, offset: f32) -> vec2<f32> {
     var tex_coord = vec2(SMAA_AREATEX_MAX_DISTANCE_DIAG) * e + dist;
@@ -707,9 +695,7 @@ fn area_diag(dist: vec2<f32>, e: vec2<f32>, offset: f32) -> vec2<f32> {
     return textureSampleLevel(area_texture, edges_sampler, tex_coord, 0.0).rg;
 }
 
-/**
- * This searches for diagonal patterns and returns the corresponding weights.
- */
+/// This searches for diagonal patterns and returns the corresponding weights.
 @if(SMAA_BLENDING_WEIGHT_CALCULATION && !SMAA_DISABLE_DIAG_DETECTION)
 fn calculate_diag_weights(tex_coord: vec2<f32>, e: vec2<f32>, subsample_indices: vec4<f32>)
         -> vec2<f32> {
@@ -791,12 +777,10 @@ fn calculate_diag_weights(tex_coord: vec2<f32>, e: vec2<f32>, subsample_indices:
 //-----------------------------------------------------------------------------
 // Horizontal/Vertical Search Functions
 
-/**
- * This allows to determine how much length should we add in the last step
- * of the searches. It takes the bilinearly interpolated edge (see
- * @PSEUDO_GATHER4), and adds 0, 1 or 2, depending on which edges and
- * crossing edges are active.
- */
+/// This allows to determine how much length should we add in the last step
+/// of the searches. It takes the bilinearly interpolated edge (see
+/// @PSEUDO_GATHER4), and adds 0, 1 or 2, depending on which edges and
+/// crossing edges are active.
 @if(SMAA_BLENDING_WEIGHT_CALCULATION)
 fn search_length(e: vec2<f32>, offset: f32) -> f32 {
     // The texture is flipped vertically, with left and right cases taking half
@@ -817,9 +801,7 @@ fn search_length(e: vec2<f32>, offset: f32) -> f32 {
     return textureSampleLevel(search_texture, edges_sampler, scale * e + bias, 0.0).r;
 }
 
-/**
- * Horizontal/vertical search functions for the 2nd pass.
- */
+/// Horizontal/vertical search functions for the 2nd pass.
 @if(SMAA_BLENDING_WEIGHT_CALCULATION)
 fn search_x_left(in_tex_coord: vec2<f32>, end: f32) -> f32 {
     var tex_coord = in_tex_coord;
@@ -887,10 +869,8 @@ fn search_y_down(in_tex_coord: vec2<f32>, end: f32) -> f32 {
     return -smaa_info.rt_metrics.y * offset + tex_coord.y;
 }
 
-/**
- * Ok, we have the distance and both crossing edges. So, what are the areas
- * at each side of current edge?
- */
+/// Ok, we have the distance and both crossing edges. So, what are the areas
+/// at each side of current edge?
 @if(SMAA_BLENDING_WEIGHT_CALCULATION)
 fn area(dist: vec2<f32>, e1: f32, e2: f32, offset: f32) -> vec2<f32> {
     // Rounding prevents precision errors of bilinear filtering:

--- a/crates/bevy_anti_alias/src/taa/taa.wesl
+++ b/crates/bevy_anti_alias/src/taa/taa.wesl
@@ -4,9 +4,9 @@
 // http://leiy.cc/publications/TAA/TAA_EG2020_Talk.pdf
 // https://advances.realtimerendering.com/s2014/index.html#_HIGH-QUALITY_TEMPORAL_SUPERSAMPLING
 
-// Controls how much to blend between the current and past samples
-// Lower numbers = less of the current sample and more of the past sample = more smoothing
-// Values chosen empirically
+/// Controls how much to blend between the current and past samples
+/// Lower numbers = less of the current sample and more of the past sample = more smoothing
+/// Values chosen empirically
 const DEFAULT_HISTORY_BLEND_RATE: f32 = 0.1; // Default blend rate to use when no confidence in history
 const MIN_HISTORY_BLEND_RATE: f32 = 0.015; // Minimum blend rate allowed, to ensure at least some of the current sample is used
 

--- a/crates/bevy_core_pipeline/src/mip_generation/downsample.wesl
+++ b/crates/bevy_core_pipeline/src/mip_generation/downsample.wesl
@@ -1,5 +1,5 @@
-// Single pass downsampling shader for creating the mip chain for a texture
-// Ported from https://github.com/GPUOpen-LibrariesAndSDKs/FidelityFX-SDK/blob/c16b1d286b5b438b75da159ab51ff426bacea3d1/sdk/include/FidelityFX/gpu/spd/ffx_spd.h
+//! Single pass downsampling shader for creating the mip chain for a texture
+//! Ported from https://github.com/GPUOpen-LibrariesAndSDKs/FidelityFX-SDK/blob/c16b1d286b5b438b75da159ab51ff426bacea3d1/sdk/include/FidelityFX/gpu/spd/ffx_spd.h
 
 @group(0) @binding(0) var sampler_linear_clamp: sampler;
 @group(0) @binding(1) var<uniform> constants: Constants;

--- a/crates/bevy_core_pipeline/src/mip_generation/experimental/downsample_depth.wesl
+++ b/crates/bevy_core_pipeline/src/mip_generation/experimental/downsample_depth.wesl
@@ -1,3 +1,9 @@
+//! Generates a hierarchical depth buffer.
+//! Based on FidelityFX SPD v2.1 https://github.com/GPUOpen-LibrariesAndSDKs/FidelityFX-SDK/blob/d7531ae47d8b36a5d4025663e731a47a38be882f/sdk/include/FidelityFX/gpu/spd/ffx_spd.h#L528
+//!
+//! `mip_0` may be of any size, but `mip_1` and down must have side lengths that
+//! are powers of two.
+
 @if(MESHLET_VISIBILITY_BUFFER_RASTER_PASS_OUTPUT)
 @group(0) @binding(0) var mip_0: texture_storage_2d<r64uint, read>;
 @elif(MESHLET)
@@ -21,12 +27,6 @@
 @group(0) @binding(13) var samplr: sampler;
 struct Constants { max_mip_level: u32 }
 var<immediate> constants: Constants;
-
-/// Generates a hierarchical depth buffer.
-/// Based on FidelityFX SPD v2.1 https://github.com/GPUOpen-LibrariesAndSDKs/FidelityFX-SDK/blob/d7531ae47d8b36a5d4025663e731a47a38be882f/sdk/include/FidelityFX/gpu/spd/ffx_spd.h#L528
-///
-/// `mip_0` may be of any size, but `mip_1` and down must have side lengths that
-/// are powers of two.
 
 // TODO:
 // * Subgroup support

--- a/crates/bevy_core_pipeline/src/mip_generation/experimental/downsample_depth.wesl
+++ b/crates/bevy_core_pipeline/src/mip_generation/experimental/downsample_depth.wesl
@@ -305,14 +305,14 @@ fn reduce_load_mip_6(tex: vec2u) -> f32 {
     ));
 }
 
-// Loads the top mip level at virtual position (x, y).
-//
-// This is the value that *would be* returned from sampling a scaled depth
-// buffer with side lengths rounded up to the next power of two, without
-// actually constructing such a depth buffer.
-//
-// See the comments in `ViewDepthPyramid::downsample_depth` for more
-// information.
+/// Loads the top mip level at virtual position (x, y).
+///
+/// This is the value that *would be* returned from sampling a scaled depth
+/// buffer with side lengths rounded up to the next power of two, without
+/// actually constructing such a depth buffer.
+///
+/// See the comments in `ViewDepthPyramid::downsample_depth` for more
+/// information.
 fn load_mip_0(x: u32, y: u32) -> f32 {
     let actual_size = textureDimensions(mip_0).xy;
     let virtual_size = vec2<u32>(
@@ -344,11 +344,11 @@ fn load_mip_0(x: u32, y: u32) -> f32 {
     }
 }
 
-// Loads a single 2×2 square of texels at the given position from the source
-// image and returns all four (like `textureGather` does).
-//
-// `st` should be in texels, not in the [0, 1] range like UVs. That is, `st` is
-// `uv * textureDimensions(mip_0).xy`.
+/// Loads a single 2×2 square of texels at the given position from the source
+/// image and returns all four (like `textureGather` does).
+///
+/// `st` should be in texels, not in the [0, 1] range like UVs. That is, `st` is
+/// `uv * textureDimensions(mip_0).xy`.
 @if(MESHLET)
 fn load_mip_0_meshlet(st: vec2<f32>, shift: u32) -> vec4<f32> {
     let st0 = vec2<u32>(floor(st - 0.5));
@@ -361,11 +361,11 @@ fn load_mip_0_meshlet(st: vec2<f32>, shift: u32) -> vec4<f32> {
     );
 }
 
-// Loads a single 2×2 square of texels at the given position from the source
-// image, reduces them, and returns the result.
-//
-// `st` should be in texels, not in the [0, 1] range like UVs. That is, `st` is
-// `uv * textureDimensions(mip_0).xy`.
+/// Loads a single 2×2 square of texels at the given position from the source
+/// image, reduces them, and returns the result.
+///
+/// `st` should be in texels, not in the [0, 1] range like UVs. That is, `st` is
+/// `uv * textureDimensions(mip_0).xy`.
 @if(MULTISAMPLE)
 fn load_mip_0_single_sample(st: vec2<f32>, sample: i32) -> f32 {
     let st0 = vec2<u32>(floor(st - 0.5));
@@ -383,10 +383,10 @@ fn reduce_4(v: vec4f) -> f32 {
     return min(min(v.x, v.y), min(v.z, v.w));
 }
 
-// Returns the next power of two of x.
-//
-// If x is itself a power of two, this still returns the *next* power of two.
-// This is different from Rust's `next_power_of_two` function.
+/// Returns the next power of two of x.
+///
+/// If x is itself a power of two, this still returns the *next* power of two.
+/// This is different from Rust's `next_power_of_two` function.
 fn next_power_of_two(x: u32) -> u32 {
     return 1u << (32u - countLeadingZeros(x));
 }

--- a/crates/bevy_core_pipeline/src/oit/draw.wesl
+++ b/crates/bevy_core_pipeline/src/oit/draw.wesl
@@ -36,10 +36,10 @@ fn oit_draw(position: vec4f, color: vec4f) {
     oit_nodes[new_node_index] = node;
 }
 
-// The packing scheme puts depth in the higher bits so that
-//    depth(a) < depth(b) <=> packed(a) < packed(b)
-// irregardless of alpha(a) and alpha(b)
-// The property is used to optimize the resolve step
+/// The packing scheme puts depth in the higher bits so that
+///    depth(a) < depth(b) <=> packed(a) < packed(b)
+/// irregardless of alpha(a) and alpha(b)
+/// The property is used to optimize the resolve step
 fn pack_24bit_depth_8bit_alpha(depth: f32, alpha: f32) -> u32 {
     let depth_bits = u32(saturate(depth) * f32(0xFFFFFFu) + 0.5);
     let alpha_bits = u32(saturate(alpha) * f32(0xFFu) + 0.5);

--- a/crates/bevy_core_pipeline/src/tonemapping.wesl
+++ b/crates/bevy_core_pipeline/src/tonemapping.wesl
@@ -9,13 +9,13 @@ import package::tonemapping::lut_bindings::{
     dt_lut_sampler,
 };
 
-// Half the size of the crossfade region between shadows and midtones and
-// between midtones and highlights. This value, 0.1, corresponds to 10% of the
-// gamut on either side of the cutoff point.
+/// Half the size of the crossfade region between shadows and midtones and
+/// between midtones and highlights. This value, 0.1, corresponds to 10% of the
+/// gamut on either side of the cutoff point.
 const LEVEL_MARGIN: f32 = 0.1;
 
-// The inverse reciprocal of twice the above, used when scaling the midtone
-// region.
+/// The inverse reciprocal of twice the above, used when scaling the midtone
+/// region.
 const LEVEL_MARGIN_DIV: f32 = 0.5 / LEVEL_MARGIN;
 
 fn sample_current_lut(p: vec3<f32>) -> vec3<f32> {
@@ -197,7 +197,7 @@ fn convertNormalizedLog2ToOpenDomain(color: vec3<f32>, minimum_ev: f32, maximum_
     Main processes
 =================*/
 
-// Prepare the data for display encoding. Converted to log domain.
+/// Prepare the data for display encoding. Converted to log domain.
 fn applyAgXLog(Image: vec3<f32>) -> vec3<f32> {
     var prepared_image = max(vec3(0.0), Image); // clamp negatives
     let r = dot(prepared_image, vec3(0.84247906, 0.0784336, 0.07922375));
@@ -225,14 +225,14 @@ fn sample_blender_filmic_lut(stimulus: vec3<f32>) -> vec3<f32> {
     return applyLUT3D(normalized, block_size);
 }
 
-// from https://64.github.io/tonemapping/
-// reinhard on RGB oversaturates colors
+/// from https://64.github.io/tonemapping/
+/// reinhard on RGB oversaturates colors
 fn tonemapping_reinhard(color: vec3<f32>) -> vec3<f32> {
     return color / (1.0 + color);
 }
 
-// luminance coefficients from Rec. 709.
-// https://en.wikipedia.org/wiki/Rec._709
+/// luminance coefficients from Rec. 709.
+/// https://en.wikipedia.org/wiki/Rec._709
 fn tonemapping_luminance(v: vec3<f32>) -> f32 {
     return dot(v, vec3<f32>(0.2126, 0.7152, 0.0722));
 }
@@ -252,9 +252,9 @@ fn rgb_to_srgb_simple(color: vec3<f32>) -> vec3<f32> {
     return pow(color, vec3<f32>(1.0 / 2.2));
 }
 
-// PBR Neutral tone mapping
-// https://github.com/KhronosGroup/ToneMapping/blob/main/PBR_Neutral/pbrNeutral.glsl
-// Adapted under Apache 2.0, per https://github.com/KhronosGroup/ToneMapping/tree/main/LICENSES
+/// PBR Neutral tone mapping
+/// https://github.com/KhronosGroup/ToneMapping/blob/main/PBR_Neutral/pbrNeutral.glsl
+/// Adapted under Apache 2.0, per https://github.com/KhronosGroup/ToneMapping/tree/main/LICENSES
 fn tonemapping_pbr_neutral(color_in: vec3<f32>) -> vec3<f32> {
     // Parameter controlling when highlight compression starts
     // (`K_s` in specification)
@@ -300,16 +300,16 @@ fn tonemapping_pbr_neutral(color_in: vec3<f32>) -> vec3<f32> {
     return mix(color, vec3(new_max_channel), g);
 }
 
-// Source: Advanced VR Rendering, GDC 2015, Alex Vlachos, Valve, Slide 49
-// https://media.steampowered.com/apps/valve/2015/Alex_Vlachos_Advanced_VR_Rendering_GDC2015.pdf
+/// Source: Advanced VR Rendering, GDC 2015, Alex Vlachos, Valve, Slide 49
+/// https://media.steampowered.com/apps/valve/2015/Alex_Vlachos_Advanced_VR_Rendering_GDC2015.pdf
 fn screen_space_dither(frag_coord: vec2<f32>) -> vec3<f32> {
     var dither = vec3<f32>(dot(vec2<f32>(171.0, 231.0), frag_coord)).xxx;
     dither = fract(dither.rgb / vec3<f32>(103.0, 71.0, 97.0));
     return (dither - 0.5) / 255.0;
 }
 
-// Performs the "sectional" color grading: i.e. the color grading that applies
-// individually to shadows, midtones, and highlights.
+/// Performs the "sectional" color grading: i.e. the color grading that applies
+/// individually to shadows, midtones, and highlights.
 fn sectional_color_grading(
     in: vec3<f32>,
     color_grading: ptr<function, ColorGrading>,
@@ -427,10 +427,10 @@ fn tone_mapping(in: vec4<f32>, in_color_grading: ColorGrading) -> vec4<f32> {
     return vec4(color, in.a);
 }
 
-// This is an **incredibly crude** approximation of the inverse of the tone mapping function.
-// We assume here that there's a simple linear relationship between the input and output
-// which is not true at all, but useful to at least preserve the overall luminance of colors
-// when sampling from an already tonemapped image. (e.g. for transmissive materials when HDR is off)
+/// This is an **incredibly crude** approximation of the inverse of the tone mapping function.
+/// We assume here that there's a simple linear relationship between the input and output
+/// which is not true at all, but useful to at least preserve the overall luminance of colors
+/// when sampling from an already tonemapped image. (e.g. for transmissive materials when HDR is off)
 fn approximate_inverse_tone_mapping(in: vec4<f32>, color_grading: ColorGrading) -> vec4<f32> {
     let out = tone_mapping(in, color_grading);
     let approximate_ratio = length(in.rgb) / length(out.rgb);

--- a/crates/bevy_dev_tools/src/frame_time_graph/frame_time_graph.wesl
+++ b/crates/bevy_dev_tools/src/frame_time_graph/frame_time_graph.wesl
@@ -13,13 +13,13 @@ struct Config {
 const RED: vec4<f32> = vec4(1.0, 0.0, 0.0, 1.0);
 const GREEN: vec4<f32> = vec4(0.0, 1.0, 0.0, 1.0);
 
-// Gets a color based on the delta time
+/// Gets a color based on the delta time
 // TODO use customizable gradient
 fn color_from_dt(dt: f32) -> vec4<f32> {
     return mix(GREEN, RED, dt / config.dt_max);
 }
 
-// Draw an SDF square
+/// Draw an SDF square
 fn sdf_square(pos: vec2<f32>, half_size: vec2<f32>, offset: vec2<f32>) -> f32 {
     let p = pos - offset;
     let dist = abs(p) - half_size;
@@ -65,4 +65,3 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
 
     return vec4(0.0, 0.0, 0.0, 0.5);
 }
-

--- a/crates/bevy_dev_tools/src/infinite_grid.wesl
+++ b/crates/bevy_dev_tools/src/infinite_grid.wesl
@@ -9,11 +9,11 @@ struct InfiniteGridUniform {
 
 struct InfiniteGridSettings {
     scale: f32,
-    // 1 / fadeout_distance
+    /// 1 / fadeout_distance
     one_over_fadeout_distance: f32,
-    // 1 / dot_fadeout_strength
+    /// 1 / dot_fadeout_strength
     one_over_dot_fadeout: f32,
-    // 1 / major_line_interval
+    /// 1 / major_line_interval
     one_over_major_line_interval: f32,
     x_axis_col: vec3<f32>,
     z_axis_col: vec3<f32>,
@@ -26,8 +26,8 @@ struct InfiniteGridSettings {
 @group(1) @binding(0) var<uniform> infinite_grid: InfiniteGridUniform;
 @group(1) @binding(1) var<uniform> grid_settings: InfiniteGridSettings;
 
-// Same as view_transformations::position_ndc_to_world but we can't use it since
-// it relies on bevy's view bind group
+/// Same as view_transformations::position_ndc_to_world but we can't use it since
+/// it relies on bevy's view bind group
 fn position_ndc_to_world(ndc_pos: vec3<f32>) -> vec3<f32> {
     let world_pos = view.world_from_clip * vec4(ndc_pos, 1.0);
     return world_pos.xyz / world_pos.w;
@@ -99,7 +99,7 @@ fn fragment(in: FullscreenVertexOutput) -> FragmentOutput {
     // Fade the grid linearly with distance from the camera.
     let dist_fadeout = min(1., 1. - grid_settings.one_over_fadeout_distance * real_depth);
     let dot_fadeout = abs(dot(infinite_grid.normal, normalize(view.world_position - frag_pos_3d)));
-    let alpha_fadeout = mix(dist_fadeout, 1., dot_fadeout) 
+    let alpha_fadeout = mix(dist_fadeout, 1., dot_fadeout)
         * min(grid_settings.one_over_dot_fadeout * dot_fadeout, 1.);
 
     // Normalize the alpha
@@ -110,14 +110,14 @@ fn fragment(in: FullscreenVertexOutput) -> FragmentOutput {
 
     // Choose the axis color based on which axis this fragment is closest to
     let axis_color = mix(
-        grid_settings.x_axis_col, 
-        grid_settings.z_axis_col, 
+        grid_settings.x_axis_col,
+        grid_settings.z_axis_col,
         step(grid3.x, grid3.y)
     );
 
     var grid_color = vec4(
-        axis_color * alpha.x 
-            + grid_settings.major_line_col.rgb * alpha.y 
+        axis_color * alpha.x
+            + grid_settings.major_line_col.rgb * alpha.y
             + grid_settings.minor_line_col.rgb * alpha.z,
         max(a_0 * alpha_fadeout, 0.0),
     );
@@ -125,4 +125,3 @@ fn fragment(in: FullscreenVertexOutput) -> FragmentOutput {
 
     return out;
 }
-

--- a/crates/bevy_feathers/src/assets/shaders/alpha_pattern.wesl
+++ b/crates/bevy_feathers/src/assets/shaders/alpha_pattern.wesl
@@ -1,4 +1,4 @@
-// This shader draws a checkerboard pattern
+//! This shader draws a checkerboard pattern
 import bevy_ui_render::ui_vertex_output::UiVertexOutput;
 import bevy_ui_render::ui::sd_rounded_box;
 
@@ -9,7 +9,7 @@ fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     let bg = mix(vec3<f32>(0.2, 0.2, 0.2), vec3<f32>(0.6, 0.6, 0.6), check);
 
     let size = vec2<f32>(in.size.x, in.size.y);
-    // With rounded non-elliptical border radius, in.border_radius_x == in.border_radius.y. 
+    // With rounded non-elliptical border radius, in.border_radius_x == in.border_radius.y.
     let external_distance = sd_rounded_box((in.uv - 0.5) * size, size, in.border_radius_x, in.border_radius_y);
     let alpha = smoothstep(0.5, -0.5, external_distance);
 

--- a/crates/bevy_feathers/src/assets/shaders/color_plane.wesl
+++ b/crates/bevy_feathers/src/assets/shaders/color_plane.wesl
@@ -1,4 +1,4 @@
-// This shader draws the color plane in various color spaces.
+//! This shader draws the color plane in various color spaces.
 import bevy_ui_render::ui_vertex_output::UiVertexOutput;
 import bevy_render::color_operations::{
     srgb_to_linear_rgb,

--- a/crates/bevy_pbr/src/atmosphere/bruneton_functions.wesl
+++ b/crates/bevy_pbr/src/atmosphere/bruneton_functions.wesl
@@ -63,10 +63,10 @@ import package::atmosphere::{
 // Our `Atmosphere` struct uses `inner_radius` and `outer_radius` for the same values so naming stays
 // meaningful when the atmosphere entity has an arbitrary transform.
 
-// Mapping from view height (r) and zenith cos angle (mu) to UV coordinates in the transmittance LUT
-// Assuming r between ground and top atmosphere boundary, and mu= cos(zenith_angle)
-// Chosen to increase precision near the ground and to work around a discontinuity at the horizon
-// See Bruneton and Neyret 2008, "Precomputed Atmospheric Scattering" section 4
+/// Mapping from view height (r) and zenith cos angle (mu) to UV coordinates in the transmittance LUT
+/// Assuming r between ground and top atmosphere boundary, and mu= cos(zenith_angle)
+/// Chosen to increase precision near the ground and to work around a discontinuity at the horizon
+/// See Bruneton and Neyret 2008, "Precomputed Atmospheric Scattering" section 4
 fn transmittance_lut_r_mu_to_uv(atm: Atmosphere, r: f32, mu: f32) -> vec2<f32> {
     // Distance along a horizontal ray from the ground to the top atmosphere boundary
     let H = sqrt(atm.outer_radius * atm.outer_radius - atm.inner_radius * atm.inner_radius);
@@ -87,7 +87,7 @@ fn transmittance_lut_r_mu_to_uv(atm: Atmosphere, r: f32, mu: f32) -> vec2<f32> {
     return vec2<f32>(u, v);
 }
 
-// Inverse of the mapping above, mapping from UV coordinates in the transmittance LUT to view height (r) and zenith cos angle (mu)
+/// Inverse of the mapping above, mapping from UV coordinates in the transmittance LUT to view height (r) and zenith cos angle (mu)
 fn transmittance_lut_uv_to_r_mu(uv: vec2<f32>) -> vec2<f32> {
     // Distance to top atmosphere boundary for a horizontal ray at ground level
     let H = sqrt(atmosphere.outer_radius * atmosphere.outer_radius - atmosphere.inner_radius * atmosphere.inner_radius);

--- a/crates/bevy_pbr/src/atmosphere/functions.wesl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wesl
@@ -1,18 +1,3 @@
-import bevy_render::maths::{PI, HALF_PI, PI_2, fast_acos, fast_acos_4, fast_atan2, ray_sphere_intersect};
-
-import package::atmosphere::{
-    types::Atmosphere,
-    bindings::{
-        atmosphere, settings, view, lights, transmittance_lut, atmosphere_lut_sampler,
-        multiscattering_lut, sky_view_lut, aerial_view_lut, atmosphere_transforms,
-        medium_density_lut, medium_scattering_lut, medium_sampler,
-    },
-    bruneton_functions::{
-        transmittance_lut_r_mu_to_uv, ray_intersects_ground,
-        distance_to_top_atmosphere_boundary, distance_to_bottom_atmosphere_boundary
-    },
-};
-
 //! NOTE FOR CONVENTIONS:
 //! r:
 //!   radius, or distance from planet center
@@ -31,6 +16,20 @@ import package::atmosphere::{
 //!   frame. This enables the non-linear latitude parametrization the paper uses
 //!   to concentrate detail near the horizon
 
+import bevy_render::maths::{PI, HALF_PI, PI_2, fast_acos, fast_acos_4, fast_atan2, ray_sphere_intersect};
+
+import package::atmosphere::{
+    types::Atmosphere,
+    bindings::{
+        atmosphere, settings, view, lights, transmittance_lut, atmosphere_lut_sampler,
+        multiscattering_lut, sky_view_lut, aerial_view_lut, atmosphere_transforms,
+        medium_density_lut, medium_scattering_lut, medium_sampler,
+    },
+    bruneton_functions::{
+        transmittance_lut_r_mu_to_uv, ray_intersects_ground,
+        distance_to_top_atmosphere_boundary, distance_to_bottom_atmosphere_boundary
+    },
+};
 
 // CONSTANTS
 /// 1 / π
@@ -180,10 +179,12 @@ fn sample_density_lut(r: f32, component: f32) -> vec3<f32> {
     return textureSampleLevel(medium_density_lut, medium_sampler, uv, 0.0).xyz;
 }
 
+
+const PHASE_MAPPING_N: f32 = 0.5;
+
 /// samples from the atmosphere scattering LUT. `neg_LdotV` is the dot product
 /// of the light direction and the incoming view vector.
 /// Nonlinear phase mapping to mitigate banding in low-resolution LUTs.
-const PHASE_MAPPING_N: f32 = 0.5;
 fn sample_scattering_lut(r: f32, neg_LdotV: f32) -> vec3<f32> {
     let normalized_altitude = (r - atmosphere.inner_radius) / (atmosphere.outer_radius - atmosphere.inner_radius);
     let phase_uv = 0.5 + 0.5 * sign(neg_LdotV) * (1.0 - pow(1.0 - abs(neg_LdotV), PHASE_MAPPING_N));

--- a/crates/bevy_pbr/src/atmosphere/functions.wesl
+++ b/crates/bevy_pbr/src/atmosphere/functions.wesl
@@ -13,38 +13,44 @@ import package::atmosphere::{
     },
 };
 
-// NOTE FOR CONVENTIONS: 
-// r:
-//   radius, or distance from planet center 
-//
-// altitude:
-//   distance from planet **surface**
-//
-// mu:
-//   cosine of the zenith angle of a ray with
-//   respect to the planet normal
-//
-// atmosphere space:
-//   abbreviated as "as" (contrast with vs, cs, ws), this space is similar
-//   to view space, but with the camera positioned horizontally on the planet
-//   surface, so the horizon is a horizontal line centered vertically in the
-//   frame. This enables the non-linear latitude parametrization the paper uses 
-//   to concentrate detail near the horizon 
+//! NOTE FOR CONVENTIONS:
+//! r:
+//!   radius, or distance from planet center
+//!
+//! altitude:
+//!   distance from planet **surface**
+//!
+//! mu:
+//!   cosine of the zenith angle of a ray with
+//!   respect to the planet normal
+//!
+//! atmosphere space:
+//!   abbreviated as "as" (contrast with vs, cs, ws), this space is similar
+//!   to view space, but with the camera positioned horizontally on the planet
+//!   surface, so the horizon is a horizontal line centered vertically in the
+//!   frame. This enables the non-linear latitude parametrization the paper uses
+//!   to concentrate detail near the horizon
 
 
 // CONSTANTS
-const FRAC_PI: f32 = 0.3183098862; // 1 / π
-const FRAC_2_PI: f32 = 0.15915494309;  // 1 / (2π)
-const FRAC_3_16_PI: f32 = 0.0596831036594607509; // 3 / (16π)
-const FRAC_4_PI: f32 = 0.07957747154594767; // 1 / (4π)
-const ROOT_2: f32 = 1.41421356; // √2
-const EPSILON: f32 = 1.0; // 1 meter
+/// 1 / π
+const FRAC_PI: f32 = 0.3183098862;
+/// 1 / (2π)
+const FRAC_2_PI: f32 = 0.15915494309;
+/// 3 / (16π)
+const FRAC_3_16_PI: f32 = 0.0596831036594607509;
+/// 1 / (4π)
+const FRAC_4_PI: f32 = 0.07957747154594767;
+/// √2
+const ROOT_2: f32 = 1.41421356;
+/// 1 meter
+const EPSILON: f32 = 1.0;
 const MIN_EXTINCTION: vec3<f32> = vec3(1e-12);
 
-// During raymarching, each segment is sampled at a single point. This constant determines
-// where in the segment that sample is taken (0.0 = start, 0.5 = middle, 1.0 = end).
-// We use 0.3 to sample closer to the start of each segment, which better approximates
-// the exponential falloff of atmospheric density.
+/// During raymarching, each segment is sampled at a single point. This constant determines
+/// where in the segment that sample is taken (0.0 = start, 0.5 = middle, 1.0 = end).
+/// We use 0.3 to sample closer to the start of each segment, which better approximates
+/// the exponential falloff of atmospheric density.
 const MIDPOINT_RATIO: f32 = 0.3;
 
 // LUT UV PARAMETERIZATIONS
@@ -81,7 +87,7 @@ fn sky_view_lut_r_mu_azimuth_to_uv(r: f32, mu: f32, azimuth: f32) -> vec2<f32> {
     let horizon_zenith = PI - beta;
     let view_zenith = fast_acos_4(mu);
 
-    // Apply non-linear transformation to compress more texels 
+    // Apply non-linear transformation to compress more texels
     // near the horizon where high-frequency details matter most
     // l is latitude in [-π/2, π/2] and v is texture coordinate in [0,1]
     let l = view_zenith - horizon_zenith;
@@ -137,8 +143,8 @@ fn ndc_to_camera_dist(ndc: vec3<f32>) -> f32 {
     return length(p_atmo - cam_atmo);
 }
 
-// RGB channels: total inscattered light along the camera ray to the current sample.
-// A channel: average transmittance across all wavelengths to the current sample.
+/// RGB channels: total inscattered light along the camera ray to the current sample.
+/// A channel: average transmittance across all wavelengths to the current sample.
 fn sample_aerial_view_lut(uv: vec2<f32>, t: f32) -> vec3<f32> {
     let t_max = settings.aerial_view_lut_max_distance;
     let num_slices = f32(settings.aerial_view_lut_size.z);
@@ -163,10 +169,10 @@ fn sample_aerial_view_lut(uv: vec2<f32>, t: f32) -> vec3<f32> {
 const ABSORPTION_DENSITY: f32 = 0.0;
 const SCATTERING_DENSITY: f32 = 1.0;
 
-// samples from the atmosphere density LUT.
-//
-// calling with `component = 0.0` will return the atmosphere's absorption density,
-// while calling with `component = 1.0` will return the atmosphere's scattering density.
+/// samples from the atmosphere density LUT.
+///
+/// calling with `component = 0.0` will return the atmosphere's absorption density,
+/// while calling with `component = 1.0` will return the atmosphere's scattering density.
 fn sample_density_lut(r: f32, component: f32) -> vec3<f32> {
     // sampler clamps to [0, 1] anyways, no need to clamp the altitude
     let normalized_altitude = (r - atmosphere.inner_radius) / (atmosphere.outer_radius - atmosphere.inner_radius);
@@ -174,9 +180,9 @@ fn sample_density_lut(r: f32, component: f32) -> vec3<f32> {
     return textureSampleLevel(medium_density_lut, medium_sampler, uv, 0.0).xyz;
 }
 
-// samples from the atmosphere scattering LUT. `neg_LdotV` is the dot product
-// of the light direction and the incoming view vector.
-// Nonlinear phase mapping to mitigate banding in low-resolution LUTs.
+/// samples from the atmosphere scattering LUT. `neg_LdotV` is the dot product
+/// of the light direction and the incoming view vector.
+/// Nonlinear phase mapping to mitigate banding in low-resolution LUTs.
 const PHASE_MAPPING_N: f32 = 0.5;
 fn sample_scattering_lut(r: f32, neg_LdotV: f32) -> vec3<f32> {
     let normalized_altitude = (r - atmosphere.inner_radius) / (atmosphere.outer_radius - atmosphere.inner_radius);
@@ -245,17 +251,17 @@ fn calculate_visible_sun_ratio(atmosphere: Atmosphere, r: f32, mu: f32, sun_angu
     let horizon_cos = -sqrt(1.0 - (inner_radius * inner_radius) / (r * r));
     let horizon_angle = fast_acos_4(horizon_cos);
     let sun_zenith_angle = fast_acos_4(mu);
-    
+
     // If sun is completely above horizon
     if sun_zenith_angle + sun_angular_size * 0.5 <= horizon_angle {
         return 1.0;
     }
-    
+
     // If sun is completely below horizon
     if sun_zenith_angle - sun_angular_size * 0.5 >= horizon_angle {
         return 0.0;
     }
-    
+
     // Calculate partial visibility using circular segment area formula
     let d = (horizon_angle - sun_zenith_angle) / (sun_angular_size * 0.5);
     let visible_ratio = 0.5 + d * 0.5;
@@ -288,20 +294,20 @@ fn get_view_position() -> vec3<f32> {
     return clamp_to_surface(atmosphere, atmo_pos);
 }
 
-// We assume the `up` vector at the view position is the y axis, since the world is locally flat/level.
-// t = distance along view ray in atmosphere space
-// NOTE: this means that if your world is actually spherical, this will be wrong.
+/// We assume the `up` vector at the view position is the y axis, since the world is locally flat/level.
+/// t = distance along view ray in atmosphere space
+/// NOTE: this means that if your world is actually spherical, this will be wrong.
 fn get_local_up(r: f32, t: f32, ray_dir: vec3<f32>) -> vec3<f32> {
     return normalize(vec3(0.0, r, 0.0) + t * ray_dir);
 }
 
-// Given a ray starting at radius r, with mu = cos(zenith angle),
-// and a t = distance along the ray, gives the new radius at point t
+/// Given a ray starting at radius r, with mu = cos(zenith angle),
+/// and a t = distance along the ray, gives the new radius at point t
 fn get_local_r(r: f32, mu: f32, t: f32) -> f32 {
     return sqrt(t * t + 2.0 * r * mu * t + r * r);
 }
 
-// Convert uv [0.0 .. 1.0] coordinate to ndc space xy [-1.0 .. 1.0]
+/// Convert uv [0.0 .. 1.0] coordinate to ndc space xy [-1.0 .. 1.0]
 fn uv_to_ndc(uv: vec2<f32>) -> vec2<f32> {
     return uv * vec2(2.0, -2.0) + vec2(-1.0, 1.0);
 }
@@ -323,8 +329,8 @@ fn direction_atmosphere_to_world(dir_as: vec3<f32>) -> vec3<f32> {
     return dir_ws.xyz;
 }
 
-// Modified from skybox.wgsl. For this pass we don't need to apply a separate sky transform or consider camera viewport.
-// Returns a normalized ray direction in world space.
+// Modified from skybox.wesl. For this pass we don't need to apply a separate sky transform or consider camera viewport.
+/// Returns a normalized ray direction in world space.
 fn uv_to_ray_direction(uv: vec2<f32>) -> vec3<f32> {
     // Using world positions of the fragment and camera to calculate a ray direction
     // breaks down at large translations. This code only needs to know the ray direction.
@@ -463,7 +469,7 @@ fn raymarch_atmosphere(
         }
     }
 
-    // include reflected luminance from planet ground 
+    // include reflected luminance from planet ground
     if ground && ray_intersects_ground(r, mu) {
         for (var light_i: u32 = 0u; light_i < lights.n_directional_lights; light_i++) {
             let light = &lights.directional_lights[light_i];

--- a/crates/bevy_pbr/src/atmosphere/multiscattering_lut.wesl
+++ b/crates/bevy_pbr/src/atmosphere/multiscattering_lut.wesl
@@ -21,7 +21,7 @@ fn s2_sequence(n: u32) -> vec2<f32> {
     return fract(0.5 + f32(n) * PHI_2);
 }
 
-// Lambert equal-area projection. 
+/// Lambert equal-area projection.
 fn uv_to_sphere(uv: vec2<f32>) -> vec3<f32> {
     let phi = PI_2 * uv.y;
     let sin_lambda = 2 * uv.x - 1;
@@ -30,11 +30,12 @@ fn uv_to_sphere(uv: vec2<f32>) -> vec3<f32> {
     return vec3(cos_lambda * cos(phi), cos_lambda * sin(phi), sin_lambda);
 }
 
-// Shared memory arrays for workgroup communication
+/// Shared memory array for workgroup communication
 var<workgroup> multi_scat_shared_mem: array<vec3<f32>, 64>;
+/// Shared memory array for workgroup communication
 var<workgroup> l_shared_mem: array<vec3<f32>, 64>;
 
-@compute 
+@compute
 @workgroup_size(1, 1, 64)
 fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     var uv = (vec2<f32>(global_id.xy) + 0.5) / vec2<f32>(settings.multiscattering_lut_size);
@@ -44,7 +45,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
     let ray_dir = uv_to_sphere(s2_sequence(global_id.z));
     let ms_sample = sample_multiscattering_dir(r_mu.x, ray_dir, light_dir);
-    
+
     // Calculate the contribution for this sample
     let sphere_solid_angle = 4.0 * PI;
     let sample_weight = sphere_solid_angle / 64.0;
@@ -69,7 +70,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     // Apply isotropic phase function
     let f_ms = multi_scat_shared_mem[0] * FRAC_4_PI;
     let l_2 = l_shared_mem[0] * FRAC_4_PI;
-    
+
     // Equation 10 from the paper: Geometric series for infinite scattering
     let psi_ms = l_2 / (1.0 - f_ms);
     textureStore(multiscattering_lut_out, global_id.xy, vec4<f32>(psi_ms, 1.0));
@@ -122,7 +123,7 @@ fn sample_multiscattering_dir(r: f32, ray_dir: vec3<f32>, light_dir: vec3<f32>) 
         }
     }
 
-    //include reflected luminance from planet ground 
+    //include reflected luminance from planet ground
     if ray_intersects_ground(r, mu_view) {
         let transmittance_to_ground = exp(-optical_depth);
         let local_up = get_local_up(r, t_max, ray_dir);

--- a/crates/bevy_pbr/src/atmosphere/types.wesl
+++ b/crates/bevy_pbr/src/atmosphere/types.wesl
@@ -1,10 +1,12 @@
 struct Atmosphere {
     ground_albedo: vec3<f32>,
-    // Radius of the planet
-    inner_radius: f32, // units: m
-    // Radius at which we consider the atmosphere to 'end' for out calculations (from center of planet)
-    outer_radius: f32, // units: m
-    // Transform from world space to atmosphere space, inverse of the atmosphere entity's transform
+    /// Radius of the planet
+    /// Units: m
+    inner_radius: f32,
+    /// Radius at which we consider the atmosphere to 'end' for out calculations (from center of planet)
+    /// Units: m
+    outer_radius: f32,
+    /// Transform from world space to atmosphere space, inverse of the atmosphere entity's transform
     world_to_atmosphere: mat4x4<f32>,
 }
 
@@ -23,9 +25,9 @@ struct AtmosphereSettings {
     rendering_method: u32,
 }
 
-// "Atmosphere space" uses local up for the zenith so the horizon-detail
-// parameterization concentrates texels at the viewer's horizon. Azimuth uses a
-// world-fixed reference so the terminator stays stable when tilting the camera.
+/// "Atmosphere space" uses local up for the zenith so the horizon-detail
+/// parameterization concentrates texels at the viewer's horizon. Azimuth uses a
+/// world-fixed reference so the terminator stays stable when tilting the camera.
 struct AtmosphereTransforms {
     world_from_atmosphere: mat4x4<f32>,
     atmosphere_from_world: mat4x4<f32>,

--- a/crates/bevy_pbr/src/cluster.wesl
+++ b/crates/bevy_pbr/src/cluster.wesl
@@ -11,10 +11,10 @@ const CLUSTERABLE_OBJECT_TYPE_RECT_LIGHT: u32 = 5u;
 const NDC_MIN: vec2<f32> = vec2<f32>(-1.0);
 const NDC_MAX: vec2<f32> = vec2<f32>(1.0);
 
-// Metadata stored on GPU that's global to all clusters for a view.
-//
-// See the comments in `bevy_pbr/src/cluster/gpu.rs` for information on the
-// fields.
+/// Metadata stored on GPU that's global to all clusters for a view.
+///
+/// See the comments in `bevy_pbr/src/cluster/gpu.rs` for information on the
+/// fields.
 struct ClusterMetadata {
     indirect_draw_params: ClusterRasterIndirectDrawParams,
 
@@ -29,7 +29,7 @@ struct ClusterMetadata {
     farthest_z: atomic<u32>,
 };
 
-// Indirect draw parameters in the format required by the WebGPU specification.
+/// Indirect draw parameters in the format required by the WebGPU specification.
 struct ClusterRasterIndirectDrawParams {
     index_count: u32,
     instance_count: atomic<u32>,
@@ -38,40 +38,40 @@ struct ClusterRasterIndirectDrawParams {
     first_instance: u32,
 }
 
-// The GPU representation of a single Z-slice of a clusterable object.
-//
-// See the comments in `bevy_pbr/src/cluster/gpu.rs` for information on the
-// fields.
+/// The GPU representation of a single Z-slice of a clusterable object.
+///
+/// See the comments in `bevy_pbr/src/cluster/gpu.rs` for information on the
+/// fields.
 struct ClusterableObjectZSlice {
     object_index: u32,
     object_type: u32,
     z_slice: u32,
 };
 
-// An axis-aligned bounding box.
+/// An axis-aligned bounding box.
 struct Aabb {
-    // The minimum extents of the box.
+    /// The minimum extents of the box.
     min: vec3<f32>,
-    // The maximum extents of the box.
+    /// The maximum extents of the box.
     max: vec3<f32>,
 };
 
-// An axis-aligned bounding box using unsigned integer coordinates.
-//
-// This is used for cluster bounds.
+/// An axis-aligned bounding box using unsigned integer coordinates.
+///
+/// This is used for cluster bounds.
 struct AabbU {
-    // The minimum extents of the box.
+    /// The minimum extents of the box.
     min: vec3<u32>,
-    // The maximum extents of the box, plus one.
-    //
-    // We add 1 here so that 0-size AABBs can be expressed.
+    /// The maximum extents of the box, plus one.
+    ///
+    /// We add 1 here so that 0-size AABBs can be expressed.
     max: vec3<u32>,
 }
 
-// Returns the AABB of an object suitable for conversion into an AABB of
-// clusters.
-//
-// See `bevy_light::cluster::assign::cluster_space_clusterable_object_aabb`.
+/// Returns the AABB of an object suitable for conversion into an AABB of
+/// clusters.
+///
+/// See `bevy_light::cluster::assign::cluster_space_clusterable_object_aabb`.
 fn cluster_space_object_aabb(
     position: vec3<f32>,
     radius: f32,
@@ -128,7 +128,7 @@ fn cluster_space_object_aabb(
     return Aabb(vec3(ndc_min.xy, view_min.z), vec3(ndc_max.xy, view_max.z));
 }
 
-// Computes the scale of the camera from the view matrix.
+/// Computes the scale of the camera from the view matrix.
 fn compute_view_from_world_scale(world_from_view: mat4x4<f32>) -> vec3<f32> {
     let world_from_view_3x3 = mat3x3<f32>(
         world_from_view[0].xyz,
@@ -144,9 +144,9 @@ fn compute_view_from_world_scale(world_from_view: mat4x4<f32>) -> vec3<f32> {
     return vec3<f32>(1.0) / scale;
 }
 
-// Returns the cluster coordinates corresponding to a position in normalized
-// device coordinates.
-// See `bevy_light::cluster::assign::ndc_position_to_cluster`.
+/// Returns the cluster coordinates corresponding to a position in normalized
+/// device coordinates.
+/// See `bevy_light::cluster::assign::ndc_position_to_cluster`.
 fn ndc_position_to_cluster(
     cluster_dimensions: vec3<u32>,
     cluster_factors: vec2<f32>,
@@ -160,7 +160,7 @@ fn ndc_position_to_cluster(
     return clamp(vec3<u32>(xy, z_slice), vec3(0u), cluster_dimensions - vec3(1u));
 }
 
-// Returns the AABB encompassing all clusters that intersect a sphere.
+/// Returns the AABB encompassing all clusters that intersect a sphere.
 fn calculate_sphere_cluster_bounds(
     position: vec3<f32>,
     radius: f32,

--- a/crates/bevy_pbr/src/cluster/cluster_allocate.wesl
+++ b/crates/bevy_pbr/src/cluster/cluster_allocate.wesl
@@ -1,6 +1,3 @@
-import package::cluster::ClusterMetadata;
-import package::render::mesh_view_types::{ClusterOffsetsAndCounts, Lights};
-
 //! The shader that allocates the clustered object ID buffer.
 //!
 //! The clustered object ID buffer consists of many tightly-packed
@@ -27,6 +24,9 @@ import package::render::mesh_view_types::{ClusterOffsetsAndCounts, Lights};
 //! [prefix sum]: https://en.wikipedia.org/wiki/Prefix_sum
 //!
 //! [Hillis-Steele scan]: https://en.wikipedia.org/wiki/Prefix_sum#Algorithm_1:_Shorter_span,_more_parallel
+
+import package::cluster::ClusterMetadata;
+import package::render::mesh_view_types::{ClusterOffsetsAndCounts, Lights};
 
 @group(0) @binding(0) var<storage, read_write> offsets_and_counts: ClusterOffsetsAndCounts;
 @group(0) @binding(1) var<uniform> lights: Lights;

--- a/crates/bevy_pbr/src/cluster/cluster_allocate.wesl
+++ b/crates/bevy_pbr/src/cluster/cluster_allocate.wesl
@@ -1,32 +1,32 @@
 import package::cluster::ClusterMetadata;
 import package::render::mesh_view_types::{ClusterOffsetsAndCounts, Lights};
 
-// The shader that allocates the clustered object ID buffer.
-//
-// The clustered object ID buffer consists of many tightly-packed
-// variable-length arrays of clustered object IDs. The offset to the start of
-// each list is stored in `ClusterOffsetsAndCounts`. To allocate the lists in
-// the buffer, the number of objects of each type in each cluster must be known.
-//
-// Since the lists are tightly packed, determining the offsets in the global
-// buffer is a [prefix sum] problem. To deal with the fact that workgroup sizes
-// are limited to 256 in `wgpu`, and we will usually have more clusters than
-// that, we use a two-pass approach:
-//
-// 1. First, the *local* allocation pass runs on workgroups of 256 clusters
-// each. A [Hillis-Steele scan] is performed to allocate the position in the
-// buffer for each 256 clusters, relative to the first cluster in the workgroup.
-//
-// 2. Next, the *global* allocation pass runs a sequential loop over each 256
-// clusters to calculate the final offsets relative to the previous 256 cluster
-// chunk.
-//
-// At the end of this process, the clusters will have been assigned to their
-// final positions in the list.
-//
-// [prefix sum]: https://en.wikipedia.org/wiki/Prefix_sum
-//
-// [Hillis-Steele scan]: https://en.wikipedia.org/wiki/Prefix_sum#Algorithm_1:_Shorter_span,_more_parallel
+//! The shader that allocates the clustered object ID buffer.
+//!
+//! The clustered object ID buffer consists of many tightly-packed
+//! variable-length arrays of clustered object IDs. The offset to the start of
+//! each list is stored in `ClusterOffsetsAndCounts`. To allocate the lists in
+//! the buffer, the number of objects of each type in each cluster must be known.
+//!
+//! Since the lists are tightly packed, determining the offsets in the global
+//! buffer is a [prefix sum] problem. To deal with the fact that workgroup sizes
+//! are limited to 256 in `wgpu`, and we will usually have more clusters than
+//! that, we use a two-pass approach:
+//!
+//! 1. First, the *local* allocation pass runs on workgroups of 256 clusters
+//! each. A [Hillis-Steele scan] is performed to allocate the position in the
+//! buffer for each 256 clusters, relative to the first cluster in the workgroup.
+//!
+//! 2. Next, the *global* allocation pass runs a sequential loop over each 256
+//! clusters to calculate the final offsets relative to the previous 256 cluster
+//! chunk.
+//!
+//! At the end of this process, the clusters will have been assigned to their
+//! final positions in the list.
+//!
+//! [prefix sum]: https://en.wikipedia.org/wiki/Prefix_sum
+//!
+//! [Hillis-Steele scan]: https://en.wikipedia.org/wiki/Prefix_sum#Algorithm_1:_Shorter_span,_more_parallel
 
 @group(0) @binding(0) var<storage, read_write> offsets_and_counts: ClusterOffsetsAndCounts;
 @group(0) @binding(1) var<uniform> lights: Lights;
@@ -34,11 +34,11 @@ import package::render::mesh_view_types::{ClusterOffsetsAndCounts, Lights};
 @group(0) @binding(3) var<storage, read_write> scratchpad_offsets_and_counts:
     ClusterOffsetsAndCounts;
 
-// The offset of the first clustered light within the buffer for each thread.
+/// The offset of the first clustered light within the buffer for each thread.
 var<workgroup> block_offsets: array<u32, 256>;
 
-// The local allocation pass that, for each chunk of 256 clusters, calculates
-// the offset for each cluster in the chunk.
+/// The local allocation pass that, for each chunk of 256 clusters, calculates
+/// the offset for each cluster in the chunk.
 @compute @workgroup_size(256, 1, 1)
 fn allocate_local_main(
     @builtin(local_invocation_id) local_id: vec3<u32>,
@@ -86,8 +86,8 @@ fn allocate_local_main(
     }
 }
 
-// The global allocation pass that propagates the offsets from each chunk of 256
-// clusters to later chunks sequentially.
+/// The global allocation pass that propagates the offsets from each chunk of 256
+/// clusters to later chunks sequentially.
 @compute @workgroup_size(256, 1, 1)
 fn allocate_global_main(@builtin(local_invocation_id) local_id: vec3<u32>) {
     let cluster_count =
@@ -118,11 +118,11 @@ fn allocate_global_main(@builtin(local_invocation_id) local_id: vec3<u32>) {
     }
 }
 
-// Returns the total number of objects in the given cluster.
-//
-// The per-type counts are laid out as:
-//   [0] = (offset, point lights, spot lights, rect lights)
-//   [1] = (reflection probes, irradiance volumes, decals, pad)
+/// Returns the total number of objects in the given cluster.
+///
+/// The per-type counts are laid out as:
+///   [0] = (offset, point lights, spot lights, rect lights)
+///   [1] = (reflection probes, irradiance volumes, decals, pad)
 fn cluster_object_count(cluster_index: u32) -> u32 {
     return
         offsets_and_counts.data[cluster_index][0].y +

--- a/crates/bevy_pbr/src/cluster/cluster_raster.wesl
+++ b/crates/bevy_pbr/src/cluster/cluster_raster.wesl
@@ -13,45 +13,45 @@ import package::render::mesh_view_types::{
 import bevy_render::view::View;
 import bevy_render::maths::quat_rotate;
 
-// The shader that performs the cluster-object intersection tests and assigns
-// objects to clusters as appropriate.
-//
-// Assuming the froxel grid has size WxHxD, this shader is expected to run on a
-// viewport of size WxH. It draws each *Z slice* as an axis aligned quad such
-// that each fragment shader invocation represents a single cluster-object pair
-// in the froxel grid. The fragment shader performs a finer test to see if the
-// object might intersects the cluster and, if it succeeds, records the result.
-// Because the result is written to storage buffers, color writes are disabled
-// for this shader invocation.
-//
-// This shader runs twice: once to accumulate the *count* of each object type in
-// each cluster, and once to *populate* the actual IDs. Both invocations of the
-// shader must compute the exact same visibility results.
+//! The shader that performs the cluster-object intersection tests and assigns
+//! objects to clusters as appropriate.
+//!
+//! Assuming the froxel grid has size WxHxD, this shader is expected to run on a
+//! viewport of size WxH. It draws each *Z slice* as an axis aligned quad such
+//! that each fragment shader invocation represents a single cluster-object pair
+//! in the froxel grid. The fragment shader performs a finer test to see if the
+//! object might intersects the cluster and, if it succeeds, records the result.
+//! Because the result is written to storage buffers, color writes are disabled
+//! for this shader invocation.
+//!
+//! This shader runs twice: once to accumulate the *count* of each object type in
+//! each cluster, and once to *populate* the actual IDs. Both invocations of the
+//! shader must compute the exact same visibility results.
 
 struct Vertex {
     @builtin(instance_index) instance_id: u32,
     @location(0) position: vec2<f32>,
 }
 
-// Data output from the vertex shader and input to the fragment shader.
+/// Data output from the vertex shader and input to the fragment shader.
 struct Varyings {
     @builtin(position) position: vec4<f32>,
-    // The index of the Z slice we're rasterizing.
+    /// The index of the Z slice we're rasterizing.
     @location(0) @interpolate(flat) instance_id: u32,
-    // The view-space center of the bounding sphere of the object.
+    /// The view-space center of the bounding sphere of the object.
     @location(1) @interpolate(flat) sphere_position: vec3<f32>,
-    // The view-space radius of the bounding sphere of the object.
+    /// The view-space radius of the bounding sphere of the object.
     @location(2) @interpolate(flat) sphere_radius: f32,
 }
 
-// The same as the `ClusterOffsetsAndCounts` structure, but with atomic fields
-// so that we can write to it.
+/// The same as the `ClusterOffsetsAndCounts` structure, but with atomic fields
+/// so that we can write to it.
 struct ClusterOffsetsAndCountsAtomic {
     data: array<ClusterOffsetsAndCountsElementAtomic>,
 }
 
-// The same as the `ClusterOffsetsAndCountsElement` structure, but with atomic
-// fields so that we can write to it.
+/// The same as the `ClusterOffsetsAndCountsElement` structure, but with atomic
+/// fields so that we can write to it.
 struct ClusterOffsetsAndCountsElementAtomic {
     offset: atomic<u32>,
     point_lights: atomic<u32>,
@@ -63,39 +63,39 @@ struct ClusterOffsetsAndCountsElementAtomic {
     pad_a: u32,
 }
 
-// The list of clusterable object Z slices that we read from to.
+/// The list of clusterable object Z slices that we read from to.
 @group(0) @binding(0) var<storage> z_slices: array<ClusterableObjectZSlice>;
 @if(!VERTEX_SHADER)
-// The list of indices per cluster that we write to in the populate pass.
+/// The list of indices per cluster that we write to in the populate pass.
 @group(0) @binding(1) var<storage, read_write> index_lists: ClusterableObjectIndexLists;
-// Information about each light.
+/// Information about each light.
 @group(0) @binding(2) var<storage> clustered_lights: ClusteredLights;
-// Information about each light probe (reflection probe or irradiance volume).
+/// Information about each light probe (reflection probe or irradiance volume).
 @group(0) @binding(3) var<uniform> light_probes: LightProbes;
-// Information about each clustered decal.
+/// Information about each clustered decal.
 @group(0) @binding(4) var<storage> clustered_decals: ClusteredDecals;
-// Information about the clusters as a whole, including the dimensions of the
-// cluster grid.
+/// Information about the clusters as a whole, including the dimensions of the
+/// cluster grid.
 @group(0) @binding(5) var<uniform> lights: Lights;
-// Information about the view.
+/// Information about the view.
 @group(0) @binding(6) var<uniform> view: View;
 @if(!VERTEX_SHADER && POPULATE_PASS) {
-// The number of objects in each cluster, and the offset of each list.
+/// The number of objects in each cluster, and the offset of each list.
 @group(0) @binding(7) var<storage> offsets_and_counts: ClusterOffsetsAndCounts;
-// For each cluster, the counts of objects written *so far* to it.
-//
-// We use this during the populate phase in order to write the ID of each object
-// to the correct spot.
+/// For each cluster, the counts of objects written *so far* to it.
+///
+/// We use this during the populate phase in order to write the ID of each object
+/// to the correct spot.
 @group(0) @binding(8) var<storage, read_write> scratchpad_offsets_and_counts:
     ClusterOffsetsAndCountsAtomic;
 }
 @if(!VERTEX_SHADER && !POPULATE_PASS)
-// The number of objects in each cluster.
-//
-// During the count pass, we write to this.
+/// The number of objects in each cluster.
+///
+/// During the count pass, we write to this.
 @group(0) @binding(7) var<storage, read_write> offsets_and_counts: ClusterOffsetsAndCountsAtomic;
 
-// The vertex entry point.
+/// The vertex entry point.
 @vertex
 fn vertex_main(vertex: Vertex) -> Varyings {
     let instance_id = vertex.instance_id;
@@ -142,9 +142,9 @@ fn vertex_main(vertex: Vertex) -> Varyings {
     );
 }
 
-// Returns the position of the quad vertex necessary to enclose all the
-// fragments that represent the cluster AABB.
-// The cluster bounds are supplied as `vec4(min X, min Y, max X, max Y)`.
+/// Returns the position of the quad vertex necessary to enclose all the
+/// fragments that represent the cluster AABB.
+/// The cluster bounds are supplied as `vec4(min X, min Y, max X, max Y)`.
 fn calculate_vertex_position(vertex: Vertex, cluster_bounds: vec4<u32>) -> vec4<f32> {
     let framebuffer_position = vec2<u32>(
         select(cluster_bounds.x, cluster_bounds.z, vertex.position.x == 1.0),
@@ -157,8 +157,8 @@ fn calculate_vertex_position(vertex: Vertex, cluster_bounds: vec4<u32>) -> vec4<
 
 @if(!VERTEX_SHADER)
 
-// Performs a fine-grained test to ensure that the object intersects a single
-// froxel and records the result.
+/// Performs a fine-grained test to ensure that the object intersects a single
+/// froxel and records the result.
 @fragment
 fn fragment_main(varyings: Varyings) -> @location(0) vec4<f32> {
     let instance_id = varyings.instance_id;
@@ -240,8 +240,8 @@ fn fragment_main(varyings: Varyings) -> @location(0) vec4<f32> {
     return vec4<f32>(0.0);
 }
 
-// Returns true if the given sphere intersects the AABB with the given
-// boundaries.
+/// Returns true if the given sphere intersects the AABB with the given
+/// boundaries.
 fn sphere_intersects_aabb(
     sphere_center: vec3<f32>,
     sphere_radius: f32,
@@ -253,7 +253,7 @@ fn sphere_intersects_aabb(
     return dist_sq <= sphere_radius * sphere_radius;
 }
 
-// See `bevy_light::cluster::assign::compute_aabb_for_cluster`.
+/// See `bevy_light::cluster::assign::compute_aabb_for_cluster`.
 fn compute_aabb_for_cluster(
     z_near: f32,
     z_far: f32,
@@ -320,8 +320,8 @@ fn compute_aabb_for_cluster(
     return Aabb(cluster_min, cluster_max);
 }
 
-// Converts a screen-space position to a view-space position.
-// See `bevy_light::cluster::assign::screen_to_view`.
+/// Converts a screen-space position to a view-space position.
+/// See `bevy_light::cluster::assign::screen_to_view`.
 fn screen_to_view(
     screen_size: vec2<f32>,
     view_from_clip: mat4x4<f32>,
@@ -338,23 +338,23 @@ fn screen_to_view(
     return clip_to_view(view_from_clip, clip);
 }
 
-// Converts a clip-space position to a view-space position.
-// See `bevy_light::cluster::assign::clip_to_view`.
+/// Converts a clip-space position to a view-space position.
+/// See `bevy_light::cluster::assign::clip_to_view`.
 fn clip_to_view(view_from_clip: mat4x4<f32>, clip: vec4<f32>) -> vec4<f32> {
     let view = view_from_clip * clip;
     return view / view.w;
 }
 
-// Calculate the intersection of a ray from the eye through the view space
-// position to a z plane
-// See `bevy_light::cluster::assign::line_intersection_to_z_plane`.
+/// Calculate the intersection of a ray from the eye through the view space
+/// position to a z plane
+/// See `bevy_light::cluster::assign::line_intersection_to_z_plane`.
 fn line_intersection_to_z_plane(origin: vec3<f32>, p: vec3<f32>, z: f32) -> vec3<f32> {
     let v = p - origin;
     let t = (z - dot(vec3(0.0, 0.0, 1.0), origin)) / dot(vec3(0.0, 0.0, 1.0), v);
     return origin + t * v;
 }
 
-// Computes the near and far extents of the cluster grid.
+/// Computes the near and far extents of the cluster grid.
 fn compute_z_near_and_z_far(is_orthographic: bool) -> vec2<f32> {
     let cluster_dimensions = vec3<f32>(lights.cluster_dimensions.xyz);
     let cluster_factors = lights.cluster_factors;
@@ -370,8 +370,8 @@ fn compute_z_near_and_z_far(is_orthographic: bool) -> vec2<f32> {
     return vec2<f32>(z_near, z_far);
 }
 
-// Returns true if a spot light should be culled.
-// See `assign_objects_to_clusters` in `bevy_light/src/cluster/assign.rs`.
+/// Returns true if a spot light should be culled.
+/// See `assign_objects_to_clusters` in `bevy_light/src/cluster/assign.rs`.
 fn cull_spot_light(
     object_index: u32,
     cluster_aabb_sphere_center: vec3<f32>,
@@ -428,7 +428,7 @@ fn cull_spot_light(
     return angle_cull || front_cull || back_cull;
 }
 
-// Returns true if a rect light should be culled.
+/// Returns true if a rect light should be culled.
 fn cull_rect_light(
     object_index: u32,
     cluster_aabb_sphere_center: vec3<f32>,
@@ -446,21 +446,21 @@ fn cull_rect_light(
     return signed_distance < -cluster_aabb_sphere_radius;
 }
 
-// Computes `cos(atan(x))` cheaply.
-// See https://en.wikipedia.org/wiki/List_of_trigonometric_identities
+/// Computes `cos(atan(x))` cheaply.
+/// See https://en.wikipedia.org/wiki/List_of_trigonometric_identities
 fn cos_atan(tan_theta: f32) -> f32 {
     return inverseSqrt(1.0 + tan_theta * tan_theta);
 }
 
-// Computes `sin(atan(x))` cheaply.
-// See https://en.wikipedia.org/wiki/List_of_trigonometric_identities
+/// Computes `sin(atan(x))` cheaply.
+/// See https://en.wikipedia.org/wiki/List_of_trigonometric_identities
 fn sin_atan(tan_theta: f32) -> f32 {
     return tan_theta * inverseSqrt(1.0 + tan_theta * tan_theta);
 }
 
 @if(!VERTEX_SHADER && POPULATE_PASS)
-// Allocates space in the appropriate list and returns the global index that the
-// object index should be written to.
+/// Allocates space in the appropriate list and returns the global index that the
+/// object index should be written to.
 fn allocate_list_entry(cluster_index: u32, object_type: u32) -> u32 {
     switch (object_type) {
         case CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT: {
@@ -510,7 +510,7 @@ fn allocate_list_entry(cluster_index: u32, object_type: u32) -> u32 {
     return 0xffffffffu;
 }
 @if(!VERTEX_SHADER && !POPULATE_PASS)
-// Increments the count of objects of the given type for the given cluster.
+/// Increments the count of objects of the given type for the given cluster.
 fn increment_object_count(cluster_index: u32, object_type: u32) {
     switch (object_type) {
         case CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT: {
@@ -535,9 +535,9 @@ fn increment_object_count(cluster_index: u32, object_type: u32) {
     }
 }
 
-// Looks up and returns the world-space center and radius of the bounding sphere
-// for the object with the given index and type.
-// Returns a 4-vector with the fields `vec4(center X, center Y, center Z, radius)`.
+/// Looks up and returns the world-space center and radius of the bounding sphere
+/// for the object with the given index and type.
+/// Returns a 4-vector with the fields `vec4(center X, center Y, center Z, radius)`.
 fn get_object_bounding_sphere(object_index: u32, object_type: u32) -> vec4<f32> {
     var position = vec3<f32>(0.0);
     var radius = 0.0;

--- a/crates/bevy_pbr/src/cluster/cluster_raster.wesl
+++ b/crates/bevy_pbr/src/cluster/cluster_raster.wesl
@@ -1,18 +1,3 @@
-import package::cluster::{
-    Aabb, CLUSTERABLE_OBJECT_TYPE_DECAL, CLUSTERABLE_OBJECT_TYPE_IRRADIANCE_VOLUME,
-    CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT, CLUSTERABLE_OBJECT_TYPE_REFLECTION_PROBE,
-    CLUSTERABLE_OBJECT_TYPE_SPOT_LIGHT, CLUSTERABLE_OBJECT_TYPE_RECT_LIGHT, ClusterableObjectZSlice,
-    calculate_sphere_cluster_bounds, compute_view_from_world_scale
-};
-import package::render::clustered_forward;
-import package::light_probe::transpose_affine_matrix;
-import package::render::mesh_view_types::{
-    ClusterOffsetsAndCounts, ClusterableObjectIndexLists, ClusteredDecals, ClusteredLights,
-    LightProbes, Lights, POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE
-};
-import bevy_render::view::View;
-import bevy_render::maths::quat_rotate;
-
 //! The shader that performs the cluster-object intersection tests and assigns
 //! objects to clusters as appropriate.
 //!
@@ -27,6 +12,21 @@ import bevy_render::maths::quat_rotate;
 //! This shader runs twice: once to accumulate the *count* of each object type in
 //! each cluster, and once to *populate* the actual IDs. Both invocations of the
 //! shader must compute the exact same visibility results.
+
+import package::cluster::{
+    Aabb, CLUSTERABLE_OBJECT_TYPE_DECAL, CLUSTERABLE_OBJECT_TYPE_IRRADIANCE_VOLUME,
+    CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT, CLUSTERABLE_OBJECT_TYPE_REFLECTION_PROBE,
+    CLUSTERABLE_OBJECT_TYPE_SPOT_LIGHT, CLUSTERABLE_OBJECT_TYPE_RECT_LIGHT, ClusterableObjectZSlice,
+    calculate_sphere_cluster_bounds, compute_view_from_world_scale
+};
+import package::render::clustered_forward;
+import package::light_probe::transpose_affine_matrix;
+import package::render::mesh_view_types::{
+    ClusterOffsetsAndCounts, ClusterableObjectIndexLists, ClusteredDecals, ClusteredLights,
+    LightProbes, Lights, POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE
+};
+import bevy_render::view::View;
+import bevy_render::maths::quat_rotate;
 
 struct Vertex {
     @builtin(instance_index) instance_id: u32,

--- a/crates/bevy_pbr/src/cluster/cluster_z_slice.wesl
+++ b/crates/bevy_pbr/src/cluster/cluster_z_slice.wesl
@@ -1,14 +1,3 @@
-import package::cluster::{
-    CLUSTERABLE_OBJECT_TYPE_DECAL, CLUSTERABLE_OBJECT_TYPE_IRRADIANCE_VOLUME,
-    CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT, CLUSTERABLE_OBJECT_TYPE_REFLECTION_PROBE,
-    CLUSTERABLE_OBJECT_TYPE_SPOT_LIGHT, CLUSTERABLE_OBJECT_TYPE_RECT_LIGHT, ClusterMetadata,
-    ClusterableObjectZSlice, calculate_sphere_cluster_bounds, compute_view_from_world_scale
-};
-import package::render::mesh_view_types::{
-    ClusteredDecals, ClusteredLights, LightProbes, Lights, POINT_LIGHT_FLAGS_SPOT_LIGHT_BIT, POINT_LIGHT_FLAGS_RECT_LIGHT_BIT
-};
-import bevy_render::view::View;
-
 //! The shader that divides clusterable objects into Z slices.
 //!
 //! Treating the cluster froxel space as a grid of size WxHxD, for each
@@ -19,6 +8,17 @@ import bevy_render::view::View;
 //! will consume. It also updates the indirect draw parameters for the
 //! rasterization pass and calculates statistics about the farthest Z value
 //! encountered that the CPU can later read back for dynamic froxel range tuning.
+
+import package::cluster::{
+    CLUSTERABLE_OBJECT_TYPE_DECAL, CLUSTERABLE_OBJECT_TYPE_IRRADIANCE_VOLUME,
+    CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT, CLUSTERABLE_OBJECT_TYPE_REFLECTION_PROBE,
+    CLUSTERABLE_OBJECT_TYPE_SPOT_LIGHT, CLUSTERABLE_OBJECT_TYPE_RECT_LIGHT, ClusterMetadata,
+    ClusterableObjectZSlice, calculate_sphere_cluster_bounds, compute_view_from_world_scale
+};
+import package::render::mesh_view_types::{
+    ClusteredDecals, ClusteredLights, LightProbes, Lights, POINT_LIGHT_FLAGS_SPOT_LIGHT_BIT, POINT_LIGHT_FLAGS_RECT_LIGHT_BIT
+};
+import bevy_render::view::View;
 
 /// Metadata, including the indirect draw parameters that we write to.
 @group(0) @binding(0) var<storage, read_write> cluster_metadata: ClusterMetadata;

--- a/crates/bevy_pbr/src/cluster/cluster_z_slice.wesl
+++ b/crates/bevy_pbr/src/cluster/cluster_z_slice.wesl
@@ -1,7 +1,7 @@
 import package::cluster::{
     CLUSTERABLE_OBJECT_TYPE_DECAL, CLUSTERABLE_OBJECT_TYPE_IRRADIANCE_VOLUME,
     CLUSTERABLE_OBJECT_TYPE_POINT_LIGHT, CLUSTERABLE_OBJECT_TYPE_REFLECTION_PROBE,
-    CLUSTERABLE_OBJECT_TYPE_SPOT_LIGHT, CLUSTERABLE_OBJECT_TYPE_RECT_LIGHT, ClusterMetadata, 
+    CLUSTERABLE_OBJECT_TYPE_SPOT_LIGHT, CLUSTERABLE_OBJECT_TYPE_RECT_LIGHT, ClusterMetadata,
     ClusterableObjectZSlice, calculate_sphere_cluster_bounds, compute_view_from_world_scale
 };
 import package::render::mesh_view_types::{
@@ -9,40 +9,40 @@ import package::render::mesh_view_types::{
 };
 import bevy_render::view::View;
 
-// The shader that divides clusterable objects into Z slices.
-//
-// Treating the cluster froxel space as a grid of size WxHxD, for each
-// clusterable object, we seek to rasterize D overlapping quads into a viewport
-// of size WxH. Each quad represents a *Z slice* of the object. This shader
-// calculates the number of Z slices needed for each object in parallel and
-// prepares the `ClusterableObjectZSlice` data that the rasterization passes
-// will consume. It also updates the indirect draw parameters for the
-// rasterization pass and calculates statistics about the farthest Z value
-// encountered that the CPU can later read back for dynamic froxel range tuning.
+//! The shader that divides clusterable objects into Z slices.
+//!
+//! Treating the cluster froxel space as a grid of size WxHxD, for each
+//! clusterable object, we seek to rasterize D overlapping quads into a viewport
+//! of size WxH. Each quad represents a *Z slice* of the object. This shader
+//! calculates the number of Z slices needed for each object in parallel and
+//! prepares the `ClusterableObjectZSlice` data that the rasterization passes
+//! will consume. It also updates the indirect draw parameters for the
+//! rasterization pass and calculates statistics about the farthest Z value
+//! encountered that the CPU can later read back for dynamic froxel range tuning.
 
-// Metadata, including the indirect draw parameters that we write to.
+/// Metadata, including the indirect draw parameters that we write to.
 @group(0) @binding(0) var<storage, read_write> cluster_metadata: ClusterMetadata;
-// The list of clusterable object Z slices that we write to.
+/// The list of clusterable object Z slices that we write to.
 @group(0) @binding(1) var<storage, read_write> z_slices: array<ClusterableObjectZSlice>;
-// Information about each light.
+/// Information about each light.
 @group(0) @binding(2) var<storage> clustered_lights: ClusteredLights;
-// Information about each light probe (reflection probe or irradiance volume).
+/// Information about each light probe (reflection probe or irradiance volume).
 @group(0) @binding(3) var<uniform> light_probes: LightProbes;
-// Information about each clustered decal.
+/// Information about each clustered decal.
 @group(0) @binding(4) var<storage> clustered_decals: ClusteredDecals;
-// Information about the clusters as a whole, including the dimensions of the
-// cluster grid.
+/// Information about the clusters as a whole, including the dimensions of the
+/// cluster grid.
 @group(0) @binding(5) var<uniform> lights: Lights;
-// Information about the view.
+/// Information about the view.
 @group(0) @binding(6) var<uniform> view: View;
 
-// A temporary workgroup-local buffer used to accelerate the "farthest depth of
-// any object" calculation.
+/// A temporary workgroup-local buffer used to accelerate the "farthest depth of
+/// any object" calculation.
 var<workgroup> shared_farthest_z: array<f32, 64>;
 
-// The shader entry point.
-//
-// We have one invocation per clusterable object.
+/// The shader entry point.
+///
+/// We have one invocation per clusterable object.
 @compute @workgroup_size(64, 1, 1)
 fn z_slice_main(
     @builtin(global_invocation_id) global_invocation_id: vec3<u32>,
@@ -139,11 +139,11 @@ fn z_slice_main(
     }
 }
 
-// Writes a Z slice to the list.
-//
-// This silently fails if the list is too small, but it still updates the
-// instance count, which the CPU reads back. So, if the list is too small, the
-// CPU will end up being notified and can resize the buffer.
+/// Writes a Z slice to the list.
+///
+/// This silently fails if the list is too small, but it still updates the
+/// instance count, which the CPU reads back. So, if the list is too small, the
+/// CPU will end up being notified and can resize the buffer.
 fn try_write_z_slice(object_index: u32, object_type: u32, z_slice: u32) {
     let z_slice_offset = atomicAdd(&cluster_metadata.indirect_draw_params.instance_count, 1u);
     if (z_slice_offset >= cluster_metadata.z_slice_list_capacity) {
@@ -155,8 +155,8 @@ fn try_write_z_slice(object_index: u32, object_type: u32, z_slice: u32) {
     z_slices[z_slice_offset].z_slice = z_slice;
 }
 
-// Records the farthest Z value for clusterable objects in this workgroup for
-// the CPU to read back.
+/// Records the farthest Z value for clusterable objects in this workgroup for
+/// the CPU to read back.
 fn accumulate_farthest_z_value(
     local_id: u32,
     position: vec3<f32>,
@@ -193,12 +193,12 @@ fn accumulate_farthest_z_value(
     atomicMax(&cluster_metadata.farthest_z, f32_bits_to_sortable_u32(bitcast<u32>(shared_farthest_z[0u])));
 }
 
-// Encodes f32 bits into a u32 whose unsigned ordering matches
-// the float's total order. Positive floats get the sign bit set so they
-// sort above negative floats; negative floats get all bits flipped so
-// their ordering is reversed (more negative -> smaller u32).
-//
-// The CPU decodes with `sortable_u32_to_f32_bits` in `gpu.rs`.
+/// Encodes f32 bits into a u32 whose unsigned ordering matches
+/// the float's total order. Positive floats get the sign bit set so they
+/// sort above negative floats; negative floats get all bits flipped so
+/// their ordering is reversed (more negative -> smaller u32).
+///
+/// The CPU decodes with `sortable_u32_to_f32_bits` in `gpu.rs`.
 fn f32_bits_to_sortable_u32(bits: u32) -> u32 {
     let mask = bitcast<u32>(bitcast<i32>(bits) >> 31) | 0x80000000u;
     return bits ^ mask;

--- a/crates/bevy_pbr/src/decal/clustered.wesl
+++ b/crates/bevy_pbr/src/decal/clustered.wesl
@@ -1,30 +1,30 @@
-// Support code for clustered decals.
-//
-// This module provides an iterator API, which you may wish to use in your own
-// shaders if you want clustered decals to provide textures other than the base
-// color. The iterator API allows you to iterate over all decals affecting the
-// current fragment. Use `clustered_decal_iterator_new()` and
-// `clustered_decal_iterator_next()` as follows:
-//
-//      let view_z = get_view_z(vec4(world_position, 1.0));
-//      let is_orthographic = view_is_orthographic();
-//
-//      let cluster_index =
-//          clustered_forward::view_fragment_cluster_index(frag_coord, view_z, is_orthographic);
-//      var clusterable_object_index_ranges =
-//          clustered_forward::unpack_clusterable_object_index_ranges(cluster_index);
-//
-//      var iterator = clustered_decal_iterator_new(world_position, &clusterable_object_index_ranges);
-//      while (clustered_decal_iterator_next(&iterator)) {
-//          ... sample from the texture at iterator.texture_index at iterator.uv ...
-//      }
-//
-// In this way, in conjunction with a custom material, you can provide your own
-// texture arrays that mirror `mesh_view_bindings::clustered_decal_textures` in
-// order to support decals with normal maps, etc.
-//
-// Note that the order in which decals are returned is currently unpredictable,
-// though generally stable from frame to frame.
+//! Support code for clustered decals.
+//!
+//! This module provides an iterator API, which you may wish to use in your own
+//! shaders if you want clustered decals to provide textures other than the base
+//! color. The iterator API allows you to iterate over all decals affecting the
+//! current fragment. Use `clustered_decal_iterator_new()` and
+//! `clustered_decal_iterator_next()` as follows:
+//!
+//!      let view_z = get_view_z(vec4(world_position, 1.0));
+//!      let is_orthographic = view_is_orthographic();
+//!
+//!      let cluster_index =
+//!          clustered_forward::view_fragment_cluster_index(frag_coord, view_z, is_orthographic);
+//!      var clusterable_object_index_ranges =
+//!          clustered_forward::unpack_clusterable_object_index_ranges(cluster_index);
+//!
+//!      var iterator = clustered_decal_iterator_new(world_position, &clusterable_object_index_ranges);
+//!      while (clustered_decal_iterator_next(&iterator)) {
+//!          ... sample from the texture at iterator.texture_index at iterator.uv ...
+//!      }
+//!
+//! In this way, in conjunction with a custom material, you can provide your own
+//! texture arrays that mirror `mesh_view_bindings::clustered_decal_textures` in
+//! order to support decals with normal maps, etc.
+//!
+//! Note that the order in which decals are returned is currently unpredictable,
+//! though generally stable from frame to frame.
 
 import package::render::clustered_forward;
 import package::render::clustered_forward::ClusterableObjectIndexRanges;
@@ -38,45 +38,45 @@ import bevy_render::maths;
 @elif(PREPASS_PIPELINE) import package::prepass::io::VertexOutput;
 @else import package::render::forward_io::VertexOutput;
 
-// An object that allows stepping through all clustered decals that affect a
-// single fragment.
+/// An object that allows stepping through all clustered decals that affect a
+/// single fragment.
 struct ClusteredDecalIterator {
-    // Public fields follow:
-    // The index of the decal base color texture in the binding array.
+    /// Public fields follow:
+    /// The index of the decal base color texture in the binding array.
     base_color_texture_index: i32,
-    // The index of the decal normal map texture in the binding array.
+    /// The index of the decal normal map texture in the binding array.
     normal_map_texture_index: i32,
-    // The index of the decal metallic-roughness texture in the binding array.
+    /// The index of the decal metallic-roughness texture in the binding array.
     metallic_roughness_texture_index: i32,
-    // The index of the decal emissive texture in the binding array.
+    /// The index of the decal emissive texture in the binding array.
     emissive_texture_index: i32,
-    // The UV coordinates at which to sample that decal texture.
+    /// The UV coordinates at which to sample that decal texture.
     uv: vec2<f32>,
-    // A custom tag you can use for your own purposes.
+    /// A custom tag you can use for your own purposes.
     tag: u32,
 
-    // Private fields follow:
-    // The current offset of the index in the `ClusterableObjectIndexRanges` list.
+    /// Private fields follow:
+    /// The current offset of the index in the `ClusterableObjectIndexRanges` list.
     decal_index_offset: i32,
-    // The end offset of the index in the `ClusterableObjectIndexRanges` list.
+    /// The end offset of the index in the `ClusterableObjectIndexRanges` list.
     end_offset: i32,
-    // The world-space position of the fragment.
+    /// The world-space position of the fragment.
     world_position: vec3<f32>,
 }
 
 @if(CLUSTERED_DECALS_ARE_USABLE)
 
-// Creates a new iterator over the decals at the current fragment.
-//
-// You can retrieve `clusterable_object_index_ranges` as follows:
-//
-//      let view_z = get_view_z(world_position);
-//      let is_orthographic = view_is_orthographic();
-//
-//      let cluster_index =
-//          clustered_forward::view_fragment_cluster_index(frag_coord, view_z, is_orthographic);
-//      var clusterable_object_index_ranges =
-//          clustered_forward::unpack_clusterable_object_index_ranges(cluster_index);
+/// Creates a new iterator over the decals at the current fragment.
+///
+/// You can retrieve `clusterable_object_index_ranges` as follows:
+///
+///      let view_z = get_view_z(world_position);
+///      let is_orthographic = view_is_orthographic();
+///
+///      let cluster_index =
+///          clustered_forward::view_fragment_cluster_index(frag_coord, view_z, is_orthographic);
+///      var clusterable_object_index_ranges =
+///          clustered_forward::unpack_clusterable_object_index_ranges(cluster_index);
 fn clustered_decal_iterator_new(
     world_position: vec3<f32>,
     clusterable_object_index_ranges: ptr<function, ClusterableObjectIndexRanges>
@@ -97,11 +97,11 @@ fn clustered_decal_iterator_new(
 }
 
 @if(CLUSTERED_DECALS_ARE_USABLE)
-// Populates the `iterator.texture_index` and `iterator.uv` fields for the next
-// decal overlapping the current world position.
-//
-// Returns true if another decal was found or false if no more decals were found
-// for this position.
+/// Populates the `iterator.texture_index` and `iterator.uv` fields for the next
+/// decal overlapping the current world position.
+///
+/// Returns true if another decal was found or false if no more decals were found
+/// for this position.
 fn clustered_decal_iterator_next(iterator: ptr<function, ClusteredDecalIterator>) -> bool {
     if ((*iterator).decal_index_offset == (*iterator).end_offset) {
         return false;
@@ -144,7 +144,7 @@ fn clustered_decal_iterator_next(iterator: ptr<function, ClusteredDecalIterator>
     return false;
 }
 
-// Returns the view-space Z coordinate for the given world position.
+/// Returns the view-space Z coordinate for the given world position.
 fn get_view_z(world_position: vec3<f32>) -> f32 {
     return dot(vec4<f32>(
         mesh_view_bindings::view.view_from_world[0].z,
@@ -154,8 +154,8 @@ fn get_view_z(world_position: vec3<f32>) -> f32 {
     ), vec4(world_position, 1.0));
 }
 
-// Returns true if the current view describes an orthographic projection or
-// false otherwise.
+/// Returns true if the current view describes an orthographic projection or
+/// false otherwise.
 fn view_is_orthographic() -> bool {
     return mesh_view_bindings::view.clip_from_view[3].w == 1.0;
 }

--- a/crates/bevy_pbr/src/deferred/functions.wesl
+++ b/crates/bevy_pbr/src/deferred/functions.wesl
@@ -17,7 +17,7 @@ import bevy_render::utils::{octahedral_encode, octahedral_decode};
 @if(MOTION_VECTOR_PREPASS)
     import package::render::pbr_prepass_functions::calculate_motion_vector;
 
-// Creates the deferred gbuffer from a PbrInput.
+/// Creates the deferred gbuffer from a PbrInput.
 fn deferred_gbuffer_from_pbr_input(in: PbrInput) -> vec4<u32> {
     // Only monochrome occlusion supported. May not be worth including at all.
     // Some models have baked occlusion, GLTF only supports monochrome.
@@ -60,7 +60,7 @@ fn deferred_gbuffer_from_pbr_input(in: PbrInput) -> vec4<u32> {
     }
 
     // Utilize the emissive channel to transmit the lightmap data. To ensure
-    // it matches the output in forward shading, pre-multiply it with the 
+    // it matches the output in forward shading, pre-multiply it with the
     // calculated diffuse color.
     let base_color = in.material.base_color.rgb;
     let metallic = in.material.metallic;
@@ -83,7 +83,7 @@ fn deferred_gbuffer_from_pbr_input(in: PbrInput) -> vec4<u32> {
     return deferred;
 }
 
-// Creates a PbrInput from the deferred gbuffer.
+/// Creates a PbrInput from the deferred gbuffer.
 fn pbr_input_from_deferred_gbuffer(frag_coord: vec4<f32>, gbuffer: vec4<u32>) -> PbrInput {
     var pbr = pbr_input_new();
 

--- a/crates/bevy_pbr/src/deferred/types.wesl
+++ b/crates/bevy_pbr/src/deferred/types.wesl
@@ -50,9 +50,9 @@ fn unpack_flags(packed: u32) -> u32 {
     return (packed >> 24u) & 0xFFu;
 }
 
-// The builtin one didn't work in webgl.
-// "'unpackUnorm4x8' : no matching overloaded function found"
-// https://github.com/gfx-rs/naga/issues/2006
+/// The builtin one didn't work in webgl.
+/// "'unpackUnorm4x8' : no matching overloaded function found"
+/// https://github.com/gfx-rs/naga/issues/2006
 fn unpack_unorm4x8_(v: u32) -> vec4<f32> {
     return vec4(
         f32(v & 0xFFu),
@@ -62,21 +62,21 @@ fn unpack_unorm4x8_(v: u32) -> vec4<f32> {
     ) / 255.0;
 }
 
-// 'packUnorm4x8' : no matching overloaded function found
-// https://github.com/gfx-rs/naga/issues/2006
+/// 'packUnorm4x8' : no matching overloaded function found
+/// https://github.com/gfx-rs/naga/issues/2006
 fn pack_unorm4x8_(values: vec4<f32>) -> u32 {
     let v = vec4<u32>(saturate(values) * 255.0 + 0.5);
     return (v.w << 24u) | (v.z << 16u) | (v.y << 8u) | v.x;
 }
 
-// Pack 3x 4bit unorm + 1x 20bit
+/// Pack 3x 4bit unorm + 1x 20bit
 fn pack_unorm3x4_plus_unorm_20_(v: vec4<f32>) -> u32 {
     let sm = vec3<u32>(saturate(v.xyz) * 15.0 + 0.5);
     let bg = u32(saturate(v.w) * U20MAXF + 0.5);
     return (bg << 12u) | (sm.z << 8u) | (sm.y << 4u) | sm.x;
 }
 
-// Unpack 3x 4bit unorm + 1x 20bit
+/// Unpack 3x 4bit unorm + 1x 20bit
 fn unpack_unorm3x4_plus_unorm_20_(v: u32) -> vec4<f32> {
     return vec4(
         f32(v & 0xfu) / 15.0,

--- a/crates/bevy_pbr/src/light_probe.wesl
+++ b/crates/bevy_pbr/src/light_probe.wesl
@@ -6,29 +6,29 @@ import package::render::mesh_view_types::{
     LIGHT_PROBE_FLAG_PARALLAX_CORRECT
 };
 
-// The result of searching for a light probe.
-//
-// Light probe iterators yield values of this type. Note that multiple light
-// probes can affect a single fragment.
+/// The result of searching for a light probe.
+///
+/// Light probe iterators yield values of this type. Note that multiple light
+/// probes can affect a single fragment.
 struct LightProbeQueryResult {
-    // The index of the light probe texture or textures in the binding array or
-    // arrays.
+    /// The index of the light probe texture or textures in the binding array or
+    /// arrays.
     texture_index: i32,
-    // A scale factor that's applied to the diffuse and specular light from the
-    // light probe. This is in units of cd/m² (candela per square meter).
+    /// A scale factor that's applied to the diffuse and specular light from the
+    /// light probe. This is in units of cd/m² (candela per square meter).
     intensity: f32,
-    // Transform from world space to the light probe model space. In light probe
-    // model space, the light probe is a 1×1×1 cube centered on the origin.
+    /// Transform from world space to the light probe model space. In light probe
+    /// model space, the light probe is a 1×1×1 cube centered on the origin.
     light_from_world: mat4x4<f32>,
-    // The boundaries of the simulated space used for parallax correction,
-    // specified as *half* extents in light probe space.
+    /// The boundaries of the simulated space used for parallax correction,
+    /// specified as *half* extents in light probe space.
     parallax_correction_bounds: vec3<f32>,
-    // The weight of this light probe, determined by the position of the
-    // fragment within the falloff range. The sum of the weights of all light
-    // probes affecting a fragment need not be 1.
+    /// The weight of this light probe, determined by the position of the
+    /// fragment within the falloff range. The sum of the weights of all light
+    /// probes affecting a fragment need not be 1.
     weight: f32,
-    // The flags that the light probe has: a combination of
-    // `LIGHT_PROBE_FLAG_*`.
+    /// The flags that the light probe has: a combination of
+    /// `LIGHT_PROBE_FLAG_*`.
     flags: u32,
 };
 
@@ -41,25 +41,25 @@ fn transpose_affine_matrix(matrix: mat3x4<f32>) -> mat4x4<f32> {
     return transpose(matrix4x4);
 }
 
-// A type that allows iterating through the list of light probes that overlap
-// the current fragment.
-//
-// This is the version used when light probes are clustered.
+/// A type that allows iterating through the list of light probes that overlap
+/// the current fragment.
+///
+/// This is the version used when light probes are clustered.
 @if(AVAILABLE_STORAGE_BUFFER_BINDINGS__GE_3)
 struct LightProbeIterator {
-    // The current offset in the light probes list.
+    /// The current offset in the light probes list.
     current_offset: u32,
-    // The last offset in the light probes list.
+    /// The last offset in the light probes list.
     end_offset: u32,
-    // The world-space position of the current fragment.
+    /// The world-space position of the current fragment.
     world_position: vec3<f32>,
-    // True if we're searching for an irradiance volume; false if we're
-    // searching for a reflection probe.
+    /// True if we're searching for an irradiance volume; false if we're
+    /// searching for a reflection probe.
     is_irradiance_volume: bool,
 }
 
-// Creates a new light probe iterator ready to iterate through light probes in
-// the froxel containing the `world_position`.
+/// Creates a new light probe iterator ready to iterate through light probes in
+/// the froxel containing the `world_position`.
 @if(AVAILABLE_STORAGE_BUFFER_BINDINGS__GE_3)
 fn light_probe_iterator_new(
     world_position: vec3<f32>,
@@ -87,11 +87,11 @@ fn light_probe_iterator_new(
     );
 }
 
-// Searches for a light probe that contains the fragment and returns the next
-// such probe.
-//
-// Note that multiple light probes can affect a fragment. The caller is
-// generally expected to blend their influences together in a weighted sum.
+/// Searches for a light probe that contains the fragment and returns the next
+/// such probe.
+///
+/// Note that multiple light probes can affect a fragment. The caller is
+/// generally expected to blend their influences together in a weighted sum.
 @if(AVAILABLE_STORAGE_BUFFER_BINDINGS__GE_3)
 fn light_probe_iterator_next(iterator: ptr<function, LightProbeIterator>) -> LightProbeQueryResult {
     let world_position = (*iterator).world_position;
@@ -152,28 +152,28 @@ fn light_probe_iterator_next(iterator: ptr<function, LightProbeIterator>) -> Lig
     return result;
 }
 
-// A type that allows iterating through the list of light probes that overlap
-// the current fragment.
-//
-// This is the version that's used when sufficient storage buffers aren't
-// available and consequently when light probes aren't clustered. It simply does
-// a brute force search of all light probes. Because platforms without
-// sufficient SSBO bindings typically lack bindless shaders, there will usually
-// only be one of each type of light probe present anyway.
+/// A type that allows iterating through the list of light probes that overlap
+/// the current fragment.
+///
+/// This is the version that's used when sufficient storage buffers aren't
+/// available and consequently when light probes aren't clustered. It simply does
+/// a brute force search of all light probes. Because platforms without
+/// sufficient SSBO bindings typically lack bindless shaders, there will usually
+/// only be one of each type of light probe present anyway.
 @if(!AVAILABLE_STORAGE_BUFFER_BINDINGS__GE_3)
 struct LightProbeIterator {
-    // The current index in the list of light probes for this cluster.
+    /// The current index in the list of light probes for this cluster.
     current_index: u32,
-    // The last index in the list.
+    /// The last index in the list.
     end_index: u32,
-    // The position of the current fragment.
+    /// The position of the current fragment.
     world_position: vec3<f32>,
-    // True if we're searching for irradiance volumes; false if we're searching
-    // for reflection probes.
+    /// True if we're searching for irradiance volumes; false if we're searching
+    /// for reflection probes.
     is_irradiance_volume: bool,
 }
 
-// Creates a new light probe iterator ready to search through light probes.
+/// Creates a new light probe iterator ready to search through light probes.
 @if(!AVAILABLE_STORAGE_BUFFER_BINDINGS__GE_3)
 fn light_probe_iterator_new(
     world_position: vec3<f32>,
@@ -192,14 +192,14 @@ fn light_probe_iterator_new(
     );
 }
 
-// Searches for a light probe that contains the fragment and returns the next
-// such probe.
-//
-// Note that, theoretically, multiple light probes can affect a fragment, and
-// the caller is generally expected to blend their influences together in a
-// weighted sum. In practice, this version of `light_probe_iterator_next` is
-// used on platforms that lack bindless shaders, so there will only be at most
-// one light probe that affects the current fragment in the first place.
+/// Searches for a light probe that contains the fragment and returns the next
+/// such probe.
+///
+/// Note that, theoretically, multiple light probes can affect a fragment, and
+/// the caller is generally expected to blend their influences together in a
+/// weighted sum. In practice, this version of `light_probe_iterator_next` is
+/// used on platforms that lack bindless shaders, so there will only be at most
+/// one light probe that affects the current fragment in the first place.
 @if(!AVAILABLE_STORAGE_BUFFER_BINDINGS__GE_3)
 fn light_probe_iterator_next(iterator: ptr<function, LightProbeIterator>) -> LightProbeQueryResult {
     var result: LightProbeQueryResult;

--- a/crates/bevy_pbr/src/light_probe/copy.wesl
+++ b/crates/bevy_pbr/src/light_probe/copy.wesl
@@ -1,6 +1,6 @@
-// Copy the base mip (level 0) from a source cubemap to a destination cubemap,
-// performing format conversion if needed (the destination is always rgba16float).
-// The alpha channel is filled with 1.0.
+//! Copy the base mip (level 0) from a source cubemap to a destination cubemap,
+//! performing format conversion if needed (the destination is always rgba16float).
+//! The alpha channel is filled with 1.0.
 
 @group(0) @binding(0) var src_cubemap: texture_2d_array<f32>;
 @group(0) @binding(1) var dst_cubemap: texture_storage_2d_array<rgba16float, write>;
@@ -18,4 +18,4 @@ fn copy(@builtin(global_invocation_id) global_id: vec3u) {
     let color = textureLoad(src_cubemap, vec2u(global_id.xy), global_id.z, 0);
 
     textureStore(dst_cubemap, vec2u(global_id.xy), global_id.z, vec4f(color.rgb, 1.0));
-} 
+}

--- a/crates/bevy_pbr/src/light_probe/environment_filter.wesl
+++ b/crates/bevy_pbr/src/light_probe/environment_filter.wesl
@@ -17,13 +17,13 @@ struct FilteringConstants {
 @group(0) @binding(3) var<uniform> constants: FilteringConstants;
 @group(0) @binding(4) var blue_noise_texture: texture_2d_array<f32>;
 
-// Sample an environment map with a specific LOD
+/// Sample an environment map with a specific LOD
 fn sample_environment(dir: vec3f, level: f32) -> vec4f {
     let cube_uv = dir_to_cube_uv(dir);
     return textureSampleLevel(input_texture, input_sampler, cube_uv.uv, cube_uv.face, level);
 }
 
-// Blue noise randomization
+/// Blue noise randomization
 @if(HAS_BLUE_NOISE)
 fn sample_noise(pixel_coords: vec2u) -> vec4f {
     let noise_size = vec2u(1) << constants.noise_size_bits;
@@ -33,21 +33,21 @@ fn sample_noise(pixel_coords: vec2u) -> vec4f {
     return textureSampleLevel(blue_noise_texture, input_sampler, uv, 0u, 0.0);
 }
 @else
-// pseudo-random numbers using RNG
+/// pseudo-random numbers using RNG
 fn sample_noise(pixel_coords: vec2u) -> vec4f {
     var rng_state: u32 = (pixel_coords.x * 3966231743u) ^ (pixel_coords.y * 3928936651u);
     let rnd = rand_vec2f(&rng_state);
     return vec4f(rnd, 0.0, 0.0);
 }
 
-// Calculate LOD for environment map lookup using filtered importance sampling
+/// Calculate LOD for environment map lookup using filtered importance sampling
 fn calculate_environment_map_lod(pdf: f32, width: f32, samples: f32) -> f32 {
     // Solid angle of current sample
     let omega_s = 1.0 / (samples * pdf);
-    
+
     // Solid angle of a texel in the environment map
     let omega_p = 4.0 * PI / (6.0 * width * width);
-    
+
     // Filtered importance sampling: compute the correct LOD
     return 0.5 * log2(omega_s / omega_p);
 }
@@ -57,86 +57,86 @@ fn calculate_environment_map_lod(pdf: f32, width: f32, samples: f32) -> f32 {
 fn generate_radiance_map(@builtin(global_invocation_id) global_id: vec3u) {
     let size = textureDimensions(output_texture).xy;
     let invSize = 1.0 / vec2f(size);
-    
+
     let coords = vec2u(global_id.xy);
     let face = global_id.z;
-    
+
     if (any(coords >= size)) {
         return;
     }
-    
+
     // Convert texture coordinates to direction vector
     let uv = (vec2f(coords) + 0.5) * invSize;
     let normal = sample_cube_dir(uv, face);
-    
+
     // For radiance map, view direction = normal for perfect reflection
     let view = normal;
-    
+
     // Convert perceptual roughness to physical microfacet roughness
     let perceptual_roughness = constants.roughness;
     let roughness = lighting::perceptualRoughnessToRoughness(perceptual_roughness);
-    
+
     // Get blue noise offset for stratification
     let vector_noise = sample_noise(coords);
-    
+
     var radiance = vec3f(0.0);
     var total_weight = 0.0;
-    
+
     // Skip sampling for mirror reflection (roughness = 0)
     if (roughness < 0.01) {
         radiance = sample_environment(normal, 0.0).rgb;
         textureStore(output_texture, coords, face, vec4f(radiance, 1.0));
         return;
     }
-    
+
     // For higher roughness values, use importance sampling
     let sample_count = constants.sample_count;
-    
+
     for (var i = 0u; i < sample_count; i++) {
         // Get sample coordinates from Hammersley sequence with blue noise offset
         var xi = hammersley_2d(i, sample_count);
         xi = fract(xi + vector_noise.rg); // Apply Cranley-Patterson rotation
-        
+
         // Sample the GGX distribution with the spherical-cap VNDF method
         let light_dir = lighting::sample_visible_ggx(xi, roughness, normal, view);
-        
+
         // Calculate weight (N·L)
         let NdotL = dot(normal, light_dir);
-        
+
         if (NdotL > 0.0) {
             // Reconstruct the microfacet half-vector from view and light and compute PDF terms
             let half_vector = normalize(view + light_dir);
             let NdotH = dot(normal, half_vector);
             let NdotV = dot(normal, view);
-            
+
             // Get the geometric shadowing term
             let G = lighting::G_Smith(NdotV, NdotL, roughness);
-            
+
             // PDF that matches the bounded-VNDF sampling
             let pdf = lighting::ggx_vndf_pdf(view, NdotH, roughness);
-            
+
             // Calculate LOD using filtered importance sampling
             // This is crucial to avoid fireflies and improve quality
             let width = f32(size.x);
             let lod = calculate_environment_map_lod(pdf, width, f32(sample_count));
-            
+
             // Get source mip level - ensure we don't go negative
             let source_mip = max(0.0, lod);
-            
+
             // Sample environment map with the light direction
             var sample_color = sample_environment(light_dir, source_mip).rgb;
-            
+
             // Accumulate weighted sample, including geometric term
             radiance += sample_color * NdotL * G;
             total_weight += NdotL * G;
         }
     }
-    
+
     // Normalize by total weight
     if (total_weight > 0.0) {
         radiance = radiance / total_weight;
     }
-    
+
     // Write result to output texture
     textureStore(output_texture, coords, face, vec4f(radiance, 1.0));
 }
@@ -146,20 +146,20 @@ fn generate_radiance_map(@builtin(global_invocation_id) global_id: vec3u) {
 fn generate_irradiance_map(@builtin(global_invocation_id) global_id: vec3u) {
     let size = textureDimensions(output_texture).xy;
     let invSize = 1.0 / vec2f(size);
-    
+
     let coords = vec2u(global_id.xy);
     let face = global_id.z;
-    
+
     if (any(coords >= size)) {
         return;
     }
-    
+
     // Convert texture coordinates to direction vector
     let uv = (vec2f(coords) + 0.5) * invSize;
     let normal = sample_cube_dir(uv, face);
-    
+
     var irradiance = vec3f(0.0);
-    
+
     // Use uniform sampling on a hemisphere
     for (var i = 0u; i < constants.sample_count; i++) {
         // Build a deterministic RNG seed for this pixel / sample
@@ -171,14 +171,14 @@ fn generate_irradiance_map(@builtin(global_invocation_id) global_id: vec3u) {
 
         // Sample environment with level 0 (no mip)
         var sample_color = sample_environment(sample_dir, 0.0).rgb;
-        
+
         // Accumulate the contribution
         irradiance += sample_color;
     }
 
     // Normalize by number of samples (cosine-weighted sampling already accounts for PDF)
     irradiance = irradiance / f32(constants.sample_count);
-    
+
     // Write result to output texture
     textureStore(output_texture, coords, face, vec4f(irradiance, 1.0));
 }

--- a/crates/bevy_pbr/src/light_probe/environment_map.wesl
+++ b/crates/bevy_pbr/src/light_probe/environment_map.wesl
@@ -8,7 +8,7 @@ import package::render::pbr_lighting::{F_Schlick_vec, LightingInput, LayerLighti
 import package::render::clustered_forward::ClusterableObjectIndexRanges;
 import bevy_render::maths::quat_rotate;
 
-// The maximum representable value in a 32-bit floating point number.
+/// The maximum representable value in a 32-bit floating point number.
 const FLOAT_MAX: f32 = 3.40282347e+38;
 
 struct EnvironmentMapLight {
@@ -27,17 +27,17 @@ struct MultiscatterResult {
     Edss: vec3<f32>,
 }
 
-// Computes the direction at which to sample the reflection probe.
-//
-// * `light_from_world` is the matrix that transforms world space into light
-//   probe space (a 1×1×1 cube centered on the origin).
-//
-// * `parallax_correction_bounds` is the half-extents of the simulated
-//   reflection boundaries used for parallax correction, in light probe space.
-//   It's ignored if the `parallax_correct` parameter is false.
-//
-// * `parallax_correct` is true if parallax correction is to be applied and
-//   false otherwise.
+/// Computes the direction at which to sample the reflection probe.
+///
+/// * `light_from_world` is the matrix that transforms world space into light
+///   probe space (a 1×1×1 cube centered on the origin).
+///
+/// * `parallax_correction_bounds` is the half-extents of the simulated
+///   reflection boundaries used for parallax correction, in light probe space.
+///   It's ignored if the `parallax_correct` parameter is false.
+///
+/// * `parallax_correct` is true if parallax correction is to be applied and
+///   false otherwise.
 fn compute_cubemap_sample_dir(
     world_ray_origin: vec3<f32>,
     world_ray_direction: vec3<f32>,
@@ -281,8 +281,8 @@ fn compute_radiances(
 
 @if(STANDARD_MATERIAL_CLEARCOAT)
 
-// Adds the environment map light from the clearcoat layer to that of the base
-// layer.
+/// Adds the environment map light from the clearcoat layer to that of the base
+/// layer.
 fn environment_map_light_clearcoat(
     out: ptr<function, EnvironmentMapLight>,
     input: ptr<function, LightingInput>,
@@ -314,10 +314,10 @@ fn environment_map_light_clearcoat(
     (*out).specular = (*out).specular * inv_Fc * inv_Fc + clearcoat_radiances.radiance * Fc;
 }
 
-// Multiscattering approximation: https://www.jcgt.org/published/0008/01/03/paper.pdf
-//
-// We initially used this (https://bruop.github.io/ibl) reference with Roughness Dependent
-// Fresnel, but it made fresnel very bright so we reverted to the "typical" fresnel term.
+/// Multiscattering approximation: https://www.jcgt.org/published/0008/01/03/paper.pdf
+///
+/// We initially used this (https://bruop.github.io/ibl) reference with Roughness Dependent
+/// Fresnel, but it made fresnel very bright so we reverted to the "typical" fresnel term.
 fn compute_multiscatter(
     F0: vec3<f32>,
     F_ab: vec2<f32>,
@@ -398,8 +398,8 @@ fn environment_map_light(
     return out;
 }
 
-// "Moving Frostbite to Physically Based Rendering 3.0", listing 22
-// https://seblagarde.wordpress.com/wp-content/uploads/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf#page=70
+/// "Moving Frostbite to Physically Based Rendering 3.0", listing 22
+/// https://seblagarde.wordpress.com/wp-content/uploads/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf#page=70
 fn radiance_sample_direction(N: vec3<f32>, R: vec3<f32>, roughness: f32) -> vec3<f32> {
     let smoothness = saturate(1.0 - roughness);
     let lerp_factor = smoothness * (sqrt(smoothness) + roughness);

--- a/crates/bevy_pbr/src/light_probe/irradiance_volume.wesl
+++ b/crates/bevy_pbr/src/light_probe/irradiance_volume.wesl
@@ -11,9 +11,9 @@ import package::render::clustered_forward::ClusterableObjectIndexRanges;
 
 @if(IRRADIANCE_VOLUMES_ARE_USABLE)
 
-// See:
-// https://advances.realtimerendering.com/s2006/Mitchell-ShadingInValvesSourceEngine.pdf
-// Slide 28, "Ambient Cube Basis"
+/// See:
+/// https://advances.realtimerendering.com/s2006/Mitchell-ShadingInValvesSourceEngine.pdf
+/// Slide 28, "Ambient Cube Basis"
 fn irradiance_volume_light(
     world_position: vec3<f32>,
     N: vec3<f32>,

--- a/crates/bevy_pbr/src/lightmap.wesl
+++ b/crates/bevy_pbr/src/lightmap.wesl
@@ -12,7 +12,7 @@ enable wgpu_binding_array;
 @group(2) @binding(5) var lightmaps_sampler: sampler;
 }
 
-// Samples the lightmap, if any, and returns indirect illumination from it.
+/// Samples the lightmap, if any, and returns indirect illumination from it.
 fn lightmap(uv: vec2<f32>, exposure: f32, instance_index: u32) -> vec3<f32> {
     let packed_uv_rect = mesh[instance_index].lightmap_uv_rect;
     let uv_rect = vec4<f32>(

--- a/crates/bevy_pbr/src/meshlet/bindings.wesl
+++ b/crates/bevy_pbr/src/meshlet/bindings.wesl
@@ -72,11 +72,11 @@ struct DrawIndirectArgs {
     first_instance: u32,
 }
 
-// Either a BVH node or a meshlet, along with the instance it is associated with.
-// Refers to BVH nodes in `meshlet_bvh_cull_queue` and `meshlet_second_pass_bvh_queue`, where `offset` is the index into `meshlet_bvh_nodes`.
-// Refers to meshlets in `meshlet_meshlet_cull_queue` and `meshlet_raster_clusters`.
-// In `meshlet_meshlet_cull_queue`, `offset` is the index into `meshlet_cull_data`.
-// In `meshlet_raster_clusters`, `offset` is the index into `meshlets`.
+/// Either a BVH node or a meshlet, along with the instance it is associated with.
+/// Refers to BVH nodes in `meshlet_bvh_cull_queue` and `meshlet_second_pass_bvh_queue`, where `offset` is the index into `meshlet_bvh_nodes`.
+/// Refers to meshlets in `meshlet_meshlet_cull_queue` and `meshlet_raster_clusters`.
+/// In `meshlet_meshlet_cull_queue`, `offset` is the index into `meshlet_cull_data`.
+/// In `meshlet_raster_clusters`, `offset` is the index into `meshlets`.
 struct InstancedOffset {
     instance_id: u32,
     offset: u32,

--- a/crates/bevy_pbr/src/meshlet/cull_shared.wesl
+++ b/crates/bevy_pbr/src/meshlet/cull_shared.wesl
@@ -9,7 +9,7 @@ import package::meshlet::bindings::{
 };
 import bevy_render::maths::affine3_to_square;
 
-// https://github.com/zeux/meshoptimizer/blob/1e48e96c7e8059321de492865165e9ef071bffba/demo/nanite.cpp#L115
+/// https://github.com/zeux/meshoptimizer/blob/1e48e96c7e8059321de492865165e9ef071bffba/demo/nanite.cpp#L115
 fn lod_error_is_imperceptible(lod_sphere: vec4<f32>, simplification_error: f32, instance_id: u32) -> bool {
     let world_from_local = affine3_to_square(meshlet_instance_uniforms[instance_id].world_from_local);
     let world_scale = max(length(world_from_local[0]), max(length(world_from_local[1]), length(world_from_local[2])));
@@ -39,8 +39,8 @@ fn normalize_plane(p: vec4<f32>) -> vec4<f32> {
     return p / length(p.xyz);
 }
 
-// https://fgiesen.wordpress.com/2012/08/31/frustum-planes-from-the-projection-matrix/
-// https://fgiesen.wordpress.com/2010/10/17/view-frustum-culling/
+/// https://fgiesen.wordpress.com/2012/08/31/frustum-planes-from-the-projection-matrix/
+/// https://fgiesen.wordpress.com/2010/10/17/view-frustum-culling/
 fn aabb_in_frustum(aabb: MeshletAabb, instance_id: u32) -> bool {
     let world_from_local = affine3_to_square(meshlet_instance_uniforms[instance_id].world_from_local);
     let clip_from_local = view.clip_from_world * world_from_local;
@@ -80,7 +80,7 @@ fn min8_4(a: vec4<f32>, b: vec4<f32>, c: vec4<f32>, d: vec4<f32>, e: vec4<f32>, 
     return min(min(min(a, b), min(c, d)), min(min(e, f), min(g, h)));
 }
 
-// https://zeux.io/2023/01/12/approximate-projected-bounds/
+/// https://zeux.io/2023/01/12/approximate-projected-bounds/
 fn project_aabb(clip_from_local: mat4x4<f32>, near: f32, aabb: MeshletAabb, out: ptr<function, ScreenAabb>) -> bool {
     let extent = aabb.half_extent * 2.0;
     let sx = clip_from_local * vec4<f32>(extent.x, 0.0, 0.0, 0.0);
@@ -155,14 +155,14 @@ fn occlusion_cull_screen_aabb(aabb: ScreenAabb, screen: vec2<f32>) -> bool {
     // it wraps around firstLeadingBit(0) = ~0 to 0
     // TODO: we actually sample a 4x4 block, so ideally this would be `max(..., 3u) - 3u`.
     var mip = max(firstLeadingBit(max_size) + 1u, 2u) - 2u;
-    
+
     if any((max_texel >> vec2(mip)) > (min_texel >> vec2(mip)) + 3) {
         mip += 1u;
     }
 
     let smin = min_texel >> vec2<u32>(mip);
     let smax = max_texel >> vec2<u32>(mip);
-    
+
     let curr_depth = sample_hzb(smin, smax, i32(mip));
     return aabb.max.z <= curr_depth;
 }

--- a/crates/bevy_pbr/src/meshlet/fill_counts.wesl
+++ b/crates/bevy_pbr/src/meshlet/fill_counts.wesl
@@ -1,4 +1,4 @@
-/// Copies the counts of meshlets in the hardware and software buckets, resetting the counters in the process.
+//! Copies the counts of meshlets in the hardware and software buckets, resetting the counters in the process.
 
 struct DispatchIndirectArgs {
     x: u32,

--- a/crates/bevy_pbr/src/meshlet/remap_1d_to_2d_dispatch.wesl
+++ b/crates/bevy_pbr/src/meshlet/remap_1d_to_2d_dispatch.wesl
@@ -1,4 +1,4 @@
-/// Remaps an indirect 1d to 2d dispatch for devices with low dispatch size limit.
+//! Remaps an indirect 1d to 2d dispatch for devices with low dispatch size limit.
 
 struct DispatchIndirectArgs {
     x: u32,

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_hardware_raster.wesl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_hardware_raster.wesl
@@ -17,7 +17,7 @@ import package::{
 import bevy_render::maths::affine3_to_square;
 var<immediate> meshlet_raster_cluster_rightmost_slot: u32;
 
-/// Vertex/fragment shader for rasterizing large clusters into a visibility buffer.
+//! Vertex/fragment shader for rasterizing large clusters into a visibility buffer.
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
@@ -77,7 +77,7 @@ fn dummy_vertex() -> VertexOutput {
     );
 }
 
-// Naga doesn't allow divide by zero literals, but this lets us work around it
+/// Naga doesn't allow divide by zero literals, but this lets us work around it
 fn divide(a: f32, b: f32) -> f32 {
     return a / b;
 }

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_hardware_raster.wesl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_hardware_raster.wesl
@@ -1,3 +1,5 @@
+//! Vertex/fragment shader for rasterizing large clusters into a visibility buffer.
+
 import package::{
     meshlet::bindings::{
         meshlet_cluster_meshlet_ids,
@@ -16,8 +18,6 @@ import package::{
 };
 import bevy_render::maths::affine3_to_square;
 var<immediate> meshlet_raster_cluster_rightmost_slot: u32;
-
-//! Vertex/fragment shader for rasterizing large clusters into a visibility buffer.
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_resolve.wesl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_resolve.wesl
@@ -1,3 +1,5 @@
+//! Functions to be used by materials for reading from a meshlet visibility buffer texture.
+
 import package::{
     meshlet::bindings::{
         Meshlet,
@@ -24,8 +26,6 @@ import package::{
     prepass::bindings::previous_view_uniforms,
     render::pbr_prepass_functions::calculate_motion_vector,
 };
-
-//! Functions to be used by materials for reading from a meshlet visibility buffer texture.
 
 @if(MESHLET_MESH_MATERIAL_PASS)
 struct PartialDerivatives {

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_resolve.wesl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_resolve.wesl
@@ -25,7 +25,7 @@ import package::{
     render::pbr_prepass_functions::calculate_motion_vector,
 };
 
-/// Functions to be used by materials for reading from a meshlet visibility buffer texture.
+//! Functions to be used by materials for reading from a meshlet visibility buffer texture.
 
 @if(MESHLET_MESH_MATERIAL_PASS)
 struct PartialDerivatives {
@@ -34,7 +34,7 @@ struct PartialDerivatives {
     ddy: vec3<f32>,
 }
 
-// https://github.com/ConfettiFX/The-Forge/blob/9d43e69141a9cd0ce2ce2d2db5122234d3a2d5b5/Common_3/Renderer/VisibilityBuffer2/Shaders/FSL/vb_shading_utilities.h.fsl#L90-L150
+/// https://github.com/ConfettiFX/The-Forge/blob/9d43e69141a9cd0ce2ce2d2db5122234d3a2d5b5/Common_3/Renderer/VisibilityBuffer2/Shaders/FSL/vb_shading_utilities.h.fsl#L90-L150
 @if(MESHLET_MESH_MATERIAL_PASS)
 fn compute_partial_derivatives(vertex_world_positions: array<vec4<f32>, 3>, ndc_uv: vec2<f32>, half_screen_size: vec2<f32>) -> PartialDerivatives {
     var result: PartialDerivatives;
@@ -205,7 +205,7 @@ fn normal_local_to_world(vertex_normal: vec3<f32>, instance_uniform: ptr<functio
     }
 }
 
-// https://www.jeremyong.com/graphics/2023/12/16/surface-gradient-bump-mapping/#surface-gradient-from-a-tangent-space-normal-vector-without-an-explicit-tangent-basis
+/// https://www.jeremyong.com/graphics/2023/12/16/surface-gradient-bump-mapping/#surface-gradient-from-a-tangent-space-normal-vector-without-an-explicit-tangent-basis
 @if(MESHLET_MESH_MATERIAL_PASS)
 fn calculate_world_tangent(
     world_normal: vec3<f32>,

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_software_raster.wesl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_software_raster.wesl
@@ -1,3 +1,5 @@
+//! Compute shader for rasterizing small clusters into a visibility buffer.
+
 import package::{
     meshlet::bindings::{
         meshlet_cluster_meshlet_ids,
@@ -20,8 +22,6 @@ import package::{
     },
 };
 import bevy_render::maths::affine3_to_square;
-
-//! Compute shader for rasterizing small clusters into a visibility buffer.
 
 // TODO: Fixed-point math and top-left rule
 

--- a/crates/bevy_pbr/src/meshlet/visibility_buffer_software_raster.wesl
+++ b/crates/bevy_pbr/src/meshlet/visibility_buffer_software_raster.wesl
@@ -21,7 +21,7 @@ import package::{
 };
 import bevy_render::maths::affine3_to_square;
 
-/// Compute shader for rasterizing small clusters into a visibility buffer.
+//! Compute shader for rasterizing small clusters into a visibility buffer.
 
 // TODO: Fixed-point math and top-left rule
 

--- a/crates/bevy_pbr/src/prepass/io.wesl
+++ b/crates/bevy_pbr/src/prepass/io.wesl
@@ -105,8 +105,8 @@ fn decompress_vertex(vertex_in: Vertex, instance_index: u32) -> UncompressedVert
 }
 
 struct VertexOutput {
-    // This is `clip position` when the struct is used as a vertex stage output
-    // and `frag coord` when used as a fragment stage input
+    /// This is `clip position` when the struct is used as a vertex stage output
+    /// and `frag coord` when used as a fragment stage input
     @builtin(position) position: vec4<f32>,
 
     @if(VERTEX_UVS_A)

--- a/crates/bevy_pbr/src/prepass/prepass.wesl
+++ b/crates/bevy_pbr/src/prepass/prepass.wesl
@@ -42,13 +42,13 @@ fn morph_vertex(vertex_in: UncompressedVertex, instance_index: u32) -> Uncompres
 }
 
 @if(MORPH_TARGETS)
-// Returns the morphed position of the given vertex from the previous frame.
-//
-// This function is used for motion vector calculation, and, as such, it doesn't
-// bother morphing the normals and tangents.
-//
-// The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
-// See https://github.com/gfx-rs/naga/issues/2416
+/// Returns the morphed position of the given vertex from the previous frame.
+///
+/// This function is used for motion vector calculation, and, as such, it doesn't
+/// bother morphing the normals and tangents.
+///
+/// The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
+/// See https://github.com/gfx-rs/naga/issues/2416
 fn morph_prev_vertex(vertex_in: UncompressedVertex, instance_index: u32) -> UncompressedVertex {
     var vertex = vertex_in;
     let first_vertex = mesh[instance_index].first_vertex_index;

--- a/crates/bevy_pbr/src/render/allocate_uniforms.wesl
+++ b/crates/bevy_pbr/src/render/allocate_uniforms.wesl
@@ -1,86 +1,86 @@
-// A compute shader that allocates `MeshUniform`s.
-//
-// This shader runs before mesh preprocessing in order to determine the
-// positions of `MeshUniform`s. Unlike `MeshInputUniform`s, which are scattered
-// throughout the buffer, `MeshUniform`s are indexed by instance ID, and so we
-// must place instances of the same mesh together in the buffer. One dispatch
-// call corresponds to one batch set (i.e. one multidraw operation), and one
-// thread corresponds to one bin (a.k.a. draw, a.k.a. batch).
-//
-// Essentially, the goal of this shader is to perform a prefix sum, using the
-// "scan-then-fan" approach. It has three phases:
-//
-// 1. *Local scan*: Perform a [Hillis-Steele scan] on each chunk of draws, where
-// the size of each chunk (i.e. the number of draws) is equal to the workgroup
-// size (256). Write the total size for this chunk to the fan buffer.
-//
-// 2. *Global scan*: Do a Hillis-Steele scan on the fan buffer. Now we know the
-// running total for each chunk.
-//
-// 3. *Fan*: Copy the running total for each chunk to every element of that
-// chunk.
-//
-// Note that, for batch sets (i.e. multidraw indirect calls) that have fewer
-// than 256 batches in them, we only need step (1). This is the common case.
-//
-// [Hillis-Steele scan]: https://en.wikipedia.org/wiki/Prefix_sum#Algorithm_1:_Shorter_span,_more_parallel
+//! A compute shader that allocates `MeshUniform`s.
+//!
+//! This shader runs before mesh preprocessing in order to determine the
+//! positions of `MeshUniform`s. Unlike `MeshInputUniform`s, which are scattered
+//! throughout the buffer, `MeshUniform`s are indexed by instance ID, and so we
+//! must place instances of the same mesh together in the buffer. One dispatch
+//! call corresponds to one batch set (i.e. one multidraw operation), and one
+//! thread corresponds to one bin (a.k.a. draw, a.k.a. batch).
+//!
+//! Essentially, the goal of this shader is to perform a prefix sum, using the
+//! "scan-then-fan" approach. It has three phases:
+//!
+//! 1. *Local scan*: Perform a [Hillis-Steele scan] on each chunk of draws, where
+//! the size of each chunk (i.e. the number of draws) is equal to the workgroup
+//! size (256). Write the total size for this chunk to the fan buffer.
+//!
+//! 2. *Global scan*: Do a Hillis-Steele scan on the fan buffer. Now we know the
+//! running total for each chunk.
+//!
+//! 3. *Fan*: Copy the running total for each chunk to every element of that
+//! chunk.
+//!
+//! Note that, for batch sets (i.e. multidraw indirect calls) that have fewer
+//! than 256 batches in them, we only need step (1). This is the common case.
+//!
+//! [Hillis-Steele scan]: https://en.wikipedia.org/wiki/Prefix_sum#Algorithm_1:_Shorter_span,_more_parallel
 
 import bevy_render::occlusion_culling::mesh_preprocess_types::{BinMetadata, IndirectParametersMetadata};
 
-// Information needed to allocate `MeshUniform`s.
+/// Information needed to allocate `MeshUniform`s.
 struct UniformAllocationMetadata {
-    // The index of this batch set in the `IndirectBatchSet` array.
-    //
-    // We write this into the `indirect_parameters_metadata`.
+    /// The index of this batch set in the `IndirectBatchSet` array.
+    ///
+    /// We write this into the `indirect_parameters_metadata`.
     batch_set_index: u32,
 
-    // The number of bins (a.k.a. draws, a.k.a. batches) in this batch set.
+    /// The number of bins (a.k.a. draws, a.k.a. batches) in this batch set.
     bin_count: u32,
 
-    // The index of the first set of indirect parameters for this batch set.
-    //
-    // This is also the index of the first `IndirectParametersMetadata`, as
-    // that's a parallel array with the indirect parameters.
+    /// The index of the first set of indirect parameters for this batch set.
+    ///
+    /// This is also the index of the first `IndirectParametersMetadata`, as
+    /// that's a parallel array with the indirect parameters.
     first_indirect_parameters_index: u32,
 
-    // The index of the first `MeshUniform` slot for this batch set.
+    /// The index of the first `MeshUniform` slot for this batch set.
     first_output_mesh_uniform_index: u32,
 
-    // Padding.
+    /// Padding.
     pad: array<vec4<f32>, 15u>,
 };
 
-// The number of threads in a workgroup.
+/// The number of threads in a workgroup.
 const WORKGROUP_SIZE: u32 = 256u;
 
-// Information needed to allocate `MeshUniform`s.
+/// Information needed to allocate `MeshUniform`s.
 @group(0) @binding(0) var<uniform> allocate_uniforms_metadata: UniformAllocationMetadata;
 
-// Information for each bin, including the indirect parameters offset and the
-// instance count.
+/// Information for each bin, including the indirect parameters offset and the
+/// instance count.
 @group(0) @binding(1) var<storage> bin_metadata: array<BinMetadata>;
 
-// The array of indirect parameters metadata that we fill out, one for each
-// batch.
+/// The array of indirect parameters metadata that we fill out, one for each
+/// batch.
 @group(0) @binding(2) var<storage, read_write> indirect_parameters_metadata:
     array<IndirectParametersMetadata>;
 
-// A temporary buffer that stores the mesh uniform index of the last instance
-// plus one for each workgroup (i.e. for each 256-bin chunk).
-//
-// This is accumulated in the second stage and written out in the third.
+/// A temporary buffer that stores the mesh uniform index of the last instance
+/// plus one for each workgroup (i.e. for each 256-bin chunk).
+///
+/// This is accumulated in the second stage and written out in the third.
 @group(0) @binding(3) var<storage, read_write> fan_buffer: array<u32>;
 
-// Scratch memory that stores the prefix sum for every element in our chunk.
+/// Scratch memory that stores the prefix sum for every element in our chunk.
 var<workgroup> output_offsets: array<u32, 256>;
 
-// The first step of the prefix sum. This computes the prefix sum for each
-// 256-element chunk.
-//
-// Note that this will be the *only* step in the operation if the total number
-// of bins in this batch set is 256 or fewer. Thus we must fill in the indirect
-// parameters metadata for each batch here, as we can't guarantee that the
-// following two steps will be run at all.
+/// The first step of the prefix sum. This computes the prefix sum for each
+/// 256-element chunk.
+///
+/// Note that this will be the *only* step in the operation if the total number
+/// of bins in this batch set is 256 or fewer. Thus we must fill in the indirect
+/// parameters metadata for each batch here, as we can't guarantee that the
+/// following two steps will be run at all.
 @compute @workgroup_size(256, 1, 1)
 fn allocate_local_scan(
     @builtin(local_invocation_id) local_id: vec3<u32>,
@@ -144,13 +144,13 @@ fn allocate_local_scan(
     }
 }
 
-// The second step of the prefix sum.
-//
-// This step takes the intermediate fan values computed in the previous step
-// (i.e. the sum going out of each chunk) and performs one or more Hillis-Steele
-// scans in order to compute the fan value going into each chunk.
-//
-// This step is omitted if there are 256 or fewer total draws.
+/// The second step of the prefix sum.
+///
+/// This step takes the intermediate fan values computed in the previous step
+/// (i.e. the sum going out of each chunk) and performs one or more Hillis-Steele
+/// scans in order to compute the fan value going into each chunk.
+///
+/// This step is omitted if there are 256 or fewer total draws.
 @compute @workgroup_size(256, 1, 1)
 fn allocate_global_scan(@builtin(local_invocation_id) local_id: vec3<u32>) {
     var sum = 0u;
@@ -184,13 +184,13 @@ fn allocate_global_scan(@builtin(local_invocation_id) local_id: vec3<u32>) {
     }
 }
 
-// The third step of the prefix sum.
-//
-// We take the summed fan value computed in the previous step and add it in to
-// each value of each chunk beyond the first. We dispatch one fewer workgroup
-// here than in step (1), because there's nothing to do for the first chunk.
-//
-// This step is omitted if there are 256 or fewer total draws.
+/// The third step of the prefix sum.
+///
+/// We take the summed fan value computed in the previous step and add it in to
+/// each value of each chunk beyond the first. We dispatch one fewer workgroup
+/// here than in step (1), because there's nothing to do for the first chunk.
+///
+/// This step is omitted if there are 256 or fewer total draws.
 @compute @workgroup_size(256, 1, 1)
 fn allocate_fan(
     @builtin(workgroup_id) group_id: vec3<u32>,
@@ -209,8 +209,8 @@ fn allocate_fan(
     indirect_parameters_metadata[indirect_parameters_offset].base_output_index += fan_value;
 }
 
-// Calculates a running exclusive sum.
-// https://en.wikipedia.org/wiki/Prefix_sum#Algorithm_1:_Shorter_span,_more_parallel
+/// Calculates a running exclusive sum.
+/// https://en.wikipedia.org/wiki/Prefix_sum#Algorithm_1:_Shorter_span,_more_parallel
 fn hillis_steele_scan(local_id: u32) {
     for (var offset = 1u; offset < WORKGROUP_SIZE; offset *= 2u) {
         var term = 0u;
@@ -223,7 +223,7 @@ fn hillis_steele_scan(local_id: u32) {
     }
 }
 
-// Divides unsigned integer a by b, rounding up.
+/// Divides unsigned integer a by b, rounding up.
 fn div_ceil(a: u32, b: u32) -> u32 {
     return (a + b - 1u) / b;
 }

--- a/crates/bevy_pbr/src/render/build_indirect_params.wesl
+++ b/crates/bevy_pbr/src/render/build_indirect_params.wesl
@@ -1,12 +1,12 @@
-// Builds GPU indirect draw parameters from metadata.
-//
-// This only runs when indirect drawing is enabled. It takes the output of
-// `mesh_preprocess.wesl` and creates indirect parameters for the GPU.
-//
-// This shader runs separately for indexed and non-indexed meshes. Unlike
-// `mesh_preprocess.wesl`, which runs one instance per mesh *instance*, one
-// instance of this shader corresponds to a single *batch* which could contain
-// arbitrarily many instances of a single mesh.
+//! Builds GPU indirect draw parameters from metadata.
+//!
+//! This only runs when indirect drawing is enabled. It takes the output of
+//! `mesh_preprocess.wesl` and creates indirect parameters for the GPU.
+//!
+//! This shader runs separately for indexed and non-indexed meshes. Unlike
+//! `mesh_preprocess.wesl`, which runs one instance per mesh *instance*, one
+//! instance of this shader corresponds to a single *batch* which could contain
+//! arbitrarily many instances of a single mesh.
 
 import bevy_render::occlusion_culling::mesh_preprocess_types::{
     IndirectBatchSet,
@@ -16,45 +16,45 @@ import bevy_render::occlusion_culling::mesh_preprocess_types::{
     MeshInput
 };
 
-// Specifies the batches that this shader invocation is to process.
+/// Specifies the batches that this shader invocation is to process.
 struct IndirectParametersBuildJob {
-    // The first batch index that this shader invocation should process
-    // (inclusive).
+    /// The first batch index that this shader invocation should process
+    /// (inclusive).
     first_batch_index: u32,
-    // The last batch index that this shader invocation should process
-    // (exclusive).
+    /// The last batch index that this shader invocation should process
+    /// (exclusive).
     last_batch_index: u32,
 }
 
-// The data for each mesh that the CPU supplied to the GPU.
+/// The data for each mesh that the CPU supplied to the GPU.
 @group(0) @binding(0) var<storage> current_input: array<MeshInput>;
 
-// Data that we use to generate the indirect parameters.
-//
-// The `mesh_preprocess.wesl` shader emits these.
+/// Data that we use to generate the indirect parameters.
+///
+/// The `mesh_preprocess.wesl` shader emits these.
 @group(0) @binding(1) var<storage> indirect_parameters_metadata:
     array<IndirectParametersMetadata>;
 
-// Information about each batch set.
-//
-// A *batch set* is a set of meshes that might be multi-drawn together.
+/// Information about each batch set.
+///
+/// A *batch set* is a set of meshes that might be multi-drawn together.
 @group(0) @binding(3) var<storage, read_write> indirect_batch_sets: array<IndirectBatchSet>;
 
-// Specifies the batches that this shader invocation is to process.
+/// Specifies the batches that this shader invocation is to process.
 @group(0) @binding(4) var<uniform> indirect_parameters_build_job: IndirectParametersBuildJob;
 
 @if(INDEXED)
-// The buffer of indirect draw parameters that we generate, and that the GPU
-// reads to issue the draws.
-//
-// This buffer is for indexed meshes.
+/// The buffer of indirect draw parameters that we generate, and that the GPU
+/// reads to issue the draws.
+///
+/// This buffer is for indexed meshes.
 @group(0) @binding(5) var<storage, read_write> indirect_parameters:
     array<IndirectParametersIndexed>;
 @else   // INDEXED
-// The buffer of indirect draw parameters that we generate, and that the GPU
-// reads to issue the draws.
-//
-// This buffer is for non-indexed meshes.
+/// The buffer of indirect draw parameters that we generate, and that the GPU
+/// reads to issue the draws.
+///
+/// This buffer is for non-indexed meshes.
 @group(0) @binding(5) var<storage, read_write> indirect_parameters:
     array<IndirectParametersNonIndexed>;
 

--- a/crates/bevy_pbr/src/render/clustered_forward.wesl
+++ b/crates/bevy_pbr/src/render/clustered_forward.wesl
@@ -8,29 +8,29 @@ import bevy_render::{
    maths::PI_2,
 };
 
-// Offsets within the `cluster_offsets_and_counts` buffer for a single cluster.
-//
-// These offsets must be monotonically nondecreasing. That is, indices are
-// always sorted into the following order: point lights, spot lights, rect
-// lights, reflection probes, irradiance volumes.
+/// Offsets within the `cluster_offsets_and_counts` buffer for a single cluster.
+///
+/// These offsets must be monotonically nondecreasing. That is, indices are
+/// always sorted into the following order: point lights, spot lights, rect
+/// lights, reflection probes, irradiance volumes.
 struct ClusterableObjectIndexRanges {
-    // The offset of the index of the first point light.
+    /// The offset of the index of the first point light.
     first_point_light_index_offset: u32,
-    // The offset of the index of the first spot light, which also terminates
-    // the list of point lights.
+    /// The offset of the index of the first spot light, which also terminates
+    /// the list of point lights.
     first_spot_light_index_offset: u32,
-    // The offset of the index of the first rect light, which also terminates
-    // the list of spot lights.
+    /// The offset of the index of the first rect light, which also terminates
+    /// the list of spot lights.
     first_rect_light_index_offset: u32,
-    // The offset of the index of the first reflection probe, which also
-    // terminates the list of rect lights.
+    /// The offset of the index of the first reflection probe, which also
+    /// terminates the list of rect lights.
     first_reflection_probe_index_offset: u32,
-    // The offset of the index of the first irradiance volumes, which also
-    // terminates the list of reflection probes.
+    /// The offset of the index of the first irradiance volumes, which also
+    /// terminates the list of reflection probes.
     first_irradiance_volume_index_offset: u32,
     first_decal_offset: u32,
-    // One past the offset of the index of the final clusterable object for this
-    // cluster.
+    /// One past the offset of the index of the final clusterable object for this
+    /// cluster.
     last_clusterable_object_index_offset: u32,
 }
 
@@ -65,7 +65,7 @@ fn view_fragment_cluster_index(frag_coord: vec2<f32>, view_z: f32, is_orthograph
     return fragment_cluster_index(vec3(xy, z_slice), bindings::lights.cluster_dimensions);
 }
 
-// Given a cluster XYZ position, returns its index in the cluster list.
+/// Given a cluster XYZ position, returns its index in the cluster list.
 fn fragment_cluster_index(p: vec3<u32>, cluster_dimensions: vec4<u32>) -> u32 {
     // NOTE: Restricting cluster index to avoid undefined behavior when accessing uniform buffer
     // arrays based on the cluster index.
@@ -78,11 +78,11 @@ fn fragment_cluster_index(p: vec3<u32>, cluster_dimensions: vec4<u32>) -> u32 {
 // this must match CLUSTER_COUNT_SIZE in light.rs
 const CLUSTER_COUNT_SIZE = 9u;
 
-// Returns the indices of clusterable objects belonging to the given cluster.
-//
-// Note that if fewer than 3 SSBO bindings are available (in WebGL 2,
-// primarily), light probes aren't clustered, and therefore both light probe
-// index ranges will be empty.
+/// Returns the indices of clusterable objects belonging to the given cluster.
+///
+/// Note that if fewer than 3 SSBO bindings are available (in WebGL 2,
+/// primarily), light probes aren't clustered, and therefore both light probe
+/// index ranges will be empty.
 fn unpack_clusterable_object_index_ranges(cluster_index: u32) -> ClusterableObjectIndexRanges {
 @if(AVAILABLE_STORAGE_BUFFER_BINDINGS__GE_3) {
 
@@ -136,10 +136,10 @@ fn unpack_clusterable_object_index_ranges(cluster_index: u32) -> ClusterableObje
 }
 }
 
-// Returns the index of the clusterable object at the given offset.
-//
-// Note that, in the case of a light probe, the index refers to an element in
-// one of the two `light_probes` sublists, not the `clustered_lights` list.
+/// Returns the index of the clusterable object at the given offset.
+///
+/// Note that, in the case of a light probe, the index refers to an element in
+/// one of the two `light_probes` sublists, not the `clustered_lights` list.
 fn get_clusterable_object_id(index: u32) -> u32 {
 @if(AVAILABLE_STORAGE_BUFFER_BINDINGS__GE_3)
     return bindings::clusterable_object_index_lists.data[index];

--- a/crates/bevy_pbr/src/render/fog.wesl
+++ b/crates/bevy_pbr/src/render/fog.wesl
@@ -1,12 +1,13 @@
+//! Fog formulas adapted from:
+//! https://learn.microsoft.com/en-us/windows/win32/direct3d9/fog-formulas
+//! https://catlikecoding.com/unity/tutorials/rendering/part-14/
+//! https://iquilezles.org/articles/fog/ (Atmospheric Fog and Scattering)
+
 import package::render::{
     mesh_view_bindings::fog,
     mesh_view_types::Fog,
 };
 
-//! Fog formulas adapted from:
-//! https://learn.microsoft.com/en-us/windows/win32/direct3d9/fog-formulas
-//! https://catlikecoding.com/unity/tutorials/rendering/part-14/
-//! https://iquilezles.org/articles/fog/ (Atmospheric Fog and Scattering)
 
 fn scattering_adjusted_fog_color(
     fog_params: Fog,

--- a/crates/bevy_pbr/src/render/fog.wesl
+++ b/crates/bevy_pbr/src/render/fog.wesl
@@ -3,10 +3,10 @@ import package::render::{
     mesh_view_types::Fog,
 };
 
-// Fog formulas adapted from:
-// https://learn.microsoft.com/en-us/windows/win32/direct3d9/fog-formulas
-// https://catlikecoding.com/unity/tutorials/rendering/part-14/
-// https://iquilezles.org/articles/fog/ (Atmospheric Fog and Scattering)
+//! Fog formulas adapted from:
+//! https://learn.microsoft.com/en-us/windows/win32/direct3d9/fog-formulas
+//! https://catlikecoding.com/unity/tutorials/rendering/part-14/
+//! https://iquilezles.org/articles/fog/ (Atmospheric Fog and Scattering)
 
 fn scattering_adjusted_fog_color(
     fog_params: Fog,

--- a/crates/bevy_pbr/src/render/forward_io.wesl
+++ b/crates/bevy_pbr/src/render/forward_io.wesl
@@ -54,8 +54,8 @@ struct Vertex {
 
 @if(!MESHLET_MESH_MATERIAL_PASS)
 
-// The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
-// See https://github.com/gfx-rs/naga/issues/2416
+/// The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
+/// See https://github.com/gfx-rs/naga/issues/2416
 fn decompress_vertex(vertex_in: Vertex, instance_index: u32) -> UncompressedVertex {
     let mesh_metadata = package::render::mesh_functions::get_metadata(instance_index);
     var uncompressed_vertex: UncompressedVertex;
@@ -96,8 +96,8 @@ fn decompress_vertex(vertex_in: Vertex, instance_index: u32) -> UncompressedVert
 }
 
 struct VertexOutput {
-    // This is `clip position` when the struct is used as a vertex stage output
-    // and `frag coord` when used as a fragment stage input
+    /// This is `clip position` when the struct is used as a vertex stage output
+    /// and `frag coord` when used as a fragment stage input
     @builtin(position) position: vec4<f32>,
     @location(0) world_position: vec4<f32>,
     @location(1) world_normal: vec3<f32>,

--- a/crates/bevy_pbr/src/render/mesh.wesl
+++ b/crates/bevy_pbr/src/render/mesh.wesl
@@ -8,8 +8,8 @@ import package::render::{
 };
 
 @if(MORPH_TARGETS)
-// The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
-// See https://github.com/gfx-rs/naga/issues/2416
+/// The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
+/// See https://github.com/gfx-rs/naga/issues/2416
 fn morph_vertex(vertex_in: UncompressedVertex, instance_index: u32) -> UncompressedVertex {
     var vertex = vertex_in;
     let first_vertex = mesh[instance_index].first_vertex_index;

--- a/crates/bevy_pbr/src/render/mesh_functions.wesl
+++ b/crates/bevy_pbr/src/render/mesh_functions.wesl
@@ -53,9 +53,9 @@ fn mesh_position_local_to_world(world_from_local: mat4x4<f32>, vertex_position: 
     return world_from_local * vertex_position;
 }
 
-// NOTE: The intermediate world_position assignment is important
-// for precision purposes when using the 'equals' depth comparison
-// function.
+/// NOTE: The intermediate world_position assignment is important
+/// for precision purposes when using the 'equals' depth comparison
+/// function.
 fn mesh_position_local_to_clip(world_from_local: mat4x4<f32>, vertex_position: vec4<f32>) -> vec4<f32> {
     let world_position = mesh_position_local_to_world(world_from_local, vertex_position);
     return position_world_to_clip(world_position.xyz);
@@ -82,8 +82,8 @@ fn mesh_normal_local_to_world(vertex_normal: vec3<f32>, instance_index: u32) -> 
     }
 }
 
-// Calculates the sign of the determinant of the 3x3 model matrix based on a
-// mesh flag
+/// Calculates the sign of the determinant of the 3x3 model matrix based on a
+/// mesh flag
 fn sign_determinant_model_3x3m(mesh_flags: u32) -> f32 {
     // bool(u32) is false if 0u else true
     // f32(bool) is 1.0 if true else 0.0
@@ -118,10 +118,10 @@ fn mesh_tangent_local_to_world(world_from_local: mat4x4<f32>, vertex_tangent: ve
     }
 }
 
-// Returns an appropriate dither level for the current mesh instance.
-//
-// This looks up the LOD range in the `visibility_ranges` table and compares the
-// camera distance to determine the dithering level.
+/// Returns an appropriate dither level for the current mesh instance.
+///
+/// This looks up the LOD range in the `visibility_ranges` table and compares the
+/// camera distance to determine the dithering level.
 @if(VISIBILITY_RANGE_DITHER)
 fn get_visibility_range_dither_level(instance_index: u32, world_position: vec4<f32>) -> i32 {
 @if(AVAILABLE_STORAGE_BUFFER_BINDINGS__GE_6)

--- a/crates/bevy_pbr/src/render/mesh_preprocess.wesl
+++ b/crates/bevy_pbr/src/render/mesh_preprocess.wesl
@@ -1,18 +1,18 @@
-// GPU mesh transforming and culling.
-//
-// This is a compute shader that expands each `MeshInputUniform` out to a full
-// `MeshUniform` for each view before rendering. (Thus `MeshInputUniform` and
-// `MeshUniform` are in a 1:N relationship.) It runs in parallel for all meshes
-// for all views. As part of this process, the shader gathers each mesh's
-// transform on the previous frame and writes it into the `MeshUniform` so that
-// TAA works. It also performs frustum culling and occlusion culling, if
-// requested.
-//
-// If occlusion culling is on, this shader runs twice: once to prepare the
-// meshes that were visible last frame, and once to prepare the meshes that
-// weren't visible last frame but became visible this frame. The two invocations
-// are known as *early mesh preprocessing* and *late mesh preprocessing*
-// respectively.
+//! GPU mesh transforming and culling.
+//!
+//! This is a compute shader that expands each `MeshInputUniform` out to a full
+//! `MeshUniform` for each view before rendering. (Thus `MeshInputUniform` and
+//! `MeshUniform` are in a 1:N relationship.) It runs in parallel for all meshes
+//! for all views. As part of this process, the shader gathers each mesh's
+//! transform on the previous frame and writes it into the `MeshUniform` so that
+//! TAA works. It also performs frustum culling and occlusion culling, if
+//! requested.
+//!
+//! If occlusion culling is on, this shader runs twice: once to prepare the
+//! meshes that were visible last frame, and once to prepare the meshes that
+//! weren't visible last frame but became visible this frame. The two invocations
+//! are known as *early mesh preprocessing* and *late mesh preprocessing*
+//! respectively.
 
 import bevy_render::occlusion_culling::mesh_preprocess_types::{
     IndirectParametersMetadata, MeshInput, PreviousMeshInput, PreprocessWorkItem
@@ -31,77 +31,77 @@ import package::render::view_transformations::{
 import bevy_render::maths;
 import bevy_render::view::View;
 
-// Information about each mesh instance needed to cull it on GPU.
-//
-// At the moment, this just consists of its axis-aligned bounding box (AABB).
+/// Information about each mesh instance needed to cull it on GPU.
+///
+/// At the moment, this just consists of its axis-aligned bounding box (AABB).
 struct MeshCullingData {
-    // The 3D center of the AABB in model space, padded with an extra unused
-    // float value.
+    /// The 3D center of the AABB in model space, padded with an extra unused
+    /// float value.
     aabb_center: vec4<f32>,
-    // The 3D extents of the AABB in model space, divided by two, padded with
-    // an extra unused float value.
+    /// The 3D extents of the AABB in model space, divided by two, padded with
+    /// an extra unused float value.
     aabb_half_extents: vec4<f32>,
 }
 
-// The parameters for the indirect compute dispatch for the late mesh
-// preprocessing phase.
+/// The parameters for the indirect compute dispatch for the late mesh
+/// preprocessing phase.
 struct LatePreprocessWorkItemIndirectParameters {
-    // The number of workgroups we're going to dispatch.
-    //
-    // This value should always be equal to `ceil(work_item_count / 64)`.
-    //
-    // In the late phase this buffer is bound read-only, and the atomic built-ins
-    // are only defined for `read_write` storage, so the fields are plain `u32`
-    // there and `atomic<u32>` in the early phase. `u32` and `atomic<u32>` are
-    // layout-identical, so the buffer's memory layout is unchanged either way.
+    /// The number of workgroups we're going to dispatch.
+    ///
+    /// This value should always be equal to `ceil(work_item_count / 64)`.
+    ///
+    /// In the late phase this buffer is bound read-only, and the atomic built-ins
+    /// are only defined for `read_write` storage, so the fields are plain `u32`
+    /// there and `atomic<u32>` in the early phase. `u32` and `atomic<u32>` are
+    /// layout-identical, so the buffer's memory layout is unchanged either way.
     @if(LATE_PHASE)
     dispatch_x: u32,
     @else   // LATE_PHASE
     dispatch_x: atomic<u32>,
-    // The number of workgroups in the Y direction; always 1.
+    /// The number of workgroups in the Y direction; always 1.
     dispatch_y: u32,
-    // The number of workgroups in the Z direction; always 1.
+    /// The number of workgroups in the Z direction; always 1.
     dispatch_z: u32,
-    // The precise number of work items.
+    /// The precise number of work items.
     @if(LATE_PHASE)
     work_item_count: u32,
     @else   // LATE_PHASE
     work_item_count: atomic<u32>,
-    // Padding.
-    //
-    // This isn't the usual structure padding; it's needed because some hardware
-    // requires indirect compute dispatch parameters to be aligned on 64-byte
-    // boundaries.
+    /// Padding.
+    ///
+    /// This isn't the usual structure padding; it's needed because some hardware
+    /// requires indirect compute dispatch parameters to be aligned on 64-byte
+    /// boundaries.
     pad: vec4<u32>,
 }
 
-// These have to be in a structure because of Naga limitations on DX12.
+/// These have to be in a structure because of Naga limitations on DX12.
 struct Immediates {
-    // The offset into the `late_preprocess_work_item_indirect_parameters`
-    // buffer.
+    /// The offset into the `late_preprocess_work_item_indirect_parameters`
+    /// buffer.
     late_preprocess_work_item_indirect_offset: u32,
 }
 
-// The current frame's `MeshInput`.
+/// The current frame's `MeshInput`.
 @group(0) @binding(3) var<storage> current_input: array<MeshInput>;
-// The `MeshInput` values from the previous frame.
+/// The `MeshInput` values from the previous frame.
 @group(0) @binding(4) var<storage> previous_input: array<PreviousMeshInput>;
-// Indices into the `MeshInput` buffer.
-//
-// There may be many indices that map to the same `MeshInput`.
+/// Indices into the `MeshInput` buffer.
+///
+/// There may be many indices that map to the same `MeshInput`.
 @group(0) @binding(5) var<storage> work_items: array<PreprocessWorkItem>;
-// The output array of `Mesh`es.
+/// The output array of `Mesh`es.
 @group(0) @binding(6) var<storage, read_write> output: array<Mesh>;
 
 @if(INDIRECT)
-// The array of indirect parameters for drawcalls.
+/// The array of indirect parameters for drawcalls.
 @group(0) @binding(7) var<storage, read_write> indirect_parameters_metadata:
     array<IndirectParametersMetadata>;
 
 @if(FRUSTUM_CULLING) {
-// Data needed to cull the meshes.
-//
-// At the moment, this consists only of AABBs.
+/// Data needed to cull the meshes.
+///
+/// At the moment, this consists only of AABBs.
 @group(0) @binding(9) var<storage> mesh_culling_data: array<MeshCullingData>;
 
 @group(0) @binding(10) var<storage> visibility_ranges: array<vec4<f32>>;
@@ -126,9 +126,9 @@ struct Immediates {
 var<immediate> immediates: Immediates;
 
 @if(FRUSTUM_CULLING)
-// Returns true if the view frustum intersects an oriented bounding box (OBB).
-//
-// `aabb_center.w` should be 1.0.
+/// Returns true if the view frustum intersects an oriented bounding box (OBB).
+///
+/// `aabb_center.w` should be 1.0.
 fn view_frustum_intersects_obb(
     world_from_local: mat4x4<f32>,
     aabb_center: vec4<f32>,

--- a/crates/bevy_pbr/src/render/mesh_types.wesl
+++ b/crates/bevy_pbr/src/render/mesh_types.wesl
@@ -1,25 +1,25 @@
 struct Mesh {
-    // Affine 4x3 matrices transposed to 3x4
-    // Use bevy_render::maths::affine3_to_square to unpack
+    /// Affine 4x3 matrices transposed to 3x4
+    /// Use bevy_render::maths::affine3_to_square to unpack
     world_from_local: mat3x4<f32>,
     previous_world_from_local: mat3x4<f32>,
-    // 3x3 matrix packed in mat2x4 and f32 as:
-    // [0].xyz, [1].x,
-    // [1].yz, [2].xy
-    // [2].z
-    // Use package::render::mesh_functions::mat2x4_f32_to_mat3x3_unpack to unpack
+    /// 3x3 matrix packed in mat2x4 and f32 as:
+    /// [0].xyz, [1].x,
+    /// [1].yz, [2].xy
+    /// [2].z
+    /// Use package::render::mesh_functions::mat2x4_f32_to_mat3x3_unpack to unpack
     local_from_world_transpose_a: mat2x4<f32>,
     local_from_world_transpose_b: f32,
-    // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
+    /// 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32,
     lightmap_uv_rect: vec2<u32>,
-    // The index of the mesh's first vertex in the vertex buffer.
+    /// The index of the mesh's first vertex in the vertex buffer.
     first_vertex_index: u32,
     current_skin_index: u32,
-    // Low 16 bits: index of the material inside the bind group data.
-    // High 16 bits: index of the lightmap in the binding array.
+    /// Low 16 bits: index of the material inside the bind group data.
+    /// High 16 bits: index of the lightmap in the binding array.
     material_and_lightmap_bind_group_slot: u32,
-    // User supplied index to identify the mesh instance
+    /// User supplied index to identify the mesh instance
     tag: u32,
     morph_descriptor_index: u32,
     /// The index of the mesh metadata buffer.
@@ -36,37 +36,37 @@ struct MorphWeights {
     weights: array<vec4<f32>, 64u>, // 64 = 256 / 4 (256 = MAX_MORPH_WEIGHTS)
 };
 
-// Describes a single mesh instance that uses morph targets.
+/// Describes a single mesh instance that uses morph targets.
 @if(MORPH_TARGETS)
 struct MorphDescriptor {
-    // The index of the first morph target weight in the `morph_weights` array.
+    /// The index of the first morph target weight in the `morph_weights` array.
     current_weights_offset: u32,
-    // The index of the first morph target weight in the `prev_morph_weights`
-    // array.
+    /// The index of the first morph target weight in the `prev_morph_weights`
+    /// array.
     prev_weights_offset: u32,
-    // The index of the first morph target for this mesh in the
-    // `MorphAttributes` array.
+    /// The index of the first morph target for this mesh in the
+    /// `MorphAttributes` array.
     targets_offset: u32,
-    // The number of vertices in the mesh.
+    /// The number of vertices in the mesh.
     vertex_count: u32,
-    // The number of morph targets this mesh has.
+    /// The number of morph targets this mesh has.
     weight_count: u32,
 };
 
-// Morph displacement for a single vertex.
+/// Morph displacement for a single vertex.
 @if(MORPH_TARGETS)
 struct MorphAttributes {
-    // The position delta.
+    /// The position delta.
     position: vec3<f32>,
-    // Padding, to ensure that each `vec3<f32>` is aligned to 16 bytes.
+    /// Padding, to ensure that each `vec3<f32>` is aligned to 16 bytes.
     pad_a: f32,
-    // The normal delta.
+    /// The normal delta.
     normal: vec3<f32>,
-    // Padding, to ensure that each `vec3<f32>` is aligned to 16 bytes.
+    /// Padding, to ensure that each `vec3<f32>` is aligned to 16 bytes.
     pad_b: f32,
-    // The tangent delta.
+    /// The tangent delta.
     tangent: vec3<f32>,
-    // Padding, to ensure that each `vec3<f32>` is aligned to 16 bytes.
+    /// Padding, to ensure that each `vec3<f32>` is aligned to 16 bytes.
     pad_c: f32,
 };
 

--- a/crates/bevy_pbr/src/render/mesh_view_types.wesl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wesl
@@ -1,10 +1,10 @@
 struct ClusteredLight {
-    // For point lights: the lower-right 2x2 values of the projection matrix [2][2] [2][3] [3][2] [3][3]
-    // For spot lights: the direction (x,z), spot_scale and spot_offset
+    /// For point lights: the lower-right 2x2 values of the projection matrix [2][2] [2][3] [3][2] [3][3]
+    /// For spot lights: the direction (x,z), spot_scale and spot_offset
     light_custom_data: vec4<f32>,
     color_inverse_square_range: vec4<f32>,
     position_radius: vec4<f32>,
-    // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
+    /// 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32,
     shadow_depth_bias: f32,
     shadow_normal_bias: f32,
@@ -33,7 +33,7 @@ struct DirectionalLight {
     cascades: array<DirectionalCascade, constants::MAX_CASCADES_PER_LIGHT>,
     color: vec4<f32>,
     direction_to_light: vec3<f32>,
-    // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
+    /// 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32,
     soft_shadow_size: f32,
     shadow_depth_bias: f32,
@@ -62,21 +62,21 @@ struct RectLight {
 };
 
 struct Lights {
-    // NOTE: this array size must be kept in sync with the constants defined in bevy_pbr/src/render/light.rs
+    /// NOTE: this array size must be kept in sync with the constants defined in bevy_pbr/src/render/light.rs
     directional_lights: array<DirectionalLight, u32(constants::MAX_DIRECTIONAL_LIGHTS)>,
     ambient_color: vec4<f32>,
-    // x/y/z dimensions and n_clusters in w
+    /// x/y/z dimensions and n_clusters in w
     cluster_dimensions: vec4<u32>,
-    // xy are vec2<f32>(cluster_dimensions.xy) / vec2<f32>(view.width, view.height)
-    //
-    // For perspective projections:
-    // z is (cluster_dimensions.z - 1) / log(far / near)
-    // w is (cluster_dimensions.z - 1) * log(near) / log(far / near)
-    //
-    // For orthographic projections:
-    // NOTE: near and far are +ve but -z is infront of the camera
-    // z is -near
-    // w is cluster_dimensions.z / (-far - -near)
+    /// xy are vec2<f32>(cluster_dimensions.xy) / vec2<f32>(view.width, view.height)
+    ///
+    /// For perspective projections:
+    /// z is (cluster_dimensions.z - 1) / log(far / near)
+    /// w is (cluster_dimensions.z - 1) * log(near) / log(far / near)
+    ///
+    /// For orthographic projections:
+    /// NOTE: near and far are +ve but -z is infront of the camera
+    /// z is -near
+    /// w is cluster_dimensions.z / (-far - -near)
     cluster_factors: vec4<f32>,
     n_directional_lights: u32,
     spot_light_shadowmap_offset: i32,
@@ -90,15 +90,15 @@ const AMBIENT_LIGHT_FLAGS_AFFECTS_LIGHTMAPPED_MESHES_BIT: u32           = 1u << 
 struct Fog {
     base_color: vec4<f32>,
     directional_light_color: vec4<f32>,
-    // `be` and `bi` are allocated differently depending on the fog mode
-    //
-    // For Linear Fog:
-    //     be.x = start, be.y = end
-    // For Exponential and ExponentialSquared Fog:
-    //     be.x = density
-    // For Atmospheric Fog:
-    //     be = per-channel extinction density
-    //     bi = per-channel inscattering density
+    /// `be` and `bi` are allocated differently depending on the fog mode
+    ///
+    /// For Linear Fog:
+    ///     be.x = start, be.y = end
+    /// For Exponential and ExponentialSquared Fog:
+    ///     be.x = density
+    /// For Atmospheric Fog:
+    ///     be = per-channel extinction density
+    ///     bi = per-channel inscattering density
     be: vec3<f32>,
     directional_light_exponent: f32,
     bi: vec3<f32>,
@@ -130,63 +130,63 @@ struct ClusteredLights {
 };
 @if(!AVAILABLE_STORAGE_BUFFER_BINDINGS__GE_3)
 struct ClusterableObjectIndexLists {
-    // each u32 contains 4 u8 indices into the ClusterableObjects array
+    /// each u32 contains 4 u8 indices into the ClusterableObjects array
     data: array<vec4<u32>, 1024u>,
 };
 @if(!AVAILABLE_STORAGE_BUFFER_BINDINGS__GE_3)
 struct ClusterOffsetsAndCounts {
-    // each u32 contains a 24-bit index into ClusterableObjectIndexLists in the high 24 bits
-    // and an 8-bit count of the number of lights in the low 8 bits
+    /// each u32 contains a 24-bit index into ClusterableObjectIndexLists in the high 24 bits
+    /// and an 8-bit count of the number of lights in the low 8 bits
     data: array<vec4<u32>, 1024u>,
 };
 
-// Whether this light probe contributes diffuse light to lightmapped meshes.
+/// Whether this light probe contributes diffuse light to lightmapped meshes.
 const LIGHT_PROBE_FLAG_AFFECTS_LIGHTMAPPED_MESH_DIFFUSE: u32 = 1;
-// Whether this light probe has parallax correction enabled.
+/// Whether this light probe has parallax correction enabled.
 const LIGHT_PROBE_FLAG_PARALLAX_CORRECT:                 u32 = 2;
 
 struct LightProbe {
-    // This is stored as the transpose in order to save space in this structure.
-    // It'll be transposed in the `environment_map_light` function.
+    /// This is stored as the transpose in order to save space in this structure.
+    /// It'll be transposed in the `environment_map_light` function.
     light_from_world_transposed: mat3x4<f32>,
-    // The falloff region, specified as a fraction of the light probe's
-    // bounding box.
+    /// The falloff region, specified as a fraction of the light probe's
+    /// bounding box.
     falloff: vec3<f32>,
     bounding_sphere_radius: f32,
-    // The boundaries of the simulated space used for parallax correction,
-    // specified as *half* extents in light probe space.
+    /// The boundaries of the simulated space used for parallax correction,
+    /// specified as *half* extents in light probe space.
     parallax_correction_bounds: vec3<f32>,
     intensity: f32,
     world_position: vec3<f32>,
     cubemap_index: i32,
-    // Various flags that apply to this light probe.
+    /// Various flags that apply to this light probe.
     flags: u32,
 };
 
 struct LightProbes {
-    // This must match `MAX_VIEW_LIGHT_PROBES` on the Rust side.
+    /// This must match `MAX_VIEW_LIGHT_PROBES` on the Rust side.
     reflection_probes: array<LightProbe, 8u>,
     irradiance_volumes: array<LightProbe, 8u>,
     reflection_probe_count: i32,
     irradiance_volume_count: i32,
-    // The index of the view environment map cubemap binding, or -1 if there's
-    // no such cubemap.
+    /// The index of the view environment map cubemap binding, or -1 if there's
+    /// no such cubemap.
     view_cubemap_index: i32,
-    // The smallest valid mipmap level for the specular environment cubemap
-    // associated with the view.
+    /// The smallest valid mipmap level for the specular environment cubemap
+    /// associated with the view.
     smallest_specular_mip_level_for_view: u32,
     view_rotation: vec4<f32>,
-    // The intensity of the environment map associated with the view.
+    /// The intensity of the environment map associated with the view.
     intensity_for_view: f32,
-    // Whether the environment map attached to the view affects the diffuse
-    // lighting for lightmapped meshes.
+    /// Whether the environment map attached to the view affects the diffuse
+    /// lighting for lightmapped meshes.
     view_environment_map_affects_lightmapped_mesh_diffuse: u32,
 };
 
-// Settings for screen space reflections.
-//
-// For more information on these settings, see the documentation for
-// `package::ssr::ScreenSpaceReflections`.
+/// Settings for screen space reflections.
+///
+/// For more information on these settings, see the documentation for
+/// `package::ssr::ScreenSpaceReflections`.
 struct ScreenSpaceReflectionsSettings {
     min_perceptual_roughness: f32,
     min_perceptual_roughness_fully_active: f32,
@@ -201,7 +201,7 @@ struct ScreenSpaceReflectionsSettings {
     use_secant: u32,
 };
 
-// See the `ContactShadows` rust struct.
+/// See the `ContactShadows` rust struct.
 struct ContactShadowsSettings {
     linear_steps: u32,
     thickness: f32,
@@ -211,11 +211,11 @@ struct ContactShadowsSettings {
 };
 
 struct EnvironmentMapUniform {
-    // Transformation matrix for the environment cubemaps in world space.
+    /// Transformation matrix for the environment cubemaps in world space.
     transform: mat4x4<f32>,
 };
 
-// Shader version of the order independent transparency settings component.
+/// Shader version of the order independent transparency settings component.
 struct OrderIndependentTransparencySettings {
   sorted_fragment_max_count: u32,
   fragments_per_pixel_average: f32,

--- a/crates/bevy_pbr/src/render/occlusion_culling.wesl
+++ b/crates/bevy_pbr/src/render/occlusion_culling.wesl
@@ -1,4 +1,4 @@
-// Occlusion culling utility functions.
+//! Occlusion culling utility functions.
 
 fn get_aabb_size_in_pixels(aabb: vec4<f32>, depth_pyramid: texture_2d<f32>) -> vec2<f32> {
     let depth_pyramid_size_mip_0 = vec2<f32>(textureDimensions(depth_pyramid, 0));

--- a/crates/bevy_pbr/src/render/parallax_mapping.wesl
+++ b/crates/bevy_pbr/src/render/parallax_mapping.wesl
@@ -35,15 +35,15 @@ fn sample_depth_map(uv: vec2<f32>, material_bind_group_slot: u32) -> f32 {
     ).r;
 }
 
-// An implementation of parallax mapping, see https://en.wikipedia.org/wiki/Parallax_mapping
-// Code derived from: https://web.archive.org/web/20150419215321/http://sunandblackcat.com/tipFullView.php?l=eng&topicid=28
+/// An implementation of parallax mapping, see https://en.wikipedia.org/wiki/Parallax_mapping
+/// Code derived from: https://web.archive.org/web/20150419215321/http://sunandblackcat.com/tipFullView.php?l=eng&topicid=28
 fn parallaxed_uv(
     depth_scale: f32,
     max_layer_count: f32,
     max_steps: u32,
-    // The original interpolated uv
+    /// The original interpolated uv
     original_uv: vec2<f32>,
-    // The vector from the camera to the fragment at the surface in tangent space
+    /// The vector from the camera to the fragment at the surface in tangent space
     Vt: vec3<f32>,
     material_bind_group_slot: u32,
 ) -> vec2<f32> {

--- a/crates/bevy_pbr/src/render/pbr_ambient.wesl
+++ b/crates/bevy_pbr/src/render/pbr_ambient.wesl
@@ -3,8 +3,8 @@ import package::render::{
     mesh_view_bindings::lights,
 };
 
-// A precomputed `NdotV` is provided because it is computed regardless,
-// but `world_normal` and the view vector `V` are provided separately for more advanced uses.
+/// A precomputed `NdotV` is provided because it is computed regardless,
+/// but `world_normal` and the view vector `V` are provided separately for more advanced uses.
 fn ambient_light(
     world_position: vec4<f32>,
     world_normal: vec3<f32>,

--- a/crates/bevy_pbr/src/render/pbr_fragment.wesl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wesl
@@ -30,7 +30,7 @@ import package::render::forward_io::VertexOutput;
 @if(BINDLESS)
 import package::render::pbr_bindings::material_indices;
 
-// prepare a basic PbrInput from the vertex stage output, mesh binding and view binding
+/// prepare a basic PbrInput from the vertex stage output, mesh binding and view binding
 fn pbr_input_from_vertex_output(
     in: VertexOutput,
     is_front: bool,
@@ -66,8 +66,8 @@ fn pbr_input_from_vertex_output(
     return pbr_input;
 }
 
-// Prepare a full PbrInput by sampling all textures to resolve
-// the material members
+/// Prepare a full PbrInput by sampling all textures to resolve
+/// the material members
 fn pbr_input_from_standard_material(
     in: VertexOutput,
     is_front: bool,

--- a/crates/bevy_pbr/src/render/pbr_functions.wesl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wesl
@@ -36,8 +36,8 @@ import bevy_render::maths::{E, powsafe};
 @if(TONEMAP_IN_SHADER) import bevy_core_pipeline::tonemapping::{tone_mapping, screen_space_dither};
 
 
-// Biasing info needed to sample from a texture. How this is done depends on
-// whether we're rendering meshlets or regular meshes.
+/// Biasing info needed to sample from a texture. How this is done depends on
+/// whether we're rendering meshlets or regular meshes.
 struct SampleBias {
     @if(MESHLET_MESH_MATERIAL_PASS)
     ddx_uv: vec2<f32>,
@@ -47,13 +47,13 @@ struct SampleBias {
     mip_bias: f32,
 }
 
-// This is the standard 4x4 ordered dithering pattern from [1].
-//
-// We can't use `array<vec4<u32>, 4>` because they can't be indexed dynamically
-// due to Naga limitations. So instead we pack into a single `vec4` and extract
-// individual bytes.
-//
-// [1]: https://en.wikipedia.org/wiki/Ordered_dithering#Threshold_map
+/// This is the standard 4x4 ordered dithering pattern from [1].
+///
+/// We can't use `array<vec4<u32>, 4>` because they can't be indexed dynamically
+/// due to Naga limitations. So instead we pack into a single `vec4` and extract
+/// individual bytes.
+///
+/// [1]: https://en.wikipedia.org/wiki/Ordered_dithering#Threshold_map
 const DITHER_THRESHOLD_MAP: vec4<u32> = vec4(
     0x0a020800,
     0x060e040c,
@@ -61,20 +61,20 @@ const DITHER_THRESHOLD_MAP: vec4<u32> = vec4(
     0x050d070f
 );
 
-// Processes a visibility range dither value and discards the fragment if
-// needed.
-//
-// Visibility ranges, also known as HLODs, are crossfades between different
-// levels of detail.
-//
-// The `dither` value ranges from [-16, 16]. When zooming out, positive values
-// are used for meshes that are in the process of disappearing, while negative
-// values are used for meshes that are in the process of appearing. In other
-// words, when the camera is moving backwards, the `dither` value counts up from
-// -16 to 0 when the object is fading in, stays at 0 while the object is
-// visible, and then counts up to 16 while the object is fading out.
-// Distinguishing between negative and positive values allows the dither
-// patterns for different LOD levels of a single mesh to mesh together properly.
+/// Processes a visibility range dither value and discards the fragment if
+/// needed.
+///
+/// Visibility ranges, also known as HLODs, are crossfades between different
+/// levels of detail.
+///
+/// The `dither` value ranges from [-16, 16]. When zooming out, positive values
+/// are used for meshes that are in the process of disappearing, while negative
+/// values are used for meshes that are in the process of appearing. In other
+/// words, when the camera is moving backwards, the `dither` value counts up from
+/// -16 to 0 when the object is fading in, stays at 0 while the object is
+/// visible, and then counts up to 16 while the object is fading out.
+/// Distinguishing between negative and positive values allows the dither
+/// patterns for different LOD levels of a single mesh to mesh together properly.
 @if(VISIBILITY_RANGE_DITHER)
 fn visibility_range_dither(frag_coord: vec4<f32>, dither: i32) {
     // If `dither` is 0, the object is visible.
@@ -141,10 +141,10 @@ fn winding_corrected_front_facing(mesh_flags: u32, is_front: bool) -> bool {
     return is_front == positive_determinant;
 }
 
-// Calculates the three TBN vectors according to [mikktspace]. Returns a matrix
-// with T, B, N columns in that order.
-//
-// [mikktspace]: http://www.mikktspace.com/
+/// Calculates the three TBN vectors according to [mikktspace]. Returns a matrix
+/// with T, B, N columns in that order.
+///
+/// [mikktspace]: http://www.mikktspace.com/
 fn calculate_tbn_mikktspace(world_normal: vec3<f32>, world_tangent: vec4<f32>) -> mat3x3<f32> {
     // NOTE: The mikktspace method of normal mapping explicitly requires that the world normal NOT
     // be re-normalized in the fragment shader. This is primarily to match the way mikktspace
@@ -212,11 +212,11 @@ fn apply_normal_mapping(
     return normalize(N);
 }
 
-// Modifies the normal to achieve a better approximate direction from the
-// environment map when using anisotropy.
-//
-// This follows the suggested implementation in the `KHR_materials_anisotropy` specification:
-// https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md#image-based-lighting
+/// Modifies the normal to achieve a better approximate direction from the
+/// environment map when using anisotropy.
+///
+/// This follows the suggested implementation in the `KHR_materials_anisotropy` specification:
+/// https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md#image-based-lighting
 @if(STANDARD_MATERIAL_ANISOTROPY)
 fn bend_normal_for_anisotropy(lighting_input: ptr<function, lighting::LightingInput>) {
     // Unpack.
@@ -246,8 +246,8 @@ fn bend_normal_for_anisotropy(lighting_input: ptr<function, lighting::LightingIn
     (*lighting_input).layers[LAYER_BASE].R = R;
 }
 
-// NOTE: Correctly calculates the view vector depending on whether
-// the projection is orthographic or perspective.
+/// NOTE: Correctly calculates the view vector depending on whether
+/// the projection is orthographic or perspective.
 fn calculate_view(
     world_position: vec4<f32>,
     is_orthographic: bool,
@@ -263,7 +263,7 @@ fn calculate_view(
     return V;
 }
 
-// Diffuse strength is inversely related to metallicity, specular and diffuse transmission
+/// Diffuse strength is inversely related to metallicity, specular and diffuse transmission
 fn calculate_diffuse_color(
     base_color: vec3<f32>,
     metallic: f32,
@@ -274,13 +274,13 @@ fn calculate_diffuse_color(
         (1.0 - diffuse_transmission);
 }
 
-// Remapping [0,1] reflectance to F0 for dielectrics
+/// Remapping [0,1] reflectance to F0 for dielectrics
 fn calculate_F0_dielectric(reflectance: vec3<f32>) -> vec3<f32> {
     return 0.16 * reflectance * reflectance;
 }
 
-// Remapping [0,1] reflectance to F0
-// See https://google.github.io/filament/Filament.md.html#materialsystem/parameterization/remapping
+/// Remapping [0,1] reflectance to F0
+/// See https://google.github.io/filament/Filament.md.html#materialsystem/parameterization/remapping
 fn calculate_F0(base_color: vec3<f32>, metallic: f32, reflectance: vec3<f32>) -> vec3<f32> {
     return mix(calculate_F0_dielectric(reflectance), base_color, metallic);
 }
@@ -973,8 +973,8 @@ fn premultiply_alpha(standard_material_flags: u32, color: vec4<f32>) -> vec4<f32
 }
 }
 
-// fog, alpha premultiply
-// for non-hdr cameras, tonemapping and debanding
+/// fog, alpha premultiply
+/// for non-hdr cameras, tonemapping and debanding
 fn main_pass_post_lighting_processing(
     pbr_input: pbr_types::PbrInput,
     input_color: vec4<f32>,

--- a/crates/bevy_pbr/src/render/pbr_lighting.wesl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wesl
@@ -1,14 +1,17 @@
-import package::{
-    render::mesh_view_types::{POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE, RectLight},
-    render::mesh_view_bindings as view_bindings,
-    atmosphere::functions::{calculate_visible_sun_ratio, clamp_to_surface},
-    atmosphere::bruneton_functions::transmittance_lut_r_mu_to_uv,
-};
-import bevy_render::maths::{PI, orthonormalize, quat_rotate};
-
-const LAYER_BASE: u32 = 0;
-const LAYER_CLEARCOAT: u32 = 1;
-
+//! The Bidirectional Reflectance Distribution Function (BRDF) describes the surface response of a standard material
+//! and consists of two components, the diffuse component (f_d) and the specular component (f_r):
+//! f(v,l) = f_d(v,l) + f_r(v,l)
+//!
+//! The form of the microfacet model is the same for diffuse and specular
+//! f_r(v,l) = f_d(v,l) = 1 / { |n⋅v||n⋅l| } ∫_Ω D(m,α) G(v,l,m) f_m(v,l,m) (v⋅m) (l⋅m) dm
+//!
+//! In which:
+//! D, also called the Normal Distribution Function (NDF) models the distribution of the microfacets
+//! G models the visibility (or occlusion or shadow-masking) of the microfacets
+//! f_m is the microfacet BRDF and differs between specular and diffuse components
+//!
+//! The above integration needs to be approximated.
+//!
 //! From the Filament design doc
 //! https://google.github.io/filament/Filament.md.html#table_symbols
 //! Symbol Definition
@@ -28,20 +31,17 @@ const LAYER_CLEARCOAT: u32 = 1;
 //! nior    Index of refraction (IOR) of an interface
 //! ⟨n⋅l⟩    Dot product clamped to [0..1]
 //! ⟨a⟩    Saturated value (clamped to [0..1])
-//!
-//! The Bidirectional Reflectance Distribution Function (BRDF) describes the surface response of a standard material
-//! and consists of two components, the diffuse component (f_d) and the specular component (f_r):
-//! f(v,l) = f_d(v,l) + f_r(v,l)
-//!
-//! The form of the microfacet model is the same for diffuse and specular
-//! f_r(v,l) = f_d(v,l) = 1 / { |n⋅v||n⋅l| } ∫_Ω D(m,α) G(v,l,m) f_m(v,l,m) (v⋅m) (l⋅m) dm
-//!
-//! In which:
-//! D, also called the Normal Distribution Function (NDF) models the distribution of the microfacets
-//! G models the visibility (or occlusion or shadow-masking) of the microfacets
-//! f_m is the microfacet BRDF and differs between specular and diffuse components
-//!
-//! The above integration needs to be approximated.
+
+import package::{
+    render::mesh_view_types::{POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE, RectLight},
+    render::mesh_view_bindings as view_bindings,
+    atmosphere::functions::{calculate_visible_sun_ratio, clamp_to_surface},
+    atmosphere::bruneton_functions::transmittance_lut_r_mu_to_uv,
+};
+import bevy_render::maths::{PI, orthonormalize, quat_rotate};
+
+const LAYER_BASE: u32 = 0;
+const LAYER_CLEARCOAT: u32 = 1;
 
 /// Input to a lighting function for a single layer (either the base layer or the
 /// clearcoat layer).

--- a/crates/bevy_pbr/src/render/pbr_lighting.wesl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wesl
@@ -9,122 +9,122 @@ import bevy_render::maths::{PI, orthonormalize, quat_rotate};
 const LAYER_BASE: u32 = 0;
 const LAYER_CLEARCOAT: u32 = 1;
 
-// From the Filament design doc
-// https://google.github.io/filament/Filament.md.html#table_symbols
-// Symbol Definition
-// v    View unit vector
-// l    Incident light unit vector
-// n    Surface normal unit vector
-// h    Half unit vector between l and v
-// f    BRDF
-// f_d    Diffuse component of a BRDF
-// f_r    Specular component of a BRDF
-// α    Roughness, remapped from using input perceptualRoughness
-// σ    Diffuse reflectance
-// Ω    Spherical domain
-// f0    Reflectance at normal incidence
-// f90    Reflectance at grazing angle
-// χ+(a)    Heaviside function (1 if a>0 and 0 otherwise)
-// nior    Index of refraction (IOR) of an interface
-// ⟨n⋅l⟩    Dot product clamped to [0..1]
-// ⟨a⟩    Saturated value (clamped to [0..1])
+//! From the Filament design doc
+//! https://google.github.io/filament/Filament.md.html#table_symbols
+//! Symbol Definition
+//! v    View unit vector
+//! l    Incident light unit vector
+//! n    Surface normal unit vector
+//! h    Half unit vector between l and v
+//! f    BRDF
+//! f_d    Diffuse component of a BRDF
+//! f_r    Specular component of a BRDF
+//! α    Roughness, remapped from using input perceptualRoughness
+//! σ    Diffuse reflectance
+//! Ω    Spherical domain
+//! f0    Reflectance at normal incidence
+//! f90    Reflectance at grazing angle
+//! χ+(a)    Heaviside function (1 if a>0 and 0 otherwise)
+//! nior    Index of refraction (IOR) of an interface
+//! ⟨n⋅l⟩    Dot product clamped to [0..1]
+//! ⟨a⟩    Saturated value (clamped to [0..1])
+//!
+//! The Bidirectional Reflectance Distribution Function (BRDF) describes the surface response of a standard material
+//! and consists of two components, the diffuse component (f_d) and the specular component (f_r):
+//! f(v,l) = f_d(v,l) + f_r(v,l)
+//!
+//! The form of the microfacet model is the same for diffuse and specular
+//! f_r(v,l) = f_d(v,l) = 1 / { |n⋅v||n⋅l| } ∫_Ω D(m,α) G(v,l,m) f_m(v,l,m) (v⋅m) (l⋅m) dm
+//!
+//! In which:
+//! D, also called the Normal Distribution Function (NDF) models the distribution of the microfacets
+//! G models the visibility (or occlusion or shadow-masking) of the microfacets
+//! f_m is the microfacet BRDF and differs between specular and diffuse components
+//!
+//! The above integration needs to be approximated.
 
-// The Bidirectional Reflectance Distribution Function (BRDF) describes the surface response of a standard material
-// and consists of two components, the diffuse component (f_d) and the specular component (f_r):
-// f(v,l) = f_d(v,l) + f_r(v,l)
-//
-// The form of the microfacet model is the same for diffuse and specular
-// f_r(v,l) = f_d(v,l) = 1 / { |n⋅v||n⋅l| } ∫_Ω D(m,α) G(v,l,m) f_m(v,l,m) (v⋅m) (l⋅m) dm
-//
-// In which:
-// D, also called the Normal Distribution Function (NDF) models the distribution of the microfacets
-// G models the visibility (or occlusion or shadow-masking) of the microfacets
-// f_m is the microfacet BRDF and differs between specular and diffuse components
-//
-// The above integration needs to be approximated.
-
-// Input to a lighting function for a single layer (either the base layer or the
-// clearcoat layer).
+/// Input to a lighting function for a single layer (either the base layer or the
+/// clearcoat layer).
 struct LayerLightingInput {
-    // The normal vector.
+    /// The normal vector.
     N: vec3<f32>,
-    // The reflected vector.
+    /// The reflected vector.
     R: vec3<f32>,
-    // The normal vector ⋅ the view vector.
+    /// The normal vector ⋅ the view vector.
     NdotV: f32,
 
-    // The perceptual roughness of the layer.
+    /// The perceptual roughness of the layer.
     perceptual_roughness: f32,
-    // The roughness of the layer.
+    /// The roughness of the layer.
     roughness: f32,
 }
 
-// Input to a lighting function (`point_light`, `spot_light`,
-// `directional_light`).
+/// Input to a lighting function (`point_light`, `spot_light`,
+/// `directional_light`).
 struct LightingInput {
     @if(STANDARD_MATERIAL_CLEARCOAT)
     layers: array<LayerLightingInput, 2>,
     @else   // STANDARD_MATERIAL_CLEARCOAT
     layers: array<LayerLightingInput, 1>,
 
-    // The world-space position.
+    /// The world-space position.
     P: vec3<f32>,
-    // The vector to the view.
+    /// The vector to the view.
     V: vec3<f32>,
 
-    // The diffuse color of the material.
+    /// The diffuse color of the material.
     diffuse_color: vec3<f32>,
 
-    // The 0-1 metallic factor of the material.
+    /// The 0-1 metallic factor of the material.
     metallic: f32,
 
-    // Specular reflectance at the normal incidence angle.
+    /// Specular reflectance at the normal incidence angle.
     F0_dielectric: vec3<f32>,
     F0_metallic: vec3<f32>,
 
-    // Constants for the BRDF approximation.
-    //
-    // See `EnvBRDFApprox` in
-    // <https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile>.
-    // What we call `F_ab` they call `AB`.
+    /// Constants for the BRDF approximation.
+    ///
+    /// See `EnvBRDFApprox` in
+    /// <https://www.unrealengine.com/en-US/blog/physically-based-shading-on-mobile>.
+    /// What we call `F_ab` they call `AB`.
     F_ab: vec2<f32>,
 
-    // The strength of the clearcoat layer.
+    /// The strength of the clearcoat layer.
     @if(STANDARD_MATERIAL_CLEARCOAT)
     clearcoat_strength: f32,
 
-    // The anisotropy strength, reflecting the amount of increased roughness in
-    // the tangent direction.
+    /// The anisotropy strength, reflecting the amount of increased roughness in
+    /// the tangent direction.
     @if(STANDARD_MATERIAL_ANISOTROPY)
     anisotropy: f32,
-    // The tangent direction for anisotropy: i.e. the direction in which
-    // roughness increases.
+    /// The tangent direction for anisotropy: i.e. the direction in which
+    /// roughness increases.
     @if(STANDARD_MATERIAL_ANISOTROPY)
     Ta: vec3<f32>,
-    // The bitangent direction, which is the cross product of the normal with
-    // the tangent direction.
+    /// The bitangent direction, which is the cross product of the normal with
+    /// the tangent direction.
     @if(STANDARD_MATERIAL_ANISOTROPY)
     Ba: vec3<f32>,
 }
 
-// Values derived from the `LightingInput` for both diffuse and specular lights.
+/// Values derived from the `LightingInput` for both diffuse and specular lights.
 struct DerivedLightingInput {
-    // The half-vector between L, the incident light vector, and V, the view
-    // vector.
+    /// The half-vector between L, the incident light vector, and V, the view
+    /// vector.
     H: vec3<f32>,
-    // The normal vector ⋅ the incident light vector.
+    /// The normal vector ⋅ the incident light vector.
     NdotL: f32,
-    // The normal vector ⋅ the half-vector.
+    /// The normal vector ⋅ the half-vector.
     NdotH: f32,
-    // The incident light vector ⋅ the half-vector.
+    /// The incident light vector ⋅ the half-vector.
     LdotH: f32,
 }
 
-// distanceAttenuation is simply the square falloff of light intensity
-// combined with a smooth attenuation at the edge of the light radius
-//
-// light radius is a non-physical construct for efficiency purposes,
-// because otherwise every light affects every fragment in the scene
+/// distanceAttenuation is simply the square falloff of light intensity
+/// combined with a smooth attenuation at the edge of the light radius
+///
+/// light radius is a non-physical construct for efficiency purposes,
+/// because otherwise every light affects every fragment in the scene
 fn getDistanceAttenuation(distanceSquare: f32, inverseRangeSquared: f32) -> f32 {
     return getRangeFalloff(distanceSquare, inverseRangeSquared) * 1.0 / max(distanceSquare, 0.0001);
 }
@@ -136,13 +136,13 @@ fn getRangeFalloff(distanceSquare: f32, inverseRangeSquared: f32) -> f32 {
     return smoothFactor * smoothFactor;
 }
 
-// Normal distribution function (specular D)
-// Based on https://google.github.io/filament/Filament.md.html#citation-walter07
-
-// D_GGX(h,α) = α^2 / { π ((n⋅h)^2 (α2−1) + 1)^2 }
-
-// Simple implementation, has precision problems when using fp16 instead of fp32
-// see https://google.github.io/filament/Filament.md.html#listing_speculardfp16
+/// Normal distribution function (specular D)
+/// Based on https://google.github.io/filament/Filament.md.html#citation-walter07
+///
+/// D_GGX(h,α) = α^2 / { π ((n⋅h)^2 (α2−1) + 1)^2 }
+///
+/// Simple implementation, has precision problems when using fp16 instead of fp32
+/// see https://google.github.io/filament/Filament.md.html#listing_speculardfp16
 fn D_GGX(roughness: f32, NdotH: f32) -> f32 {
     let oneMinusNdotHSquared = 1.0 - NdotH * NdotH;
     let a = NdotH * roughness;
@@ -151,22 +151,22 @@ fn D_GGX(roughness: f32, NdotH: f32) -> f32 {
     return d;
 }
 
-// An approximation of the anisotropic GGX distribution function.
-//
-//                                     1
-//     D(𝐡) = ───────────────────────────────────────────────────
-//            παₜα_b((𝐡 ⋅ 𝐭)² / αₜ²) + (𝐡 ⋅ 𝐛)² / α_b² + (𝐡 ⋅ 𝐧)²)²
-//
-// * `T` = 𝐭 = the tangent direction = the direction of increased roughness.
-//
-// * `B` = 𝐛 = the bitangent direction = the direction of decreased roughness.
-//
-// * `at` = αₜ = the alpha-roughness in the tangent direction.
-//
-// * `ab` = α_b = the alpha-roughness in the bitangent direction.
-//
-// This is from the `KHR_materials_anisotropy` spec:
-// <https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md#individual-lights>
+/// An approximation of the anisotropic GGX distribution function.
+///
+///                                     1
+///     D(𝐡) = ───────────────────────────────────────────────────
+///            παₜα_b((𝐡 ⋅ 𝐭)² / αₜ²) + (𝐡 ⋅ 𝐛)² / α_b² + (𝐡 ⋅ 𝐧)²)²
+///
+/// * `T` = 𝐭 = the tangent direction = the direction of increased roughness.
+///
+/// * `B` = 𝐛 = the bitangent direction = the direction of decreased roughness.
+///
+/// * `at` = αₜ = the alpha-roughness in the tangent direction.
+///
+/// * `ab` = α_b = the alpha-roughness in the bitangent direction.
+///
+/// This is from the `KHR_materials_anisotropy` spec:
+/// <https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md#individual-lights>
 fn D_GGX_anisotropic(at: f32, ab: f32, NdotH: f32, TdotH: f32, BdotH: f32) -> f32 {
     let a2 = at * ab;
     let f = vec3(ab * TdotH, at * BdotH, a2 * NdotH);
@@ -175,13 +175,13 @@ fn D_GGX_anisotropic(at: f32, ab: f32, NdotH: f32, TdotH: f32, BdotH: f32) -> f3
     return d;
 }
 
-// Visibility function (Specular G)
-// V(v,l,a) = G(v,l,α) / { 4 (n⋅v) (n⋅l) }
-// such that f_r becomes
-// f_r(v,l) = D(h,α) V(v,l,α) F(v,h,f0)
-// where
-// V(v,l,α) = 0.5 / { n⋅l sqrt((n⋅v)^2 (1−α2) + α2) + n⋅v sqrt((n⋅l)^2 (1−α2) + α2) }
-// Note the two sqrt's, that may be slow on mobile, see https://google.github.io/filament/Filament.md.html#listing_approximatedspecularv
+/// Visibility function (Specular G)
+/// V(v,l,a) = G(v,l,α) / { 4 (n⋅v) (n⋅l) }
+/// such that f_r becomes
+/// f_r(v,l) = D(h,α) V(v,l,α) F(v,h,f0)
+/// where
+/// V(v,l,α) = 0.5 / { n⋅l sqrt((n⋅v)^2 (1−α2) + α2) + n⋅v sqrt((n⋅l)^2 (1−α2) + α2) }
+/// Note the two sqrt's, that may be slow on mobile, see https://google.github.io/filament/Filament.md.html#listing_approximatedspecularv
 fn V_SmithGGXCorrelated(roughness: f32, NdotV: f32, NdotL: f32) -> f32 {
     let a2 = roughness * roughness;
     let lambdaV = NdotL * sqrt((NdotV - a2 * NdotV) * NdotV + a2);
@@ -190,7 +190,7 @@ fn V_SmithGGXCorrelated(roughness: f32, NdotV: f32, NdotL: f32) -> f32 {
     return v;
 }
 
-// The visibility function, anisotropic variant.
+/// The visibility function, anisotropic variant.
 fn V_GGX_anisotropic(
     at: f32,
     ab: f32,
@@ -207,8 +207,8 @@ fn V_GGX_anisotropic(
     return saturate(v);
 }
 
-// Probability-density function that matches the bounded VNDF sampler
-// https://gpuopen.com/download/Bounded_VNDF_Sampling_for_Smith-GGX_Reflections.pdf (Listing 2)
+/// Probability-density function that matches the bounded VNDF sampler
+/// https://gpuopen.com/download/Bounded_VNDF_Sampling_for_Smith-GGX_Reflections.pdf (Listing 2)
 fn ggx_vndf_pdf(i: vec3<f32>, NdotH: f32, roughness: f32) -> f32 {
     let ndf = D_GGX(roughness, NdotH);
 
@@ -229,7 +229,7 @@ fn ggx_vndf_pdf(i: vec3<f32>, NdotH: f32, roughness: f32) -> f32 {
     return ndf * (t - i.z) / (2.0 * len2);
 }
 
-// https://gpuopen.com/download/Bounded_VNDF_Sampling_for_Smith-GGX_Reflections.pdf (Listing 1)
+/// https://gpuopen.com/download/Bounded_VNDF_Sampling_for_Smith-GGX_Reflections.pdf (Listing 1)
 fn sample_visible_ggx(
     xi: vec2<f32>,
     roughness: f32,
@@ -283,7 +283,7 @@ fn sample_visible_ggx(
     return reflect(-view, H);
 }
 
-// Smith geometric shadowing function
+/// Smith geometric shadowing function
 fn G_Smith(NdotV: f32, NdotL: f32, roughness: f32) -> f32 {
     let k = roughness / 2.0;
     let GGXL = NdotL / (NdotL * (1.0 - k) + k);
@@ -291,23 +291,26 @@ fn G_Smith(NdotV: f32, NdotL: f32, roughness: f32) -> f32 {
     return GGXL * GGXV;
 }
 
-// A simpler, but nonphysical, alternative to Smith-GGX. We use this for
-// clearcoat, per the Filament spec.
-//
-// https://google.github.io/filament/Filament.md.html#materialsystem/clearcoatmodel
+/// A simpler, but nonphysical, alternative to Smith-GGX. We use this for
+/// clearcoat, per the Filament spec.
+///
+/// https://google.github.io/filament/Filament.md.html#materialsystem/clearcoatmodel
 fn V_Kelemen(LdotH: f32) -> f32 {
     let l_dot_h = max(LdotH, 0.0001);
     return 0.25 / (l_dot_h * l_dot_h);
 }
 
-// Fresnel function
-// see https://google.github.io/filament/Filament.md.html#citation-schlick94
-// F_Schlick(v,h,f_0,f_90) = f_0 + (f_90 − f_0) (1 − v⋅h)^5
+/// Fresnel function
+/// see https://google.github.io/filament/Filament.md.html#citation-schlick94
+/// F_Schlick(v,h,f_0,f_90) = f_0 + (f_90 − f_0) (1 − v⋅h)^5
 fn F_Schlick_vec(f0: vec3<f32>, f90: f32, VdotH: f32) -> vec3<f32> {
     // not using mix to keep the vec3 and float versions identical
     return f0 + (f90 - f0) * pow(1.0 - VdotH, 5.0);
 }
 
+/// Fresnel function
+/// see https://google.github.io/filament/Filament.md.html#citation-schlick94
+/// F_Schlick(v,h,f_0,f_90) = f_0 + (f_90 − f_0) (1 − v⋅h)^5
 fn F_Schlick(f0: f32, f90: f32, VdotH: f32) -> f32 {
     // not using mix to keep the vec3 and float versions identical
     return f0 + (f90 - f0) * pow(1.0 - VdotH, 5.0);
@@ -320,11 +323,11 @@ fn fresnel(f0: vec3<f32>, LdotH: f32) -> vec3<f32> {
     return F_Schlick_vec(f0, f90, LdotH);
 }
 
-// Given distribution, visibility, and Fresnel term, calculates the final
-// specular light.
-//
-// Multiscattering approximation:
-// <https://google.github.io/filament/Filament.md.html#listing_energycompensationimpl>
+/// Given distribution, visibility, and Fresnel term, calculates the final
+/// specular light.
+///
+/// Multiscattering approximation:
+/// <https://google.github.io/filament/Filament.md.html#listing_energycompensationimpl>
 fn specular_multiscatter(
     D: f32,
     V: f32,
@@ -343,7 +346,7 @@ fn specular_multiscatter(
 // Specular BRDF
 // https://google.github.io/filament/Filament.md.html#materialsystem/specularbrdf
 
-// N, V, and L must all be normalized.
+/// N, V, and L must all be normalized.
 fn derive_lighting_input(N: vec3<f32>, V: vec3<f32>, L: vec3<f32>) -> DerivedLightingInput {
     var input: DerivedLightingInput;
     var H: vec3<f32> = normalize(L + V);
@@ -354,7 +357,7 @@ fn derive_lighting_input(N: vec3<f32>, V: vec3<f32>, L: vec3<f32>) -> DerivedLig
     return input;
 }
 
-// Returns L in the `xyz` components and the modified roughness in the `w` component.
+/// Returns L in the `xyz` components and the modified roughness in the `w` component.
 fn compute_specular_layer_values_for_point_light(
     input: ptr<function, LightingInput>,
     layer: u32,
@@ -397,8 +400,8 @@ fn compute_specular_layer_values_for_point_light(
     return vec4(L, a_prime);
 }
 
-// Cook-Torrance approximation of the microfacet model integration using Fresnel law F to model f_m
-// f_r(v,l) = { D(h,α) G(v,l,α) F(v,h,f0) } / { 4 (n⋅v) (n⋅l) }
+/// Cook-Torrance approximation of the microfacet model integration using Fresnel law F to model f_m
+/// f_r(v,l) = { D(h,α) G(v,l,α) F(v,h,f0) } / { 4 (n⋅v) (n⋅l) }
 fn specular(
     input: ptr<function, LightingInput>,
     derived_input: ptr<function, DerivedLightingInput>,
@@ -424,11 +427,11 @@ fn specular(
     return Fr;
 }
 
-// Calculates the specular light for the clearcoat layer. Returns Fc, the
-// Fresnel term, in the first channel, and Frc, the specular clearcoat light, in
-// the second channel.
-//
-// <https://google.github.io/filament/Filament.md.html#listing_clearcoatbrdf>
+/// Calculates the specular light for the clearcoat layer. Returns Fc, the
+/// Fresnel term, in the first channel, and Frc, the specular clearcoat light, in
+/// the second channel.
+///
+/// <https://google.github.io/filament/Filament.md.html#listing_clearcoatbrdf>
 fn specular_clearcoat(
     input: ptr<function, LightingInput>,
     derived_input: ptr<function, DerivedLightingInput>,
@@ -490,20 +493,20 @@ fn specular_anisotropy(
     return Fr;
 }
 
-// Diffuse BRDF
-// https://google.github.io/filament/Filament.md.html#materialsystem/diffusebrdf
-// fd(v,l) = σ/π * 1 / { |n⋅v||n⋅l| } ∫Ω D(m,α) G(v,l,m) (v⋅m) (l⋅m) dm
-//
-// simplest approximation
-// float Fd_Lambert() {
-//     return 1.0 / PI;
-// }
-//
-// vec3 Fd = diffuseColor * Fd_Lambert();
-//
-// Disney approximation
-// See https://google.github.io/filament/Filament.md.html#citation-burley12
-// minimal quality difference
+/// Diffuse BRDF
+/// https://google.github.io/filament/Filament.md.html#materialsystem/diffusebrdf
+/// fd(v,l) = σ/π * 1 / { |n⋅v||n⋅l| } ∫Ω D(m,α) G(v,l,m) (v⋅m) (l⋅m) dm
+///
+/// simplest approximation
+/// float Fd_Lambert() {
+///     return 1.0 / PI;
+/// }
+///
+/// vec3 Fd = diffuseColor * Fd_Lambert();
+///
+/// Disney approximation
+/// See https://google.github.io/filament/Filament.md.html#citation-burley12
+/// minimal quality difference
 fn Fd_Burley(
     input: ptr<function, LightingInput>,
     derived_input: ptr<function, DerivedLightingInput>,
@@ -614,14 +617,14 @@ fn cubemap_uv(direction: vec3<f32>, cubemap_type: u32) -> vec2<f32> {
     return (vec2<f32>(corner_uv) + face_uv) * face_size;
 }
 
-// This is a modification to Karis 2013 for area lights to fix an issue where the specular
-// reflection on smooth materials looks too rough and dim. We lerp between the base roughness
-// and Karis2013 roughness with a lerp factor tuned by looking at reference renders. The goal
-// is to preserve sharp specular highlights on smooth materials, without blowing out specular
-// highlights on rough materials.
-//
-// The ideal solution is to switch to Linearly Transformed Cosines, which is more accurate in
-// all cases, and a popular choice for realtime.
+/// This is a modification to Karis 2013 for area lights to fix an issue where the specular
+/// reflection on smooth materials looks too rough and dim. We lerp between the base roughness
+/// and Karis2013 roughness with a lerp factor tuned by looking at reference renders. The goal
+/// is to preserve sharp specular highlights on smooth materials, without blowing out specular
+/// highlights on rough materials.
+///
+/// The ideal solution is to switch to Linearly Transformed Cosines, which is more accurate in
+/// all cases, and a popular choice for realtime.
 fn specular_fix_remap(a: f32) -> f32 {
     let inv_a_sq = (1.0 - a) * (1.0 - a);
     return 1.0 - inv_a_sq * inv_a_sq;
@@ -943,12 +946,12 @@ color *= (*light).color.rgb * texture_sample;
     return color;
 }
 
-// Linearly Transformed Cosines (LTC) area light evaluation.
-// Based on: Heitz et al. 2016, "Real-Time Polygonal-Light Shading with Linearly Transformed Cosines"
-
-// Integrate one edge of the spherical polygon formed by the LTC-transformed quad.
-// Implements Eq. 11 using a polynomial approximation based on https://advances.realtimerendering.com/s2016/s2016_ltc_rnd.pdf
-// Using the equation as-is produces visible artifacts.
+/// Linearly Transformed Cosines (LTC) area light evaluation.
+/// Based on: Heitz et al. 2016, "Real-Time Polygonal-Light Shading with Linearly Transformed Cosines"
+///
+/// Integrate one edge of the spherical polygon formed by the LTC-transformed quad.
+/// Implements Eq. 11 using a polynomial approximation based on https://advances.realtimerendering.com/s2016/s2016_ltc_rnd.pdf
+/// Using the equation as-is produces visible artifacts.
 fn ltc_integrate_edge(v1: vec3<f32>, v2: vec3<f32>) -> f32 {
     let x = dot(v1, v2);
     let y = abs(x);
@@ -1016,8 +1019,8 @@ fn ltc_integrate_quad(
 }
 
 @if(AREA_LIGHT_LUTS)
-// Decodes a rect light packed into a `ClusteredLight` (see `GpuClusteredLight`
-// in bevy_pbr/src/cluster/mod.rs).
+/// Decodes a rect light packed into a `ClusteredLight` (see `GpuClusteredLight`
+/// in bevy_pbr/src/cluster/mod.rs).
 fn unpack_clustered_rect_light(light_id: u32) -> RectLight {
     let light = &view_bindings::clustered_lights.data[light_id];
     let rotation = (*light).light_custom_data;

--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wesl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wesl
@@ -14,11 +14,11 @@ import package::{
 @if(BINDLESS)
 import package::render::pbr_bindings::material_indices;
 
-// Cutoff used for the premultiplied alpha modes BLEND, ADD, and ALPHA_TO_COVERAGE.
+/// Cutoff used for the premultiplied alpha modes BLEND, ADD, and ALPHA_TO_COVERAGE.
 const PREMULTIPLIED_ALPHA_CUTOFF = 0.05;
 
-// Reusable alpha discard logic suitable for use by custom materials in the prepass.
-// We can use a simplified version of alpha_discard() here since we only need to handle the alpha_cutoff
+/// Reusable alpha discard logic suitable for use by custom materials in the prepass.
+/// We can use a simplified version of alpha_discard() here since we only need to handle the alpha_cutoff
 fn prepass_alpha_discard(material_flags: u32, alpha_cutoff: f32, output_color: vec4<f32>) {
     let alpha_mode = material_flags & pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS;
     if alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MASK {
@@ -38,8 +38,8 @@ fn prepass_alpha_discard(material_flags: u32, alpha_cutoff: f32, output_color: v
     }
 }
 
-// Samples the StandardMaterial's base color (including the base color texture, if any) and then
-// invokes `prepass_alpha_discard` with the material's flags and alpha cutoff.
+/// Samples the StandardMaterial's base color (including the base color texture, if any) and then
+/// invokes `prepass_alpha_discard` with the material's flags and alpha cutoff.
 fn prepass_sample_color_and_alpha_discard(in: VertexOutput) {
 
 @if(MAY_DISCARD) {

--- a/crates/bevy_pbr/src/render/pbr_types.wesl
+++ b/crates/bevy_pbr/src/render/pbr_types.wesl
@@ -17,7 +17,7 @@ struct StandardMaterial {
     clearcoat_perceptual_roughness: f32,
     anisotropy_strength: f32,
     anisotropy_rotation: vec2<f32>,
-    // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
+    /// 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32,
     alpha_cutoff: f32,
     parallax_depth_scale: f32,
@@ -62,7 +62,7 @@ const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MULTIPLY: u32               = 5u << 29u
 const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_ALPHA_TO_COVERAGE: u32      = 6u << 29u;
 
 
-// Creates a StandardMaterial with default values
+/// Creates a StandardMaterial with default values
 fn standard_material_new() -> StandardMaterial {
     var material: StandardMaterial;
 
@@ -94,35 +94,35 @@ fn standard_material_new() -> StandardMaterial {
 
 struct PbrInput {
     material: StandardMaterial,
-    // Note: this gets monochromized upon deferred PbrInput reconstruction.
+    /// Note: this gets monochromized upon deferred PbrInput reconstruction.
     diffuse_occlusion: vec3<f32>,
-    // Note: this is 1.0 (entirely unoccluded) when SSAO and SSR are off.
+    /// Note: this is 1.0 (entirely unoccluded) when SSAO and SSR are off.
     specular_occlusion: f32,
     frag_coord: vec4<f32>,
     world_position: vec4<f32>,
-    // Normalized world normal used for shadow mapping as normal-mapping is not used for shadow
-    // mapping
+    /// Normalized world normal used for shadow mapping as normal-mapping is not used for shadow
+    /// mapping
     world_normal: vec3<f32>,
-    // Normalized normal-mapped world normal used for lighting
+    /// Normalized normal-mapped world normal used for lighting
     N: vec3<f32>,
-    // Normalized view vector in world space, pointing from the fragment world position toward the
-    // view world position
+    /// Normalized view vector in world space, pointing from the fragment world position toward the
+    /// view world position
     V: vec3<f32>,
     lightmap_light: vec3<f32>,
     clearcoat_N: vec3<f32>,
     anisotropy_strength: f32,
-    // These two aren't specific to anisotropy, but we only fill them in if
-    // we're doing anisotropy, so they're prefixed with `anisotropy_`.
+    /// These two aren't specific to anisotropy, but we only fill them in if
+    /// we're doing anisotropy, so they're prefixed with `anisotropy_`.
     anisotropy_T: vec3<f32>,
     anisotropy_B: vec3<f32>,
     is_orthographic: bool,
     flags: u32,
-    // Multiplier applied to all directional lights before cascade and contact shadows,
-    // use this for custom shadow maps. Defaults to 1.0. 
+    /// Multiplier applied to all directional lights before cascade and contact shadows,
+    /// use this for custom shadow maps. Defaults to 1.0.
     directional_shadow_factor: f32,
 };
 
-// Creates a PbrInput with default values
+/// Creates a PbrInput with default values
 fn pbr_input_new() -> PbrInput {
     var pbr_input: PbrInput;
 

--- a/crates/bevy_pbr/src/render/reset_indirect_batch_sets.wesl
+++ b/crates/bevy_pbr/src/render/reset_indirect_batch_sets.wesl
@@ -1,10 +1,10 @@
-// Resets the indirect draw counts to zero.
-//
-// This shader is needed because we reuse the same indirect batch set count
-// buffer (i.e. the buffer that gets passed to `multi_draw_indirect_count` to
-// determine how many objects to draw) between phases (early, late, and main).
-// Before launching `build_indirect_params.wesl`, we need to reinitialize the
-// value to 0.
+//! Resets the indirect draw counts to zero.
+//!
+//! This shader is needed because we reuse the same indirect batch set count
+//! buffer (i.e. the buffer that gets passed to `multi_draw_indirect_count` to
+//! determine how many objects to draw) between phases (early, late, and main).
+//! Before launching `build_indirect_params.wesl`, we need to reinitialize the
+//! value to 0.
 
 import bevy_render::occlusion_culling::mesh_preprocess_types::IndirectBatchSet;
 

--- a/crates/bevy_pbr/src/render/rgb9e5.wesl
+++ b/crates/bevy_pbr/src/render/rgb9e5.wesl
@@ -23,7 +23,7 @@ fn floor_log2_(x: f32) -> i32 {
     return i32(biasedexponent) - 127;
 }
 
-// https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_shared_exponent.txt
+/// https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_shared_exponent.txt
 fn vec3_to_rgb9e5_(rgb_in: vec3<f32>) -> u32 {
     let rgb = clamp(rgb_in, vec3(0.0), vec3(MAX_RGB9E5_));
 
@@ -38,12 +38,12 @@ fn vec3_to_rgb9e5_(rgb_in: vec3<f32>) -> u32 {
     }
 
     let n = vec3<u32>(floor(rgb / denom + 0.5));
-    
+
     return (u32(exp_shared) << 27u) | (n.b << 18u) | (n.g << 9u) | (n.r << 0u);
 }
 
-// Builtin extractBits() is not working on WEBGL or DX12
-// DX12: HLSL: Unimplemented("write_expr_math ExtractBits")
+/// Builtin extractBits() is not working on WEBGL or DX12
+/// DX12: HLSL: Unimplemented("write_expr_math ExtractBits")
 fn extract_bits(value: u32, offset: u32, bits: u32) -> u32 {
     let mask = (1u << bits) - 1u;
     return (value >> offset) & mask;

--- a/crates/bevy_pbr/src/render/shadow_sampling.wesl
+++ b/crates/bevy_pbr/src/render/shadow_sampling.wesl
@@ -5,7 +5,7 @@ import package::render::{
 };
 import bevy_render::maths::{orthonormalize, PI};
 
-// Do the lookup, using HW 2x2 PCF and comparison
+/// Do the lookup, using HW 2x2 PCF and comparison
 fn sample_shadow_map_hardware(light_local: vec2<f32>, depth: f32, array_index: i32) -> f32 {
     @if(NO_ARRAY_TEXTURES_SUPPORT)
     return textureSampleCompare(
@@ -24,8 +24,8 @@ fn sample_shadow_map_hardware(light_local: vec2<f32>, depth: f32, array_index: i
     );
 }
 
-// Does a single sample of the blocker search, a part of the PCSS algorithm.
-// This is the variant used for directional lights.
+/// Does a single sample of the blocker search, a part of the PCSS algorithm.
+/// This is the variant used for directional lights.
 fn search_for_blockers_in_shadow_map_hardware(
     light_local: vec2<f32>,
     depth: f32,
@@ -68,10 +68,10 @@ const SPOT_SHADOW_TEXEL_SIZE: f32 = 0.0134277345;
 const POINT_SHADOW_SCALE: f32 = 0.003;
 const POINT_SHADOW_TEMPORAL_OFFSET_SCALE: f32 = 0.5;
 
-// These are the standard MSAA sample point positions from D3D. They were chosen
-// to get a reasonable distribution that's not too regular.
-//
-// https://learn.microsoft.com/en-us/windows/win32/api/d3d11/ne-d3d11-d3d11_standard_multisample_quality_levels?redirectedfrom=MSDN
+/// These are the standard MSAA sample point positions from D3D. They were chosen
+/// to get a reasonable distribution that's not too regular.
+///
+/// https://learn.microsoft.com/en-us/windows/win32/api/d3d11/ne-d3d11-d3d11_standard_multisample_quality_levels?redirectedfrom=MSDN
 const D3D_SAMPLE_POINT_POSITIONS: array<vec2<f32>, 8> = array(
     vec2( 0.125, -0.375),
     vec2(-0.125,  0.375),
@@ -83,9 +83,9 @@ const D3D_SAMPLE_POINT_POSITIONS: array<vec2<f32>, 8> = array(
     vec2( 0.875, -0.875),
 );
 
-// And these are the coefficients corresponding to the probability distribution
-// function of a 2D Gaussian lobe with zero mean and the identity covariance
-// matrix at those points.
+/// And these are the coefficients corresponding to the probability distribution
+/// function of a 2D Gaussian lobe with zero mean and the identity covariance
+/// matrix at those points.
 const D3D_SAMPLE_POINT_COEFFS: array<f32, 8> = array(
     0.157112,
     0.157112,
@@ -97,7 +97,7 @@ const D3D_SAMPLE_POINT_COEFFS: array<f32, 8> = array(
     0.079001,
 );
 
-// https://web.archive.org/web/20230210095515/http://the-witness.net/news/2013/09/shadow-mapping-summary-part-1
+/// https://web.archive.org/web/20230210095515/http://the-witness.net/news/2013/09/shadow-mapping-summary-part-1
 fn sample_shadow_map_castano_thirteen(light_local: vec2<f32>, depth: f32, array_index: i32) -> f32 {
     let shadow_map_size = vec2<f32>(textureDimensions(view_bindings::directional_shadow_textures));
     let inv_shadow_map_size = 1.0 / shadow_map_size;
@@ -146,9 +146,9 @@ fn map(min1: f32, max1: f32, min2: f32, max2: f32, value: f32) -> f32 {
     return min2 + (value - min1) * (max2 - min2) / (max1 - min1);
 }
 
-// Creates a random rotation matrix using interleaved gradient noise.
-//
-// See: https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare/
+/// Creates a random rotation matrix using interleaved gradient noise.
+///
+/// See: https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare/
 fn random_rotation_matrix(scale: vec2<f32>, temporal: bool) -> mat2x2<f32> {
     let random_angle = 2.0 * PI * interleaved_gradient_noise(
         scale, select(1u, view_bindings::globals.frame_count, temporal));
@@ -159,9 +159,9 @@ fn random_rotation_matrix(scale: vec2<f32>, temporal: bool) -> mat2x2<f32> {
     );
 }
 
-// Calculates the distance between spiral samples for the given texel size and
-// penumbra size. This is used for the Jimenez '14 (i.e. temporal) variant of
-// shadow sampling.
+/// Calculates the distance between spiral samples for the given texel size and
+/// penumbra size. This is used for the Jimenez '14 (i.e. temporal) variant of
+/// shadow sampling.
 fn calculate_uv_offset_scale_jimenez_fourteen(texel_size: f32, blur_size: f32) -> vec2<f32> {
     let shadow_map_size = vec2<f32>(textureDimensions(view_bindings::directional_shadow_textures));
 
@@ -204,16 +204,16 @@ fn sample_shadow_map_jimenez_fourteen(
     return sum / 8.0;
 }
 
-// Performs the blocker search portion of percentage-closer soft shadows (PCSS).
-// This is the variation used for directional lights.
-//
-// We can't use Castano '13 here because that has a hard-wired fixed size, while
-// the PCSS algorithm requires a search size that varies based on the size of
-// the light. So we instead use the D3D sample point positions, spaced according
-// to the search size, to provide a sample pattern in a similar manner to the
-// cubemap sampling approach we use for PCF.
-//
-// `search_size` is the size of the search region in texels.
+/// Performs the blocker search portion of percentage-closer soft shadows (PCSS).
+/// This is the variation used for directional lights.
+///
+/// We can't use Castano '13 here because that has a hard-wired fixed size, while
+/// the PCSS algorithm requires a search size that varies based on the size of
+/// the light. So we instead use the D3D sample point positions, spaced according
+/// to the search size, to provide a sample pattern in a similar manner to the
+/// cubemap sampling approach we use for PCF.
+///
+/// `search_size` is the size of the search region in texels.
 fn search_for_blockers_in_shadow_map(
     light_local: vec2<f32>,
     depth: f32,
@@ -271,17 +271,17 @@ fn sample_shadow_map(
     return 0.0;
 }
 
-// Samples the shadow map for a directional light when percentage-closer soft
-// shadows are being used.
-//
-// We first search for a *blocker*, which is the average depth value of any
-// shadow map samples that are adjacent to the sample we're considering. That
-// allows us to determine the penumbra size; a larger gap between the blocker
-// and the depth of this sample results in a wider penumbra. Finally, we sample
-// the shadow map the same way we do in PCF, using that penumbra width.
-//
-// A good overview of the technique:
-// <https://medium.com/@varunm100/soft-shadows-for-mobile-ar-9e8da2e6f4ba>
+/// Samples the shadow map for a directional light when percentage-closer soft
+/// shadows are being used.
+///
+/// We first search for a *blocker*, which is the average depth value of any
+/// shadow map samples that are adjacent to the sample we're considering. That
+/// allows us to determine the penumbra size; a larger gap between the blocker
+/// and the depth of this sample results in a wider penumbra. Finally, we sample
+/// the shadow map the same way we do in PCF, using that penumbra width.
+///
+/// A good overview of the technique:
+/// <https://medium.com/@varunm100/soft-shadows-for-mobile-ar-9e8da2e6f4ba>
 fn sample_shadow_map_pcss(
     light_local: vec2<f32>,
     depth: f32,
@@ -333,8 +333,8 @@ fn sample_shadow_cubemap_hardware(light_local: vec3<f32>, depth: f32, light_id: 
     );
 }
 
-// Performs one sample of the blocker search. This variation of the blocker
-// search function is for point and spot lights.
+/// Performs one sample of the blocker search. This variation of the blocker
+/// search function is for point and spot lights.
 fn search_for_blockers_in_shadow_cubemap_hardware(
     light_local: vec3<f32>,
     depth: f32,
@@ -387,11 +387,11 @@ fn sample_shadow_cubemap_at_offset(
     ) * coeff;
 }
 
-// Computes the search position and performs one sample of the blocker search.
-// This variation of the blocker search function is for point and spot lights.
-//
-// `x_basis`, `y_basis`, and `light_local` form an orthonormal basis over which
-// the blocker search happens.
+/// Computes the search position and performs one sample of the blocker search.
+/// This variation of the blocker search function is for point and spot lights.
+///
+/// `x_basis`, `y_basis`, and `light_local` form an orthonormal basis over which
+/// the blocker search happens.
 fn search_for_blockers_in_shadow_cubemap_at_offset(
     position: vec2<f32>,
     x_basis: vec3<f32>,
@@ -407,11 +407,11 @@ fn search_for_blockers_in_shadow_cubemap_at_offset(
     );
 }
 
-// This more or less does what Castano13 does, but in 3D space. Castano13 is
-// essentially an optimized 2D Gaussian filter that takes advantage of the
-// bilinear filtering hardware to reduce the number of samples needed. This
-// trick doesn't apply to cubemaps, so we manually apply a Gaussian filter over
-// the standard 8xMSAA pattern instead.
+/// This more or less does what Castano13 does, but in 3D space. Castano13 is
+/// essentially an optimized 2D Gaussian filter that takes advantage of the
+/// bilinear filtering hardware to reduce the number of samples needed. This
+/// trick doesn't apply to cubemaps, so we manually apply a Gaussian filter over
+/// the standard 8xMSAA pattern instead.
 fn sample_shadow_cubemap_gaussian(
     light_local: vec3<f32>,
     depth: f32,
@@ -451,9 +451,9 @@ fn sample_shadow_cubemap_gaussian(
     return sum;
 }
 
-// This is a port of the Jimenez14 filter above to the 3D space. It jitters the
-// points in the spiral pattern after first creating a 2D orthonormal basis
-// along the principal light direction.
+/// This is a port of the Jimenez14 filter above to the 3D space. It jitters the
+/// points in the spiral pattern after first creating a 2D orthonormal basis
+/// along the principal light direction.
 fn sample_shadow_cubemap_jittered(
     light_local: vec3<f32>,
     depth: f32,
@@ -529,13 +529,13 @@ fn sample_shadow_cubemap(
     return 0.0;
 }
 
-// Searches for PCSS blockers in a cubemap. This is the variant of the blocker
-// search used for point and spot lights.
-//
-// This follows the logic in `sample_shadow_cubemap_gaussian`, but uses linear
-// sampling instead of percentage-closer filtering.
-//
-// The `scale` parameter represents the size of the light.
+/// Searches for PCSS blockers in a cubemap. This is the variant of the blocker
+/// search used for point and spot lights.
+///
+/// This follows the logic in `sample_shadow_cubemap_gaussian`, but uses linear
+/// sampling instead of percentage-closer filtering.
+///
+/// The `scale` parameter represents the size of the light.
 fn search_for_blockers_in_shadow_cubemap(
     light_local: vec3<f32>,
     depth: f32,
@@ -571,11 +571,11 @@ fn search_for_blockers_in_shadow_cubemap(
     return sum.x / sum.y;
 }
 
-// Samples the shadow map for a point or spot light when percentage-closer soft
-// shadows are being used.
-//
-// A good overview of the technique:
-// <https://medium.com/@varunm100/soft-shadows-for-mobile-ar-9e8da2e6f4ba>
+/// Samples the shadow map for a point or spot light when percentage-closer soft
+/// shadows are being used.
+///
+/// A good overview of the technique:
+/// <https://medium.com/@varunm100/soft-shadows-for-mobile-ar-9e8da2e6f4ba>
 fn sample_shadow_cubemap_pcss(
     light_local: vec3<f32>,
     distance_to_light: f32,

--- a/crates/bevy_pbr/src/render/shadows.wesl
+++ b/crates/bevy_pbr/src/render/shadows.wesl
@@ -142,10 +142,10 @@ fn get_cascade_index(light_id: u32, view_z: f32) -> u32 {
     return (*light).num_cascades;
 }
 
-// Converts from world space to the uv position in the light's shadow map.
-//
-// The depth is stored in the return value's z coordinate. If the return value's
-// w coordinate is 0.0, then we landed outside the shadow map entirely.
+/// Converts from world space to the uv position in the light's shadow map.
+///
+/// The depth is stored in the return value's z coordinate. If the return value's
+/// w coordinate is 0.0, then we landed outside the shadow map entirely.
 fn world_to_directional_light_local(
     light_id: u32,
     cascade_index: u32,

--- a/crates/bevy_pbr/src/render/skinning.wesl
+++ b/crates/bevy_pbr/src/render/skinning.wesl
@@ -6,12 +6,12 @@ import package::render::mesh_bindings::mesh;
 @if(SKINNED && !SKINS_USE_UNIFORM_BUFFERS)
 @group(2) @binding(1) var<storage> joint_matrices: array<mat4x4<f32>>;
 
-// An array of matrices specifying the joint positions from the previous frame.
-//
-// This is used for motion vector computation.
-//
-// If this is the first frame, or we're otherwise prevented from using data from
-// the previous frame, this is simply the same as `joint_matrices` above.
+/// An array of matrices specifying the joint positions from the previous frame.
+///
+/// This is used for motion vector computation.
+///
+/// If this is the first frame, or we're otherwise prevented from using data from
+/// the previous frame, this is simply the same as `joint_matrices` above.
 @if(SKINNED && SKINS_USE_UNIFORM_BUFFERS)
 @group(2) @binding(6) var<uniform> prev_joint_matrices: SkinnedMesh;
 @if(SKINNED && !SKINS_USE_UNIFORM_BUFFERS)
@@ -37,10 +37,10 @@ fn skin_model(
         + weights.w * joint_matrices[skin_index + indexes.w];
 }
 
-// Returns the skinned position of a vertex with the given weights from the
-// previous frame.
-//
-// This is used for motion vector computation.
+/// Returns the skinned position of a vertex with the given weights from the
+/// previous frame.
+///
+/// This is used for motion vector computation.
 @if(SKINNED)
 fn skin_prev_model(
     indexes: vec4<u32>,

--- a/crates/bevy_pbr/src/render/unpack_bins.wesl
+++ b/crates/bevy_pbr/src/render/unpack_bins.wesl
@@ -1,67 +1,67 @@
-// A compute shader that unpacks bins.
-//
-// This shader runs before mesh preprocessing in order to generate
-// `PreprocessWorkItem`s from cached bins. A single dispatch of this shader
-// corresponds to a single batch set, and one invocation of this shader
-// corresponds to one binned entity. Each shader invocation builds the work item
-// for its entity by copying over the mesh input uniform index and calculating
-// the position of the command in the indirect parameters buffer that will draw
-// that entity.
+//! A compute shader that unpacks bins.
+//!
+//! This shader runs before mesh preprocessing in order to generate
+//! `PreprocessWorkItem`s from cached bins. A single dispatch of this shader
+//! corresponds to a single batch set, and one invocation of this shader
+//! corresponds to one binned entity. Each shader invocation builds the work item
+//! for its entity by copying over the mesh input uniform index and calculating
+//! the position of the command in the indirect parameters buffer that will draw
+//! that entity.
 
 import bevy_render::occlusion_culling::mesh_preprocess_types::{BinMetadata, PreprocessWorkItem};
 
-// Information needed to unpack bins belonging to a single batch set.
+/// Information needed to unpack bins belonging to a single batch set.
 struct BinUnpackingMetadata {
-    // The index of the first `PreprocessWorkItem` that this compute shader
-    // dispatch is to write to.
+    /// The index of the first `PreprocessWorkItem` that this compute shader
+    /// dispatch is to write to.
     base_output_work_item_index: u32,
-    // The index of the first GPU indirect parameters command for this batch
-    // set.
+    /// The index of the first GPU indirect parameters command for this batch
+    /// set.
     base_indirect_parameters_index: u32,
-    // The number of binned mesh instances in the `binned_mesh_instances`
-    // array.
+    /// The number of binned mesh instances in the `binned_mesh_instances`
+    /// array.
     binned_mesh_instance_count: u32,
-    // Padding.
+    /// Padding.
     pad_a: u32,
-    // Padding.
+    /// Padding.
     pad_b: array<vec4<u32>, 15>,
 };
 
-// One mesh instance in a bin.
-//
-// This corresponds to the CPU-side `GpuRenderBinnedMeshInstance` structure.
-//
-// Note that this structure isn't sorted within the
-// `binned_mesh_instances` buffer. Instances from the same bin aren't
-// guaranteed to be adjacent to one another.
+/// One mesh instance in a bin.
+///
+/// This corresponds to the CPU-side `GpuRenderBinnedMeshInstance` structure.
+///
+/// Note that this structure isn't sorted within the
+/// `binned_mesh_instances` buffer. Instances from the same bin aren't
+/// guaranteed to be adjacent to one another.
 struct BinnedMeshInstance {
-    // The index of the `MeshInputUniform` corresponding to this mesh instance
-    // in the `MeshInputUniform` buffer.
+    /// The index of the `MeshInputUniform` corresponding to this mesh instance
+    /// in the `MeshInputUniform` buffer.
     input_uniform_index: u32,
-    // The index of the bin that this mesh instance belongs to.
+    /// The index of the bin that this mesh instance belongs to.
     bin_index: u32,
 };
 
-// Metadata for the entire batch set.
+/// Metadata for the entire batch set.
 @group(0) @binding(0) var<uniform> bin_unpacking_metadata: BinUnpackingMetadata;
 
-// The input array of `BinnedMeshInstance`s.
-//
-// Note that this array isn't sorted.
+/// The input array of `BinnedMeshInstance`s.
+///
+/// Note that this array isn't sorted.
 @group(0) @binding(1) var<storage> binned_mesh_instances: array<BinnedMeshInstance>;
 
-// The output list of `PreprocessWorkItem`s.
+/// The output list of `PreprocessWorkItem`s.
 @group(0) @binding(2) var<storage, read_write> preprocess_work_items: array<PreprocessWorkItem>;
 
-// The bin metadata, which contains the index of the GPU indirect parameters for
-// this bin, relative to the start of the indirect parameters for this batch
-// set.
-//
-// This is indexed by the bin metadata index below.
+/// The bin metadata, which contains the index of the GPU indirect parameters for
+/// this bin, relative to the start of the indirect parameters for this batch
+/// set.
+///
+/// This is indexed by the bin metadata index below.
 @group(0) @binding(3) var<storage> bin_metadata: array<BinMetadata>;
 
-// A mapping from the bin index to the metadata index within the `bin_metadata`
-// buffer.
+/// A mapping from the bin index to the metadata index within the `bin_metadata`
+/// buffer.
 @group(0) @binding(4) var<storage> bin_index_to_bin_metadata_index: array<u32>;
 
 @compute

--- a/crates/bevy_pbr/src/render/utils.wesl
+++ b/crates/bevy_pbr/src/render/utils.wesl
@@ -1,63 +1,63 @@
 import package::render::rgb9e5;
 import bevy_render::maths::{PI, PI_2, orthonormalize};
 
-// Generates a random u32 in range [0, u32::MAX].
-//
-// `state` is a mutable reference to a u32 used as the seed.
-//
-// Values are generated via "white noise", with no correlation between values.
-// In shaders, you often want spatial and/or temporal correlation. Use a different RNG method for these use cases.
-//
-// https://www.pcg-random.org
-// https://www.reedbeta.com/blog/hash-functions-for-gpu-rendering
+/// Generates a random u32 in range [0, u32::MAX].
+///
+/// `state` is a mutable reference to a u32 used as the seed.
+///
+/// Values are generated via "white noise", with no correlation between values.
+/// In shaders, you often want spatial and/or temporal correlation. Use a different RNG method for these use cases.
+///
+/// https://www.pcg-random.org
+/// https://www.reedbeta.com/blog/hash-functions-for-gpu-rendering
 fn rand_u(state: ptr<function, u32>) -> u32 {
     *state = *state * 747796405u + 2891336453u;
     let word = ((*state >> ((*state >> 28u) + 4u)) ^ *state) * 277803737u;
     return (word >> 22u) ^ word;
 }
 
-// Generates a random f32 in range [0, 1.0].
+/// Generates a random f32 in range [0, 1.0].
 fn rand_f(state: ptr<function, u32>) -> f32 {
     *state = *state * 747796405u + 2891336453u;
     let word = ((*state >> ((*state >> 28u) + 4u)) ^ *state) * 277803737u;
     return f32((word >> 22u) ^ word) * bitcast<f32>(0x2f800004u);
 }
 
-// Generates a random vec2<f32> where each value is in range [0, 1.0].
+/// Generates a random vec2<f32> where each value is in range [0, 1.0].
 fn rand_vec2f(state: ptr<function, u32>) -> vec2<f32> {
     return vec2(rand_f(state), rand_f(state));
 }
 
-// Generates a random u32 in range [0, n).
+/// Generates a random u32 in range [0, n).
 fn rand_range_u(n: u32, state: ptr<function, u32>) -> u32 {
     return rand_u(state) % n;
 }
 
-// returns the (0-1, 0-1) position within the given viewport for the current buffer coords .
-// buffer coords can be obtained from `@builtin(position).xy`.
-// the view uniform struct contains the current camera viewport in `view.viewport`.
-// topleft = 0,0
+/// returns the (0-1, 0-1) position within the given viewport for the current buffer coords .
+/// buffer coords can be obtained from `@builtin(position).xy`.
+/// the view uniform struct contains the current camera viewport in `view.viewport`.
+/// topleft = 0,0
 fn coords_to_viewport_uv(position: vec2<f32>, viewport: vec4<f32>) -> vec2<f32> {
     return (position - viewport.xy) / viewport.zw;
 }
 
-// https://blog.demofox.org/2022/01/01/interleaved-gradient-noise-a-different-kind-of-low-discrepancy-sequence
+/// https://blog.demofox.org/2022/01/01/interleaved-gradient-noise-a-different-kind-of-low-discrepancy-sequence
 fn interleaved_gradient_noise(pixel_coordinates: vec2<f32>, frame: u32) -> f32 {
     let xy = pixel_coordinates + 5.588238 * f32(frame % 64u);
     return fract(52.9829189 * fract(0.06711056 * xy.x + 0.00583715 * xy.y));
 }
 
-// Hammersley sequence for quasi-random points
+/// Hammersley sequence for quasi-random points
 fn hammersley_2d(i: u32, n: u32) -> vec2f {
     let inv_n = 1.0 / f32(n);
     let vdc = f32(reverseBits(i)) * 2.3283064365386963e-10; // 1/2^32
     return vec2f(f32(i) * inv_n, vdc);
 }
 
-// https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare (slides 120-135)
-// TODO: Use an array here instead of a bunch of constants, once arrays work properly under DX12.
-// NOTE: The names have a final underscore to avoid the following error:
-// `Composable module identifiers must not require substitution according to naga writeback rules`
+/// https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare (slides 120-135)
+/// TODO: Use an array here instead of a bunch of constants, once arrays work properly under DX12.
+/// NOTE: The names have a final underscore to avoid the following error:
+/// `Composable module identifiers must not require substitution according to naga writeback rules`
 const SPIRAL_OFFSET_0_ = vec2<f32>(-0.7071,  0.7071);
 const SPIRAL_OFFSET_1_ = vec2<f32>(-0.0000, -0.8750);
 const SPIRAL_OFFSET_2_ = vec2<f32>( 0.5303,  0.5303);
@@ -67,7 +67,7 @@ const SPIRAL_OFFSET_5_ = vec2<f32>(-0.0000,  0.3750);
 const SPIRAL_OFFSET_6_ = vec2<f32>(-0.1768, -0.1768);
 const SPIRAL_OFFSET_7_ = vec2<f32>( 0.1250,  0.0000);
 
-// https://www.realtimerendering.com/raytracinggems/unofficial_RayTracingGems_v1.9.pdf#0004286901.INDD%3ASec28%3A303
+/// https://www.realtimerendering.com/raytracinggems/unofficial_RayTracingGems_v1.9.pdf#0004286901.INDD%3ASec28%3A303
 fn sample_cosine_hemisphere(normal: vec3<f32>, rng: ptr<function, u32>) -> vec3<f32> {
     let cos_theta = 1.0 - 2.0 * rand_f(rng);
     let phi = PI_2 * rand_f(rng);
@@ -78,7 +78,7 @@ fn sample_cosine_hemisphere(normal: vec3<f32>, rng: ptr<function, u32>) -> vec3<
     return direction * inverseSqrt(len_sq);
 }
 
-// https://www.pbr-book.org/3ed-2018/Monte_Carlo_Integration/2D_Sampling_with_Multidimensional_Transformations#UniformlySamplingaHemisphere
+/// https://www.pbr-book.org/3ed-2018/Monte_Carlo_Integration/2D_Sampling_with_Multidimensional_Transformations#UniformlySamplingaHemisphere
 fn sample_uniform_hemisphere(normal: vec3<f32>, rng: ptr<function, u32>) -> vec3<f32> {
     let cos_theta = rand_f(rng);
     let phi = PI_2 * rand_f(rng);
@@ -93,7 +93,7 @@ fn uniform_hemisphere_inverse_pdf() -> f32 {
     return PI_2;
 }
 
-// https://www.realtimerendering.com/raytracinggems/unofficial_RayTracingGems_v1.9.pdf#0004286901.INDD%3ASec19%3A294
+/// https://www.realtimerendering.com/raytracinggems/unofficial_RayTracingGems_v1.9.pdf#0004286901.INDD%3ASec19%3A294
 fn sample_disk(disk_radius: f32, rng: ptr<function, u32>) -> vec2<f32> {
     let ab = 2.0 * rand_vec2f(rng) - 1.0;
     let a = ab.x;
@@ -115,7 +115,7 @@ fn sample_disk(disk_radius: f32, rng: ptr<function, u32>) -> vec2<f32> {
     return vec2(x, y);
 }
 
-// Convert UV and face index to direction vector
+/// Convert UV and face index to direction vector
 fn sample_cube_dir(uv: vec2f, face: u32) -> vec3f {
     // Convert from [0,1] to [-1,1]
     let uvc = 2.0 * uv - 1.0;
@@ -178,8 +178,8 @@ fn dir_to_cube_uv(dir: vec3f) -> CubeUV {
     return CubeUV(uv * 0.5 + 0.5, face);
 }
 
-// The Porter-Duff OVER operator on RGBA, correctly computing alpha of the
-// result.
+/// The Porter-Duff OVER operator on RGBA, correctly computing alpha of the
+/// result.
 fn porter_duff_over(bg: vec4<f32>, fg: vec4<f32>) -> vec4<f32> {
     return vec4<f32>(mix(bg.rgb * bg.a, fg.rgb, fg.a), bg.a + fg.a * (1.0 - bg.a));
 }

--- a/crates/bevy_pbr/src/render/view_transformations.wesl
+++ b/crates/bevy_pbr/src/render/view_transformations.wesl
@@ -1,6 +1,3 @@
-import package::render::mesh_view_bindings as view_bindings;
-import package::prepass::bindings as prepass_bindings;
-
 //! World space:
 //! +y is up
 //!
@@ -27,6 +24,8 @@ import package::prepass::bindings as prepass_bindings;
 //! 0.0, 0.0 is the top left
 //! 1.0, 1.0 is the bottom right
 
+import package::render::mesh_view_bindings as view_bindings;
+import package::prepass::bindings as prepass_bindings;
 
 // -----------------
 // TO WORLD --------

--- a/crates/bevy_pbr/src/render/view_transformations.wesl
+++ b/crates/bevy_pbr/src/render/view_transformations.wesl
@@ -1,31 +1,31 @@
 import package::render::mesh_view_bindings as view_bindings;
 import package::prepass::bindings as prepass_bindings;
 
-/// World space:
-/// +y is up
-
-/// View space:
-/// -z is forward, +x is right, +y is up
-/// Forward is from the camera position into the scene.
-/// (0.0, 0.0, -1.0) is linear distance of 1.0 in front of the camera's view relative to the camera's rotation
-/// (0.0, 1.0, 0.0) is linear distance of 1.0 above the camera's view relative to the camera's rotation
-
-/// NDC (normalized device coordinate):
-/// https://www.w3.org/TR/webgpu/#coordinate-systems
-/// (-1.0, -1.0) in NDC is located at the bottom-left corner of NDC
-/// (1.0, 1.0) in NDC is located at the top-right corner of NDC
-/// Z is depth where: 
-///    1.0 is near clipping plane
-///    Perspective projection: 0.0 is inf far away
-///    Orthographic projection: 0.0 is far clipping plane
-
-/// Clip space:
-/// This is NDC before the perspective divide, still in homogenous coordinate space.
-/// Dividing a clip space point by its w component yields a point in NDC space.
-
-/// UV space:
-/// 0.0, 0.0 is the top left
-/// 1.0, 1.0 is the bottom right
+//! World space:
+//! +y is up
+//!
+//! View space:
+//! -z is forward, +x is right, +y is up
+//! Forward is from the camera position into the scene.
+//! (0.0, 0.0, -1.0) is linear distance of 1.0 in front of the camera's view relative to the camera's rotation
+//! (0.0, 1.0, 0.0) is linear distance of 1.0 above the camera's view relative to the camera's rotation
+//!
+//! NDC (normalized device coordinate):
+//! https://www.w3.org/TR/webgpu/#coordinate-systems
+//! (-1.0, -1.0) in NDC is located at the bottom-left corner of NDC
+//! (1.0, 1.0) in NDC is located at the top-right corner of NDC
+//! Z is depth where:
+//!    1.0 is near clipping plane
+//!    Perspective projection: 0.0 is inf far away
+//!    Orthographic projection: 0.0 is far clipping plane
+//!
+//! Clip space:
+//! This is NDC before the perspective divide, still in homogenous coordinate space.
+//! Dividing a clip space point by its w component yields a point in NDC space.
+//!
+//! UV space:
+//! 0.0, 0.0 is the top left
+//! 1.0, 1.0 is the bottom right
 
 
 // -----------------
@@ -165,7 +165,7 @@ fn perspective_camera_near() -> f32 {
     return view_bindings::view.clip_from_view[3][2];
 }
 
-/// Convert ndc depth to linear view z. 
+/// Convert ndc depth to linear view z.
 /// Note: Depth values in front of the camera will be negative as -z is forward
 fn depth_ndc_to_view_z(ndc_depth: f32) -> f32 {
 @if(VIEW_PROJECTION_PERSPECTIVE)
@@ -178,7 +178,7 @@ fn depth_ndc_to_view_z(ndc_depth: f32) -> f32 {
 }
 }
 
-/// Convert linear view z to ndc depth. 
+/// Convert linear view z to ndc depth.
 /// Note: View z input should be negative for values in front of the camera as -z is forward
 fn view_z_to_depth_ndc(view_z: f32) -> f32 {
 @if(VIEW_PROJECTION_PERSPECTIVE)

--- a/crates/bevy_pbr/src/render/wireframe.wesl
+++ b/crates/bevy_pbr/src/render/wireframe.wesl
@@ -34,7 +34,7 @@ struct WireframeVertexOutput {
     @location(0) @interpolate(linear) edge_distance: vec4<f32>,
 }
 
-// unsigned perpendicular distance from point p to the infinite line through a and b.
+/// unsigned perpendicular distance from point p to the infinite line through a and b.
 fn point_line_distance(p: vec2<f32>, a: vec2<f32>, b: vec2<f32>) -> f32 {
     let edge = b - a;
     let len = length(edge);
@@ -44,9 +44,9 @@ fn point_line_distance(p: vec2<f32>, a: vec2<f32>, b: vec2<f32>) -> f32 {
     return abs(edge.x * (p.y - a.y) - edge.y * (p.x - a.x)) / len;
 }
 
-// finds the local-space vertex position for a given vertex index by reading from the vertex buffer using the provided
-// parameters. the vertex buffer is interpreted as an array of u32s, so the parameters allow us to calculate the
-// correct offset for the position attribute of the vertex at the given index.
+/// finds the local-space vertex position for a given vertex index by reading from the vertex buffer using the provided
+/// parameters. the vertex buffer is interpreted as an array of u32s, so the parameters allow us to calculate the
+/// correct offset for the position attribute of the vertex at the given index.
 fn read_local_position(first_vertex: u32, vertex_index: u32) -> vec3<f32> {
     let base = (first_vertex + vertex_index) * vp_params.vertex_stride
                + vp_params.position_offset;

--- a/crates/bevy_pbr/src/ssao/preprocess_depth.wesl
+++ b/crates/bevy_pbr/src/ssao/preprocess_depth.wesl
@@ -1,9 +1,9 @@
-// Inputs a depth texture and outputs a MIP-chain of depths.
-//
-// Because SSAO's performance is bound by texture reads, this increases
-// performance over using the full resolution depth for every sample.
-
-// Reference: https://research.nvidia.com/sites/default/files/pubs/2012-06_Scalable-Ambient-Obscurance/McGuire12SAO.pdf, section 2.2
+//! Inputs a depth texture and outputs a MIP-chain of depths.
+//!
+//! Because SSAO's performance is bound by texture reads, this increases
+//! performance over using the full resolution depth for every sample.
+//!
+//! Reference: https://research.nvidia.com/sites/default/files/pubs/2012-06_Scalable-Ambient-Obscurance/McGuire12SAO.pdf, section 2.2
 
 import bevy_render::view::View;
 
@@ -26,7 +26,7 @@ import bevy_render::view::View;
 @group(1) @binding(1) var linear_clamp_sampler: sampler;
 @group(1) @binding(2) var<uniform> view: View;
 
-// Using 4 depths from the previous MIP, compute a weighted average for the depth of the current MIP
+/// Using 4 depths from the previous MIP, compute a weighted average for the depth of the current MIP
 fn weighted_average(depth0: f32, depth1: f32, depth2: f32, depth3: f32) -> f32 {
     let depth_range_scale_factor = 0.75;
     let effect_radius = depth_range_scale_factor * 0.5 * 1.457;
@@ -45,7 +45,7 @@ fn weighted_average(depth0: f32, depth1: f32, depth2: f32, depth3: f32) -> f32 {
     return ((weight0 * depth0) + (weight1 * depth1) + (weight2 * depth2) + (weight3 * depth3)) / weight_total;
 }
 
-// Used to share the depths from the previous MIP level between all invocations in a workgroup
+/// Used to share the depths from the previous MIP level between all invocations in a workgroup
 var<workgroup> previous_mip_depth: array<array<f32, 8>, 8>;
 
 @compute

--- a/crates/bevy_pbr/src/ssao/spatial_denoise.wesl
+++ b/crates/bevy_pbr/src/ssao/spatial_denoise.wesl
@@ -1,13 +1,13 @@
-// 3x3 bilaterial filter (edge-preserving blur)
-// https://people.csail.mit.edu/sparis/bf_course/course_notes.pdf
-
-// Note: Does not use the Gaussian kernel part of a typical bilateral blur
-// From the paper: "use the information gathered on a neighborhood of 4 × 4 using a bilateral filter for
-// reconstruction, using _uniform_ convolution weights"
-
-// Note: The paper does a 4x4 (not quite centered) filter, offset by +/- 1 pixel every other frame
-// XeGTAO does a 3x3 filter, on two pixels at a time per compute thread, applied twice
-// We do a 3x3 filter, on 1 pixel per compute thread, applied once
+//! 3x3 bilaterial filter (edge-preserving blur)
+//! https://people.csail.mit.edu/sparis/bf_course/course_notes.pdf
+//!
+//! Note: Does not use the Gaussian kernel part of a typical bilateral blur
+//! From the paper: "use the information gathered on a neighborhood of 4 × 4 using a bilateral filter for
+//! reconstruction, using _uniform_ convolution weights"
+//!
+//! Note: The paper does a 4x4 (not quite centered) filter, offset by +/- 1 pixel every other frame
+//! XeGTAO does a 3x3 filter, on two pixels at a time per compute thread, applied twice
+//! We do a 3x3 filter, on 1 pixel per compute thread, applied once
 
 import bevy_render::view::View;
 

--- a/crates/bevy_pbr/src/ssao/ssao.wesl
+++ b/crates/bevy_pbr/src/ssao/ssao.wesl
@@ -1,14 +1,14 @@
-// Visibility Bitmask Ambient Occlusion (VBAO)
-// Paper: ttps://ar5iv.labs.arxiv.org/html/2301.11376
-
-// Source code heavily based on XeGTAO v1.30 from Intel
-// https://github.com/GameTechDev/XeGTAO/blob/0d177ce06bfa642f64d8af4de1197ad1bcb862d4/Source/Rendering/Shaders/XeGTAO.hlsli
-
-// Source code based on the existing XeGTAO implementation and
-// https://cdrinmatane.github.io/posts/ssaovb-code/
-
-// Source code base on SSRT3 implementation
-// https://github.com/cdrinmatane/SSRT3
+//! Visibility Bitmask Ambient Occlusion (VBAO)
+//! Paper: ttps://ar5iv.labs.arxiv.org/html/2301.11376
+//!
+//! Source code heavily based on XeGTAO v1.30 from Intel
+//! https://github.com/GameTechDev/XeGTAO/blob/0d177ce06bfa642f64d8af4de1197ad1bcb862d4/Source/Rendering/Shaders/XeGTAO.hlsli
+//!
+//! Source code based on the existing XeGTAO implementation and
+//! https://cdrinmatane.github.io/posts/ssaovb-code/
+//!
+//! Source code base on SSRT3 implementation
+//! https://github.com/cdrinmatane/SSRT3
 
 import bevy_render::maths::fast_acos;
 
@@ -46,7 +46,7 @@ fn load_noise(pixel_coordinates: vec2<i32>) -> vec2<f32> {
     return fract(0.5 + f32(index) * vec2<f32>(0.75487766624669276005, 0.5698402909980532659114));
 }
 
-// Calculate differences in depth between neighbor pixels (later used by the spatial denoiser pass to preserve object edges)
+/// Calculate differences in depth between neighbor pixels (later used by the spatial denoiser pass to preserve object edges)
 fn calculate_neighboring_depth_differences(pixel_coordinates: vec2<i32>) -> f32 {
     // Sample the pixel's depth and 4 depths around it
     let uv = vec2<f32>(pixel_coordinates) / view.viewport.zw;

--- a/crates/bevy_pbr/src/ssao/utils.wesl
+++ b/crates/bevy_pbr/src/ssao/utils.wesl
@@ -1,7 +1,7 @@
 import bevy_render::maths::{PI, HALF_PI};
 
-// Approximates single-bounce ambient occlusion to multi-bounce ambient occlusion
-// https://blog.selfshadow.com/publications/s2016-shading-course/activision/s2016_pbs_activision_occlusion.pdf#page=78
+/// Approximates single-bounce ambient occlusion to multi-bounce ambient occlusion
+/// https://blog.selfshadow.com/publications/s2016-shading-course/activision/s2016_pbs_activision_occlusion.pdf#page=78
 fn ssao_multibounce(visibility: f32, base_color: vec3<f32>) -> vec3<f32> {
     let a = 2.0404 * base_color - 0.3324;
     let b = -4.7951 * base_color + 0.6417;

--- a/crates/bevy_pbr/src/ssr.wesl
+++ b/crates/bevy_pbr/src/ssr.wesl
@@ -1,4 +1,4 @@
-// A postprocessing pass that performs screen-space reflections.
+//! A postprocessing pass that performs screen-space reflections.
 
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
 import package::{
@@ -44,10 +44,10 @@ import bevy_render::{
 
 @if(ENVIRONMENT_MAP) import package::light_probe::environment_map;
 
-// The texture representing the color framebuffer.
+/// The texture representing the color framebuffer.
 @group(2) @binding(0) var color_texture: texture_2d<f32>;
 
-// The sampler that lets us sample from the color framebuffer.
+/// The sampler that lets us sample from the color framebuffer.
 @group(2) @binding(1) var color_sampler: sampler;
 
 // Group 1, bindings 2 and 3 are in `raymarch.wesl`.
@@ -61,7 +61,7 @@ struct BrdfSample {
 
 fn sample_specular_brdf(wo: vec3<f32>, roughness: f32, F0: vec3<f32>, urand: vec2<f32>, N: vec3<f32>) -> BrdfSample {
     var brdf_sample: BrdfSample;
-    
+
     // Use VNDF sampling for the half-vector.
     let wi = lighting::sample_visible_ggx(urand, roughness, N, wo);
     let H = normalize(wo + wi);
@@ -82,23 +82,23 @@ fn sample_specular_brdf(wo: vec3<f32>, roughness: f32, F0: vec3<f32>, urand: vec
     return brdf_sample;
 }
 
-// Returns the reflected color in the RGB channel and the specular occlusion in
-// the alpha channel.
-//
-// The general approach here is similar to [1]. We first project the reflection
-// ray into screen space. Then we perform uniform steps along that screen-space
-// reflected ray, converting each step to view space.
-//
-// The arguments are:
-//
-// * `R_world`: The reflection vector in world space.
-//
-// * `P_world`: The current position in world space.
-//
-// * `jitter`: Jitter to apply to the first step of the linear search; 0..=1
-//   range.
-//
-// [1]: https://lettier.github.io/3d-game-shaders-for-beginners/screen-space-reflection.html
+/// Returns the reflected color in the RGB channel and the specular occlusion in
+/// the alpha channel.
+///
+/// The general approach here is similar to [1]. We first project the reflection
+/// ray into screen space. Then we perform uniform steps along that screen-space
+/// reflected ray, converting each step to view space.
+///
+/// The arguments are:
+///
+/// * `R_world`: The reflection vector in world space.
+///
+/// * `P_world`: The current position in world space.
+///
+/// * `jitter`: Jitter to apply to the first step of the linear search; 0..=1
+///   range.
+///
+/// [1]: https://lettier.github.io/3d-game-shaders-for-beginners/screen-space-reflection.html
 fn evaluate_ssr(R_world: vec3<f32>, P_world: vec3<f32>, jitter: f32) -> vec4<f32> {
     let depth_size = vec2<f32>(textureDimensions(depth_prepass_texture));
 
@@ -220,7 +220,7 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     // Sample the BRDF.
     let N_tangent = vec3(0.0, 0.0, 1.0);
     let V_tangent = V * tangent_to_world;
-    
+
     let brdf_sample = sample_specular_brdf(V_tangent, roughness, F0, urand, N_tangent);
     let R_stochastic = tangent_to_world * brdf_sample.wi;
     let brdf_sample_value_over_pdf = brdf_sample.value_over_pdf;

--- a/crates/bevy_pbr/src/ssr/raymarch.wesl
+++ b/crates/bevy_pbr/src/ssr/raymarch.wesl
@@ -6,13 +6,13 @@
 //     MIT license (http://opensource.org/licenses/MIT)
 //
 // at your option.
-//
-// This is a port of the original [`raymarch.hlsl`] to WGSL. It's deliberately
-// kept as close as possible so that patches to the original `raymarch.hlsl`
-// have the greatest chances of applying to this version.
-//
-// [`raymarch.hlsl`]:
-// https://gist.github.com/h3r2tic/9c8356bdaefbe80b1a22ae0aaee192db
+
+//! This is a port of the original [`raymarch.hlsl`] to WGSL. It's deliberately
+//! kept as close as possible so that patches to the original `raymarch.hlsl`
+//! have the greatest chances of applying to this version.
+//!
+//! [`raymarch.hlsl`]:
+//! https://gist.github.com/h3r2tic/9c8356bdaefbe80b1a22ae0aaee192db
 
 import package::render::mesh_view_bindings::depth_prepass_texture;
 import package::render::view_transformations::{
@@ -22,15 +22,15 @@ import package::render::view_transformations::{
     position_world_to_ndc,
 };
 
-// Allows us to sample from the depth buffer with bilinear filtering.
+/// Allows us to sample from the depth buffer with bilinear filtering.
 @if(USE_DEPTH_SAMPLERS) {
 @group(2) @binding(2) var depth_linear_sampler: sampler;
 
-// Allows us to sample from the depth buffer with nearest-neighbor filtering.
+/// Allows us to sample from the depth buffer with nearest-neighbor filtering.
 @group(2) @binding(3) var depth_nearest_sampler: sampler;
 }
 
-// Manual depth fetch helpers used on WebGPU where depth + filtering sampler is invalid.
+/// Manual depth fetch helpers used on WebGPU where depth + filtering sampler is invalid.
 @if(!USE_DEPTH_SAMPLERS)
 fn depth_texel_clamped(texel: vec2<i32>) -> f32 {
     let dims = textureDimensions(depth_prepass_texture);

--- a/crates/bevy_pbr/src/ssr/raymarch.wesl
+++ b/crates/bevy_pbr/src/ssr/raymarch.wesl
@@ -1,3 +1,10 @@
+//! This is a port of the original [`raymarch.hlsl`] to WGSL. It's deliberately
+//! kept as close as possible so that patches to the original `raymarch.hlsl`
+//! have the greatest chances of applying to this version.
+//!
+//! [`raymarch.hlsl`]:
+//! https://gist.github.com/h3r2tic/9c8356bdaefbe80b1a22ae0aaee192db
+
 // Copyright (c) 2023 Tomasz Stachowiak
 //
 // This contribution is dual licensed under EITHER OF
@@ -6,13 +13,6 @@
 //     MIT license (http://opensource.org/licenses/MIT)
 //
 // at your option.
-
-//! This is a port of the original [`raymarch.hlsl`] to WGSL. It's deliberately
-//! kept as close as possible so that patches to the original `raymarch.hlsl`
-//! have the greatest chances of applying to this version.
-//!
-//! [`raymarch.hlsl`]:
-//! https://gist.github.com/h3r2tic/9c8356bdaefbe80b1a22ae0aaee192db
 
 import package::render::mesh_view_bindings::depth_prepass_texture;
 import package::render::view_transformations::{

--- a/crates/bevy_pbr/src/transmission.wesl
+++ b/crates/bevy_pbr/src/transmission.wesl
@@ -15,11 +15,11 @@ import bevy_core_pipeline::tonemapping::approximate_inverse_tone_mapping;
 
 @if (VIEW_TRANSMISSION_TEXTURE) {
 
-// The IOR impacts how much a single microfacet refracts incoming light. In turn this changes how
-// "wide" the distribution of output ray directions is and how rough the BRDF should be.
-// This function scales the roughness toward 0.0 as IOR tends towards 1.0, while leaving the default
-// roughness for IOR = 1.5.
-// Adapted from Khronos gltf-Sample-Renderer (https://github.com/KhronosGroup/glTF-Sample-Renderer/blob/bec106e53da4a6a398aa3205f0f96563519a657e/source/Renderer/shaders/functions.glsl#L84-L89)
+/// The IOR impacts how much a single microfacet refracts incoming light. In turn this changes how
+/// "wide" the distribution of output ray directions is and how rough the BRDF should be.
+/// This function scales the roughness toward 0.0 as IOR tends towards 1.0, while leaving the default
+/// roughness for IOR = 1.5.
+/// Adapted from Khronos gltf-Sample-Renderer (https://github.com/KhronosGroup/glTF-Sample-Renderer/blob/bec106e53da4a6a398aa3205f0f96563519a657e/source/Renderer/shaders/functions.glsl#L84-L89)
 fn ior_corrected_roughness(roughness: f32, ior: f32) -> f32 {
     return roughness * clamp(ior * 2.0 - 2.0, 0.0, 1.0);
 }

--- a/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wesl
+++ b/crates/bevy_pbr/src/volumetric_fog/volumetric_fog.wesl
@@ -1,17 +1,17 @@
-// A postprocessing shader that implements volumetric fog via raymarching and
-// sampling directional light shadow maps.
-//
-// The overall approach is a combination of the volumetric rendering in [1] and
-// the shadow map raymarching in [2]. First, we raytrace the AABB of the fog
-// volume in order to determine how long our ray is. Then we do a raymarch, with
-// physically-based calculations at each step to determine how much light was
-// absorbed, scattered out, and scattered in. To determine in-scattering, we
-// sample the shadow map for the light to determine whether the point was in
-// shadow or not.
-//
-// [1]: https://www.scratchapixel.com/lessons/3d-basic-rendering/volume-rendering-for-developers/intro-volume-rendering.html
-//
-// [2]: http://www.alexandre-pestana.com/volumetric-lights/
+//! A postprocessing shader that implements volumetric fog via raymarching and
+//! sampling directional light shadow maps.
+//!
+//! The overall approach is a combination of the volumetric rendering in [1] and
+//! the shadow map raymarching in [2]. First, we raytrace the AABB of the fog
+//! volume in order to determine how long our ray is. Then we do a raymarch, with
+//! physically-based calculations at each step to determine how much light was
+//! absorbed, scattered out, and scattered in. To determine in-scattering, we
+//! sample the shadow map for the light to determine whether the point was in
+//! shadow or not.
+//!
+//! [1]: https://www.scratchapixel.com/lessons/3d-basic-rendering/volume-rendering-for-developers/intro-volume-rendering.html
+//!
+//! [2]: http://www.alexandre-pestana.com/volumetric-lights/
 
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
 import package::atmosphere::{
@@ -48,8 +48,8 @@ import bevy_render::maths::orthonormalize;
 import package::render::clustered_forward as clustering;
 import package::render::pbr_lighting::getDistanceAttenuation;
 
-// The GPU version of [`VolumetricFog`]. See the comments in
-// `volumetric_fog/mod.rs` for descriptions of the fields here.
+/// The GPU version of [`VolumetricFog`]. See the comments in
+/// `volumetric_fog/mod.rs` for descriptions of the fields here.
 struct VolumetricFog {
     clip_from_local: mat4x4<f32>,
     uvw_from_world: mat4x4<f32>,
@@ -81,7 +81,7 @@ struct VolumetricFog {
 @group(1) @binding(3) var density_sampler: sampler;
 }
 
-// 1 / (4π)
+/// 1 / (4π)
 const FRAC_4_PI: f32 = 0.07957747154594767;
 
 struct Vertex {
@@ -94,15 +94,15 @@ fn vertex(vertex: Vertex) -> @builtin(position) vec4<f32> {
     return volumetric_fog.clip_from_local * vec4<f32>(vertex.position, 1.0);
 }
 
-// The common Henyey-Greenstein asymmetric phase function [1] [2].
-//
-// This determines how much light goes toward the viewer as opposed to away from
-// the viewer. From a visual point of view, it controls how the light shafts
-// appear and disappear as the camera looks at the light source.
-//
-// [1]: https://www.scratchapixel.com/lessons/3d-basic-rendering/volume-rendering-for-developers/ray-marching-get-it-right.html
-//
-// [2]: https://www.pbr-book.org/4ed/Volume_Scattering/Phase_Functions#TheHenyeyndashGreensteinPhaseFunction
+/// The common Henyey-Greenstein asymmetric phase function [1] [2].
+///
+/// This determines how much light goes toward the viewer as opposed to away from
+/// the viewer. From a visual point of view, it controls how the light shafts
+/// appear and disappear as the camera looks at the light source.
+///
+/// [1]: https://www.scratchapixel.com/lessons/3d-basic-rendering/volume-rendering-for-developers/ray-marching-get-it-right.html
+///
+/// [2]: https://www.pbr-book.org/4ed/Volume_Scattering/Phase_Functions#TheHenyeyndashGreensteinPhaseFunction
 fn henyey_greenstein(neg_LdotV: f32) -> f32 {
     let g = volumetric_fog.scattering_asymmetry;
     let denom = 1.0 + g * g - 2.0 * g * neg_LdotV;

--- a/crates/bevy_post_process/src/auto_exposure/auto_exposure.wesl
+++ b/crates/bevy_post_process/src/auto_exposure/auto_exposure.wesl
@@ -1,26 +1,26 @@
-// Auto exposure
-//
-// This shader computes an auto exposure value for the current frame,
-// which is then used as an exposure correction in the tone mapping shader.
-//
-// The auto exposure value is computed in two passes:
-// * The compute_histogram pass calculates a histogram of the luminance values in the scene,
-// taking into account the metering mask texture. The metering mask is a grayscale texture
-// that defines the areas of the screen that should be given more weight when calculating
-// the average luminance value. For example, the middle area of the screen might be more important
-// than the edges.
-// * The compute_average pass calculates the average luminance value of the scene, taking
-// into account the low_percent and high_percent settings. These settings define the
-// percentage of the histogram that should be excluded when calculating the average. This
-// is useful to avoid overexposure when you have a lot of shadows, or underexposure when you
-// have a lot of bright specular reflections.
-//
-// The final target_exposure is finally used to smoothly adjust the exposure value over time.
+//! Auto exposure
+//!
+//! This shader computes an auto exposure value for the current frame,
+//! which is then used as an exposure correction in the tone mapping shader.
+//!
+//! The auto exposure value is computed in two passes:
+//! * The compute_histogram pass calculates a histogram of the luminance values in the scene,
+//! taking into account the metering mask texture. The metering mask is a grayscale texture
+//! that defines the areas of the screen that should be given more weight when calculating
+//! the average luminance value. For example, the middle area of the screen might be more important
+//! than the edges.
+//! * The compute_average pass calculates the average luminance value of the scene, taking
+//! into account the low_percent and high_percent settings. These settings define the
+//! percentage of the histogram that should be excluded when calculating the average. This
+//! is useful to avoid overexposure when you have a lot of shadows, or underexposure when you
+//! have a lot of bright specular reflections.
+//!
+//! The final target_exposure is finally used to smoothly adjust the exposure value over time.
 
 import bevy_render::view::View;
 import bevy_render::globals::Globals;
 
-// Constant to convert RGB to luminance, taken from Real Time Rendering, Vol 4 pg. 278, 4th edition
+/// Constant to convert RGB to luminance, taken from Real Time Rendering, Vol 4 pg. 278, 4th edition
 const RGB_TO_LUM = vec3<f32>(0.2125, 0.7154, 0.0721);
 
 struct AutoExposure {
@@ -61,7 +61,7 @@ struct CompensationCurve {
 
 var<workgroup> histogram_shared: array<atomic<u32>, 64>;
 
-// For a given color, return the histogram bin index
+/// For a given color, return the histogram bin index
 fn color_to_bin(hdr: vec3<f32>) -> u32 {
     // Convert color to luminance
     let lum = dot(hdr, RGB_TO_LUM);
@@ -78,11 +78,11 @@ fn color_to_bin(hdr: vec3<f32>) -> u32 {
     return u32(log_lum * 62.0 + 1.0);
 }
 
-// Read the metering mask at the given UV coordinates, returning a weight for the histogram.
-//
-// Since the histogram is summed in the compute_average step, there is a limit to the amount of
-// distinct values that can be represented. When using the chosen value of 16, the maximum
-// amount of pixels that can be weighted and summed is 2^32 / 16 = 16384^2.
+/// Read the metering mask at the given UV coordinates, returning a weight for the histogram.
+///
+/// Since the histogram is summed in the compute_average step, there is a limit to the amount of
+/// distinct values that can be represented. When using the chosen value of 16, the maximum
+/// amount of pixels that can be weighted and summed is 2^32 / 16 = 16384^2.
 fn metering_weight(coords: vec2<f32>) -> u32 {
     let pos = vec2<i32>(coords * vec2<f32>(textureDimensions(tex_mask)));
     let mask = textureLoad(tex_mask, pos, 0).r;

--- a/crates/bevy_post_process/src/bloom/bloom.wesl
+++ b/crates/bevy_post_process/src/bloom/bloom.wesl
@@ -1,10 +1,10 @@
-// Bloom works by creating an intermediate texture with a bunch of mip levels, each half the size of the previous.
-// You then downsample each mip (starting with the original texture) to the lower resolution mip under it, going in order.
-// You then upsample each mip (starting from the smallest mip) and blend with the higher resolution mip above it (ending on the original texture).
-//
-// References:
-// * [COD] - Next Generation Post Processing in Call of Duty - http://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
-// * [PBB] - Physically Based Bloom - https://learnopengl.com/Guest-Articles/2022/Phys.-Based-Bloom
+//! Bloom works by creating an intermediate texture with a bunch of mip levels, each half the size of the previous.
+//! You then downsample each mip (starting with the original texture) to the lower resolution mip under it, going in order.
+//! You then upsample each mip (starting from the smallest mip) and blend with the higher resolution mip above it (ending on the original texture).
+//!
+//! References:
+//! * [COD] - Next Generation Post Processing in Call of Duty - http://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
+//! * [PBB] - Physically Based Bloom - https://learnopengl.com/Guest-Articles/2022/Phys.-Based-Bloom
 
 struct BloomUniforms {
     threshold_precomputations: vec4<f32>,
@@ -19,7 +19,7 @@ struct BloomUniforms {
 @group(0) @binding(2) var<uniform> uniforms: BloomUniforms;
 
 @if(FIRST_DOWNSAMPLE)
-// https://catlikecoding.com/unity/tutorials/advanced-rendering/bloom/#3.4
+/// https://catlikecoding.com/unity/tutorials/advanced-rendering/bloom/#3.4
 fn soft_threshold(color: vec3<f32>) -> vec3<f32> {
     let brightness = max(color.r, max(color.g, color.b));
     var softness = brightness - uniforms.threshold_precomputations.y;
@@ -30,13 +30,13 @@ fn soft_threshold(color: vec3<f32>) -> vec3<f32> {
     return color * contribution;
 }
 
-// luminance coefficients from Rec. 709.
-// https://en.wikipedia.org/wiki/Rec._709
+/// luminance coefficients from Rec. 709.
+/// https://en.wikipedia.org/wiki/Rec._709
 fn tonemapping_luminance(v: vec3<f32>) -> f32 {
     return dot(v, vec3<f32>(0.2126, 0.7152, 0.0722));
 }
 
-// http://graphicrants.blogspot.com/2013/12/tone-mapping.html
+/// http://graphicrants.blogspot.com/2013/12/tone-mapping.html
 fn karis_average(color: vec3<f32>) -> f32 {
     // Luminance calculated based on Rec. 709 color primaries.
     // This must be done in *linear* color space.
@@ -44,7 +44,7 @@ fn karis_average(color: vec3<f32>) -> f32 {
     return 1.0 / (1.0 + luma);
 }
 
-// [COD] slide 153
+/// [COD] slide 153
 fn sample_input_13_tap(uv: vec2<f32>) -> vec3<f32> {
     var a: vec3<f32>;
     var b: vec3<f32>;
@@ -138,7 +138,7 @@ fn sample_input_13_tap(uv: vec2<f32>) -> vec3<f32> {
 }
 }
 
-// [COD] slide 162
+/// [COD] slide 162
 fn sample_input_3x3_tent(uv: vec2<f32>) -> vec3<f32> {
     // While this is probably technically incorrect, it makes nonuniform bloom smoother, without
     // having any impact on uniform bloom, which simply evaluates to 1.0 here.

--- a/crates/bevy_post_process/src/dof/dof.wesl
+++ b/crates/bevy_post_process/src/dof/dof.wesl
@@ -1,19 +1,19 @@
-// Performs depth of field postprocessing, with both Gaussian and bokeh kernels.
-//
-// Gaussian blur is performed as a separable convolution: first blurring in the
-// X direction, and then in the Y direction. This is asymptotically more
-// efficient than performing a 2D convolution.
-//
-// The Bokeh blur uses a similar, but more complex, separable convolution
-// technique. The algorithm is described in Colin Barré-Brisebois, "Hexagonal
-// Bokeh Blur Revisited" [1]. It's motivated by the observation that we can use
-// separable convolutions not only to produce boxes but to produce
-// parallelograms. Thus, by performing three separable convolutions in sequence,
-// we can produce a hexagonal shape. The first and second convolutions are done
-// simultaneously using multiple render targets to cut the total number of
-// passes down to two.
-//
-// [1]: https://colinbarrebrisebois.com/2017/04/18/hexagonal-bokeh-blur-revisited-part-2-improved-2-pass-version/
+//! Performs depth of field postprocessing, with both Gaussian and bokeh kernels.
+//!
+//! Gaussian blur is performed as a separable convolution: first blurring in the
+//! X direction, and then in the Y direction. This is asymptotically more
+//! efficient than performing a 2D convolution.
+//!
+//! The Bokeh blur uses a similar, but more complex, separable convolution
+//! technique. The algorithm is described in Colin Barré-Brisebois, "Hexagonal
+//! Bokeh Blur Revisited" [1]. It's motivated by the observation that we can use
+//! separable convolutions not only to produce boxes but to produce
+//! parallelograms. Thus, by performing three separable convolutions in sequence,
+//! we can produce a hexagonal shape. The first and second convolutions are done
+//! simultaneously using multiple render targets to cut the total number of
+//! passes down to two.
+//!
+//! [1]: https://colinbarrebrisebois.com/2017/04/18/hexagonal-bokeh-blur-revisited-part-2-improved-2-pass-version/
 
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
 import bevy_pbr::render::mesh_view_bindings::view;
@@ -21,9 +21,9 @@ import bevy_pbr::render::view_transformations::depth_ndc_to_view_z;
 import package::gaussian_blur::gaussian_blur;
 import bevy_render::view::View;
 
-// Parameters that control the depth of field effect. See
-// `bevy_core_pipeline::dof::DepthOfFieldUniforms` for information on what these
-// parameters mean.
+/// Parameters that control the depth of field effect. See
+/// `bevy_core_pipeline::dof::DepthOfFieldUniforms` for information on what these
+/// parameters mean.
 struct DepthOfFieldParams {
     /// The distance in meters to the location in focus.
     focal_distance: f32,
@@ -64,54 +64,54 @@ struct DepthOfFieldParams {
     pad_c: u32,
 }
 
-// The first bokeh pass outputs to two render targets. We declare them here.
+/// The first bokeh pass outputs to two render targets. We declare them here.
 struct DualOutput {
-    // The vertical output.
+    /// The vertical output.
     @location(0) output_0: vec4<f32>,
-    // The diagonal output.
+    /// The diagonal output.
     @location(1) output_1: vec4<f32>,
 }
 
 // @group(0) @binding(0) is `mesh_view_bindings::view`.
 
-// The depth texture for the main view.
+/// The depth texture for the main view.
 @if(MULTISAMPLED)
 @group(0) @binding(1) var depth_texture: texture_depth_multisampled_2d;
 @else   // MULTISAMPLED
 @group(0) @binding(1) var depth_texture: texture_depth_2d;
 
-// The main color texture.
+/// The main color texture.
 @group(0) @binding(2) var color_texture_a: texture_2d<f32>;
 
-// The auxiliary color texture that we're sampling from. This is only used as
-// part of the second bokeh pass.
+/// The auxiliary color texture that we're sampling from. This is only used as
+/// part of the second bokeh pass.
 @if(DUAL_INPUT)
 @group(0) @binding(3) var color_texture_b: texture_2d<f32>;
 
 // The global uniforms, representing data backed by buffers shared among all
 // views in the scene.
 
-// The parameters that control the depth of field effect.
+/// The parameters that control the depth of field effect.
 @group(1) @binding(0) var<uniform> dof_params: DepthOfFieldParams;
 
-// The sampler that's used to fetch texels from the source color buffer.
+/// The sampler that's used to fetch texels from the source color buffer.
 @group(1) @binding(1) var color_texture_sampler: sampler;
 
-// used to ensure `depth * (focus - f)` is always a positive number,
+/// used to ensure `depth * (focus - f)` is always a positive number,
 const EPSILON: f32 = 1.19209290e-07;
-// cos(-30°), used for the bokeh blur.
+/// cos(-30°), used for the bokeh blur.
 const COS_NEG_FRAC_PI_6: f32 = 0.8660254037844387;
-// sin(-30°), used for the bokeh blur.
+/// sin(-30°), used for the bokeh blur.
 const SIN_NEG_FRAC_PI_6: f32 = -0.5;
-// cos(-150°), used for the bokeh blur.
+/// cos(-150°), used for the bokeh blur.
 const COS_NEG_FRAC_PI_5_6: f32 = -0.8660254037844387;
-// sin(-150°), used for the bokeh blur.
+/// sin(-150°), used for the bokeh blur.
 const SIN_NEG_FRAC_PI_5_6: f32 = -0.5;
 
-// Calculates and returns the diameter (not the radius) of the [circle of
-// confusion].
-//
-// [circle of confusion]: https://en.wikipedia.org/wiki/Circle_of_confusion
+/// Calculates and returns the diameter (not the radius) of the [circle of
+/// confusion].
+///
+/// [circle of confusion]: https://en.wikipedia.org/wiki/Circle_of_confusion
 fn calculate_circle_of_confusion(in_frag_coord: vec4<f32>) -> f32 {
     // Unpack the depth of field parameters.
     let focus = dof_params.focal_distance;
@@ -135,16 +135,16 @@ fn calculate_circle_of_confusion(in_frag_coord: vec4<f32>) -> f32 {
     return clamp(candidate_coc * framebuffer_size.y, 0.0, max_coc_diameter);
 }
 
-// Performs a box blur in a single direction, sampling `color_texture_a`.
-//
-// * `frag_coord` is the screen-space pixel coordinate of the fragment (i.e. the
-//   `position` input to the fragment).
-//
-// * `coc` is the diameter (not the radius) of the circle of confusion for this
-//   fragment.
-//
-// * `frag_offset` is the vector, in screen-space units, from one sample to the
-//   next. This need not be horizontal or vertical.
+/// Performs a box blur in a single direction, sampling `color_texture_a`.
+///
+/// * `frag_coord` is the screen-space pixel coordinate of the fragment (i.e. the
+///   `position` input to the fragment).
+///
+/// * `coc` is the diameter (not the radius) of the circle of confusion for this
+///   fragment.
+///
+/// * `frag_offset` is the vector, in screen-space units, from one sample to the
+///   next. This need not be horizontal or vertical.
 fn box_blur_a(frag_coord: vec4<f32>, coc: f32, frag_offset: vec2<f32>) -> vec4<f32> {
     let support = i32(round(coc * 0.5));
     let uv = frag_coord.xy / vec2<f32>(textureDimensions(color_texture_a));
@@ -160,16 +160,16 @@ fn box_blur_a(frag_coord: vec4<f32>, coc: f32, frag_offset: vec2<f32>) -> vec4<f
     return vec4(sum / vec3(1.0 + f32(support)), 1.0);
 }
 
-// Performs a box blur in a single direction, sampling `color_texture_b`.
-//
-// * `frag_coord` is the screen-space pixel coordinate of the fragment (i.e. the
-//   `position` input to the fragment).
-//
-// * `coc` is the diameter (not the radius) of the circle of confusion for this
-//   fragment.
-//
-// * `frag_offset` is the vector, in screen-space units, from one sample to the
-//   next. This need not be horizontal or vertical.
+/// Performs a box blur in a single direction, sampling `color_texture_b`.
+///
+/// * `frag_coord` is the screen-space pixel coordinate of the fragment (i.e. the
+///   `position` input to the fragment).
+///
+/// * `coc` is the diameter (not the radius) of the circle of confusion for this
+///   fragment.
+///
+/// * `frag_offset` is the vector, in screen-space units, from one sample to the
+///   next. This need not be horizontal or vertical.
 @if(DUAL_INPUT)
 fn box_blur_b(frag_coord: vec4<f32>, coc: f32, frag_offset: vec2<f32>) -> vec4<f32> {
     let support = i32(round(coc * 0.5));
@@ -186,28 +186,28 @@ fn box_blur_b(frag_coord: vec4<f32>, coc: f32, frag_offset: vec2<f32>) -> vec4<f
     return vec4(sum / vec3(1.0 + f32(support)), 1.0);
 }
 
-// Calculates the horizontal component of the separable Gaussian blur.
+/// Calculates the horizontal component of the separable Gaussian blur.
 @fragment
 fn gaussian_horizontal(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let coc = calculate_circle_of_confusion(in.position);
     return gaussian_blur(color_texture_a, color_texture_sampler, in.position, coc, vec2(1.0, 0.0));
 }
 
-// Calculates the vertical component of the separable Gaussian blur.
+/// Calculates the vertical component of the separable Gaussian blur.
 @fragment
 fn gaussian_vertical(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let coc = calculate_circle_of_confusion(in.position);
     return gaussian_blur(color_texture_a, color_texture_sampler, in.position, coc, vec2(0.0, 1.0));
 }
 
-// Calculates the vertical and first diagonal components of the separable
-// hexagonal bokeh blur.
-//
-//         ╱
-//        ╱
-//       •
-//       │
-//       │
+/// Calculates the vertical and first diagonal components of the separable
+/// hexagonal bokeh blur.
+///
+///         ╱
+///        ╱
+///       •
+///       │
+///       │
 @fragment
 fn bokeh_pass_a(in: FullscreenVertexOutput) -> DualOutput {
     let coc = calculate_circle_of_confusion(in.position);
@@ -221,12 +221,12 @@ fn bokeh_pass_a(in: FullscreenVertexOutput) -> DualOutput {
     return output;
 }
 
-// Calculates the second diagonal components of the separable hexagonal bokeh
-// blur.
-//
-//     ╲   ╱
-//      ╲ ╱
-//       •
+/// Calculates the second diagonal components of the separable hexagonal bokeh
+/// blur.
+///
+///     ╲   ╱
+///      ╲ ╱
+///       •
 @if(DUAL_INPUT)
 @fragment
 fn bokeh_pass_b(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {

--- a/crates/bevy_post_process/src/effect_stack/chromatic_aberration.wesl
+++ b/crates/bevy_post_process/src/effect_stack/chromatic_aberration.wesl
@@ -1,9 +1,9 @@
-// The chromatic aberration postprocessing effect.
-//
-// This makes edges of objects turn into multicolored streaks.
+//! The chromatic aberration postprocessing effect.
+//!
+//! This makes edges of objects turn into multicolored streaks.
 
-// See `package::effect_stack::ChromaticAberration` for more
-// information on these fields.
+/// See `package::effect_stack::ChromaticAberration` for more
+/// information on these fields.
 struct ChromaticAberrationSettings {
     intensity: f32,
     max_samples: u32,
@@ -11,20 +11,19 @@ struct ChromaticAberrationSettings {
     unused_b: u32,
 }
 
-// The source framebuffer texture.
+/// The source framebuffer texture.
 @group(0) @binding(0) var source_texture: texture_2d<f32>;
-// The sampler used to sample the source framebuffer texture.
+/// The sampler used to sample the source framebuffer texture.
 @group(0) @binding(1) var common_sampler: sampler;
-// The 1D lookup table for chromatic aberration.
+/// The 1D lookup table for chromatic aberration.
 @group(0) @binding(2) var chromatic_aberration_lut_texture: texture_2d<f32>;
-// The settings supplied by the developer.
+/// The settings supplied by the developer.
 @group(0) @binding(3) var<uniform> chromatic_aberration_settings: ChromaticAberrationSettings;
 
+/// Radial chromatic aberration implemented using the *Inside* technique:
+///
+/// <https://github.com/playdeadgames/publications/blob/master/INSIDE/rendering_inside_gdc2016.pdf>
 fn chromatic_aberration(start_pos: vec2<f32>) -> vec3<f32> {
-    // Radial chromatic aberration implemented using the *Inside* technique:
-    //
-    // <https://github.com/playdeadgames/publications/blob/master/INSIDE/rendering_inside_gdc2016.pdf>
-
     let end_pos = mix(start_pos, vec2(0.5), chromatic_aberration_settings.intensity);
 
     // Determine the number of samples. We aim for one sample per texel, unless

--- a/crates/bevy_post_process/src/effect_stack/lens_distortion.wesl
+++ b/crates/bevy_post_process/src/effect_stack/lens_distortion.wesl
@@ -1,7 +1,7 @@
-// The lens distortion postprocessing effect.
+//! The lens distortion postprocessing effect.
 
-// See `package::effect_stack::LensDistortion` for more
-// information on these fields.
+/// See `package::effect_stack::LensDistortion` for more
+/// information on these fields.
 struct LensDistortionSettings {
     intensity: f32,
     scale: f32,
@@ -14,7 +14,7 @@ struct LensDistortionSettings {
 const VISUAL_THRESHOLD: f32 = 1e-4;
 const MATH_EPSILON: f32 = 1e-6;
 
-// The settings supplied by the developer.
+/// The settings supplied by the developer.
 @group(0) @binding(5) var<uniform> lens_distortion_settings: LensDistortionSettings;
 
 fn lens_distortion(uv: vec2<f32>) -> vec2<f32> {

--- a/crates/bevy_post_process/src/effect_stack/post_process.wesl
+++ b/crates/bevy_post_process/src/effect_stack/post_process.wesl
@@ -1,4 +1,4 @@
-// Miscellaneous postprocessing effects, currently just chromatic aberration.
+//! Miscellaneous postprocessing effects, currently just chromatic aberration.
 
 import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput;
 import package::effect_stack::chromatic_aberration::chromatic_aberration;

--- a/crates/bevy_post_process/src/effect_stack/vignette.wesl
+++ b/crates/bevy_post_process/src/effect_stack/vignette.wesl
@@ -1,9 +1,9 @@
-// The vignette postprocessing effect.
+//! The vignette postprocessing effect.
 
 import package::effect_stack::chromatic_aberration::source_texture;
 
-// See `package::effect_stack::Vignette` for more
-// information on these fields.
+/// See `package::effect_stack::Vignette` for more
+/// information on these fields.
 struct VignetteSettings {
     intensity: f32,
     radius: f32,
@@ -17,7 +17,7 @@ struct VignetteSettings {
 
 const VISUAL_THRESHOLD: f32 = 1e-4;
 
-// The settings supplied by the developer.
+/// The settings supplied by the developer.
 @group(0) @binding(4) var<uniform> vignette_settings: VignetteSettings;
 
 fn vignette(uv: vec2<f32>, color: vec3<f32>) -> vec3<f32> {

--- a/crates/bevy_post_process/src/gaussian_blur.wesl
+++ b/crates/bevy_post_process/src/gaussian_blur.wesl
@@ -1,26 +1,26 @@
-// A library containing a 1D Gaussian blur kernel.
-//
-// This is used by depth of field, but you can also use it in custom
-// postprocessing passes.
+//! A library containing a 1D Gaussian blur kernel.
+//!
+//! This is used by depth of field, but you can also use it in custom
+//! postprocessing passes.
 
-// Performs a single direction of the separable Gaussian blur kernel.
-//
-// * `color_texture` is the texture to blur.
-//
-// * `color_texture_sampler` is a sampler to sample the texture. It must have
-//   linear filtering for both minification and magnification.
-//
-// * `frag_coord` is the screen-space pixel coordinate of the fragment (i.e. the
-//   `position` input to the fragment).
-//
-// * `coc` is the diameter (not the radius) of the circle of confusion for this
-//   fragment.
-//
-// * `frag_offset` is the vector, in screen-space units, from one sample to the
-//   next. For a horizontal blur this will be `vec2(1.0, 0.0)`; for a vertical
-//   blur this will be `vec2(0.0, 1.0)`.
-//
-// Returns the resulting color of the fragment.
+/// Performs a single direction of the separable Gaussian blur kernel.
+///
+/// * `color_texture` is the texture to blur.
+///
+/// * `color_texture_sampler` is a sampler to sample the texture. It must have
+///   linear filtering for both minification and magnification.
+///
+/// * `frag_coord` is the screen-space pixel coordinate of the fragment (i.e. the
+///   `position` input to the fragment).
+///
+/// * `coc` is the diameter (not the radius) of the circle of confusion for this
+///   fragment.
+///
+/// * `frag_offset` is the vector, in screen-space units, from one sample to the
+///   next. For a horizontal blur this will be `vec2(1.0, 0.0)`; for a vertical
+///   blur this will be `vec2(0.0, 1.0)`.
+///
+/// Returns the resulting color of the fragment.
 fn gaussian_blur(color_texture: texture_2d<f32>, color_texture_sampler: sampler, frag_coord: vec4<f32>, coc: f32, frag_offset: vec2<f32>) -> vec4<f32> {
     // Usually σ (the standard deviation) is half the radius, and the radius is
     // half the CoC. So we multiply by 0.25.
@@ -70,4 +70,3 @@ fn gaussian_blur(color_texture: texture_2d<f32>, color_texture_sampler: sampler,
 
     return vec4(sum / weight_sum, 1.0);
 }
-

--- a/crates/bevy_render/src/bindless.wesl
+++ b/crates/bevy_render/src/bindless.wesl
@@ -1,36 +1,36 @@
 @if(BINDLESS)
 enable wgpu_binding_array;
 
-// Defines the common arrays used to access bindless resources.
-//
-// This need to be kept up to date with the `BINDING_NUMBERS` table in
-// `bindless.rs`.
-//
-// You access these by indexing into the bindless index table, and from there
-// indexing into the appropriate binding array. For example, to access the base
-// color texture of a `StandardMaterial` in bindless mode, write
-// `bindless_textures_2d[materials[slot].base_color_texture]`, where
-// `materials` is the bindless index table and `slot` is the index into that
-// table (which can be found in the `Mesh`).
+//! Defines the common arrays used to access bindless resources.
+//!
+//! This need to be kept up to date with the `BINDING_NUMBERS` table in
+//! `bindless.rs`.
+//!
+//! You access these by indexing into the bindless index table, and from there
+//! indexing into the appropriate binding array. For example, to access the base
+//! color texture of a `StandardMaterial` in bindless mode, write
+//! `bindless_textures_2d[materials[slot].base_color_texture]`, where
+//! `materials` is the bindless index table and `slot` is the index into that
+//! table (which can be found in the `Mesh`).
 
 // Binding 0 is the bindless index table.
-// Filtering samplers.
+/// Filtering samplers.
 @if(BINDLESS) {
 @group(constants::MATERIAL_BIND_GROUP) @binding(1) var bindless_samplers_filtering: binding_array<sampler>;
-// Non-filtering samplers (nearest neighbor).
+/// Non-filtering samplers (nearest neighbor).
 @group(constants::MATERIAL_BIND_GROUP) @binding(2) var bindless_samplers_non_filtering: binding_array<sampler>;
-// Comparison samplers (typically for shadow mapping).
+/// Comparison samplers (typically for shadow mapping).
 @group(constants::MATERIAL_BIND_GROUP) @binding(3) var bindless_samplers_comparison: binding_array<sampler>;
-// 1D textures.
+/// 1D textures.
 @group(constants::MATERIAL_BIND_GROUP) @binding(4) var bindless_textures_1d: binding_array<texture_1d<f32>>;
-// 2D textures.
+/// 2D textures.
 @group(constants::MATERIAL_BIND_GROUP) @binding(5) var bindless_textures_2d: binding_array<texture_2d<f32>>;
-// 2D array textures.
+/// 2D array textures.
 @group(constants::MATERIAL_BIND_GROUP) @binding(6) var bindless_textures_2d_array: binding_array<texture_2d_array<f32>>;
-// 3D textures.
+/// 3D textures.
 @group(constants::MATERIAL_BIND_GROUP) @binding(7) var bindless_textures_3d: binding_array<texture_3d<f32>>;
-// Cubemap textures.
+/// Cubemap textures.
 @group(constants::MATERIAL_BIND_GROUP) @binding(8) var bindless_textures_cube: binding_array<texture_cube<f32>>;
-// Cubemap array textures.
+/// Cubemap array textures.
 @group(constants::MATERIAL_BIND_GROUP) @binding(9) var bindless_textures_cube_array: binding_array<texture_cube_array<f32>>;
 }

--- a/crates/bevy_render/src/bindless.wesl
+++ b/crates/bevy_render/src/bindless.wesl
@@ -1,6 +1,3 @@
-@if(BINDLESS)
-enable wgpu_binding_array;
-
 //! Defines the common arrays used to access bindless resources.
 //!
 //! This need to be kept up to date with the `BINDING_NUMBERS` table in
@@ -12,6 +9,9 @@ enable wgpu_binding_array;
 //! `bindless_textures_2d[materials[slot].base_color_texture]`, where
 //! `materials` is the bindless index table and `slot` is the index into that
 //! table (which can be found in the `Mesh`).
+
+@if(BINDLESS)
+enable wgpu_binding_array;
 
 // Binding 0 is the bindless index table.
 /// Filtering samplers.

--- a/crates/bevy_render/src/color_operations.wesl
+++ b/crates/bevy_render/src/color_operations.wesl
@@ -2,7 +2,7 @@ import package::maths::{PI_2,PI,FRAC_PI_3};
 
 const HUE_GUARD: f32 = 0.0001;
 
-// https://en.wikipedia.org/wiki/SRGB
+/// https://en.wikipedia.org/wiki/SRGB
 fn gamma(value: f32) -> f32 {
     if value <= 0.0 {
         return value;
@@ -14,7 +14,7 @@ fn gamma(value: f32) -> f32 {
     }
 }
 
-// https://en.wikipedia.org/wiki/SRGB
+/// https://en.wikipedia.org/wiki/SRGB
 fn inverse_gamma(value: f32) -> f32 {
     if value <= 0.0 {
         return value;
@@ -51,7 +51,7 @@ fn srgb_to_linear(color: vec3<f32>) -> vec3<f32> {
     return srgb_to_linear_rgb(color);
 }
 
-// https://bottosson.github.io/posts/oklab/
+/// https://bottosson.github.io/posts/oklab/
 fn oklab_to_linear_rgb(c: vec3<f32>) -> vec3<f32> {
     let l_ = c.x + 0.39633778 * c.y + 0.21580376 * c.z;
     let m_ = c.x - 0.105561346 * c.y - 0.06385417 * c.z;
@@ -117,7 +117,7 @@ fn okhsl_to_linear_rgb(okhsl: vec3<f32>) -> vec3<f32> {
     return oklab_to_linear_rgb(oklab);
 }
 
-// https://bottosson.github.io/posts/oklab/ - inverse of oklab_to_linear_rgb
+/// https://bottosson.github.io/posts/oklab/ - inverse of oklab_to_linear_rgb
 fn linear_rgb_to_oklab(c: vec3<f32>) -> vec3<f32> {
     let l_ = pow(c.x * 0.4122214708 + c.y * 0.5363325363 + c.z * 0.0514459929, 1.0 / 3.0);
     let m_ = pow(c.x * 0.2119034982 + c.y * 0.6806995451 + c.z * 0.1073969566, 1.0 / 3.0);
@@ -188,8 +188,8 @@ fn oklch_to_linear_rgb(c: vec3<f32>) -> vec3<f32> {
 }
 
 fn mix_oklch(a: vec3<f32>, b: vec3<f32>, t: f32) -> vec3<f32> {
-    // If the chroma is close to zero for one of the endpoints, don't interpolate 
-    // the hue and instead use the hue of the other endpoint. This allows gradients that smoothly 
+    // If the chroma is close to zero for one of the endpoints, don't interpolate
+    // the hue and instead use the hue of the other endpoint. This allows gradients that smoothly
     // transition from black or white to a target color without passing through unrelated hues.
     var h = a.z;
     var g = b.z;
@@ -243,10 +243,10 @@ fn mix_oklch_long(a: vec3<f32>, b: vec3<f32>, t: f32) -> vec3<f32> {
 }
 
 fn mix_hsl(a: vec3<f32>, b: vec3<f32>, t: f32) -> vec3<f32> {
-    // If the saturation is close to zero for one of the endpoints, don't interpolate 
-    // the hue and instead use the hue of the other endpoint. This allows gradients that smoothly 
+    // If the saturation is close to zero for one of the endpoints, don't interpolate
+    // the hue and instead use the hue of the other endpoint. This allows gradients that smoothly
     // transition from black or white to a target color without passing through unrelated hues.
-    var h = a.x; 
+    var h = a.x;
     var g = b.x;
     if a.y < HUE_GUARD {
         h = g;
@@ -314,8 +314,8 @@ fn mix_okhsl_long(a: vec3<f32>, b: vec3<f32>, t: f32) -> vec3<f32> {
 }
 
 fn mix_hsv(a: vec3<f32>, b: vec3<f32>, t: f32) -> vec3<f32> {
-    // If the saturation is close to zero for one of the endpoints, don't interpolate 
-    // the hue and instead use the hue of the other endpoint. This allows gradients that smoothly 
+    // If the saturation is close to zero for one of the endpoints, don't interpolate
+    // the hue and instead use the hue of the other endpoint. This allows gradients that smoothly
     // transition from black or white to a target color without passing through unrelated hues.
     var h = a.x;
     var g = b.x;
@@ -368,24 +368,24 @@ fn mix_hsv_long(a: vec3<f32>, b: vec3<f32>, t: f32) -> vec3<f32> {
     );
 }
 
-// Converts HSV to RGB.
-//
-// Input: H ∈ [0, 2π), S ∈ [0, 1], V ∈ [0, 1].
-// Output: R ∈ [0, 1], G ∈ [0, 1], B ∈ [0, 1].
-//
-// <https://en.wikipedia.org/wiki/HSL_and_HSV#HSV_to_RGB_alternative>
+/// Converts HSV to RGB.
+///
+/// Input: H ∈ [0, 2π), S ∈ [0, 1], V ∈ [0, 1].
+/// Output: R ∈ [0, 1], G ∈ [0, 1], B ∈ [0, 1].
+///
+/// <https://en.wikipedia.org/wiki/HSL_and_HSV#HSV_to_RGB_alternative>
 fn hsv_to_rgb(hsv: vec3<f32>) -> vec3<f32> {
     let n = vec3(5.0, 3.0, 1.0);
     let k = (n + hsv.x / FRAC_PI_3) % 6.0;
     return hsv.z - hsv.z * hsv.y * max(vec3(0.0), min(k, min(4.0 - k, vec3(1.0))));
 }
 
-// Converts RGB to HSV.
-//
-// Input: R ∈ [0, 1], G ∈ [0, 1], B ∈ [0, 1].
-// Output: H ∈ [0, 2π), S ∈ [0, 1], V ∈ [0, 1].
-//
-// <https://en.wikipedia.org/wiki/HSL_and_HSV#From_RGB>
+/// Converts RGB to HSV.
+///
+/// Input: R ∈ [0, 1], G ∈ [0, 1], B ∈ [0, 1].
+/// Output: H ∈ [0, 2π), S ∈ [0, 1], V ∈ [0, 1].
+///
+/// <https://en.wikipedia.org/wiki/HSL_and_HSV#From_RGB>
 fn rgb_to_hsv(rgb: vec3<f32>) -> vec3<f32> {
     let x_max = max(rgb.r, max(rgb.g, rgb.b));  // i.e. V
     let x_min = min(rgb.r, min(rgb.g, rgb.b));
@@ -426,8 +426,8 @@ fn okhsl_to_ST(cusp: vec2<f32>) -> vec2<f32> {
     return vec2<f32>(cusp.y / cusp.x, cusp.y / (1.0 - cusp.x));
 }
 
-// Polynomial approximation for mid-gamut ST values.
-// Derived by optimization to ensure S_mid < S_max and T_mid < T_max.
+/// Polynomial approximation for mid-gamut ST values.
+/// Derived by optimization to ensure S_mid < S_max and T_mid < T_max.
 fn okhsl_get_ST_mid(a_: f32, b_: f32) -> vec2<f32> {
     let S = 0.11516993
         + 1.0 / (7.4477897
@@ -448,8 +448,8 @@ fn okhsl_get_ST_mid(a_: f32, b_: f32) -> vec2<f32> {
     return vec2<f32>(S, T);
 }
 
-// Approximate max saturation using a polynomial, then refine with 1 step of Halley's method.
-// a and b must be normalized (a^2 + b^2 == 1).
+/// Approximate max saturation using a polynomial, then refine with 1 step of Halley's method.
+/// a and b must be normalized (a^2 + b^2 == 1).
 fn okhsl_compute_max_saturation(a: f32, b: f32) -> f32 {
     var k0: f32 = 0.0; var k1: f32 = 0.0; var k2: f32 = 0.0;
     var k3: f32 = 0.0; var k4: f32 = 0.0;
@@ -474,12 +474,12 @@ fn okhsl_compute_max_saturation(a: f32, b: f32) -> f32 {
 
     var S = k0 + k1 * a + k2 * b + k3 * a * a + k4 * a * b;
 
-    // This step is done once for faster rendering. 
+    // This step is done once for faster rendering.
     // Most render targets will support 8 to 16 bit precision.
     let k_l = 0.39633778 * a + 0.21580376 * b;
     let k_m = -0.105561346 * a - 0.06385417 * b;
     let k_s = -0.08948418 * a - 1.2914855 * b;
-    
+
     let l_ = 1.0 + S * k_l;
     let m_ = 1.0 + S * k_m;
     let s_ = 1.0 + S * k_s;
@@ -511,8 +511,8 @@ fn okhsl_find_cusp(a: f32, b: f32) -> vec2<f32> {
     return vec2<f32>(L_cusp, L_cusp * S_cusp);
 }
 
-// Find intersection of the gamut boundary with the line from (L0, 0) to (L1, C1).
-// Uses 1 step of Halley's method.
+/// Find intersection of the gamut boundary with the line from (L0, 0) to (L1, C1).
+/// Uses 1 step of Halley's method.
 fn okhsl_find_gamut_intersection(a: f32, b: f32, L1: f32, C1: f32, L0: f32, cusp: vec2<f32>) -> f32 {
     let cusp_L = cusp.x;
     let cusp_C = cusp.y;
@@ -586,7 +586,7 @@ fn okhsl_find_gamut_intersection(a: f32, b: f32, L1: f32, C1: f32, L0: f32, cusp
     return t;
 }
 
-// Returns C_0, C_mid, C_max for a given Oklab L and hue direction (a_, b_).
+/// Returns C_0, C_mid, C_max for a given Oklab L and hue direction (a_, b_).
 fn okhsl_get_Cs(L: f32, a_: f32, b_: f32) -> vec3<f32> {
     let cusp = okhsl_find_cusp(a_, b_);
     let C_max = okhsl_find_gamut_intersection(a_, b_, L, 1.0, L, cusp);

--- a/crates/bevy_render/src/globals.wesl
+++ b/crates/bevy_render/src/globals.wesl
@@ -1,11 +1,11 @@
 struct Globals {
-    // The time since startup in seconds
-    // Wraps to 0 after 1 hour.
+    /// The time since startup in seconds
+    /// Wraps to 0 after 1 hour.
     time: f32,
-    // The delta time since the previous frame in seconds
+    /// The delta time since the previous frame in seconds
     delta_time: f32,
-    // Frame count since the start of the app.
-    // It wraps to zero when it reaches the maximum value of a u32.
+    /// Frame count since the start of the app.
+    /// It wraps to zero when it reaches the maximum value of a u32.
     frame_count: u32,
     @if(SIXTEEN_BYTE_ALIGNMENT)
     // WebGL2 structs must be 16 byte aligned.

--- a/crates/bevy_render/src/maths.wesl
+++ b/crates/bevy_render/src/maths.wesl
@@ -1,9 +1,14 @@
 
-const PI: f32 = 3.141592653589793;      // π
-const PI_2: f32 = 6.283185307179586;    // 2π
-const HALF_PI: f32 = 1.57079632679;     // π/2
-const FRAC_PI_3: f32 = 1.0471975512;    // π/3
-const E: f32 = 2.718281828459045;       // exp(1)
+/// π
+const PI: f32 = 3.141592653589793;
+/// 2π
+const PI_2: f32 = 6.283185307179586;
+/// π/2
+const HALF_PI: f32 = 1.57079632679;
+/// π/3
+const FRAC_PI_3: f32 = 1.0471975512;
+/// exp(1)
+const E: f32 = 2.718281828459045;
 
 fn affine2_to_square(affine: mat3x2<f32>) -> mat3x3<f32> {
     return mat3x3<f32>(
@@ -33,13 +38,13 @@ fn mat2x4_f32_to_mat3x3_unpack(
     );
 }
 
-// Extracts the square portion of an affine matrix: i.e. discards the
-// translation.
+/// Extracts the square portion of an affine matrix: i.e. discards the
+/// translation.
 fn affine3_to_mat3x3(affine: mat4x3<f32>) -> mat3x3<f32> {
     return mat3x3<f32>(affine[0].xyz, affine[1].xyz, affine[2].xyz);
 }
 
-// Returns the inverse of a 3x3 matrix.
+/// Returns the inverse of a 3x3 matrix.
 fn inverse_mat3x3(matrix: mat3x3<f32>) -> mat3x3<f32> {
     let tmp0 = cross(matrix[1], matrix[2]);
     let tmp1 = cross(matrix[2], matrix[0]);
@@ -48,34 +53,34 @@ fn inverse_mat3x3(matrix: mat3x3<f32>) -> mat3x3<f32> {
     return transpose(mat3x3<f32>(tmp0 * inv_det, tmp1 * inv_det, tmp2 * inv_det));
 }
 
-// Returns the inverse of an affine matrix.
-//
-// https://en.wikipedia.org/wiki/Affine_transformation#Groups
+/// Returns the inverse of an affine matrix.
+///
+/// https://en.wikipedia.org/wiki/Affine_transformation#Groups
 fn inverse_affine3(affine: mat4x3<f32>) -> mat4x3<f32> {
     let matrix3 = affine3_to_mat3x3(affine);
     let inv_matrix3 = inverse_mat3x3(matrix3);
     return mat4x3<f32>(inv_matrix3[0], inv_matrix3[1], inv_matrix3[2], -(inv_matrix3 * affine[3]));
 }
 
-// Extracts the upper 3x3 portion of a 4x4 matrix.
+/// Extracts the upper 3x3 portion of a 4x4 matrix.
 fn mat4x4_to_mat3x3(m: mat4x4<f32>) -> mat3x3<f32> {
     return mat3x3<f32>(m[0].xyz, m[1].xyz, m[2].xyz);
 }
 
-// Copy the sign bit from B onto A.
-// copysign allows proper handling of negative zero to match the rust implementation of orthonormalize
+/// Copy the sign bit from B onto A.
+/// copysign allows proper handling of negative zero to match the rust implementation of orthonormalize
 fn copysign(a: f32, b: f32) -> f32 {
     return bitcast<f32>((bitcast<u32>(a) & 0x7FFFFFFF) | (bitcast<u32>(b) & 0x80000000));
 }
 
-// Constructs a right-handed orthonormal basis from a given unit Z vector.
-//
-// NOTE: requires unit-length (normalized) input to function properly.
-//
-// https://jcgt.org/published/0006/01/01/paper.pdf
-// this method of constructing a basis from a vec3 is also used by `glam::Vec3::any_orthonormal_pair`
-// the construction of the orthonormal basis up and right vectors here needs to precisely match the rust
-// implementation in bevy_light/spot_light.rs:spot_light_world_from_view
+/// Constructs a right-handed orthonormal basis from a given unit Z vector.
+///
+/// NOTE: requires unit-length (normalized) input to function properly.
+///
+/// https://jcgt.org/published/0006/01/01/paper.pdf
+/// this method of constructing a basis from a vec3 is also used by `glam::Vec3::any_orthonormal_pair`
+/// the construction of the orthonormal basis up and right vectors here needs to precisely match the rust
+/// implementation in bevy_light/spot_light.rs:spot_light_world_from_view
 fn orthonormalize(z_basis: vec3<f32>) -> mat3x3<f32> {
     let sign = copysign(1.0, z_basis.z);
     let a = -1.0 / (sign + z_basis.z);
@@ -85,17 +90,17 @@ fn orthonormalize(z_basis: vec3<f32>) -> mat3x3<f32> {
     return mat3x3(x_basis, y_basis, z_basis);
 }
 
-// Rotates a direction by a rotation quaternion q.
+/// Rotates a direction by a rotation quaternion q.
 fn quat_rotate(q: vec4<f32>, dir: vec3<f32>) -> vec3<f32> {
     let t = 2.0 * cross(q.xyz, dir);
     return dir + q.w * t + cross(q.xyz, t);
 }
 
-// Returns true if any part of a sphere is on the positive side of a plane.
-//
-// `sphere_center.w` should be 1.0.
-//
-// This is used for frustum culling.
+/// Returns true if any part of a sphere is on the positive side of a plane.
+///
+/// `sphere_center.w` should be 1.0.
+///
+/// This is used for frustum culling.
 fn sphere_intersects_plane_half_space(
     plane: vec4<f32>,
     sphere_center: vec4<f32>,
@@ -104,25 +109,25 @@ fn sphere_intersects_plane_half_space(
     return dot(plane, sphere_center) + sphere_radius > 0.0;
 }
 
-// Returns the distances along the ray to its intersections with a sphere
-// centered at the origin.
-//
-// r: distance from the sphere center to the ray origin
-// mu: cosine of the zenith angle
-// sphere_radius: radius of the sphere
-//
-// Returns vec2(t0, t1). If there is no intersection, returns vec2(-1.0).
+/// Returns the distances along the ray to its intersections with a sphere
+/// centered at the origin.
+///
+/// r: distance from the sphere center to the ray origin
+/// mu: cosine of the zenith angle
+/// sphere_radius: radius of the sphere
+///
+/// Returns vec2(t0, t1). If there is no intersection, returns vec2(-1.0).
 fn ray_sphere_intersect(r: f32, mu: f32, sphere_radius: f32) -> vec2<f32> {
     let discriminant = r * r * (mu * mu - 1.0) + sphere_radius * sphere_radius;
-    
+
     // No intersection
     if discriminant < 0.0 {
         return vec2(-1.0);
     }
-    
+
     let q = -r * mu;
     let sqrt_discriminant = sqrt(discriminant);
-    
+
     // Return both intersection distances
     return vec2(
         q - sqrt_discriminant,
@@ -130,12 +135,12 @@ fn ray_sphere_intersect(r: f32, mu: f32, sphere_radius: f32) -> vec2<f32> {
     );
 }
 
-// pow() but safe for NaNs/negatives
+/// pow() but safe for NaNs/negatives
 fn powsafe(color: vec3<f32>, power: f32) -> vec3<f32> {
     return pow(abs(color), vec3(power)) * sign(color);
 }
 
-// https://en.wikipedia.org/wiki/Vector_projection#Vector_projection_2
+/// https://en.wikipedia.org/wiki/Vector_projection#Vector_projection_2
 fn project_onto(lhs: vec3<f32>, rhs: vec3<f32>) -> vec3<f32> {
     let other_len_sq_rcp = 1.0 / dot(rhs, rhs);
     return rhs * dot(lhs, rhs) * other_len_sq_rcp;
@@ -145,7 +150,7 @@ fn project_onto(lhs: vec3<f32>, rhs: vec3<f32>) -> vec3<f32> {
 // are likely most useful when raymarching, for example, where complete numeric
 // accuracy can be sacrificed for greater sample count.
 
-// Slightly less accurate than fast_acos_4, but much simpler.
+/// Slightly less accurate than fast_acos_4, but much simpler.
 fn fast_acos(in_x: f32) -> f32 {
     let x = abs(in_x);
     var res = -0.156583 * x + HALF_PI;
@@ -153,10 +158,10 @@ fn fast_acos(in_x: f32) -> f32 {
     return select(PI - res, res, in_x >= 0.0);
 }
 
-// 4th order polynomial approximation
-// 4 VGRP, 16 ALU Full Rate
-// 7 * 10^-5 radians precision
-// Reference : Handbook of Mathematical Functions (chapter : Elementary Transcendental Functions), M. Abramowitz and I.A. Stegun, Ed.
+/// 4th order polynomial approximation
+/// 4 VGRP, 16 ALU Full Rate
+/// 7 * 10^-5 radians precision
+/// Reference : Handbook of Mathematical Functions (chapter : Elementary Transcendental Functions), M. Abramowitz and I.A. Stegun, Ed.
 fn fast_acos_4(x: f32) -> f32 {
     let x1 = abs(x);
     let x2 = x1 * x1;

--- a/crates/bevy_render/src/mesh/metadata_types.wesl
+++ b/crates/bevy_render/src/mesh/metadata_types.wesl
@@ -1,10 +1,10 @@
 
 struct MeshMetadata {
-    // AABB for decompressing positions.
+    /// AABB for decompressing positions.
     aabb_center: vec3<f32>,
     pad_a: u32,
     aabb_half_extents: vec3<f32>,
     pad_b: u32,
-    // UV channels range for decompressing UVs coordinates.
+    /// UV channels range for decompressing UVs coordinates.
     uv_channels_min_and_extents: array<vec4<f32>, 2>,
 };

--- a/crates/bevy_render/src/occlusion_culling/mesh_preprocess_types.wesl
+++ b/crates/bevy_render/src/occlusion_culling/mesh_preprocess_types.wesl
@@ -1,53 +1,53 @@
-// Types needed for GPU mesh uniform building.
+//! Types needed for GPU mesh uniform building.
 
-// Per-frame data that the CPU supplies to the GPU.
+/// Per-frame data that the CPU supplies to the GPU.
 struct MeshInput {
-    // The model transform.
+    /// The model transform.
     world_from_local: mat3x4<f32>,
-    // The lightmap UV rect, packed into 64 bits.
+    /// The lightmap UV rect, packed into 64 bits.
     lightmap_uv_rect: vec2<u32>,
-    // Various flags.
+    /// Various flags.
     flags: u32,
-    // The index of the `PreviousMeshInput` uniform in the buffer, or `u32::MAX`
-    // if there's no such uniform.
+    /// The index of the `PreviousMeshInput` uniform in the buffer, or `u32::MAX`
+    /// if there's no such uniform.
     previous_input_index: u32,
     first_vertex_index: u32,
     first_index_index: u32,
     index_count: u32,
     current_skin_index: u32,
-    // Low 16 bits: index of the material inside the bind group data.
-    // High 16 bits: index of the lightmap in the binding array.
+    /// Low 16 bits: index of the material inside the bind group data.
+    /// High 16 bits: index of the lightmap in the binding array.
     material_and_lightmap_bind_group_slot: u32,
     timestamp: u32,
-    // User supplied index to identify the mesh instance
+    /// User supplied index to identify the mesh instance
     tag: u32,
-    // The index of the morph descriptor for this mesh instance in the
-    // `morph_descriptors` table.
-    //
-    // If the mesh has no morph targets, this is `u32::MAX`.
+    /// The index of the morph descriptor for this mesh instance in the
+    /// `morph_descriptors` table.
+    ///
+    /// If the mesh has no morph targets, this is `u32::MAX`.
     morph_descriptor_index: u32,
     metadata_index: u32
 }
 
-// Per-mesh-instance data that we retain from the previous frame.
+/// Per-mesh-instance data that we retain from the previous frame.
 struct PreviousMeshInput {
-    // The model transform.
+    /// The model transform.
     world_from_local: mat3x4<f32>,
 };
 
-// The `wgpu` indirect parameters structure. This is a union of two structures.
-// For more information, see the corresponding comment in
-// `gpu_preprocessing.rs`.
+/// The `wgpu` indirect parameters structure. This is a union of two structures.
+/// For more information, see the corresponding comment in
+/// `gpu_preprocessing.rs`.
 struct IndirectParametersIndexed {
-    // `vertex_count` or `index_count`.
+    /// `vertex_count` or `index_count`.
     index_count: u32,
-    // `instance_count` in both structures.
+    /// `instance_count` in both structures.
     instance_count: u32,
-    // `first_vertex` or `first_index`.
+    /// `first_vertex` or `first_index`.
     first_index: u32,
-    // `base_vertex` or `first_instance`.
+    /// `base_vertex` or `first_instance`.
     base_vertex: u32,
-    // A read-only copy of `instance_index`.
+    /// A read-only copy of `instance_index`.
     first_instance: u32,
 }
 
@@ -58,51 +58,51 @@ struct IndirectParametersNonIndexed {
     first_instance: u32,
 }
 
-// Information needed to construct indirect draw parameters for a single draw.
-//
-// Note that is per-*draw* (i.e. per-mesh), not per-mesh-instance or
-// per-batch-set. A single multi-draw indirect call can perform multiple draws.
-//
-// Typically, the uniform allocation and mesh preprocessing phases fill in this
-// structure. However, parts of it may be filled in on the CPU for objects that
-// aren't multidrawn.
+/// Information needed to construct indirect draw parameters for a single draw.
+///
+/// Note that is per-*draw* (i.e. per-mesh), not per-mesh-instance or
+/// per-batch-set. A single multi-draw indirect call can perform multiple draws.
+///
+/// Typically, the uniform allocation and mesh preprocessing phases fill in this
+/// structure. However, parts of it may be filled in on the CPU for objects that
+/// aren't multidrawn.
 struct IndirectParametersMetadata {
-    // The index of the first `MeshUniform` for this draw in the mesh uniform
-    // buffer.
-    //
-    // `MeshUniform`s for all instances are stored consecutively.
-    //
-    // This is filled in in the `allocate_uniforms` shader, or on the CPU when
-    // multidraw isn't in use.
+    /// The index of the first `MeshUniform` for this draw in the mesh uniform
+    /// buffer.
+    ///
+    /// `MeshUniform`s for all instances are stored consecutively.
+    ///
+    /// This is filled in in the `allocate_uniforms` shader, or on the CPU when
+    /// multidraw isn't in use.
     base_output_index: u32,
 
-    // The index of this batch set in the `IndirectBatchSet` array.
-    //
-    // This is filled in in the `allocate_uniforms` shader, or on the CPU when
-    // multidraw isn't in use.
+    /// The index of this batch set in the `IndirectBatchSet` array.
+    ///
+    /// This is filled in in the `allocate_uniforms` shader, or on the CPU when
+    /// multidraw isn't in use.
     batch_set_index: u32,
 
-    // The index of the mesh in the `MeshInput` buffer.
-    //
-    // The mesh preprocessing shader fills this in.
+    /// The index of the mesh in the `MeshInput` buffer.
+    ///
+    /// The mesh preprocessing shader fills this in.
     mesh_index: u32,
 
-    // The number of instances that were visible last frame (if occlusion
-    // culling is in use) or that were visible at all (if occlusion culling
-    // isn't in use).
+    /// The number of instances that were visible last frame (if occlusion
+    /// culling is in use) or that were visible at all (if occlusion culling
+    /// isn't in use).
     @if(WRITE_INDIRECT_PARAMETERS_METADATA)
     early_instance_count: atomic<u32>,
-    // The number of instances that were visible this frame if occlusion culling
-    // is in use.
+    /// The number of instances that were visible this frame if occlusion culling
+    /// is in use.
     @if(WRITE_INDIRECT_PARAMETERS_METADATA)
     late_instance_count: atomic<u32>,
-    // The number of instances that were visible last frame (if occlusion
-    // culling is in use) or that were visible at all (if occlusion culling
-    // isn't in use).
+    /// The number of instances that were visible last frame (if occlusion
+    /// culling is in use) or that were visible at all (if occlusion culling
+    /// isn't in use).
     @if(!WRITE_INDIRECT_PARAMETERS_METADATA)
     early_instance_count: u32,
-    // The number of instances that were visible this frame if occlusion culling
-    // is in use.
+    /// The number of instances that were visible this frame if occlusion culling
+    /// is in use.
     @if(!WRITE_INDIRECT_PARAMETERS_METADATA)
     late_instance_count: u32,
 }
@@ -112,38 +112,38 @@ struct IndirectBatchSet {
     indirect_parameters_base: u32,
 }
 
-// One invocation of this compute shader: i.e. one mesh instance in a view.
+/// One invocation of this compute shader: i.e. one mesh instance in a view.
 struct PreprocessWorkItem {
-    // The index of the `MeshInput` in the `current_input` buffer that we read
-    // from.
+    /// The index of the `MeshInput` in the `current_input` buffer that we read
+    /// from.
     input_index: u32,
-    // In direct mode, the index of the `Mesh` in `output` that we write to. In
-    // indirect mode, the index of the `IndirectParameters` in
-    // `indirect_parameters` that we write to.
+    /// In direct mode, the index of the `Mesh` in `output` that we write to. In
+    /// indirect mode, the index of the `IndirectParameters` in
+    /// `indirect_parameters` that we write to.
     output_or_indirect_parameters_index: u32,
 }
 
-// Information about each bin in a batch set.
-//
-// This is maintained by the CPU and cached for bins that don't change from
-// frame to frame.
+/// Information about each bin in a batch set.
+///
+/// This is maintained by the CPU and cached for bins that don't change from
+/// frame to frame.
 struct BinMetadata {
-    // The index of the indirect parameters for this bin, relative to the first
-    // indirect parameter index for the batch set.
-    //
-    // That is, the final indirect parameters index for this bin is
-    // `first_indirect_parameters_index` in the `UniformAllocationMetadata` plus
-    // this value.
+    /// The index of the indirect parameters for this bin, relative to the first
+    /// indirect parameter index for the batch set.
+    ///
+    /// That is, the final indirect parameters index for this bin is
+    /// `first_indirect_parameters_index` in the `UniformAllocationMetadata` plus
+    /// this value.
     indirect_parameters_offset: u32,
 
-    // The index of the bin that this metadata corresponds to.
-    //
-    // The GPU doesn't use this, but the CPU does in order to perform the
-    // reverse mapping from bin metadata index back to the bin. We could store
-    // this in a non-GPU-accessible buffer, but I figured the extra complexity
-    // wasn't worth it.
+    /// The index of the bin that this metadata corresponds to.
+    ///
+    /// The GPU doesn't use this, but the CPU does in order to perform the
+    /// reverse mapping from bin metadata index back to the bin. We could store
+    /// this in a non-GPU-accessible buffer, but I figured the extra complexity
+    /// wasn't worth it.
     bin_index: u32,
 
-    // The number of mesh instances in this bin.
+    /// The number of mesh instances in this bin.
     instance_count: u32,
 };

--- a/crates/bevy_render/src/render_resource/sparse_buffer_update.wesl
+++ b/crates/bevy_render/src/render_resource/sparse_buffer_update.wesl
@@ -1,29 +1,29 @@
-// A compute shader that performs scattering sparse updates to
-// `AtomicSparseBufferVec` types.
-//
-// This shader isn't used for every update. Only if the number of updates is
-// small is this shader used. Otherwise, the standard `write_buffer` `wgpu`
-// command is used to update the buffer in bulk.
-//
-// We issue one thread per *word*, not per element. That allows us to achieve
-// maximum parallelism, without any loops.
+//! A compute shader that performs scattering sparse updates to
+//! `AtomicSparseBufferVec` types.
+//!
+//! This shader isn't used for every update. Only if the number of updates is
+//! small is this shader used. Otherwise, the standard `write_buffer` `wgpu`
+//! command is used to update the buffer in bulk.
+//!
+//! We issue one thread per *word*, not per element. That allows us to achieve
+//! maximum parallelism, without any loops.
 
-// Metadata that describes the update.
+/// Metadata that describes the update.
 struct SparseBufferUpdateMetadata {
-    // The size of a single element in words.
+    /// The size of a single element in words.
     element_size: u32,
-    // The total number of elements to be updated.
+    /// The total number of elements to be updated.
     updated_element_count: u32,
 };
 
-// The buffer we're copying to.
+/// The buffer we're copying to.
 @group(0) @binding(0) var<storage, read_write> dest_buffer: array<u32>;
-// The buffer we're copying from.
+/// The buffer we're copying from.
 @group(0) @binding(1) var<storage> src_buffer: array<u32>;
-// For each element in `src_buffer`, the element in `dest_buffer` that we should
-// copy it to.
+/// For each element in `src_buffer`, the element in `dest_buffer` that we should
+/// copy it to.
 @group(0) @binding(2) var<storage> indices: array<u32>;
-// Metadata that describes the operation.
+/// Metadata that describes the operation.
 @group(0) @binding(3) var<uniform> metadata: SparseBufferUpdateMetadata;
 
 @workgroup_size(256, 1, 1)

--- a/crates/bevy_render/src/utils.wesl
+++ b/crates/bevy_render/src/utils.wesl
@@ -15,7 +15,7 @@ fn decompress_vertex_uv(compressed_uv: vec2<f32>, uv_min_and_extents: vec4<f32>)
     return uv_min_and_extents.xy + uv_min_and_extents.zw * compressed_uv;
 }
 
-// For decoding normals or unit direction vectors from octahedral coordinates. Input is [-1, 1].
+/// For decoding normals or unit direction vectors from octahedral coordinates. Input is [-1, 1].
 fn octahedral_decode_signed(v: vec2<f32>) -> vec3<f32> {
     var n = vec3(v.xy, 1.0 - abs(v.x) - abs(v.y));
     let t = saturate(-n.z);
@@ -24,7 +24,7 @@ fn octahedral_decode_signed(v: vec2<f32>) -> vec3<f32> {
     return normalize(n);
 }
 
-// Decode tangent vectors from octahedral coordinates and return the sign. Input is [-1, 1]. The y component should have been mapped to always be positive and then encoded the sign.
+/// Decode tangent vectors from octahedral coordinates and return the sign. Input is [-1, 1]. The y component should have been mapped to always be positive and then encoded the sign.
 fn octahedral_decode_tangent(v: vec2<f32>) -> vec4<f32> {
     let sign = select(-1.0, 1.0, v.y >= 0.0);
     var f = v;
@@ -33,8 +33,8 @@ fn octahedral_decode_tangent(v: vec2<f32>) -> vec4<f32> {
     return vec4<f32>(octahedral_decode_signed(f), sign);
 }
 
-// https://jcgt.org/published/0003/02/01/paper.pdf
-// For encoding normals or unit direction vectors as octahedral coordinates.
+/// https://jcgt.org/published/0003/02/01/paper.pdf
+/// For encoding normals or unit direction vectors as octahedral coordinates.
 fn octahedral_encode(v: vec3<f32>) -> vec2<f32> {
     var n = v / (abs(v.x) + abs(v.y) + abs(v.z));
     let octahedral_wrap = (1.0 - abs(n.yx)) * select(vec2(-1.0), vec2(1.0), n.xy > vec2f(0.0));
@@ -42,7 +42,7 @@ fn octahedral_encode(v: vec3<f32>) -> vec2<f32> {
     return n_xy * 0.5 + 0.5;
 }
 
-// For decoding normals or unit direction vectors from octahedral coordinates.
+/// For decoding normals or unit direction vectors from octahedral coordinates.
 fn octahedral_decode(v: vec2<f32>) -> vec3<f32> {
     let f = v * 2.0 - 1.0;
     return octahedral_decode_signed(f);

--- a/crates/bevy_render/src/view.wesl
+++ b/crates/bevy_render/src/view.wesl
@@ -17,84 +17,84 @@ struct View {
     world_from_clip: mat4x4<f32>,
     world_from_view: mat4x4<f32>,
     view_from_world: mat4x4<f32>,
-    // Typically a column-major right-handed projection matrix, one of either:
-    //
-    // Perspective (infinite reverse z)
-    // ```
-    // f = 1 / tan(fov_y_radians / 2)
-    //
-    // ⎡ f / aspect  0   0     0 ⎤
-    // ⎢          0  f   0     0 ⎥
-    // ⎢          0  0   0  near ⎥
-    // ⎣          0  0  -1     0 ⎦
-    // ```
-    //
-    // Orthographic
-    // ```
-    // w = right - left
-    // h = top - bottom
-    // d = far - near
-    // cw = -right - left
-    // ch = -top - bottom
-    //
-    // ⎡ 2 / w      0      0   cw / w ⎤
-    // ⎢     0  2 / h      0   ch / h ⎥
-    // ⎢     0      0  1 / d  far / d ⎥
-    // ⎣     0      0      0        1 ⎦
-    // ```
-    //
-    // `clip_from_view[3][3] == 1.0` is the standard way to check if a projection is orthographic
-    //
-    // Wgsl matrices are column major, so for example getting the near plane of a perspective projection is `clip_from_view[3][2]`
-    //
-    // Custom projections are also possible however.
+    /// Typically a column-major right-handed projection matrix, one of either:
+    ///
+    /// Perspective (infinite reverse z)
+    /// ```
+    /// f = 1 / tan(fov_y_radians / 2)
+    ///
+    /// ⎡ f / aspect  0   0     0 ⎤
+    /// ⎢          0  f   0     0 ⎥
+    /// ⎢          0  0   0  near ⎥
+    /// ⎣          0  0  -1     0 ⎦
+    /// ```
+    ///
+    /// Orthographic
+    /// ```
+    /// w = right - left
+    /// h = top - bottom
+    /// d = far - near
+    /// cw = -right - left
+    /// ch = -top - bottom
+    ///
+    /// ⎡ 2 / w      0      0   cw / w ⎤
+    /// ⎢     0  2 / h      0   ch / h ⎥
+    /// ⎢     0      0  1 / d  far / d ⎥
+    /// ⎣     0      0      0        1 ⎦
+    /// ```
+    ///
+    /// `clip_from_view[3][3] == 1.0` is the standard way to check if a projection is orthographic
+    ///
+    /// Wgsl matrices are column major, so for example getting the near plane of a perspective projection is `clip_from_view[3][2]`
+    ///
+    /// Custom projections are also possible however.
     clip_from_view: mat4x4<f32>,
     view_from_clip: mat4x4<f32>,
     world_position: vec3<f32>,
     exposure: f32,
-    // viewport(x_origin, y_origin, width, height)
+    /// viewport(x_origin, y_origin, width, height)
     viewport: vec4<f32>,
     main_pass_viewport: vec4<f32>,
-    // 6 world-space half spaces (normal: vec3, distance: f32) ordered left, right, top, bottom, near, far.
-    // The normal vectors point towards the interior of the frustum.
-    // A half space contains `p` if `normal.dot(p) + distance > 0.`
+    /// 6 world-space half spaces (normal: vec3, distance: f32) ordered left, right, top, bottom, near, far.
+    /// The normal vectors point towards the interior of the frustum.
+    /// A half space contains `p` if `normal.dot(p) + distance > 0.`
     frustum: array<vec4<f32>, 6>,
-    // The world-space position of the camera used to resolve visibility ranges.
-    //
-    // This is the position of the camera itself, unless this view isn't
-    // associated with a camera, in which case it's the position of the primary
-    // camera.
+    /// The world-space position of the camera used to resolve visibility ranges.
+    ///
+    /// This is the position of the camera itself, unless this view isn't
+    /// associated with a camera, in which case it's the position of the primary
+    /// camera.
     lod_view_world_position: vec3<f32>,
     color_grading: ColorGrading,
     mip_bias: f32,
     frame_count: u32,
 };
 
-/// World space:
-/// +y is up
-
-/// View space:
-/// -z is forward, +x is right, +y is up
-/// Forward is from the camera position into the scene.
-/// (0.0, 0.0, -1.0) is linear distance of 1.0 in front of the camera's view relative to the camera's rotation
-/// (0.0, 1.0, 0.0) is linear distance of 1.0 above the camera's view relative to the camera's rotation
-
-/// NDC (normalized device coordinate):
-/// https://www.w3.org/TR/webgpu/#coordinate-systems
-/// (-1.0, -1.0) in NDC is located at the bottom-left corner of NDC
-/// (1.0, 1.0) in NDC is located at the top-right corner of NDC
-/// Z is depth where:
-///    1.0 is near clipping plane
-///    Perspective projection: 0.0 is inf far away
-///    Orthographic projection: 0.0 is far clipping plane
-
-/// Clip space:
-/// This is NDC before the perspective divide, still in homogenous coordinate space.
-/// Dividing a clip space point by its w component yields a point in NDC space.
-
-/// UV space:
-/// 0.0, 0.0 is the top left
-/// 1.0, 1.0 is the bottom right
+//! World space:
+//! +y is up
+//!
+//! View space:
+//! -z is forward, +x is right, +y is up
+//! Forward is from the camera position into the scene.
+//! (0.0, 0.0, -1.0) is linear distance of 1.0 in front of the camera's view relative to the camera's rotation
+//! (0.0, 1.0, 0.0) is linear distance of 1.0 above the camera's view relative to the camera's rotation
+//!
+//! NDC (normalized device coordinate):
+//! https://www.w3.org/TR/webgpu/#coordinate-systems
+//! (-1.0, -1.0) in NDC is located at the bottom-left corner of NDC
+//! (1.0, 1.0) in NDC is located at the top-right corner of NDC
+//! Z is depth where:
+//!    1.0 is near clipping plane
+//!    Perspective projection: 0.0 is inf far away
+//!    Orthographic projection: 0.0 is far clipping plane
+//!
+//! Clip space:
+//! This is NDC before the perspective divide, still in homogenous coordinate space.
+//! Dividing a clip space point by its w component yields a point in NDC space.
+//!
+//! UV space:
+//! 0.0, 0.0 is the top left
+//! 1.0, 1.0 is the bottom right
 
 
 // -----------------

--- a/crates/bevy_render/src/view.wesl
+++ b/crates/bevy_render/src/view.wesl
@@ -1,3 +1,29 @@
+//! World space:
+//! +y is up
+//!
+//! View space:
+//! -z is forward, +x is right, +y is up
+//! Forward is from the camera position into the scene.
+//! (0.0, 0.0, -1.0) is linear distance of 1.0 in front of the camera's view relative to the camera's rotation
+//! (0.0, 1.0, 0.0) is linear distance of 1.0 above the camera's view relative to the camera's rotation
+//!
+//! NDC (normalized device coordinate):
+//! https://www.w3.org/TR/webgpu/#coordinate-systems
+//! (-1.0, -1.0) in NDC is located at the bottom-left corner of NDC
+//! (1.0, 1.0) in NDC is located at the top-right corner of NDC
+//! Z is depth where:
+//!    1.0 is near clipping plane
+//!    Perspective projection: 0.0 is inf far away
+//!    Orthographic projection: 0.0 is far clipping plane
+//!
+//! Clip space:
+//! This is NDC before the perspective divide, still in homogenous coordinate space.
+//! Dividing a clip space point by its w component yields a point in NDC space.
+//!
+//! UV space:
+//! 0.0, 0.0 is the top left
+//! 1.0, 1.0 is the bottom right
+
 struct ColorGrading {
     balance: mat3x3<f32>,
     saturation: vec3<f32>,
@@ -69,33 +95,6 @@ struct View {
     mip_bias: f32,
     frame_count: u32,
 };
-
-//! World space:
-//! +y is up
-//!
-//! View space:
-//! -z is forward, +x is right, +y is up
-//! Forward is from the camera position into the scene.
-//! (0.0, 0.0, -1.0) is linear distance of 1.0 in front of the camera's view relative to the camera's rotation
-//! (0.0, 1.0, 0.0) is linear distance of 1.0 above the camera's view relative to the camera's rotation
-//!
-//! NDC (normalized device coordinate):
-//! https://www.w3.org/TR/webgpu/#coordinate-systems
-//! (-1.0, -1.0) in NDC is located at the bottom-left corner of NDC
-//! (1.0, 1.0) in NDC is located at the top-right corner of NDC
-//! Z is depth where:
-//!    1.0 is near clipping plane
-//!    Perspective projection: 0.0 is inf far away
-//!    Orthographic projection: 0.0 is far clipping plane
-//!
-//! Clip space:
-//! This is NDC before the perspective divide, still in homogenous coordinate space.
-//! Dividing a clip space point by its w component yields a point in NDC space.
-//!
-//! UV space:
-//! 0.0, 0.0 is the top left
-//! 1.0, 1.0 is the bottom right
-
 
 // -----------------
 // TO WORLD --------
@@ -248,18 +247,18 @@ fn view_z_to_depth_ndc(view_z: f32, clip_from_view: mat4x4<f32>) -> f32 {
 // UV --------------
 // -----------------
 
-/// Convert ndc space xy coordinate [-1.0 .. 1.0] to uv [0.0 .. 1.0]
+/// Convert ndc space xy coordinate `[-1.0 .. 1.0]` to uv `[0.0 .. 1.0]`
 fn ndc_to_uv(ndc: vec2<f32>) -> vec2<f32> {
     return ndc * vec2(0.5, -0.5) + vec2(0.5);
 }
 
-/// Convert uv [0.0 .. 1.0] coordinate to ndc space xy [-1.0 .. 1.0]
+/// Convert uv `[0.0 .. 1.0]` coordinate to ndc space xy `[-1.0 .. 1.0]`
 fn uv_to_ndc(uv: vec2<f32>) -> vec2<f32> {
     return uv * vec2(2.0, -2.0) + vec2(-1.0, 1.0);
 }
 
-/// returns the (0.0, 0.0) .. (1.0, 1.0) position within the viewport for the current render target
-/// [0 .. render target viewport size] eg. [(0.0, 0.0) .. (1280.0, 720.0)] to [(0.0, 0.0) .. (1.0, 1.0)]
+/// returns the `(0.0, 0.0) .. (1.0, 1.0)` position within the viewport for the current render target
+/// `[0 .. render target viewport size]` eg. `[(0.0, 0.0) .. (1280.0, 720.0)]` to `[(0.0, 0.0) .. (1.0, 1.0)]`
 fn frag_coord_to_uv(frag_coord: vec2<f32>, viewport: vec4<f32>) -> vec2<f32> {
     return (frag_coord - viewport.xy) / viewport.zw;
 }
@@ -269,8 +268,8 @@ fn frag_coord_to_ndc(frag_coord: vec4<f32>, viewport: vec4<f32>) -> vec3<f32> {
     return vec3(uv_to_ndc(frag_coord_to_uv(frag_coord.xy, viewport)), frag_coord.z);
 }
 
-/// Convert ndc space xy coordinate [-1.0 .. 1.0] to [0 .. render target
-/// viewport size]
+/// Convert ndc space xy coordinate `[-1.0 .. 1.0]` to `[0 .. render target
+/// viewport size]`
 fn ndc_to_frag_coord(ndc: vec2<f32>, viewport: vec4<f32>) -> vec2<f32> {
     return ndc_to_uv(ndc) * viewport.zw;
 }

--- a/crates/bevy_render/src/view/window/screenshot.wesl
+++ b/crates/bevy_render/src/view/window/screenshot.wesl
@@ -1,5 +1,5 @@
-// This vertex shader will create a triangle that will cover the entire screen
-// with minimal effort, avoiding the need for a vertex buffer etc.
+/// This vertex shader will create a triangle that will cover the entire screen
+/// with minimal effort, avoiding the need for a vertex buffer etc.
 @vertex
 fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> @builtin(position) vec4<f32> {
     let x = f32((in_vertex_index & 1u) << 2u);

--- a/crates/bevy_solari/src/realtime/bindings.wesl
+++ b/crates/bevy_solari/src/realtime/bindings.wesl
@@ -30,8 +30,8 @@ enable wgpu_ray_query;
 @group(2) @binding(4) var specular_motion_vectors: texture_storage_2d<rg16float, write>;
 }
 
-// User-configurable settings from the `SolariLighting` component, plus per-frame
-// state. Field order and types must match `SolariLightingUniforms` in `prepare.rs`.
+/// User-configurable settings from the `SolariLighting` component, plus per-frame
+/// state. Field order and types must match `SolariLightingUniforms` in `prepare.rs`.
 struct SolariLightingSettings {
     confidence_weight_cap: f32,
     primary_di_samples: u32,
@@ -47,7 +47,7 @@ struct SolariLightingSettings {
     reset: u32,
 }
 
-// Don't adjust the size of this struct without also adjusting `prepare::RESOLVED_LIGHT_SAMPLE_STRUCT_SIZE`.
+/// Don't adjust the size of this struct without also adjusting `prepare::RESOLVED_LIGHT_SAMPLE_STRUCT_SIZE`.
 struct ResolvedLightSamplePacked {
     world_position_x: f32,
     world_position_y: f32,
@@ -57,7 +57,7 @@ struct ResolvedLightSamplePacked {
     inverse_pdf: f32,
 }
 
-// Don't adjust the size of this struct without also adjusting `prepare::RESERVOIR_STRUCT_SIZE`.
+/// Don't adjust the size of this struct without also adjusting `prepare::RESERVOIR_STRUCT_SIZE`.
 struct Reservoir {
     sample_point_world_position: vec3<f32>,
     unbiased_contribution_weight: f32,
@@ -85,7 +85,7 @@ struct WorldCacheGeometryData {
     padding_b: u32,
 }
 
-// Keep in sync with the packed world-cache layout constants in `prepare.rs`.
+/// Keep in sync with the packed world-cache layout constants in `prepare.rs`.
 struct WorldCache {
     checksums: array<atomic<u32>, constants::WORLD_CACHE_SIZE>,
     @if(WORLD_CACHE_NON_ATOMIC_LIFE_BUFFER)

--- a/crates/bevy_solari/src/realtime/gbuffer_utils.wesl
+++ b/crates/bevy_solari/src/realtime/gbuffer_utils.wesl
@@ -34,7 +34,7 @@ fn reconstruct_world_position(pixel_id: vec2<u32>, depth: f32, view_size: vec2<f
     return world_pos.xyz / world_pos.w;
 }
 
-// Reject if tangent plane differs more than 0.3% or angle between normals more than 90 degrees
+/// Reject if tangent plane differs more than 0.3% or angle between normals more than 90 degrees
 fn pixel_dissimilar(depth: f32, world_position: vec3<f32>, other_world_position: vec3<f32>, normal: vec3<f32>, other_normal: vec3<f32>, view: View) -> bool {
     // https://developer.download.nvidia.com/video/gputechconf/gtc/2020/presentations/s22699-fast-denoising-with-self-stabilizing-recurrent-blurs.pdf#page=45
     let tangent_plane_distance = abs(dot(normal, other_world_position - world_position));

--- a/crates/bevy_solari/src/realtime/initial_path.wesl
+++ b/crates/bevy_solari/src/realtime/initial_path.wesl
@@ -20,34 +20,34 @@ const RECONNECTION_RELAX_DISTANCE = 1.0;
 
 const CACHE_TERMINATION_MIN_SOLID_ANGLE = PI;
 
-// What tracing one path produced.
-//
-// `radiance` is shaded straight into the pixel. With ReSTIR the reservoir additionally carries the
-// candidate chosen for reuse, and `radiance` holds the radiance that can not be reused.
-// Without ReSTIR there is no reservoir and `radiance` is the entire estimate.
+/// What tracing one path produced.
+///
+/// `radiance` is shaded straight into the pixel. With ReSTIR the reservoir additionally carries the
+/// candidate chosen for reuse, and `radiance` holds the radiance that can not be reused.
+/// Without ReSTIR there is no reservoir and `radiance` is the entire estimate.
 struct InitialSamplingResult {
     @if(RESTIR) reservoir: Reservoir,
     radiance: vec3<f32>,
 }
 
-// Path vertices use the following convention: x0 = camera, x1 = primary ray hit (the G-buffer
-// surface), x2 = first BRDF-sampled hit (the reconnection vertex).
+/// Path vertices use the following convention: x0 = camera, x1 = primary ray hit (the G-buffer
+/// surface), x2 = first BRDF-sampled hit (the reconnection vertex).
 struct PathState {
     ray_origin: vec3<f32>,
     normal: vec3<f32>,
     wo: vec3<f32>,
     material: ResolvedMaterial,
-    // Throughput past x1. With ReSTIR the brdf*cos at x1 is factored out of it, see x1_brdf.
+    /// Throughput past x1. With ReSTIR the brdf*cos at x1 is factored out of it, see x1_brdf.
     throughput_past_first_hit: vec3<f32>,
-    // Reconnection vertex x2, the first BRDF-sampled hit shared by every length >= 2 candidate
+    /// Reconnection vertex x2, the first BRDF-sampled hit shared by every length >= 2 candidate
     @if(RESTIR) x2_position: vec3<f32>,
     @if(RESTIR) x2_normal: vec3<f32>,
-    // If false, candidates built on x2 are shaded directly into radiance instead of
-    // published to the reservoir
+    /// If false, candidates built on x2 are shaded directly into radiance instead of
+    /// published to the reservoir
     @if(RESTIR) x2_reusable: bool,
-    // brdf*cos at x1 for the direction toward x2, applied at shade time
+    /// brdf*cos at x1 for the direction toward x2, applied at shade time
     @if(RESTIR) x1_brdf: vec3<f32>,
-    // Radiance shaded directly at this pixel
+    /// Radiance shaded directly at this pixel
     radiance: vec3<f32>,
     @if(RESTIR) reservoir: Reservoir,
     @if(RESTIR) weight_sum: f32,
@@ -433,9 +433,9 @@ fn terminate_into_cache(
     return true;
 }
 
-// ReSTIR PT Enhanced: Algorithmic Advances for Faster and More Robust ReSTIR Path Tracing
-// Section 4 (sorta)
-// https://research.nvidia.com/labs/rtr/publication/lin2026restirptenhanced/lin2026restirptenhanced.pdf
+/// ReSTIR PT Enhanced: Algorithmic Advances for Faster and More Robust ReSTIR Path Tracing
+/// Section 4 (sorta)
+/// https://research.nvidia.com/labs/rtr/publication/lin2026restirptenhanced/lin2026restirptenhanced.pdf
 @if(RESTIR)
 fn reconnection_reusable(ray_t: f32, p_brdf: f32, wi: vec3<f32>, diffuse_selected: bool, ray_hit: ResolvedRayHitFull, world_position: vec3<f32>, x1_perceptual_roughness: f32, primary_NdotV: f32) -> bool {
     // ray_footprint = t^2 / (p_brdf * cos_x2) is the area a sample represents at x2. It goes to 0 for

--- a/crates/bevy_solari/src/realtime/resolve_dlss_rr_textures.wesl
+++ b/crates/bevy_solari/src/realtime/resolve_dlss_rr_textures.wesl
@@ -9,19 +9,19 @@ import package::scene::bindings::{MIRROR_ROUGHNESS_THRESHOLD, ResolvedMaterial, 
 
 enable wgpu_ray_query;
 
-// A surface is replaced outright only when nearly all of its reflectance leaves through the delta
-// lobe.
+/// A surface is replaced outright only when nearly all of its reflectance leaves through the delta
+/// lobe.
 const FULL_REPLACEMENT_FRACTION = 0.9;
 
-// How far a reflector's virtual image may shift between neighboring pixels, as a fraction of the
-// virtual distance itself, before the surface is treated as too curved to replace.
+/// How far a reflector's virtual image may shift between neighboring pixels, as a fraction of the
+/// virtual distance itself, before the surface is treated as too curved to replace.
 const MAX_VIRTUAL_DEPTH_JITTER = 0.002;
 
-// Even a perfectly flat surface measures a small nonzero normal change, because G-buffer normals are
-// 24-bit octahedral and neighboring texels round differently.
+/// Even a perfectly flat surface measures a small nonzero normal change, because G-buffer normals are
+/// 24-bit octahedral and neighboring texels round differently.
 const NORMAL_QUANTIZATION_FLOOR = 0.002;
 
-// Distance, in meters, standing in for "infinitely far" when a mirror ray finds nothing.
+/// Distance, in meters, standing in for "infinitely far" when a mirror ray finds nothing.
 const ENVIRONMENT_VIRTUAL_DISTANCE = 10000.0;
 
 @compute @workgroup_size(8, 8, 1)
@@ -62,24 +62,24 @@ fn needs_specular_motion_vector(roughness: f32) -> bool {
     return roughness <= 0.0625;
 }
 
-// Carried across every bounce of the path walk, so anything derivable from a value the walk already
-// holds is derived at the end instead of stored. What is left is only what the walk itself produces.
+/// Carried across every bounce of the path walk, so anything derivable from a value the walk already
+/// holds is derived at the end instead of stored. What is left is only what the walk itself produces.
 struct PsrState {
     finished: bool,
-    // Whether this pixel's surface is being swapped out for the reflected one, or is only having its
-    // reflection's motion described. Keyed on the primary surface only, and false for anything glossy.
+    /// Whether this pixel's surface is being swapped out for the reflected one, or is only having its
+    /// reflection's motion described. Keyed on the primary surface only, and false for anything glossy.
     replace_fully: bool,
-    // The chain's cumulative transform - the product of one Householder reflection per mirror, in
-    // chain order - stored as a rotor plus the parity of the reflection count rather than as the 3x3
-    // matrix it denotes.
+    /// The chain's cumulative transform - the product of one Householder reflection per mirror, in
+    /// chain order - stored as a rotor plus the parity of the reflection count rather than as the 3x3
+    /// matrix it denotes.
     mirror_rotor: vec4<f32>,
     mirror_parity_odd: bool,
-    // Distance traveled since the primary surface, camera through every mirror. Not the total path
-    // length: keeping the reflection's own share means the primary distance is only ever added, never
-    // subtracted back out, so it can be recovered at the end without the two disagreeing.
+    /// Distance traveled since the primary surface, camera through every mirror. Not the total path
+    /// length: keeping the reflection's own share means the primary distance is only ever added, never
+    /// subtracted back out, so it can be recovered at the end without the two disagreeing.
     reflection_length: f32,
-    // Product of the Fresnel term at each mirror in the chain: what the reflected surface's color is
-    // multiplied by on its way back to the eye.
+    /// Product of the Fresnel term at each mirror in the chain: what the reflected surface's color is
+    /// multiplied by on its way back to the eye.
     throughput: vec3<f32>,
 }
 
@@ -95,12 +95,12 @@ fn psr_init(world_normal: vec3<f32>, material: ResolvedMaterial) -> PsrState {
     return psr;
 }
 
-// Fold one more mirror into the chain, equivalent to right-multiplying the chain's matrix by this
-// mirror's Householder reflection.
-// https://en.wikipedia.org/wiki/Householder_transformation
-//
-// A product of k Householder reflections is orthogonal with determinant (-1)^k, so it is a rotation
-// when k is even, and a rotation composed with any one fixed reflection when k is odd.
+/// Fold one more mirror into the chain, equivalent to right-multiplying the chain's matrix by this
+/// mirror's Householder reflection.
+/// https://en.wikipedia.org/wiki/Householder_transformation
+///
+/// A product of k Householder reflections is orthogonal with determinant (-1)^k, so it is a rotation
+/// when k is even, and a rotation composed with any one fixed reflection when k is odd.
 fn psr_chain_mirror(psr: PsrState, plane_normal: vec3<f32>) -> PsrState {
     var chained = psr;
     chained.mirror_rotor = quaternion_multiply(psr.mirror_rotor, mirror_chain_rotor(plane_normal, psr.mirror_parity_odd));
@@ -113,10 +113,10 @@ fn psr_environment_miss(pixel_id: vec2<u32>, primary_wo: vec3<f32>) {
     textureStore(specular_motion_vectors, pixel_id, vec4(calculate_motion_vector(far_position, far_position), vec2(0.0)));
 }
 
-// Primary surface replacement for perfect mirrors. The reflection chain has been followed to its
-// first non-mirror hit; write that surface's attributes, reflected into the mirror's virtual space,
-// to the DLSS RR guide buffers so the denoiser treats this pixel as directly seeing it.
-// https://developer.nvidia.com/blog/rendering-perfect-reflections-and-refractions-in-path-traced-games/#primary_surface_replacement
+/// Primary surface replacement for perfect mirrors. The reflection chain has been followed to its
+/// first non-mirror hit; write that surface's attributes, reflected into the mirror's virtual space,
+/// to the DLSS RR guide buffers so the denoiser treats this pixel as directly seeing it.
+/// https://developer.nvidia.com/blog/rendering-perfect-reflections-and-refractions-in-path-traced-games/#primary_surface_replacement
 fn replace_primary_surface(
     pixel_id: vec2<u32>,
     psr: PsrState,
@@ -176,7 +176,7 @@ fn is_delta_mirror(material: ResolvedMaterial) -> bool {
         && specular_fraction(material, F_AB(material.perceptual_roughness, 1.0)) >= FULL_REPLACEMENT_FRACTION;
 }
 
-// Share of a surface's total reflectance that leaves through the specular lobe, in 0..1.
+/// Share of a surface's total reflectance that leaves through the specular lobe, in 0..1.
 fn specular_fraction(material: ResolvedMaterial, F_ab: vec2<f32>) -> f32 {
     let rho = lobe_reflectances(material.base_color, calculate_F0_dielectric(vec3(material.reflectance)), material, F_ab);
     let specular_luminance = luminance(rho.specular);
@@ -190,7 +190,7 @@ fn psr_bounce_reflectance(wo: vec3<f32>, wi: vec3<f32>, normal: vec3<f32>, mater
     return lobe_reflectances(material.base_color, calculate_F0_dielectric(vec3(material.reflectance)), material, F_ab).specular;
 }
 
-// Angle, in radians, that the shading normal changes over one pixel in screen space.
+/// Angle, in radians, that the shading normal changes over one pixel in screen space.
 fn reflector_curvature(pixel_id: vec2<u32>, normal: vec3<f32>) -> f32 {
     let max_pixel_id = vec2<u32>(view.main_pass_viewport.zw) - vec2(1u);
     let right = load_gbuffer_normal(min(pixel_id + vec2(1u, 0u), max_pixel_id));
@@ -213,8 +213,8 @@ fn apply_mirror_chain(psr: PsrState, v: vec3<f32>) -> vec3<f32> {
     return reflected + psr.mirror_rotor.w * t + cross(psr.mirror_rotor.xyz, t);
 }
 
-// The rotation half of `H(n) * F` at even parity, or of `F * H(n)` at odd, where `H(n)` is the
-// Householder reflection about `plane_normal` and `F` the fixed z-axis one.
+/// The rotation half of `H(n) * F` at even parity, or of `F * H(n)` at odd, where `H(n)` is the
+/// Householder reflection about `plane_normal` and `F` the fixed z-axis one.
 fn mirror_chain_rotor(plane_normal: vec3<f32>, parity_odd: bool) -> vec4<f32> {
     if parity_odd {
         return vec4(plane_normal.y, -plane_normal.x, 0.0, plane_normal.z);

--- a/crates/bevy_solari/src/realtime/restir.wesl
+++ b/crates/bevy_solari/src/realtime/restir.wesl
@@ -1,4 +1,4 @@
-// https://intro-to-restir.cwyman.org/presentations/2023ReSTIR_Course_Notes.pdf
+//! https://intro-to-restir.cwyman.org/presentations/2023ReSTIR_Course_Notes.pdf
 
 import bevy_core_pipeline::tonemapping::tonemapping_luminance as luminance;
 import bevy_pbr::render::utils::{rand_f, rand_u, sample_disk};

--- a/crates/bevy_solari/src/scene/brdf.wesl
+++ b/crates/bevy_solari/src/scene/brdf.wesl
@@ -20,7 +20,7 @@ struct LobeReflectances {
     diffuse: vec3<f32>,
 }
 
-// Hemispherical reflectance of each lobe
+/// Hemispherical reflectance of each lobe
 fn lobe_reflectances(F0_metal: vec3<f32>, F0_dielectric: vec3<f32>, material: ResolvedMaterial, F_ab: vec2<f32>) -> LobeReflectances {
     let multiscattering_factor = 1.0 / (F_ab.x + F_ab.y) - 1.0;
     let rho_specular_metallic = (F0_metal * F_ab.x + F_ab.y) * (1.0 + F0_metal * multiscattering_factor);
@@ -169,7 +169,7 @@ fn fresnel(f0: vec3<f32>, LdotH: f32) -> vec3<f32> {
     return f0 + (1.0 - f0) * pow(1.0 - LdotH, 5.0);
 }
 
-// Scale/bias approximation
+/// Scale/bias approximation
 fn F_AB(perceptual_roughness: f32, NdotV: f32) -> vec2<f32> {
     return textureSampleLevel(brdf_dfg_lut, brdf_dfg_lut_sampler, vec2<f32>(NdotV, perceptual_roughness), 0.0).rg;
 }

--- a/crates/bevy_solari/src/scene/sampling.wesl
+++ b/crates/bevy_solari/src/scene/sampling.wesl
@@ -17,8 +17,8 @@ fn balance_heuristic(f: f32, g: f32) -> f32 {
     return max(0.0, 1.0 / (1.0 + (g / f)));
 }
 
-// https://gpuopen.com/download/Bounded_VNDF_Sampling_for_Smith-GGX_Reflections.pdf (Listing 1)
-// Result is invalid when output.z <= 0.0, and must be discarded
+/// https://gpuopen.com/download/Bounded_VNDF_Sampling_for_Smith-GGX_Reflections.pdf (Listing 1)
+/// Result is invalid when output.z <= 0.0, and must be discarded
 fn sample_ggx_vndf(wi_tangent: vec3<f32>, roughness: f32, rng: ptr<function, u32>) -> vec3<f32> {
     // Mirror BRDF case
     if roughness <= MIRROR_ROUGHNESS_THRESHOLD {
@@ -47,7 +47,7 @@ fn ggx_vndf_sample_invalid(ray_tangent: vec3<f32>) -> bool {
     return !(ray_tangent.z > 0.0);
 }
 
-// https://gpuopen.com/download/Bounded_VNDF_Sampling_for_Smith-GGX_Reflections.pdf (Listing 2)
+/// https://gpuopen.com/download/Bounded_VNDF_Sampling_for_Smith-GGX_Reflections.pdf (Listing 2)
 fn ggx_vndf_pdf(wi_tangent: vec3<f32>, wo_tangent: vec3<f32>, roughness: f32) -> f32 {
     // Mirror BRDF case
     if roughness <= MIRROR_ROUGHNESS_THRESHOLD {
@@ -106,9 +106,9 @@ struct ResolvedLightSample {
 struct LightContribution {
     radiance: vec3<f32>,
     inverse_pdf: f32,
-    // inverse_pdf may not be in solid angle measure (e.g. area measure)
-    // but inverse_solid_angle_pdf is always in solid angle measure
-    // for cases where it's required, e.g. MIS between light sampling techniques
+    /// inverse_pdf may not be in solid angle measure (e.g. area measure)
+    /// but inverse_solid_angle_pdf is always in solid angle measure
+    /// for cases where it's required, e.g. MIS between light sampling techniques
     inverse_solid_angle_pdf: f32,
     wi: vec3<f32>,
     brdf_rays_can_hit: bool,
@@ -246,7 +246,7 @@ fn trace_visibility_previous_frame(ray_origin: vec3<f32>, point: vec4<f32>) -> f
     return f32(ray_hit.kind == RAY_QUERY_INTERSECTION_NONE);
 }
 
-// https://www.realtimerendering.com/raytracinggems/unofficial_RayTracingGems_v1.9.pdf#0004286901.INDD%3ASec22%3A297
+/// https://www.realtimerendering.com/raytracinggems/unofficial_RayTracingGems_v1.9.pdf#0004286901.INDD%3ASec22%3A297
 fn triangle_barycentrics(seed: u32) -> vec3<f32> {
     var rng = seed;
     var barycentrics = rand_vec2f(&rng);

--- a/crates/bevy_sprite_render/src/mesh2d/color_material.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/color_material.wesl
@@ -15,13 +15,13 @@ import bevy_render::color_operations::linear_rgb_to_oklab;
 struct ColorMaterial {
     color: vec4<f32>,
     uv_transform: mat3x3<f32>,
-    // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
+    /// 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32,
     alpha_cutoff: f32,
 };
 
 @if(BINDLESS) {
-// The index table for bindless operation.
+/// The index table for bindless operation.
 struct ColorMaterialBindings {
     material: u32,          // 0
     color_texture: u32,     // 1

--- a/crates/bevy_sprite_render/src/mesh2d/types.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/types.wesl
@@ -1,17 +1,17 @@
 struct Mesh2d {
-    // Affine 4x3 matrix transposed to 3x4
-    // Use bevy_render::maths::affine3_to_square to unpack
+    /// Affine 4x3 matrix transposed to 3x4
+    /// Use bevy_render::maths::affine3_to_square to unpack
     world_from_local: mat3x4<f32>,
-    // 3x3 matrix packed in mat2x4 and f32 as:
-    // [0].xyz, [1].x,
-    // [1].yz, [2].xy
-    // [2].z
-    // Use bevy_render::maths::mat2x4_f32_to_mat3x3_unpack to unpack
+    /// 3x3 matrix packed in mat2x4 and f32 as:
+    /// [0].xyz, [1].x,
+    /// [1].yz, [2].xy
+    /// [2].z
+    /// Use bevy_render::maths::mat2x4_f32_to_mat3x3_unpack to unpack
     local_from_world_transpose_a: mat2x4<f32>,
     local_from_world_transpose_b: f32,
-    // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
+    /// 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32,
-    // Index of the material in the bind group data.
+    /// Index of the material in the bind group data.
     material_bind_group_slot: u32,
     tag: u32,
     /// The index of the mesh metadata buffer.

--- a/crates/bevy_sprite_render/src/mesh2d/vertex_input.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/vertex_input.wesl
@@ -36,8 +36,8 @@ struct Vertex {
     @location(4) color: vec4<f32>,
 };
 
-// The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
-// See https://github.com/gfx-rs/naga/issues/2416
+/// The instance_index parameter must match vertex_in.instance_index. This is a work around for a wgpu dx12 bug.
+/// See https://github.com/gfx-rs/naga/issues/2416
 fn decompress_vertex(vertex_in: Vertex, instance_index: u32) -> UncompressedVertex {
     let mesh_metadata = mesh_functions::get_metadata(instance_index);
     var uncompressed_vertex: UncompressedVertex;

--- a/crates/bevy_sprite_render/src/mesh2d/vertex_output.wesl
+++ b/crates/bevy_sprite_render/src/mesh2d/vertex_output.wesl
@@ -1,6 +1,6 @@
 struct VertexOutput {
-    // this is `clip position` when the struct is used as a vertex stage output 
-    // and `frag coord` when used as a fragment stage input
+    /// this is `clip position` when the struct is used as a vertex stage output
+    /// and `frag coord` when used as a fragment stage input
     @builtin(position) position: vec4<f32>,
     @location(0) world_position: vec4<f32>,
     @location(1) world_normal: vec3<f32>,

--- a/crates/bevy_sprite_render/src/render/sprite.wesl
+++ b/crates/bevy_sprite_render/src/render/sprite.wesl
@@ -15,10 +15,11 @@ import package::render::sprite_view_bindings::view;
 struct VertexInput {
     @builtin(vertex_index) index: u32,
     // NOTE: Instance-rate vertex buffer members prefixed with i_
-    // NOTE: i_model_transpose_colN are the 3 columns of a 3x4 matrix that is the transpose of the
-    // affine 4x3 model matrix.
+    /// the first column of a 3x4 matrix that is the transpose of the affine 4x3 model matrix.
     @location(0) i_model_transpose_col0: vec4<f32>,
+    /// the second column of a 3x4 matrix that is the transpose of the affine 4x3 model matrix.
     @location(1) i_model_transpose_col1: vec4<f32>,
+    /// the third column of a 3x4 matrix that is the transpose of the affine 4x3 model matrix.
     @location(2) i_model_transpose_col2: vec4<f32>,
     @location(3) i_color: vec4<f32>,
     @location(4) i_uv_offset_scale: vec4<f32>,

--- a/crates/bevy_sprite_render/src/sprite_mesh/functions.wesl
+++ b/crates/bevy_sprite_render/src/sprite_mesh/functions.wesl
@@ -17,13 +17,13 @@ import package::sprite_mesh::bindings::{texture, texture_sampler};
 import package::mesh2d::bindings::mesh;
 import bevy_render::bindless::{bindless_samplers_filtering, bindless_textures_2d};
 
-// Samples the sprite's final color, including the tint and alpha discard, at a given UV.
+/// Samples the sprite's final color, including the tint and alpha discard, at a given UV.
 fn sample_final_color(uv: vec2<f32>, instance_index: u32) -> vec4<f32> {
     let sprite_color = sample_sprite_texture(uv, instance_index);
     return get_final_color(sprite_color, instance_index);
 }
 
-// Samples the sprite's texture without tint and alpha discard at a given UV.
+/// Samples the sprite's texture without tint and alpha discard at a given UV.
 fn sample_sprite_texture(uv: vec2<f32>, instance_index: u32) -> vec4<f32> {
     let final_uv = get_final_uv(uv, instance_index);
 @if(BINDLESS)
@@ -38,14 +38,14 @@ fn sample_sprite_texture(uv: vec2<f32>, instance_index: u32) -> vec4<f32> {
     return textureSample(texture, texture_sampler, final_uv);
 }
 
-// Applies tint and alpha discard to the sprite's color.
+/// Applies tint and alpha discard to the sprite's color.
 fn get_final_color(sprite_color: vec4<f32>, instance_index: u32) -> vec4<f32> {
     var output_color = apply_tint(sprite_color, instance_index);
     output_color = alpha_discard(output_color, instance_index);
     return output_color;
 }
 
-// Applies all the necessary transformations to get the final UV that the texture should be sampled from.
+/// Applies all the necessary transformations to get the final UV that the texture should be sampled from.
 fn get_final_uv(uv: vec2<f32>, instance_index: u32) -> vec2<f32> {
     var out = uv;
     out = apply_flip(out, instance_index);
@@ -55,7 +55,7 @@ fn get_final_uv(uv: vec2<f32>, instance_index: u32) -> vec2<f32> {
     return out;
 }
 
-// Flips the UV based on the sprite's flip X and Y properties.
+/// Flips the UV based on the sprite's flip X and Y properties.
 fn apply_flip(uv: vec2<f32>, instance_index: u32) -> vec2<f32> {
 @if(BINDLESS)
     let slot = mesh[instance_index].material_bind_group_slot;
@@ -75,7 +75,7 @@ fn apply_flip(uv: vec2<f32>, instance_index: u32) -> vec2<f32> {
     return out;
 }
 
-// Applies tiling to the UV based on the sprite's tiling properties when `image_mode` is `Tiled`.
+/// Applies tiling to the UV based on the sprite's tiling properties when `image_mode` is `Tiled`.
 fn apply_tiling(uv: vec2<f32>, instance_index: u32) -> vec2<f32> {
 @if(BINDLESS)
     let slot = mesh[instance_index].material_bind_group_slot;
@@ -99,9 +99,9 @@ fn apply_tiling(uv: vec2<f32>, instance_index: u32) -> vec2<f32> {
     return out;
 }
 
-// Applies the sprite's UV transform,
-// which is used for sampling the correct region from a texture atlas
-// and scaling the sprite when `image_mode` is `Scaled`.
+/// Applies the sprite's UV transform,
+/// which is used for sampling the correct region from a texture atlas
+/// and scaling the sprite when `image_mode` is `Scaled`.
 fn apply_uv_transform(uv: vec2<f32>, instance_index: u32) -> vec2<f32> {
 @if(BINDLESS)
     let slot = mesh[instance_index].material_bind_group_slot;
@@ -113,7 +113,7 @@ fn apply_uv_transform(uv: vec2<f32>, instance_index: u32) -> vec2<f32> {
     return (uv_transform * vec3(uv, 1.0)).xy;
 }
 
-// Applies UV slicing based on the sprite's slicing properties when `image_mode` is `Sliced`.
+/// Applies UV slicing based on the sprite's slicing properties when `image_mode` is `Sliced`.
 fn apply_slicing(uv: vec2<f32>, instance_index: u32) -> vec2<f32> {
 @if(BINDLESS)
     let slot = mesh[instance_index].material_bind_group_slot;
@@ -216,7 +216,7 @@ fn apply_slicing(uv: vec2<f32>, instance_index: u32) -> vec2<f32> {
     );
 }
 
-// Applies the tint from the sprite's `color` property.
+/// Applies the tint from the sprite's `color` property.
 fn apply_tint(sprite_color: vec4<f32>, instance_index: u32) -> vec4<f32> {
 @if(BINDLESS)
     let slot = mesh[instance_index].material_bind_group_slot;
@@ -228,7 +228,7 @@ fn apply_tint(sprite_color: vec4<f32>, instance_index: u32) -> vec4<f32> {
     return sprite_color * color;
 }
 
-// Discards fragments based on the sprite's `alpha_cutoff` and `alpha_mode`.
+/// Discards fragments based on the sprite's `alpha_cutoff` and `alpha_mode`.
 fn alpha_discard(output_color: vec4<f32>, instance_index: u32) -> vec4<f32> {
 @if(BINDLESS)
     let slot = mesh[instance_index].material_bind_group_slot;
@@ -265,7 +265,7 @@ fn alpha_discard(output_color: vec4<f32>, instance_index: u32) -> vec4<f32> {
     return color;
 }
 
-// Maps a point p from [a, b] to [c, d], tiling it if stretch_value is not 0.
+/// Maps a point p from [a, b] to [c, d], tiling it if stretch_value is not 0.
 fn tile_or_stretch(p: f32, a: f32, b: f32, c: f32, d: f32, stretch_value: f32) -> f32 {
     if stretch_value == 0.0 {
         return stretch_interval(p, a, b, c, d);
@@ -273,14 +273,14 @@ fn tile_or_stretch(p: f32, a: f32, b: f32, c: f32, d: f32, stretch_value: f32) -
     return tile_interval(p, a, b, c, d, stretch_value);
 }
 
-// Takes a point p from an interval [a, b] and maps it to a portion of the tile [c, d]
+/// Takes a point p from an interval [a, b] and maps it to a portion of the tile [c, d]
 fn tile_interval(p: f32, a: f32, b: f32, c: f32, d: f32, stretch_value: f32) -> f32 {
     let value = (p - a) / (b - a);
     let tile_value = (value - stretch_value * floor(value / stretch_value)) / stretch_value;
     return tile_value * (d - c) + c;
 }
 
-// Takes a point p from an interval [a, b] and translates it to the interval [c, d]
+/// Takes a point p from an interval [a, b] and translates it to the interval [c, d]
 fn stretch_interval(p: f32, a: f32, b: f32, c: f32, d: f32) -> f32 {
     return (p - a) / (b - a) * (d - c) + c;
 }

--- a/crates/bevy_ui_render/src/box_shadow.wesl
+++ b/crates/bevy_ui_render/src/box_shadow.wesl
@@ -23,7 +23,7 @@ fn gaussian(x: f32, sigma: f32) -> f32 {
     return exp(-(x * x) / (2. * sigma * sigma)) / (sqrt(2. * PI) * sigma);
 }
 
-// Approximates the Gauss error function: https://en.wikipedia.org/wiki/Error_function
+/// Approximates the Gauss error function: https://en.wikipedia.org/wiki/Error_function
 fn erf(p: vec2<f32>) -> vec2<f32> {
     let s = sign(p);
     let a = abs(p);
@@ -33,7 +33,7 @@ fn erf(p: vec2<f32>) -> vec2<f32> {
     return s - s / (result * result);
 }
 
-fn horizontalRoundedBoxShadow(x: f32, y: f32, blur: f32, radius: vec2<f32>, half_size: vec2<f32>) -> f32 {    
+fn horizontalRoundedBoxShadow(x: f32, y: f32, blur: f32, radius: vec2<f32>, half_size: vec2<f32>) -> f32 {
     var c = half_size.x;
     if 0.0 < min(radius.x, radius.y) {
         let d = min(half_size.y - radius.y - abs(y), 0.);
@@ -98,5 +98,3 @@ fn fragment(
     let g = in.color.a * roundedBoxShadow(-0.5 * in.size, 0.5 * in.size, in.point, max(in.blur, 0.01), in.radius_x, in.radius_y);
     return vec4(in.color.rgb, g);
 }
-
-

--- a/crates/bevy_ui_render/src/gradient.wesl
+++ b/crates/bevy_ui_render/src/gradient.wesl
@@ -52,7 +52,7 @@ struct GradientVertexOutput {
     @location(4) @interpolate(flat) radius_y: vec4<f32>,
     @location(5) @interpolate(flat) border: vec4<f32>,
 
-    // Position relative to the center of the rectangle.
+    /// Position relative to the center of the rectangle.
     @location(6) point: vec2<f32>,
     @location(7) @interpolate(flat) g_start: vec2<f32>,
     @location(8) @interpolate(flat) dir: vec2<f32>,
@@ -70,11 +70,11 @@ fn vertex(
     @location(1) vertex_uv: vec2<f32>,
     @location(2) flags: u32,
 
-    // x: top left, y: top right, z: bottom right, w: bottom left.
+    /// x: top left, y: top right, z: bottom right, w: bottom left.
     @location(3) radius_x: vec4<f32>,
     @location(4) radius_y: vec4<f32>,
 
-    // x: left, y: top, z: right, w: bottom.
+    /// x: left, y: top, z: right, w: bottom.
     @location(5) border: vec4<f32>,
     @location(6) size: vec2<f32>,
     @location(7) point: vec2<f32>,
@@ -168,7 +168,7 @@ fn conic_distance(
     return (((angle - start) % TAU) + TAU) % TAU;
 }
 
-// Mix the colors, choosing the appropriate interpolation method for the given color space
+/// Mix the colors, choosing the appropriate interpolation method for the given color space
 fn mix_colors(
     start_color: vec3<f32>,
     end_color: vec3<f32>,
@@ -195,7 +195,7 @@ fn mix_colors(
     return mix(start_color, end_color, t);
 }
 
-// Convert a color from the interpolation color space to linear rgba
+/// Convert a color from the interpolation color space to linear rgba
 fn convert_to_linear_rgba(
     color: vec4<f32>,
 ) -> vec4<f32> {

--- a/crates/bevy_ui_render/src/ui.wesl
+++ b/crates/bevy_ui_render/src/ui.wesl
@@ -27,7 +27,7 @@ struct VertexOutput {
     @location(5) @interpolate(flat) radius_y: vec4<f32>,
     @location(6) @interpolate(flat) border: vec4<f32>,
 
-    // Position relative to the center of the rectangle.
+    /// Position relative to the center of the rectangle.
     @location(7) point: vec2<f32>,
     @builtin(position) position: vec4<f32>,
 };
@@ -39,11 +39,11 @@ fn vertex(
     @location(2) vertex_color: vec4<f32>,
     @location(3) flags: u32,
 
-    // x: top left, y: top right, z: bottom right, w: bottom left.
+    /// x: top left, y: top right, z: bottom right, w: bottom left.
     @location(4) radius_x: vec4<f32>,
     @location(5) radius_y: vec4<f32>,
 
-    // x: left, y: top, z: right, w: bottom.
+    /// x: left, y: top, z: right, w: bottom.
     @location(6) border: vec4<f32>,
     @location(7) size: vec2<f32>,
     @location(8) point: vec2<f32>,
@@ -66,13 +66,13 @@ fn vertex(
 @group(1) @binding(1) var sprite_sampler: sampler;
 
 
-// Returns the radius of the corner closest to the given point.
-//
-// Arguments:
-//  - `point`          -> The point used to choose the closest corner.
-//  - `corner_radii_x` -> The horizontal radius of each rounded corner.
-//  - `corner_radii_y` -> The vertical radius of each rounded corner.
-//                        Both ordered x: top left, y: top right, z: bottom right, w: bottom left.
+/// Returns the radius of the corner closest to the given point.
+///
+/// Arguments:
+///  - `point`          -> The point used to choose the closest corner.
+///  - `corner_radii_x` -> The horizontal radius of each rounded corner.
+///  - `corner_radii_y` -> The vertical radius of each rounded corner.
+///                        Both ordered x: top left, y: top right, z: bottom right, w: bottom left.
 fn select_corner_radius(
     point: vec2<f32>,
     corner_radii_x: vec4<f32>,
@@ -82,23 +82,23 @@ fn select_corner_radius(
     // Else select top left (x) and top right corner radius (y).
     let rxs = select(corner_radii_x.xy, corner_radii_x.wz, 0.0 < point.y);
     let rys = select(corner_radii_y.xy, corner_radii_y.wz, 0.0 < point.y);
-    // w and z are swapped above so that both pairs are in left to right order, otherwise this second 
+    // w and z are swapped above so that both pairs are in left to right order, otherwise this second
     // select statement would return the incorrect value for the bottom pair.
     return vec2(select(rxs.x, rxs.y, 0.0 < point.x), select(rys.x, rys.y, 0.0 < point.x));
 }
 
-// The returned value is the shortest distance from the given point to the boundary of the rounded 
-// box.
-// 
-// Negative values indicate that the point is inside the rounded box, positive values that the point 
-// is outside, and zero is exactly on the boundary.
-//
-// Arguments: 
-//  - `point`           -> The function will return the distance from this point to the closest point on 
-//                          the boundary.
-//  - `size`            -> The maximum width and height of the box.
-//  - `corner_radii_x`   -> The horizontal semi-axis of each rounded corner. Ordered counter clockwise starting top left.
-//  - `corner_radii_y`   -> The vertical semi-axis of each rounded corner. Ordered counter clockwise starting top left.
+/// The returned value is the shortest distance from the given point to the boundary of the rounded
+/// box.
+///
+/// Negative values indicate that the point is inside the rounded box, positive values that the point
+/// is outside, and zero is exactly on the boundary.
+///
+/// Arguments:
+///  - `point`           -> The function will return the distance from this point to the closest point on
+///                          the boundary.
+///  - `size`            -> The maximum width and height of the box.
+///  - `corner_radii_x`   -> The horizontal semi-axis of each rounded corner. Ordered counter clockwise starting top left.
+///  - `corner_radii_y`   -> The vertical semi-axis of each rounded corner. Ordered counter clockwise starting top left.
 fn sd_rounded_box(
     point: vec2<f32>,
     size: vec2<f32>,
@@ -116,7 +116,7 @@ fn sd_rounded_box(
     let q = corner_to_point + radius;
     let edge_distance = max(q.x - radius.x, q.y - radius.y);
     let inv_radii_sq = 1.0 / (radius * radius);
-    let corner_distance = distance_to_ellipse_approx(q, inv_radii_sq, 1.0); 
+    let corner_distance = distance_to_ellipse_approx(q, inv_radii_sq, 1.0);
     return select(edge_distance, corner_distance, q.x > 0.0 && q.y > 0.0);
 }
 
@@ -165,24 +165,24 @@ fn nearest_border_active(point_vs_mid: vec2<f32>, size: vec2<f32>, width: vec4<f
     if (flags & BORDER_ANY) == BORDER_ANY {
         return true;
     }
- 
+
     // get point vs top left
     let point = clamp(point_vs_mid + size * 0.49999, vec2(0.0), size);
- 
+
     let left = point.x / width.x;
     let top = point.y / width.y;
     let right = (size.x - point.x) / width.z;
     let bottom = (size.y - point.y) / width.w;
- 
+
     let min_dist = min(min(left, top), min(right, bottom));
- 
+
     return (enabled(flags, BORDER_LEFT) && min_dist == left) ||
-        (enabled(flags, BORDER_TOP) && min_dist == top) || 
-        (enabled(flags, BORDER_RIGHT) && min_dist == right) || 
+        (enabled(flags, BORDER_TOP) && min_dist == top) ||
+        (enabled(flags, BORDER_RIGHT) && min_dist == right) ||
         (enabled(flags, BORDER_BOTTOM) && min_dist == bottom);
 }
 
-// get alpha for antialiasing for sdf
+/// get alpha for antialiasing for sdf
 fn antialias(distance: f32) -> f32 {
     // Using the fwidth(distance) was causing artifacts, so just use the distance.
     return saturate(0.5 - distance);
@@ -205,13 +205,13 @@ fn draw_uinode_border(
     // Signed distance from the exterior boundary.
     let external_distance = sd_rounded_box(point, size, radius_x, radius_y);
 
-    // Signed distance from the border's internal edge (the signed distance is negative if the point 
+    // Signed distance from the border's internal edge (the signed distance is negative if the point
     // is inside the rect but not on the border).
     // If the border size is set to zero, this is the same as the external distance.
     let internal_distance = sd_inset_rounded_box(point, size, radius_x, radius_y, border);
 
     // Signed distance from the border (the intersection of the rect with its border).
-    // Points inside the border have negative signed distance. Any point outside the border, whether 
+    // Points inside the border have negative signed distance. Any point outside the border, whether
     // outside the outside edge, or inside the inner edge have positive signed distance.
     let border_distance = max(external_distance, -internal_distance);
 
@@ -219,9 +219,9 @@ fn draw_uinode_border(
     let nearest_border = select(0.0, 1.0, nearest_border_active(point, size, border, flags));
 
     @if(ANTI_ALIAS)
-    // At external edges with no border, `border_distance` is equal to zero. 
-    // This select statement ensures we only perform anti-aliasing where a non-zero width border 
-    // is present, otherwise an outline about the external boundary would be drawn even without 
+    // At external edges with no border, `border_distance` is equal to zero.
+    // This select statement ensures we only perform anti-aliasing where a non-zero width border
+    // is present, otherwise an outline about the external boundary would be drawn even without
     // a border.
     let t = select(1.0 - step(0.0, border_distance), antialias(border_distance), external_distance < internal_distance);
     @else
@@ -255,7 +255,7 @@ fn draw_uinode_background(
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     let texture_color = textureSample(sprite_texture, sprite_sampler, in.uv);
 
-    // Only use the color sampled from the texture if the `TEXTURED` flag is enabled. 
+    // Only use the color sampled from the texture if the `TEXTURED` flag is enabled.
     // This allows us to draw both textured and untextured shapes together in the same batch.
     let color = select(in.color, in.color * texture_color, enabled(in.flags, TEXTURED));
 
@@ -266,24 +266,24 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     }
 }
 
-// One iteration of Newton's method on the 2D equation of an ellipse:  
-//  
-//     E(x, y) = x^2/a^2 + y^2/b^2 - 1  
-//  
-// The Jacobian of this equation is:  
-//  
-//     J(E(x, y)) = [ 2*x/a^2 2*y/b^2 ]  
-//  
-// We approximate the distance with:  
-//  
-//     E(x, y) / ||J(E(x, y))||  
-//  
-// See G. Taubin, "Distance Approximations for Rasterizing Implicit  
-// Curves", section 3.  
-//  
-// A scale relative to the unit scale of the ellipse may be passed in to cause  
-// the math to degenerate to length(p) when scale is 0, or otherwise give the  
-// normal distance approximation if scale is 1.
+/// One iteration of Newton's method on the 2D equation of an ellipse:
+///
+///     E(x, y) = x^2/a^2 + y^2/b^2 - 1
+///
+/// The Jacobian of this equation is:
+///
+///     J(E(x, y)) = [ 2*x/a^2 2*y/b^2 ]
+///
+/// We approximate the distance with:
+///
+///     E(x, y) / ||J(E(x, y))||
+///
+/// See G. Taubin, "Distance Approximations for Rasterizing Implicit
+/// Curves", section 3.
+///
+/// A scale relative to the unit scale of the ellipse may be passed in to cause
+/// the math to degenerate to length(p) when scale is 0, or otherwise give the
+/// normal distance approximation if scale is 1.
 fn distance_to_ellipse_approx(p: vec2<f32>, inv_radii_sq: vec2<f32>, scale: f32) -> f32 {
     let p_r = p * inv_radii_sq;
     let g = dot(p, p_r) - scale;

--- a/crates/bevy_ui_render/src/ui_texture_slice.wesl
+++ b/crates/bevy_ui_render/src/ui_texture_slice.wesl
@@ -13,32 +13,32 @@ struct UiVertexOutput {
     @location(0) uv: vec2<f32>,
     @location(1) color: vec4<f32>,
 
-    // Defines the dividing line that are used to split the texture atlas rect into corner, side and center slices
-    // The distances are normalized and from the top left corner of the texture atlas rect
-    // x = distance of the left vertical dividing line
-    // y = distance of the top horizontal dividing line
-    // z = distance of the right vertical dividing line
-    // w = distance of the bottom horizontal dividing line
+    /// Defines the dividing line that are used to split the texture atlas rect into corner, side and center slices
+    /// The distances are normalized and from the top left corner of the texture atlas rect
+    /// x = distance of the left vertical dividing line
+    /// y = distance of the top horizontal dividing line
+    /// z = distance of the right vertical dividing line
+    /// w = distance of the bottom horizontal dividing line
     @location(2) @interpolate(flat) texture_slices: vec4<f32>,
 
-    // Defines the dividing line that are used to split the render target into corner, side and center slices
-    // The distances are normalized and from the top left corner of the render target
-    // x = distance of left vertical dividing line
-    // y = distance of top horizontal dividing line
-    // z = distance of right vertical dividing line
-    // w = distance of bottom horizontal dividing line
+    /// Defines the dividing line that are used to split the render target into corner, side and center slices
+    /// The distances are normalized and from the top left corner of the render target
+    /// x = distance of left vertical dividing line
+    /// y = distance of top horizontal dividing line
+    /// z = distance of right vertical dividing line
+    /// w = distance of bottom horizontal dividing line
     @location(3) @interpolate(flat) target_slices: vec4<f32>,
 
-    // The number of times the side or center texture slices should be repeated when mapping them to the border slices
-    // x = number of times to repeat along the horizontal axis for the side textures
-    // y = number of times to repeat along the vertical axis for the side textures
-    // z = number of times to repeat along the horizontal axis for the center texture
-    // w = number of times to repeat along the vertical axis for the center texture
+    /// The number of times the side or center texture slices should be repeated when mapping them to the border slices
+    /// x = number of times to repeat along the horizontal axis for the side textures
+    /// y = number of times to repeat along the vertical axis for the side textures
+    /// z = number of times to repeat along the horizontal axis for the center texture
+    /// w = number of times to repeat along the vertical axis for the center texture
     @location(4) @interpolate(flat) repeat: vec4<f32>,
 
-    // normalized texture atlas rect coordinates
-    // x, y = top, left corner of the atlas rect
-    // z, w = bottom, right corner of the atlas rect
+    /// normalized texture atlas rect coordinates
+    /// x, y = top, left corner of the atlas rect
+    /// z, w = bottom, right corner of the atlas rect
     @location(5) @interpolate(flat) atlas_rect: vec4<f32>,
     @builtin(position) position: vec4<f32>,
 }
@@ -65,18 +65,19 @@ fn vertex(
 }
 
 /// maps a point along the axis of the render target to slice coordinates
+/// Arguments:
+///   - p: normalized distance along the axis
+///   - il: target min dividing point
+///   - ih: target max dividing point
+///   - tl: slice min dividing point
+///   - th: lice max dividing point
+///   - r: number of times to repeat the slice for sides and the center
 fn map_axis_with_repeat(
-    // normalized distance along the axis
     p: f32,
-    // target min dividing point
     il: f32,
-    // target max dividing point
     ih: f32,
-    // slice min dividing point
     tl: f32,
-    // slice max dividing point
     th: f32,
-    // number of times to repeat the slice for sides and the center
     r: f32,
 ) -> f32 {
     if p < il {

--- a/crates/bevy_ui_render/src/ui_texture_slice.wesl
+++ b/crates/bevy_ui_render/src/ui_texture_slice.wesl
@@ -70,7 +70,7 @@ fn vertex(
 ///   - il: target min dividing point
 ///   - ih: target max dividing point
 ///   - tl: slice min dividing point
-///   - th: lice max dividing point
+///   - th: slice max dividing point
 ///   - r: number of times to repeat the slice for sides and the center
 fn map_axis_with_repeat(
     p: f32,

--- a/crates/bevy_ui_render/src/ui_vertex_output.wesl
+++ b/crates/bevy_ui_render/src/ui_vertex_output.wesl
@@ -1,13 +1,13 @@
-// The Vertex output of the default vertex shader for the Ui Material pipeline.
+/// The Vertex output of the default vertex shader for the Ui Material pipeline.
 struct UiVertexOutput {
     @location(0) uv: vec2<f32>,
-    // The size of the borders in UV space. Order is Left, Right, Top, Bottom.
+    /// The size of the borders in UV space. Order is Left, Right, Top, Bottom.
     @location(1) border_widths: vec4<f32>,
-    // The border radius x value in pixels. Order is top left, top right, bottom right, bottom left.
+    /// The border radius x value in pixels. Order is top left, top right, bottom right, bottom left.
     @location(2) border_radius_x: vec4<f32>,
-    // The border radius y value in pixels. Order is top left, top right, bottom right, bottom left.
+    /// The border radius y value in pixels. Order is top left, top right, bottom right, bottom left.
     @location(3) border_radius_y: vec4<f32>,
-    // The size of the node in pixels. Order is width, height.
+    /// The size of the node in pixels. Order is width, height.
     @location(4) @interpolate(flat) size: vec2<f32>,
     @builtin(position) position: vec4<f32>,
 };


### PR DESCRIPTION
# Objective

A lot of Bevy's shader functions have documentation comments that aren't visible when using tools like wesldoc or wgsl-analyzer due to them being `//` comments rather than `///` or `//!` comments. Fix this

Fixes #25680

## Solution

Workspace find & replace `//` with `///`, then a _lot_ of manual clicking :p