### PR TITLE
SpriteScalingMode: fix FitStart / FitEnd

### DIFF
--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_mesh_material.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_mesh_material.rs
@@ -226,12 +226,12 @@ impl AsBindGroupShaderType<SpriteMeshMaterialUniform> for SpriteMeshMaterial {
                         }
                         SpriteScalingMode::FitStart => {
                             let fit_size = fit_size();
-                            quad_offset -= (custom_size - fit_size) * 0.5;
+                            quad_offset += (custom_size - fit_size) * vec2(-0.5, 0.5);
                             quad_size = fit_size;
                         }
                         SpriteScalingMode::FitEnd => {
                             let fit_size = fit_size();
-                            quad_offset += (custom_size - fit_size) * 0.5;
+                            quad_offset += (custom_size - fit_size) * vec2(0.5, -0.5);
                             quad_size = fit_size;
                         }
                     }


### PR DESCRIPTION
# Objective

- SpriteScalingMode::FitStart and FitEnd are reversed
- See example `sprite_scale`
- Visible since #25432 but likely introduced before, code was just not used in any example
<img width="1424" height="438" alt="Screenshot 2026-09-08 at 00 03 46" src="https://github.com/user-attachments/assets/59a4caa3-0e75-481f-9654-1226d824f2ef" />

## Solution

- Correctly offset

## Testing

- ran example `sprite_scale`