### PR TITLE
Allow the name of a `PipeSystem` to be set

### DIFF
--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -288,27 +288,83 @@ where
 
 /// An [`IntoSystem`] creating an instance of [`PipeSystem`].
 #[derive(Clone)]
-pub struct IntoPipeSystem<A, B> {
+pub struct IntoPipeSystem<A, B, N: PipeSystemName = ()> {
     a: A,
     b: B,
+    name: N,
 }
 
 impl<A, B> IntoPipeSystem<A, B> {
     /// Creates a new [`IntoSystem`] that pipes two inner systems.
     pub const fn new(a: A, b: B) -> Self {
-        Self { a, b }
+        Self { a, b, name: () }
+    }
+
+    /// Set the name of the output [`PipeSystem`] to the output of a function.
+    ///
+    /// The parameters to the function are the names of the two systems.
+    pub fn with_name_fn(
+        self,
+        name: impl FnOnce(DebugName, DebugName) -> DebugName,
+    ) -> IntoPipeSystem<A, B, impl PipeSystemName> {
+        IntoPipeSystem {
+            a: self.a,
+            b: self.b,
+            name,
+        }
+    }
+
+    /// Set the name of the output [`PipeSystem`] to the given string.
+    pub fn with_name(
+        self,
+        name: impl Into<DebugName>,
+    ) -> IntoPipeSystem<A, B, impl PipeSystemName> {
+        self.with_name_fn(move |_, _| name.into())
+    }
+
+    /// Set the name of the output [`PipeSystem`] to the name of the first system.
+    pub fn with_first_name(self) -> IntoPipeSystem<A, B, impl PipeSystemName> {
+        self.with_name_fn(|name_1, _name_2| name_1)
+    }
+
+    /// Set the name of the output [`PipeSystem`] to the name of the second system.
+    pub fn with_second_name(self) -> IntoPipeSystem<A, B, impl PipeSystemName> {
+        self.with_name_fn(|_name_1, name_2| name_2)
+    }
+}
+
+/// A function for determining the name of a [`PipeSystem`]
+/// from the names of its inner systems.
+///
+/// This is a trait so that a [`IntoPipeSystem`] with a name function
+/// can still be a ZST for use in [`World::run_system_cached`].
+pub trait PipeSystemName {
+    /// Determines the name of the [`PipeSystem`].
+    fn name(self, name1: DebugName, name2: DebugName) -> DebugName;
+}
+
+impl<F: FnOnce(DebugName, DebugName) -> DebugName> PipeSystemName for F {
+    fn name(self, name1: DebugName, name2: DebugName) -> DebugName {
+        self(name1, name2)
+    }
+}
+
+impl PipeSystemName for () {
+    fn name(self, name1: DebugName, name2: DebugName) -> DebugName {
+        DebugName::owned(format!("Pipe({name1}, {name2})"))
     }
 }
 
 #[doc(hidden)]
 pub struct IsPipeSystemMarker;
 
-impl<A, B, IA, OA, IB, OB, MA, MB> IntoSystem<IA, OB, (IsPipeSystemMarker, OA, IB, MA, MB)>
-    for IntoPipeSystem<A, B>
+impl<A, B, N, IA, OA, IB, OB, MA, MB> IntoSystem<IA, OB, (IsPipeSystemMarker, OA, IB, MA, MB)>
+    for IntoPipeSystem<A, B, N>
 where
     IA: SystemInput,
     A: IntoSystem<IA, OA, MA>,
     B: IntoSystem<IB, OB, MB>,
+    N: PipeSystemName,
     for<'a> IB: SystemInput<Inner<'a> = OA>,
 {
     type System = PipeSystem<A::System, B::System>;
@@ -316,8 +372,8 @@ where
     fn into_system(this: Self) -> Self::System {
         let system_a = IntoSystem::into_system(this.a);
         let system_b = IntoSystem::into_system(this.b);
-        let name = format!("Pipe({}, {})", system_a.name(), system_b.name());
-        PipeSystem::new(system_a, system_b, DebugName::owned(name))
+        let name = this.name.name(system_a.name(), system_b.name());
+        PipeSystem::new(system_a, system_b, name)
     }
 }
 
@@ -522,5 +578,46 @@ mod tests {
         schedule.add_systems(my_exclusive_system.pipe(out_pipe));
 
         schedule.run(&mut world);
+    }
+
+    #[test]
+    fn pipe_system_names() {
+        let make_system = || {
+            let system1 = IntoSystem::into_system(|| {}).with_name(DebugName::borrowed("system1"));
+            let system2 = IntoSystem::into_system(|| {}).with_name(DebugName::borrowed("system2"));
+            system1.pipe(system2)
+        };
+
+        let system = IntoSystem::into_system(make_system());
+        assert_eq!(
+            DebugName::owned("Pipe(system1, system2)".into()),
+            system.name()
+        );
+
+        let system = IntoSystem::into_system(make_system().with_name("custom name"));
+        assert_eq!(DebugName::borrowed("custom name"), system.name());
+
+        let system = IntoSystem::into_system(make_system().with_first_name());
+        assert_eq!(DebugName::borrowed("system1"), system.name());
+
+        let system = IntoSystem::into_system(make_system().with_second_name());
+        assert_eq!(DebugName::borrowed("system2"), system.name());
+    }
+
+    #[test]
+    fn pipe_system_zst() {
+        let mut world = World::new();
+
+        fn system1() {}
+        fn system2() {}
+
+        // Ensure `IntoPipeSystem` is a ZST that can be used with `run_system_cached`
+        world.run_system_cached(system1.pipe(system2)).unwrap();
+        world
+            .run_system_cached(system1.pipe(system2).with_first_name())
+            .unwrap();
+        world
+            .run_system_cached(system1.pipe(system2).with_second_name())
+            .unwrap();
     }
 }

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -287,15 +287,25 @@ where
 }
 
 /// An [`IntoSystem`] creating an instance of [`PipeSystem`].
