### PR TITLE
Fix sprites skipping a frame when changed

### DIFF
--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -904,6 +904,10 @@ pub fn specialize_material2d_meshes(
                         .insert((*render_entity, *visible_entity));
                     continue;
                 };
+                // The instance may have been extracted before the material was prepared,
+                // or the material may have been reallocated to a new binding.
+                mesh_instance.material_bindings_index = material_2d.binding;
+
                 let Some(mesh) = render_meshes.get(mesh_instance.mesh_asset_id) else {
                     continue;
                 };

--- a/crates/bevy_sprite_render/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/mesh.rs
@@ -416,11 +416,14 @@ fn extract_2d_mesh(
         reextract_entities.insert(main_entity);
         return;
     };
-    let Some(mesh_material_binding_id) = render_material_bindings.get(mesh_material).copied()
-    else {
-        reextract_entities.insert(main_entity);
-        return;
-    };
+    // The material may not be prepared yet (it was created this frame). Extract
+    // the instance anyway with a placeholder binding; `specialize_material2d_meshes`
+    // writes the real binding once the material is prepared, which happens
+    // before batching reads it.
+    let mesh_material_binding_id = render_material_bindings
+        .get(mesh_material)
+        .copied()
+        .unwrap_or_default();
 
     // Go ahead and extract the mesh instance.
     render_mesh_instances.insert(

--- a/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
@@ -46,7 +46,7 @@ impl Plugin for SpriteMeshPlugin {
                 .chain()
                 .before(check_entities_needing_specialization::<SpriteMeshMaterial>)
                 .before(mark_2d_meshes_as_changed_if_their_assets_changed)
-                .after(AssetEventSystems),
+                .before(AssetEventSystems),
         );
     }
 }

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_extended_material.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_extended_material.rs
@@ -60,8 +60,13 @@ where
             ))
             .add_systems(
                 PostUpdate,
+                add_material::<M>
+                    .before(check_entities_needing_specialization::<SpriteExt<M>>)
+                    .before(AssetEventSystems),
+            )
+            .add_systems(
+                PostUpdate,
                 (
-                    add_material::<M>.before(check_entities_needing_specialization::<SpriteExt<M>>),
                     update_changed_material_extensions::<M>,
                     clean_sprite_material_cache::<M>,
                 )


### PR DESCRIPTION
# Objective

- #25432 broke sprites that change every frame, they never render. Sprites that change less often skip a frame. Fixes #25709.
- Also fixes the `color_animation`, `compute_shader_game_of_life` and `sprite_tile` examples, which were blank.

## Solution

Two things went wrong, one in each world:

- `add_material` ran after `AssetEventSystems`, so the `Added` event for the new material wasn't flushed until the next frame. Move it before that set in both `SpriteMeshPlugin` and `SpriteMaterialPlugin`.
- `extract_2d_mesh` bailed when the material had no binding yet, which is always the case for a material created this frame, and retried next frame. A sprite that changes every frame never got a mesh instance. Extract the instance with a placeholder binding and have `specialize_material2d_meshes` write the real one once the material is prepared, which happens before batching reads it.

## Testing

- Tested all the sprite examples.

---

Used Fable 5.1 to sprinkle lots of debugging messages to track down the timing parts
