### PR TITLE
Fix unmatched `DirtySpecializations` lifecycle against `SpecializedMaterialPipelineCache`

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -35,6 +35,7 @@ use bevy_mesh::{
     skinning::SkinnedMesh, BaseMeshPipelineKey, Mesh, Mesh3d, MeshAttributeCompressionFlags,
     MeshTag, MeshVertexBufferLayoutRef, VertexAttributeDescriptor,
 };
+use bevy_platform::collections::HashSet;
 use bevy_platform::collections::{hash_map::Entry, HashMap};
 use bevy_render::batching::gpu_preprocessing::{
     BufferDataInput, PreviousInstanceInputUniformBuffer,
@@ -388,7 +389,10 @@ pub fn check_views_need_specialization(
             Has<ContactShadows>,
         ),
     )>,
+    mut seen_views: Local<HashSet<RetainedViewEntity>>,
 ) {
+    seen_views.clear();
+
     for (
         view,
         camera,
@@ -405,6 +409,8 @@ pub fn check_views_need_specialization(
         (has_oit, has_atmosphere, has_ssr, has_contact_shadows),
     ) in views.iter_mut()
     {
+        seen_views.insert(view.retained_view_entity);
+
         let mut view_key = MeshPipelineKey::from_msaa_samples(msaa.samples())
             | MeshPipelineKey::from_target_format(view.target_format);
 
@@ -506,6 +512,8 @@ pub fn check_views_need_specialization(
                 .insert(view.retained_view_entity);
         }
     }
+
+    view_key_cache.retain(|view, _| seen_views.contains(view));
 }
 
 #[derive(Component)]


### PR DESCRIPTION
# Objective

Fixes #25712 

## Solution

`SpecializedMaterialPipelineCache` is cleaning up removed views, including minimized windows. But when the window is restored, `DirtySpecializations` does not trigger a must_wipe for view logic, thus causing `SpecializedMaterialPipelineCache` to be completely NONE.

This pr focuses on a simple fix to make `DirtySpecializations` must wipe logic matching the `SpecializedMaterialPipelineCache` instead of refactor the entire render view lifecycle logic.

## Testing

Tested against wireframe example. The original issue went away
