### PR TITLE
Add lazy loading for labeled assets

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -734,12 +734,12 @@ mod tests {
             gated::{GateOpener, GatedReader},
             memory::{Dir, MemoryAssetReader, MemoryAssetWriter},
             AssetReader, AssetReaderError, AssetSourceBuilder, AssetSourceEvent, AssetSourceId,
-            AssetWatcher, Reader,
+            AssetWatcher, PathStream, Reader, VecReader,
         },
-        loader::{AssetLoader, LoadContext},
+        loader::{AssetLoader, LabeledAssetReader, LoadContext},
         Asset, AssetApp, AssetEvent, AssetId, AssetLoadError, AssetLoadFailedEvent, AssetPath,
-        AssetPlugin, AssetServer, Assets, InvalidGenerationError, LoadState, LoadedAsset,
-        LoadedUntypedAsset, UnapprovedPathMode, UntypedHandle, VisitAssetDependencies,
+        AssetPlugin, AssetServer, Assets, InvalidGenerationError, LabeledAssetLoadError, LoadState,
+        LoadedAsset, LoadedUntypedAsset, UnapprovedPathMode, UntypedHandle, VisitAssetDependencies,
         WriteDefaultMetaError,
     };
     use alloc::{
@@ -785,6 +785,146 @@ mod tests {
     #[derive(Asset, TypePath, Debug)]
     pub struct SubText {
         pub text: String,
+    }
+
+    #[derive(Asset, TypePath, Debug)]
+    struct TextArchiveIndex {
+        labels: Vec<String>,
+    }
+
+    #[derive(Asset, TypePath, Debug)]
+    struct TextArchiveEntry {
+        value: String,
+        #[dependency]
+        referenced_entries: Vec<Handle<TextArchiveEntry>>,
+    }
+
+    #[derive(Default, Serialize, Deserialize)]
+    struct TextArchiveEntrySettings {
+        suffix: String,
+    }
+
+    struct TextArchiveReader {
+        entries: HashMap<String, Vec<u8>>,
+    }
+
+    impl LabeledAssetReader for TextArchiveReader {
+        async fn read<'a>(&'a self, label: &'a str) -> Result<impl Reader + 'a, AssetReaderError> {
+            let bytes = self
+                .entries
+                .get(label)
+                .ok_or_else(|| AssetReaderError::NotFound(label.into()))?;
+            Ok(VecReader::new(bytes.clone()))
+        }
+
+        async fn read_meta<'a>(
+            &'a self,
+            label: &'a str,
+        ) -> Result<impl Reader + 'a, AssetReaderError> {
+            Err::<VecReader, _>(AssetReaderError::NotFound(label.into()))
+        }
+    }
+
+    #[derive(Default, TypePath)]
+    struct TextArchiveIndexLoader;
+
+    impl AssetLoader for TextArchiveIndexLoader {
+        type Asset = TextArchiveIndex;
+        type Settings = ();
+        type Error = std::io::Error;
+
+        async fn load(
+            &self,
+            reader: &mut dyn Reader,
+            _settings: &Self::Settings,
+            load_context: &mut LoadContext<'_>,
+        ) -> Result<Self::Asset, Self::Error> {
+            let mut bytes = Vec::new();
+            reader.read_to_end(&mut bytes).await?;
+            let contents = String::from_utf8(bytes)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+            let mut entries = HashMap::new();
+            let mut labels = Vec::new();
+            for line in contents.lines() {
+                let (label, quoted_value) = line.split_once('=').ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("archive entry is missing '=': {line}"),
+                    )
+                })?;
+                let value = quoted_value
+                    .strip_prefix('"')
+                    .and_then(|value| value.strip_suffix('"'))
+                    .ok_or_else(|| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!("archive entry has an unquoted value: {line}"),
+                        )
+                    })?;
+                labels.push(label.to_string());
+                entries.insert(label.to_string(), value.as_bytes().to_vec());
+            }
+            load_context.set_labeled_asset_reader(TextArchiveReader { entries });
+            Ok(TextArchiveIndex { labels })
+        }
+
+        fn extensions(&self) -> &[&str] {
+            &["textarchive"]
+        }
+    }
+
+    #[derive(Default, TypePath)]
+    struct TextArchiveEntryLoader;
+
+    impl AssetLoader for TextArchiveEntryLoader {
+        type Asset = TextArchiveEntry;
+        type Settings = TextArchiveEntrySettings;
+        type Error = std::io::Error;
+
+        async fn load(
+            &self,
+            reader: &mut dyn Reader,
+            settings: &Self::Settings,
+            load_context: &mut LoadContext<'_>,
+        ) -> Result<Self::Asset, Self::Error> {
+            let mut bytes = Vec::new();
+            reader.read_to_end(&mut bytes).await?;
+            let mut text = String::from_utf8(bytes)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+            let mut referenced_entries = Vec::new();
+            let mut remaining = text.as_str();
+            while let Some(start) = remaining.find("${") {
+                let reference = &remaining[start + 2..];
+                let end = reference.find('}').ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "unterminated labeled asset reference",
+                    )
+                })?;
+                let label = reference[..end].to_string();
+                if label.is_empty() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "empty labeled asset reference",
+                    ));
+                }
+                referenced_entries.push(
+                    load_context
+                        .load_labeled(label)
+                        .map_err(std::io::Error::other)?,
+                );
+                remaining = &reference[end + 1..];
+            }
+            text.push_str(&settings.suffix);
+            Ok(TextArchiveEntry {
+                value: text,
+                referenced_entries,
+            })
+        }
+
+        fn extensions(&self) -> &[&str] {
+            &[]
+        }
     }
 
     /// An asset whose loader performs a nested *untyped* load, to exercise
