### PR TITLE
Uniformize stress tests

### DIFF
--- a/examples/stress_tests/bevymark_3d.rs
+++ b/examples/stress_tests/bevymark_3d.rs
@@ -189,6 +189,8 @@ fn setup(
     images: ResMut<Assets<Image>>,
     counter: ResMut<BevyCounter>,
 ) {
+    warn!(include_str!("warning_string.txt"));
+
     let args = args.into_inner();
     let images = images.into_inner();
 

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -74,8 +74,6 @@ fn main() {
     #[cfg(target_arch = "wasm32")]
     let args = Args::from_args(&[], &[]).unwrap();
 
-    warn!(include_str!("warning_string.txt"));
-
     let mut app = App::new();
 
     app.add_plugins((
@@ -91,6 +89,7 @@ fn main() {
         LogDiagnosticsPlugin::default(),
     ))
     .insert_resource(WinitSettings::continuous())
+    .add_systems(Startup, || warn!(include_str!("warning_string.txt")))
     .add_systems(Update, (button_system, set_text_colors_changed));
 
     if !args.no_camera {

--- a/examples/stress_tests/many_cameras_lights.rs
+++ b/examples/stress_tests/many_cameras_lights.rs
@@ -4,6 +4,7 @@ use std::f32::consts::PI;
 
 use bevy::{
     camera::Viewport,
+    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     math::ops::{cos, sin},
     prelude::*,
     window::{PresentMode, WindowResolution},
@@ -12,14 +13,18 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                present_mode: PresentMode::AutoNoVsync,
-                resolution: WindowResolution::new(1920, 1080).with_scale_factor_override(1.0),
+        .add_plugins((
+            DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    present_mode: PresentMode::AutoNoVsync,
+                    resolution: WindowResolution::new(1920, 1080).with_scale_factor_override(1.0),
+                    ..default()
+                }),
                 ..default()
             }),
-            ..default()
-        }))
+            FrameTimeDiagnosticsPlugin::default(),
+            LogDiagnosticsPlugin::default(),
+        ))
         .insert_resource(WinitSettings::continuous())
         .add_systems(Startup, setup)
         .add_systems(Update, rotate_cameras)

--- a/examples/stress_tests/many_cameras_lights.rs
+++ b/examples/stress_tests/many_cameras_lights.rs
@@ -42,6 +42,8 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
     window: Query<&Window>,
 ) -> Result {
+    warn!(include_str!("warning_string.txt"));
+
     // circular base
     commands.spawn((
         Mesh3d(meshes.add(Circle::new(4.0))),

--- a/examples/stress_tests/many_gradients.rs
+++ b/examples/stress_tests/many_gradients.rs
@@ -40,7 +40,12 @@ struct Args {
 }
 
 fn main() {
+    // `from_env` panics on the web
+    #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args = Args::from_args(&[], &[]).unwrap();
+
     let total_gradients = args.gradient_count;
 
     println!("Gradient stress test with {total_gradients} gradients");

--- a/examples/stress_tests/many_gradients.rs
+++ b/examples/stress_tests/many_gradients.rs
@@ -77,6 +77,8 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, args: Res<Args>) {
+    warn!(include_str!("warning_string.txt"));
+
     commands.spawn(Camera2d);
 
     let rows_to_spawn = args.gradient_count.div_ceil(COLS);

--- a/examples/stress_tests/many_materials.rs
+++ b/examples/stress_tests/many_materials.rs
@@ -50,6 +50,8 @@ fn setup(
     mesh_assets: ResMut<Assets<Mesh>>,
     material_assets: ResMut<Assets<StandardMaterial>>,
 ) {
+    warn!(include_str!("warning_string.txt"));
+
     let args = args.into_inner();
     let material_assets = material_assets.into_inner();
     let mesh_assets = mesh_assets.into_inner();

--- a/examples/stress_tests/many_meshlet_materials.rs
+++ b/examples/stress_tests/many_meshlet_materials.rs
@@ -31,7 +31,6 @@ const ASSET_URL: &str =
 fn main() {
     let args: Args = argh::from_env();
 
-    warn!(include_str!("warning_string.txt"));
     println!("Meshlet Stress Test");
     println!(
         "Grid size: {}x{} ({} instances)",
@@ -76,6 +75,8 @@ fn setup(
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
+    warn!(include_str!("warning_string.txt"));
+
     let meshlet_handle = asset_server.load(ASSET_URL);
 
     let n = args.grid_size;

--- a/examples/stress_tests/many_morph_targets.rs
+++ b/examples/stress_tests/many_morph_targets.rs
@@ -211,6 +211,8 @@ fn setup(
     mut graphs: ResMut<Assets<AnimationGraph>>,
     state: Res<State>,
 ) {
+    warn!(include_str!("warning_string.txt"));
+
     let (x_dim, _) = dims(state.slot_count);
 
     commands.spawn((

--- a/examples/stress_tests/many_morph_targets.rs
+++ b/examples/stress_tests/many_morph_targets.rs
@@ -153,9 +153,9 @@ fn main() {
                         present_mode: PresentMode::AutoNoVsync,
                         resolution: WindowResolution::new(1920, 1080)
                             .with_scale_factor_override(1.0),
-                        ..Default::default()
+                        ..default()
                     }),
-                    ..Default::default()
+                    ..default()
                 })
                 .set(GltfPlugin {
                     mesh_attribute_compression: if args.vertex_compression {
@@ -172,7 +172,7 @@ fn main() {
         .insert_resource(WinitSettings::continuous())
         .insert_resource(GlobalAmbientLight {
             brightness: 1000.0,
-            ..Default::default()
+            ..default()
         })
         .insert_resource(MorphAssets::default())
         .insert_resource(Rng(ChaCha8Rng::seed_from_u64(856673)))
@@ -236,7 +236,7 @@ fn setup(
             MotionBlur {
                 // Use an unrealistically large shutter angle so that motion blur is clearly visible.
                 shutter_angle: 3.0,
-                ..Default::default()
+                ..default()
             },
             // MSAA and MotionBlur are not compatible on WebGL.
             #[cfg(all(feature = "webgl2", target_arch = "wasm32", not(feature = "webgpu")))]


### PR DESCRIPTION
# Objective

- There are a few differences between stress tests, uniformize them

## Solution

- Add the diagnostics plugins
- log the profile warning in a system
- don't crash when using args in wasm
- ..default()