+///
+/// This `struct` is created by [`IntoSystem::pipe()`].
+/// See its documentation for more.
 #[derive(Clone)]
 pub struct IntoPipeSystem<A, B, N: PipeSystemName = ()> {
     a: A,
     b: B,
+    /// A function for determining the name of the [`PipeSystem`].
+    ///
+    /// The default value of `()` implements [`PipeSystemName`]
+    /// by combining the names of both systems.
     name: N,
 }
 
 impl<A, B> IntoPipeSystem<A, B> {
     /// Creates a new [`IntoSystem`] that pipes two inner systems.
+    ///
+    /// Unless changed, the name of the system will be
+    /// set to a combination of the names of the inner systems.
     pub const fn new(a: A, b: B) -> Self {
         Self { a, b, name: () }
     }
@@ -319,7 +329,7 @@ impl<A, B> IntoPipeSystem<A, B> {
         self,
         name: impl Into<DebugName>,
     ) -> IntoPipeSystem<A, B, impl PipeSystemName> {
-        self.with_name_fn(move |_, _| name.into())
+        self.with_name_fn(|_, _| name.into())
     }
 
     /// Set the name of the output [`PipeSystem`] to the name of the first system.
@@ -378,6 +388,9 @@ where
 }
 
 /// A [`System`] created by piping the output of the first system into the input of the second.