@@ -920,7 +1060,7 @@ mod tests {
         async fn read_directory<'a>(
             &'a self,
             path: &'a Path,
-        ) -> Result<Box<bevy_asset::io::PathStream>, AssetReaderError> {
+        ) -> Result<Box<PathStream>, AssetReaderError> {
             self.memory_reader.read_directory(path).await
         }
         async fn read_meta<'a>(
@@ -1034,6 +1174,120 @@ mod tests {
             .get_measurement(&AssetServer::STARTED_LOAD_COUNT)
             .map(|measurement| measurement.value as _)
             .unwrap_or_default()
+    }
+
+    #[test]
+    fn load_labeled_uses_existing_loader_and_its_settings() {
+        let (mut app, dir) = create_app();
+        dir.insert_asset_text(Path::new("test.textarchive"), "a=\"foo\"\nb=\"bar\"");
+        app.init_asset::<TextArchiveIndex>()
+            .init_asset::<TextArchiveEntry>()
+            .register_asset_loader(TextArchiveIndexLoader)
+            .register_asset_loader(TextArchiveEntryLoader);
+
+        let asset_server = app.world().resource::<AssetServer>().clone();
+        let root = asset_server.load::<TextArchiveIndex>("test.textarchive");
+        run_app_until(&mut app, |world| {
+            world
+                .resource::<Assets<TextArchiveIndex>>()
+                .contains(&root)
+                .then_some(())
+        });
+        assert!(app
+            .world()
+            .resource::<Assets<TextArchiveEntry>>()
+            .is_empty());
+
+        let a = asset_server
+            .load_labeled_builder(&root)
+            .unwrap()
+            .with_settings(|settings: &mut TextArchiveEntrySettings| {
+                settings.suffix = ":configured".to_string();
+            })
+            .load::<TextArchiveEntry>("a");
+        let b = asset_server
+            .load_labeled::<TextArchiveEntry>(&root, "b")
+            .unwrap();
+        run_app_until(&mut app, |world| {
+            let texts = world.resource::<Assets<TextArchiveEntry>>();
+            (texts.contains(&a) && texts.contains(&b)).then_some(())
+        });
+        assert_eq!(
+            app.world()
+                .resource::<Assets<TextArchiveEntry>>()
+                .get(&a)
+                .unwrap()
+                .value,
+            "foo:configured"
+        );
+        assert_eq!(
+            app.world()
+                .resource::<Assets<TextArchiveEntry>>()
+                .get(&b)
+                .unwrap()
+                .value,
+            "bar"
+        );
+        let root_asset = app
+            .world()
+            .resource::<Assets<TextArchiveIndex>>()
+            .get(&root)
+            .unwrap();
+        assert_eq!(root_asset.labels, ["a", "b"]);
+    }
+
+    #[test]
+    fn load_labeled_can_load_a_dependency_from_the_same_archive() {
+        let (mut app, dir) = create_app();
+        dir.insert_asset_text(Path::new("test.textarchive"), "b=\"bar\"\nc=\"${b} baz\"");
+        app.init_asset::<TextArchiveIndex>()
+            .init_asset::<TextArchiveEntry>()
+            .register_asset_loader(TextArchiveIndexLoader)
+            .register_asset_loader(TextArchiveEntryLoader);
+
+        let asset_server = app.world().resource::<AssetServer>().clone();
+        let root = asset_server.load::<TextArchiveIndex>("test.textarchive");
+        run_app_until(&mut app, |world| {
+            world
+                .resource::<Assets<TextArchiveIndex>>()
+                .contains(&root)
+                .then_some(())
+        });
+
+        let c = asset_server
+            .load_labeled::<TextArchiveEntry>(&root, "c")
+            .unwrap();
+        run_app_until(&mut app, |world| {
+            (world.resource::<Assets<TextArchiveEntry>>().contains(&c)
+                && asset_server.recursive_dependency_load_state(&c).is_loaded())
+            .then_some(())
+        });
+
+        let texts = app.world().resource::<Assets<TextArchiveEntry>>();
+        let c = texts.get(&c).unwrap();
+        assert_eq!(c.value, "${b} baz");
+        assert_eq!(c.referenced_entries.len(), 1);
+        let b = &c.referenced_entries[0];
+        assert_eq!(b.path().unwrap(), &AssetPath::parse("test.textarchive#b"));
+        assert_eq!(texts.get(b).unwrap().value, "bar");
+    }
+
+    #[test]
+    fn load_labeled_requires_a_loaded_root() {
+        let (mut app, dir) = create_app();
+        dir.insert_asset_text(Path::new("test.textarchive"), "a=\"foo\"");
+        app.init_asset::<TextArchiveIndex>()
+            .init_asset::<TextArchiveEntry>()
+            .register_asset_loader(TextArchiveIndexLoader)
+            .register_asset_loader(TextArchiveEntryLoader);
+
+        let asset_server = app.world().resource::<AssetServer>().clone();
+        let root = asset_server.load::<TextArchiveIndex>("test.textarchive");
+
+        assert!(matches!(
+            asset_server.load_labeled::<TextArchiveEntry>(&root, "a"),
+            Err(LabeledAssetLoadError::RootNotLoaded { .. })
+        ));
     }
 
     #[derive(Resource, Default)]

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -1,12 +1,15 @@
 use crate::{
-    io::{AssetReaderError, MissingAssetSourceError, MissingProcessedAssetReaderError, Reader},
+    io::{
+        AssetReaderError, AssetReaderFuture, MissingAssetSourceError,
+        MissingProcessedAssetReaderError, Reader,
+    },
     loader_builders::NestedLoadBuilder,
     meta::{AssetHash, AssetMeta, AssetMetaDyn, ProcessedInfo, ProcessedInfoMinimal, Settings},
     path::AssetPath,
     Asset, AssetIndex, AssetLoadError, AssetServer, AssetServerMode, Assets, ErasedAssetIndex,
-    Handle, UntypedAssetId, UntypedHandle,
+    Handle, LabeledAssetLoadError, UntypedAssetId, UntypedHandle,
 };
-use alloc::{boxed::Box, string::ToString, vec::Vec};
+use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use atomicow::CowArc;
 use bevy_ecs::{error::BevyError, world::World};
 use bevy_platform::collections::{hash_map::Entry, HashMap, HashSet};
@@ -15,6 +18,7 @@ use bevy_tasks::{BoxedFuture, ConditionalSendFuture};
 use core::{
     any::{Any, TypeId},
     convert::Infallible,
+    fmt,
 };
 use downcast_rs::{impl_downcast, Downcast};
 use ron::error::SpannedError;
@@ -132,6 +136,92 @@ where
     }
 }
 
+/// Provides byte inputs for labeled assets contained by a root asset.
+///
+/// Labeled assets are still loaded by their ordinary [`AssetLoader`]. The reader provides the
+/// bytes addressed by each label.
+///
+/// Labels are scoped to the root asset that registered this reader and are interpreted only by the
+/// reader. The loaded asset's [`AssetPath`] contains both the root path and the label.
+///
+/// ```no_run
+/// # use bevy_asset::{io::{AssetReaderError, Reader, VecReader}, LabeledAssetReader};
+/// # use std::collections::HashMap;
+/// struct BsaLabeledAssetReader {
+///     entries: HashMap<String, Vec<u8>>,
+/// }
+///
+/// impl LabeledAssetReader for BsaLabeledAssetReader {
+///     async fn read<'a>(
+///         &'a self,
+///         label: &'a str,
+///     ) -> Result<impl Reader + 'a, AssetReaderError> {
+///         let bytes = self
+///             .entries
+///             .get(label)
+///             .ok_or_else(|| AssetReaderError::NotFound(label.into()))?;
+///         Ok(VecReader::new(bytes.clone()))
+///     }
+///
+///     async fn read_meta<'a>(
+///         &'a self,
+///         label: &'a str,
+///     ) -> Result<impl Reader + 'a, AssetReaderError> {
+///         Err::<VecReader, _>(AssetReaderError::NotFound(label.into()))
+///     }
+/// }
+/// ```
+pub trait LabeledAssetReader: Send + Sync + 'static {
+    /// Returns the bytes for `label`.
+    fn read<'a>(&'a self, label: &'a str) -> impl AssetReaderFuture<Value: Reader + 'a>;
+
+    /// Returns the metadata bytes for `label`.
+    fn read_meta<'a>(&'a self, label: &'a str) -> impl AssetReaderFuture<Value: Reader + 'a>;
+}
+
+/// Object-safe counterpart to [`LabeledAssetReader`].
+pub(crate) trait ErasedLabeledAssetReader: Downcast + Send + Sync + 'static {
+    fn read<'a>(
+        &'a self,
+        label: &'a str,
+    ) -> BoxedFuture<'a, Result<Box<dyn Reader + 'a>, AssetReaderError>>;
+
+    fn read_meta<'a>(
+        &'a self,
+        label: &'a str,
+    ) -> BoxedFuture<'a, Result<Box<dyn Reader + 'a>, AssetReaderError>>;
+}
+
+impl_downcast!(ErasedLabeledAssetReader);
+
+impl<R: LabeledAssetReader> ErasedLabeledAssetReader for R {
+    fn read<'a>(
+        &'a self,
+        label: &'a str,
+    ) -> BoxedFuture<'a, Result<Box<dyn Reader + 'a>, AssetReaderError>> {
+        Box::pin(async move {
+            let reader = LabeledAssetReader::read(self, label).await?;
+            Ok(Box::new(reader) as Box<dyn Reader>)
+        })
+    }
+
+    fn read_meta<'a>(
+        &'a self,
+        label: &'a str,
+    ) -> BoxedFuture<'a, Result<Box<dyn Reader + 'a>, AssetReaderError>> {
+        Box::pin(async move {
+            let reader = LabeledAssetReader::read_meta(self, label).await?;
+            Ok(Box::new(reader) as Box<dyn Reader>)
+        })
+    }
+}
+
+impl fmt::Debug for dyn ErasedLabeledAssetReader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ErasedLabeledAssetReader")
+    }
+}
+
 pub(crate) struct LabeledAsset {
     pub(crate) asset: ErasedLoadedAsset,
     pub(crate) handle: UntypedHandle,
@@ -154,6 +244,8 @@ pub struct LoadedAsset<A: Asset> {
     /// This is entirely redundant with [`Self::labeled_assets`], but it allows looking up the
     /// labeled asset by its asset ID.
     pub(crate) asset_id_to_asset_index: HashMap<UntypedAssetId, usize>,
+    /// A reader for labeled assets associated with this asset's root path.
+    pub(crate) labeled_asset_reader: Option<Arc<dyn ErasedLabeledAssetReader>>,
 }
 
 impl<A: Asset> LoadedAsset<A> {
@@ -173,6 +265,7 @@ impl<A: Asset> LoadedAsset<A> {
             labeled_assets: Default::default(),
             label_to_asset_index: Default::default(),
             asset_id_to_asset_index: Default::default(),
+            labeled_asset_reader: None,
         }
     }
 
@@ -230,6 +323,8 @@ pub struct ErasedLoadedAsset {
     /// This is entirely redundant with [`Self::labeled_assets`], but it allows looking up the
     /// labeled asset by its asset ID.
     pub(crate) asset_id_to_asset_index: HashMap<UntypedAssetId, usize>,
+    /// A reader for labeled assets associated with this asset's root path.
+    pub(crate) labeled_asset_reader: Option<Arc<dyn ErasedLabeledAssetReader>>,
 }
 
 impl<A: Asset> From<LoadedAsset<A>> for ErasedLoadedAsset {
@@ -241,6 +336,7 @@ impl<A: Asset> From<LoadedAsset<A>> for ErasedLoadedAsset {
             labeled_assets: asset.labeled_assets,
             label_to_asset_index: asset.label_to_asset_index,
             asset_id_to_asset_index: asset.asset_id_to_asset_index,
+            labeled_asset_reader: asset.labeled_asset_reader,
         }
     }
 }