+///
+/// This `struct` is created by [`IntoSystem::pipe()`].
+/// See its documentation for more.
 ///
 /// This can be repeated indefinitely, but system pipes cannot branch: the output is consumed by the receiving system.
 ///

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -313,6 +313,10 @@ impl<A, B> IntoPipeSystem<A, B> {
     /// Set the name of the output [`PipeSystem`] to the output of a function.
     ///
     /// The parameters to the function are the names of the two systems.
+    /// The first system is the one passed as `self` to [`IntoSystem::pipe`],
+    /// and the second system is the one passed as a parameter.
+    ///
+    /// Note that when piping multiple systems, they may themselves be [`PipeSystem`]s!
     pub fn with_name_fn(
         self,
         name: impl FnOnce(DebugName, DebugName) -> DebugName,
@@ -333,11 +337,45 @@ impl<A, B> IntoPipeSystem<A, B> {
     }
 
     /// Set the name of the output [`PipeSystem`] to the name of the first system.
+    ///
+    /// Note that the "first" system is the one passed as `self` to [`IntoSystem::pipe`].
+    /// When piping multiple systems, that may itself by another [`PipeSystem`]!
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// # let a = IntoSystem::into_system(|| {}).with_name("a");
+    /// # let b = IntoSystem::into_system(|| {}).with_name("b");
+    /// # let c = IntoSystem::into_system(|| {}).with_name("c");
+    /// let system = a.pipe(b).pipe(c).with_first_name();
+    /// assert_eq!("Pipe(a, b)", &*IntoSystem::into_system(system).name());
+    /// # let a = IntoSystem::into_system(|| {}).with_name("a");
+    /// # let b = IntoSystem::into_system(|| {}).with_name("b");
+    /// # let c = IntoSystem::into_system(|| {}).with_name("c");
+    /// let system = a.pipe(b.pipe(c)).with_first_name();
+    /// assert_eq!("a", &*IntoSystem::into_system(system).name());
+    /// ```
     pub fn with_first_name(self) -> IntoPipeSystem<A, B, impl PipeSystemName> {
         self.with_name_fn(|name_1, _name_2| name_1)
     }
 
     /// Set the name of the output [`PipeSystem`] to the name of the second system.
+    ///   
+    /// Note that the "second" system is the one passed as a parameter to [`IntoSystem::pipe`].
+    /// When piping multiple systems, that may itself by another [`PipeSystem`]!
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// # let a = IntoSystem::into_system(|| {}).with_name("a");
+    /// # let b = IntoSystem::into_system(|| {}).with_name("b");
+    /// # let c = IntoSystem::into_system(|| {}).with_name("c");
+    /// let system = a.pipe(b).pipe(c).with_second_name();
+    /// assert_eq!("c", &*IntoSystem::into_system(system).name());
+    /// # let a = IntoSystem::into_system(|| {}).with_name("a");
+    /// # let b = IntoSystem::into_system(|| {}).with_name("b");
+    /// # let c = IntoSystem::into_system(|| {}).with_name("c");
+    /// let system = a.pipe(b.pipe(c)).with_second_name();
+    /// assert_eq!("Pipe(b, c)", &*IntoSystem::into_system(system).name());
+    /// ```
     pub fn with_second_name(self) -> IntoPipeSystem<A, B, impl PipeSystemName> {
         self.with_name_fn(|_name_1, name_2| name_2)
     }

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -191,6 +191,15 @@ pub trait IntoSystem<In: SystemInput, Out, Marker>: Sized {
     ///
     /// The second system must have [`In<T>`](crate::system::In) as its first parameter,
     /// where `T` is the return type of the first system.
+    ///
+    /// # System Names
+    ///
+    /// By default, the [`System::name()`] of the resulting [`PipeSystem`] will be
+    /// set to a combination of the names of the inner systems.
+    /// This can be changed by calling [`IntoPipeSystem::with_first_name`] or
+    /// [`IntoPipeSystem::with_second_name`] to take the name from one of the inner systems,
+    /// or [`IntoPipeSystem::with_name`] or [`IntoPipeSystem::with_name_fn`]
+    /// to set a different name.
     fn pipe<B, BIn, BOut, MarkerB>(self, system: B) -> IntoPipeSystem<Self, B>
     where
         Out: 'static,


### PR DESCRIPTION
# Objective

Make it possible to set the name of a `PipeSystem`.  That's currently impossible, and the default name can be very verbose.  

In particular, make it easy to take the name from either the first or second system.  System piping is often used to add a generic wrapper to a specific system, and it's useful to be able to use the inner system's name for the wrapped system.  But sometimes the wrapping adds a prefix and sometimes it adds a suffix, so trying to pick one name by default would be unhelpful most of the time.  

## Solution

Add `with_name_fn`, `with_name`, `with_first_name`, and `with_last_name` methods to `IntoPipeSystem`.  

Put the methods on `IntoPipeSystem` and store the naming strategy instead of the name so that a system with a modified name can still be a ZST for use in `run_system_cached`.  

## Showcase

```rust
// This system will be named `system_a`,
// since that's the name of the first inner system
schedule.add_systems(system_a.pipe(system_b).with_first_name());
// This system will be named `system_b`
schedule.add_systems(system_a.pipe(system_b).with_second_name());
// And this system will be named `custom`
schedule.add_systems(system_a.pipe(system_b).with_name("custom"));
```