@@ -308,6 +404,7 @@ impl ErasedLoadedAsset {
                 labeled_assets: self.labeled_assets,
                 label_to_asset_index: self.label_to_asset_index,
                 asset_id_to_asset_index: self.asset_id_to_asset_index,
+                labeled_asset_reader: self.labeled_asset_reader,
             }),
             Err(value) => {
                 self.value = value;
@@ -395,6 +492,8 @@ pub struct LoadContext<'a> {
     /// This is entirely redundant with [`Self::labeled_assets`], but it allows looking up the
     /// labeled asset by its asset ID.
     pub(crate) asset_id_to_asset_index: HashMap<UntypedAssetId, usize>,
+    /// The labeled asset reader registered by the root loader.
+    pub(crate) labeled_asset_reader: Option<Arc<dyn ErasedLabeledAssetReader>>,
 }
 
 impl<'a> LoadContext<'a> {
@@ -415,6 +514,7 @@ impl<'a> LoadContext<'a> {
             labeled_assets: Default::default(),
             label_to_asset_index: Default::default(),
             asset_id_to_asset_index: Default::default(),
+            labeled_asset_reader: None,
         }
     }
 
@@ -566,7 +666,47 @@ impl<'a> LoadContext<'a> {
             labeled_assets: self.labeled_assets,
             label_to_asset_index: self.label_to_asset_index,
             asset_id_to_asset_index: self.asset_id_to_asset_index,
+            labeled_asset_reader: self.labeled_asset_reader,
         }
+    }
+
+    /// Registers a labeled reader for the root asset's path.
+    pub fn set_labeled_asset_reader<R: LabeledAssetReader>(&mut self, reader: R) {
+        self.labeled_asset_reader = Some(Arc::new(reader));
+    }
+
+    /// Gets the registered labeled asset reader for this root asset's path.
+    pub fn labeled_asset_reader<R: LabeledAssetReader>(&self) -> Option<&R> {
+        self.labeled_asset_reader.as_ref()?.downcast_ref::<R>()
+    }
+
+    /// Loads a labeled asset using the labeled reader registered to this context.
+    ///
+    /// This method is intended for dependencies of a reader-backed labeled asset.
+    pub fn load_labeled<'b, A: Asset>(
+        &mut self,
+        label: impl Into<CowArc<'b, str>>,
+    ) -> Result<Handle<A>, LabeledAssetLoadError> {
+        let root_path = self.asset_path.without_label().into_owned();
+        let reader = self.labeled_asset_reader.clone().ok_or_else(|| {
+            LabeledAssetLoadError::MissingReader {
+                path: root_path.clone(),
+            }
+        })?;
+        let label = label.into();
+        let handle = self
+            .asset_server
+            .load_labeled_with_meta_transform(
+                root_path.with_label(CowArc::Owned(Arc::from(&*label))),
+                TypeId::of::<A>(),
+                Some(core::any::type_name::<A>()),
+                None,
+                reader,
+            )
+            .typed_unchecked();
+        let index = (&handle).try_into().unwrap();
+        self.dependencies.insert(index);
+        Ok(handle)
     }
 
     /// Gets the source asset path for this load context.

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -1,4 +1,5 @@
 use crate::{
+    loader::ErasedLabeledAssetReader,
     meta::{AssetHash, MetaTransform},
     Asset, AssetHandleProvider, AssetIndex, AssetLoadError, AssetPath, DependencyLoadState,
     ErasedAssetIndex, ErasedLoadedAsset, Handle, InternalAssetEvent, LoadState,
@@ -47,6 +48,8 @@ pub(crate) struct AssetInfo {
     handle_drops_to_skip: usize,
     /// List of tasks waiting for this asset to complete loading
     pub(crate) waiting_tasks: Vec<Waker>,
+    /// The root-scoped reader used to load this asset when it came from a label.
+    labeled_asset_reader: Option<Arc<dyn ErasedLabeledAssetReader>>,
 }
 
 // Manual Debug impl since MetaTransform is not Debug.
@@ -107,6 +110,7 @@ impl AssetInfo {
             dependents_waiting_on_recursive_dep_load: HashSet::default(),
             handle_drops_to_skip: 0,
             waiting_tasks: Vec::new(),
+            labeled_asset_reader: None,
         }
     }
 }
@@ -150,6 +154,14 @@ impl core::fmt::Debug for AssetInfos {
 }
 
 impl AssetInfos {
+    /// Returns the labeled asset reader registered for an asset.
+    pub(crate) fn get_labeled_asset_reader(
+        &self,
+        index: ErasedAssetIndex,
+    ) -> Option<Arc<dyn ErasedLabeledAssetReader>> {
+        self.infos.get(&index)?.labeled_asset_reader.clone()
+    }
+
     pub(crate) fn create_loading_handle_untyped(
         &mut self,
         type_id: TypeId,
@@ -449,6 +461,8 @@ impl AssetInfos {
         world: &mut World,
         sender: &Sender<InternalAssetEvent>,
     ) {
+        let labeled_asset_reader = loaded_asset.labeled_asset_reader.clone();
+
         // Process all the labeled assets first so that they don't get skipped due to the "parent"
         // not having its handle alive.
         for asset in loaded_asset.labeled_assets {
@@ -575,6 +589,7 @@ impl AssetInfos {
             info.load_state = LoadState::Loaded;
             info.dep_load_state = dep_load_state;
             info.rec_dep_load_state = rec_dep_load_state.clone();
+            info.labeled_asset_reader = labeled_asset_reader;
             if watching_for_changes {
                 info.loader_dependencies = loaded_asset.loader_dependencies;
             }

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         AssetWriterError, ErasedAssetReader, MissingAssetSourceError, MissingAssetWriterError,
         MissingProcessedAssetReaderError, Reader,
     },
-    loader::{AssetLoader, ErasedAssetLoader, LoadContext, LoadedAsset},
+    loader::{AssetLoader, ErasedAssetLoader, ErasedLabeledAssetReader, LoadContext, LoadedAsset},
     meta::{
         loader_settings_meta_transform, AssetActionMinimal, AssetMetaDyn, AssetMetaMinimal,
         MetaTransform, Settings,
@@ -86,6 +86,54 @@ pub enum AssetServerMode {
     Unprocessed,
     /// This server loads processed assets.
     Processed,
+}
+
+#[derive(Clone, Copy)]
+enum AnyAssetReader<'a> {
+    Root(&'a dyn ErasedAssetReader),
+    Labeled(&'a dyn ErasedLabeledAssetReader),
+}
+
+impl<'a> AnyAssetReader<'a> {
+    fn resolve_loader(
+        self,
+        loaders: &AssetLoaders,
+        asset_type_id: Option<TypeId>,
+        asset_path: &AssetPath<'_>,
+    ) -> Option<MaybeAssetLoader> {
+        match self {
+            Self::Root(_) => loaders.find(asset_type_id, asset_path),
+            Self::Labeled(_) => asset_type_id.and_then(|type_id| loaders.get_by_type(type_id)),
+        }
+    }
+
+    fn read(
+        self,
+        asset_path: &'a AssetPath<'_>,
+    ) -> bevy_tasks::BoxedFuture<'a, Result<Box<dyn Reader + 'a>, AssetReaderError>> {
+        match self {
+            Self::Root(reader) => reader.read(asset_path.path()),
+            Self::Labeled(reader) => reader.read(
+                asset_path
+                    .label()
+                    .expect("labeled asset reader loads always have a label"),
+            ),
+        }
+    }
+
+    fn read_meta(
+        self,
+        asset_path: &'a AssetPath<'_>,
+    ) -> bevy_tasks::BoxedFuture<'a, Result<Box<dyn Reader + 'a>, AssetReaderError>> {
+        match self {
+            Self::Root(reader) => reader.read_meta(asset_path.path()),
+            Self::Labeled(reader) => reader.read_meta(
+                asset_path
+                    .label()
+                    .expect("labeled asset reader loads always have a label"),
+            ),
+        }
+    }
 }
 
 impl AssetServer {
@@ -372,6 +420,52 @@ impl AssetServer {
         LoadBuilder::new(self)
     }
 
+    /// Loads a labeled asset exposed by a root asset.
+    ///
+    /// The root must have finished loading and registered a
+    /// [`LabeledAssetReader`](crate::LabeledAssetReader).
+    pub fn load_labeled<'a, A: Asset>(
+        &self,
+        root: &Handle<impl Asset>,
+        label: impl Into<CowArc<'a, str>>,
+    ) -> Result<Handle<A>, LabeledAssetLoadError> {
+        Ok(self.load_labeled_builder(root)?.load(label))
+    }
+
+    /// Returns a [`LabeledLoadBuilder`] that can be used to start more complex loads. See [`LabeledLoadBuilder`]
+    /// for details.
+    ///
+    /// The root must have finished loading and registered a
+    /// [`LabeledAssetReader`](crate::LabeledAssetReader).
+    pub fn load_labeled_builder(
+        &self,
+        root: &Handle<impl Asset>,
+    ) -> Result<LabeledLoadBuilder<'_>, LabeledAssetLoadError> {
+        let root_path = root
+            .path()
+            .ok_or(LabeledAssetLoadError::RootHandleHasNoPath)?
+            .clone();
+        if root_path.label().is_some() {
+            return Err(LabeledAssetLoadError::RootHandleIsLabeled { path: root_path });
+        }
+        let root_index: ErasedAssetIndex = root
+            .try_into()
+            .map_err(|_| LabeledAssetLoadError::RootHandleHasNoPath)?;
+        let infos = self.read_infos();
+        let Some(info) = infos.get(root_index) else {
+            return Err(LabeledAssetLoadError::RootNotLoaded { path: root_path });
+        };
+        if !info.load_state.is_loaded() {
+            return Err(LabeledAssetLoadError::RootNotLoaded { path: root_path });
+        }
+        let reader = infos.get_labeled_asset_reader(root_index).ok_or_else(|| {
+            LabeledAssetLoadError::MissingReader {
+                path: root_path.clone(),
+            }
+        })?;
+        Ok(LabeledLoadBuilder::new(self, root_path, reader))
+    }
+
     pub(crate) fn load_with_meta_transform<'a, G: Send + Sync + 'static>(
         &self,
         path: impl Into<AssetPath<'a>>,
@@ -445,6 +539,61 @@ impl AssetServer {
         infos
             .pending_tasks
             .insert((&handle).try_into().unwrap(), task);
+    }
+
+    pub(crate) fn load_labeled_with_meta_transform(
+        &self,
+        path: AssetPath<'static>,
+        type_id: TypeId,
+        type_name: Option<&str>,
+        meta_transform: Option<MetaTransform>,
+        reader: Arc<dyn ErasedLabeledAssetReader>,
+    ) -> UntypedHandle {
+        debug_assert!(path.label().is_some());
+        let mut infos = self.write_infos();
+        let (handle, should_load) = infos.get_or_create_path_handle_erased(
+            path.clone(),
+            type_id,
+            type_name,
+            HandleLoadingMode::Request,
+            meta_transform,
+        );
+
+        if !should_load {
+            return handle;
+        }
+
+        infos.stats.started_load_tasks += 1;
+
+        bevy_tasks::cfg::multi_threaded! {
+            if {} else {
+                drop(infos);
+            }
+        }
+
+        let owned_handle = handle.clone();
+        let server = self.clone();
+        let task = IoTaskPool::get().spawn(async move {
+            if let Err(error) = server
+                .load_labeled_asset_from_reader(owned_handle, path, reader)
+                .await
+            {
+                error!("{error}");
+            }
+        });
+
+        let mut infos = bevy_tasks::cfg::multi_threaded! {
+            if {
+                infos
+            } else {
+                self.write_infos()
+            }
+        };
+        infos
+            .pending_tasks
+            .insert((&handle).try_into().unwrap(), task);
+
+        handle
     }
 
     pub(crate) fn load_unknown_type_with_meta_transform<'a, G: Send + Sync + 'static>(
@@ -770,6 +919,79 @@ impl AssetServer {
                 Err(err)
             }
         }
+    }
+
+    async fn load_labeled_asset_from_reader(
+        &self,
+        input_handle: UntypedHandle,
+        path: AssetPath<'static>,
+        labeled_asset_reader: Arc<dyn ErasedLabeledAssetReader>,
+    ) -> Result<(), AssetLoadError> {
+        let asset_id: ErasedAssetIndex = (&input_handle).try_into().unwrap();
+        let requested_type = asset_id.type_id;
+
+        let result: Result<(), AssetLoadError> = async {
+            let read_meta = match &self.data.meta_check {
+                AssetMetaCheck::Always => true,
+                AssetMetaCheck::Paths(paths) => paths.contains(&path),
+                AssetMetaCheck::Never => false,
+            };
+            let (mut meta, loader, mut reader) = self
+                .get_meta_loader_and_reader_from_reader(
+                    AnyAssetReader::Labeled(&*labeled_asset_reader),
+                    &path,
+                    Some(requested_type),
+                    read_meta,
+                )
+                .await?;
+
+            if let Some(meta_transform) = input_handle.meta_transform() {
+                (*meta_transform)(&mut *meta);
+            }
+
+            if requested_type != loader.asset_type_id() {
+                return Err(Box::new(RequestedHandleTypeMismatchError {
+                    path: path.clone(),
+                    requested: requested_type,
+                    actual_asset_name: loader.asset_type_name(),
+                    loader_name: loader.type_path(),
+                })
+                .into());
+            }
+
+            // The caller already marked this handle as loading. Drop our copy before awaiting the
+            // loader so an externally dropped handle can still cancel insertion.
+            drop(input_handle);
+
+            let loaded_asset = self
+                .load_with_settings_loader_reader_and_labeled_reader(
+                    &path,
+                    meta.loader_settings().expect("meta is set to Load"),
+                    &*loader,
+                    &mut *reader,
+                    true,
+                    false,
+                    Some(labeled_asset_reader.clone()),
+                )
+                .await?;
+
+            self.send_asset_event(InternalAssetEvent::Loaded {
+                index: asset_id,
+                loaded_asset,
+            });
+            Ok(())
+        }
+        .await;
+
+        if let Err(error) = &result {
+            self.send_asset_event(InternalAssetEvent::Failed {
+                index: asset_id,
+                path,
+                error: error.clone(),
+            });
+        }
+
+        result
     }
 
     /// Kicks off a reload of the asset stored at the given path. This will only reload the asset if it currently loaded.
@@ -1399,6 +1621,29 @@ impl AssetServer {
             AssetMetaCheck::Never => false,
         };
 
+        self.get_meta_loader_and_reader_from_reader(
+            AnyAssetReader::Root(asset_reader),
+            asset_path,
+            asset_type_id,
+            read_meta,
+        )
+        .await
+    }
+
+    async fn get_meta_loader_and_reader_from_reader<'a>(
+        &'a self,
+        asset_reader: AnyAssetReader<'a>,
+        asset_path: &'a AssetPath<'_>,
+        asset_type_id: Option<TypeId>,
+        read_meta: bool,
+    ) -> Result<
+        (
+            Box<dyn AssetMetaDyn>,
+            Arc<dyn ErasedAssetLoader>,
+            Box<dyn Reader + 'a>,
+        ),
+        AssetLoadError,
+    > {
         // Scope the meta reader up here. This allows the reader to be "transactional": for sources
         // that want to lock the asset before reading it (e.g., with a RwLock), this allows the meta
         // reader to take the RwLock, and since it overlaps with the asset reader, the asset reader
@@ -1406,7 +1651,7 @@ impl AssetServer {
         let mut meta_reader;
 
         let (meta, loader) = if read_meta {
-            match asset_reader.read_meta(asset_path.path()).await {
+            match asset_reader.read_meta(asset_path).await {
                 Ok(new_meta_reader) => {
                     meta_reader = new_meta_reader;
                     let mut meta_bytes = vec![];
@@ -1447,7 +1692,10 @@ impl AssetServer {
                 }
                 Err(AssetReaderError::NotFound(_)) => {
                     // TODO: Handle error transformation
-                    let loader = { self.read_loaders().find(asset_type_id, asset_path) };
+                    let loader = {
+                        let loaders = self.read_loaders();
+                        asset_reader.resolve_loader(&loaders, asset_type_id, asset_path)
+                    };
 
                     let error = || AssetLoadError::MissingAssetLoader {
                         asset_type_id,
@@ -1462,7 +1710,10 @@ impl AssetServer {
                 Err(err) => return Err(err.into()),
             }
         } else {
-            let loader = { self.read_loaders().find(asset_type_id, asset_path) };
+            let loader = {
+                let loaders = self.read_loaders();
+                asset_reader.resolve_loader(&loaders, asset_type_id, asset_path)
+            };
 
             let error = || AssetLoadError::MissingAssetLoader {
                 asset_type_id,
@@ -1474,7 +1725,7 @@ impl AssetServer {
             let meta = loader.default_meta();
             (meta, loader)
         };
-        let reader = asset_reader.read(asset_path.path()).await?;
+        let reader = asset_reader.read(asset_path).await?;
         Ok((meta, loader, reader))
     }
 
@@ -1487,10 +1738,33 @@ impl AssetServer {
         load_dependencies: bool,
         populate_hashes: bool,
     ) -> Result<ErasedLoadedAsset, AssetLoadError> {
+        self.load_with_settings_loader_reader_and_labeled_reader(
+            asset_path,
+            settings,
+            loader,
+            reader,
+            load_dependencies,
+            populate_hashes,
+            None,
+        )
+        .await
+    }
+
+    async fn load_with_settings_loader_reader_and_labeled_reader(
+        &self,
+        asset_path: &AssetPath<'_>,
+        settings: &dyn Settings,
+        loader: &dyn ErasedAssetLoader,
+        reader: &mut dyn Reader,
+        load_dependencies: bool,
+        populate_hashes: bool,
+        labeled_asset_reader: Option<Arc<dyn ErasedLabeledAssetReader>>,
+    ) -> Result<ErasedLoadedAsset, AssetLoadError> {
         // TODO: experiment with this
         let asset_path = asset_path.clone_owned();
-        let load_context =
+        let mut load_context =
             LoadContext::new(self, asset_path.clone(), load_dependencies, populate_hashes);
+        load_context.labeled_asset_reader = labeled_asset_reader;
         let load = AssertUnwindSafe(loader.load(reader, settings, load_context)).catch_unwind();
         #[cfg(feature = "trace")]
         let load = {
@@ -1688,6 +1962,88 @@ impl AssetServer {
             .await?;
 
         Ok(())
+    }
+}
+
+/// An error returned when a labeled asset cannot be loaded from a root asset.
+#[derive(Error, Debug)]
+pub enum LabeledAssetLoadError {
+    /// The root handle does not identify a path-based asset.
+    #[error("the root asset handle does not have a path")]
+    RootHandleHasNoPath,
+    /// A labeled asset was passed where an unlabeled root asset was required.
+    #[error("'{path}' is labeled; load_labeled requires an unlabeled root asset")]
+    RootHandleIsLabeled {
+        /// The supplied root path.
+        path: AssetPath<'static>,
+    },
+    /// The root asset has not finished loading.
+    #[error("root asset '{path}' has not finished loading")]
+    RootNotLoaded {
+        /// The supplied root path.
+        path: AssetPath<'static>,
+    },
+    /// The root asset did not register a labeled asset reader.
+    #[error("root asset '{path}' does not provide a labeled asset reader")]
+    MissingReader {
+        /// The root asset path.
+        path: AssetPath<'static>,
+    },
+}
+
+/// A builder for loading an asset exposed by a root asset.
+pub struct LabeledLoadBuilder<'a> {
+    asset_server: &'a AssetServer,
+    root_path: AssetPath<'static>,
+    reader: Arc<dyn ErasedLabeledAssetReader>,
+    meta_transform: Option<MetaTransform>,
+}
+
+impl<'a> LabeledLoadBuilder<'a> {
+    fn new(
+        asset_server: &'a AssetServer,
+        root_path: AssetPath<'static>,
+        reader: Arc<dyn ErasedLabeledAssetReader>,
+    ) -> Self {
+        Self {
+            asset_server,
+            root_path,
+            reader,
+            meta_transform: None,
+        }
+    }
+
+    /// Overrides the settings used by the labeled asset's loader.
+    #[must_use = "the load doesn't start until LabeledAssetLoadBuilder has been consumed"]
+    pub fn with_settings<S: Settings>(
+        mut self,
+        settings: impl Fn(&mut S) + Send + Sync + 'static,
+    ) -> Self {
+        let new_transform = loader_settings_meta_transform(settings);
+        if let Some(previous_transform) = self.meta_transform.take() {
+            self.meta_transform = Some(Box::new(move |meta| {
+                previous_transform(meta);
+                new_transform(meta);
+            }));
+        } else {
+            self.meta_transform = Some(new_transform);
+        }
+        self
+    }
+
+    /// Starts loading `label` through the existing asset loader selected by its requested type.
+    #[must_use = "not using the returned strong handle may release the labeled asset"]
+    pub fn load<'b, A: Asset>(self, label: impl Into<CowArc<'b, str>>) -> Handle<A> {
+        let label = label.into();
+        self.asset_server
+            .load_labeled_with_meta_transform(
+                self.root_path.with_label(CowArc::Owned(Arc::from(&*label))),
+                TypeId::of::<A>(),
+                Some(type_name::<A>()),
+                self.meta_transform,
+                self.reader,
+            )
+            .typed_unchecked()
     }
 }
 

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -945,8 +945,12 @@ impl AssetServer {
                 )
                 .await?;
 
-            if let Some(meta_transform) = input_handle.meta_transform() {
-                (*meta_transform)(&mut *meta);
+            {
+                let infos = self.read_infos();
+                let info = infos.get(asset_id).unwrap();
+                if let Some(meta_transform) = info.meta_transform.as_ref() {
+                    (*meta_transform)(&mut *meta);
+                }
             }
 
             if requested_type != loader.asset_type_id() {


### PR DESCRIPTION
# Objective

This pull request adds labeled asset readers so that developers can lazily load labeled assets. This is useful for so-called "random access assets", such as archives.

This resolves #25517, #21758, and #21641.

## Solution

An asset loader can now register a labeled asset reader to the load context of an asset. The asset server now has various `load_labeled` methods which can load a labeled asset using the registered labeled asset reader and standard asset loader resolution. ie, the labeled asset reader reads the bytes from the root asset, then passes those bytes to the loader.

## Testing

I wrote three tests, in crates\bevy_asset\src\lib.rs: `load_labeled_uses_existing_loader_and_its_settings`, `load_labeled_can_load_a_dependency_from_the_same_archive`, and `load_labeled_can_load_a_dependency_from_the_same_archive`. I tested these changes on `x86_64-pc-windows-msvc`.

# Remarks

The code was co-authored with GPT-5.6 Sol.

This is the first step for labeled asset readers; there is more work to be done, probably requiring design and planning:

- reloading
- preloading
- refactoring existing loaders with eager/ lazy loading which uses new labeled machinery
- deprecating existing labeled asset loading 
- lifecycle (adopting labeled handles if root is already loading, etc)