### PR TITLE
CI: specify rust versions in a single place

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -1,6 +1,6 @@
 # This action installs the rust version used by Bevy CI. By default it installs
-# the stable currently pinned. Version are specified either exactly or by channel,
-# and this action will resolve to the correct version depending on the channel.
+# the currently pinned stable. Versions are specified either explicitly or by channel,
+# and this action will resolve the correct version depending on the channel.
 
 name: Install Rust
 description: Install a Rust toolchain.

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -1,0 +1,49 @@
+# This action installs the rust version used by Bevy CI. By default it installs
+# the stable currently pinned. Version are specified either exactly or by channel,
+# and this action will resolve to the correct version depending on the channel.
+
+name: Install Rust
+description: Install a Rust toolchain.
+
+inputs:
+  channel:
+    description: "`stable`, `nightly`, or an explicit version such as the MSRV."
+    required: false
+    default: stable
+  components:
+    description: Comma separated rustup components to install.
+    required: false
+    default: ""
+  target:
+    description: Additional rustup target to install.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install toolchain
+      shell: bash
+      run: |
+        case "$CHANNEL" in
+          stable)
+            toolchain="1.98.1"
+            ;;
+          nightly)
+            # If nightly is breaking CI, pin this to a specific `nightly-YYYY-MM-DD`.
+            toolchain="nightly"
+            ;;
+          *)
+            toolchain="$CHANNEL"
+            ;;
+        esac
+        rustup toolchain install "$toolchain" --no-self-update --profile=minimal ${COMPONENTS:+--component "$COMPONENTS"}
+        if [ -n "$TARGET" ]; then
+          rustup target add "$TARGET" --toolchain "$toolchain"
+        fi
+        rustup override set "$toolchain"
+        cargo -V
+      env:
+        CHANNEL: ${{ inputs.channel }}
+        COMPONENTS: ${{ inputs.components }}
+        TARGET: ${{ inputs.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build & run tests
@@ -77,8 +76,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
         with:
           components: clippy,rustfmt
       - name: Install Linux dependencies
@@ -113,8 +111,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
         with:
           channel: nightly
           components: miri
@@ -151,8 +148,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -181,8 +177,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
         with:
           target: x86_64-unknown-none
       - name: Install Linux dependencies
@@ -217,8 +212,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
         with:
           target: thumbv6m-none-eabi
       - name: Install Linux dependencies
@@ -248,8 +242,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
         with:
           target: x86_64-unknown-none
       - name: Install Linux dependencies
@@ -279,8 +272,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
         with:
           target: wasm32-unknown-unknown
       - name: Check wasm
@@ -310,8 +302,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
         with:
           channel: nightly
           components: rust-src
@@ -401,8 +392,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
         with:
@@ -428,8 +418,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: check for missing metadata
         id: missing-metadata
         run: cargo run -p build-templated-pages -- check-missing examples
@@ -466,8 +455,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: check for missing features
         id: missing-features
         run: cargo run -p build-templated-pages -- check-missing features
@@ -504,15 +492,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: get MSRV
         id: msrv
         run: |
           msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
           echo "msrv=$msrv" >> $GITHUB_OUTPUT
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
         with:
           channel: ${{ steps.msrv.outputs.msrv }}
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -576,8 +562,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: Check Release Content
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_TEST_DEBUG: 0
   CARGO_PROFILE_DEV_DEBUG: 0
-  # If nightly is breaking CI, modify this variable to target a specific nightly version.
-  NIGHTLY_TOOLCHAIN: nightly
   # Keep in sync between all workflows
   RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
@@ -51,10 +49,7 @@ jobs:
             ~/.cargo/git/db/
             target/
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build & run tests
@@ -83,10 +78,9 @@ jobs:
             ~/.cargo/git/db/
             target/
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal --component clippy,rustfmt
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
+        with:
+          components: clippy,rustfmt
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
         with:
@@ -108,11 +102,11 @@ jobs:
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # key won't match, will rely on restore-keys
-          key: ${{ runner.os }}-${{ env.NIGHTLY_TOOLCHAIN }}--${{ hashFiles('**/Cargo.toml') }}-
+          key: ${{ runner.os }}-nightly--${{ hashFiles('**/Cargo.toml') }}-
           # See .github/workflows/update-caches.yml for how keys are generated
           restore-keys: |
-            ${{ runner.os }}-${{ env.NIGHTLY_TOOLCHAIN }}--${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ env.NIGHTLY_TOOLCHAIN }}--
+            ${{ runner.os }}-nightly--${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-nightly--
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
@@ -120,10 +114,10 @@ jobs:
             ~/.cargo/git/db/
             target/
       - name: Install toolchain
-        run: |
-          rustup toolchain install ${{ env.NIGHTLY_TOOLCHAIN }} --no-self-update --profile=minimal --component miri
-          rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
-          cargo -V
+        uses: ./.github/actions/install-rust
+        with:
+          channel: nightly
+          components: miri
       - name: CI job
         # To run the tests one item at a time for troubleshooting, use
         # cargo --quiet test --lib -- --list | sed 's/: test$//' | MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation" xargs -n1 cargo miri test -p bevy_ecs --lib -- --exact
@@ -158,10 +152,7 @@ jobs:
             ~/.cargo/git/db/
             target/
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -191,11 +182,9 @@ jobs:
             ~/.cargo/git/db/
             target/
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup target add x86_64-unknown-none --toolchain stable
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
+        with:
+          target: x86_64-unknown-none
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -229,11 +218,9 @@ jobs:
             ~/.cargo/git/db/
             target/
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup target add thumbv6m-none-eabi --toolchain stable
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
+        with:
+          target: thumbv6m-none-eabi
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -262,11 +249,9 @@ jobs:
             ~/.cargo/git/db/
             target/
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup target add x86_64-unknown-none --toolchain stable
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
+        with:
+          target: x86_64-unknown-none
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Check Compile
@@ -295,11 +280,9 @@ jobs:
             ~/.cargo/git/db/
             target/
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup target add wasm32-unknown-unknown --toolchain stable
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
+        with:
+          target: wasm32-unknown-unknown
       - name: Check wasm
         env:
           RUSTFLAGS: '-C debuginfo=0 -D warnings --cfg getrandom_backend="wasm_js"'
@@ -316,11 +299,11 @@ jobs:
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # key won't match, will rely on restore-keys
-          key: ${{ runner.os }}-${{ env.NIGHTLY_TOOLCHAIN }}-wasm32-unknown-unknown-${{ hashFiles('**/Cargo.toml') }}-
+          key: ${{ runner.os }}-nightly-wasm32-unknown-unknown-${{ hashFiles('**/Cargo.toml') }}-
           # See .github/workflows/update-caches.yml for how keys are generated
           restore-keys: |
-            ${{ runner.os }}-${{ env.NIGHTLY_TOOLCHAIN }}-wasm32-unknown-unknown-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ env.NIGHTLY_TOOLCHAIN }}-wasm32-unknown-unknown-
+            ${{ runner.os }}-nightly-wasm32-unknown-unknown-${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-nightly-wasm32-unknown-unknown-
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
@@ -328,11 +311,11 @@ jobs:
             ~/.cargo/git/db/
             target/
       - name: Install toolchain
-        run: |
-          rustup toolchain install ${{ env.NIGHTLY_TOOLCHAIN }} --no-self-update --profile=minimal --component rust-src
-          rustup target add wasm32-unknown-unknown --toolchain ${{ env.NIGHTLY_TOOLCHAIN }}
-          rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
-          cargo -V
+        uses: ./.github/actions/install-rust
+        with:
+          channel: nightly
+          components: rust-src
+          target: wasm32-unknown-unknown
       - name: Check wasm
         run: cargo check --target wasm32-unknown-unknown -Z build-std=std,panic_abort
         env:
@@ -419,10 +402,7 @@ jobs:
             ~/.cargo/git/db/
             target/
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
         with:
@@ -449,10 +429,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: check for missing metadata
         id: missing-metadata
         run: cargo run -p build-templated-pages -- check-missing examples
@@ -490,10 +467,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: check for missing features
         id: missing-features
         run: cargo run -p build-templated-pages -- check-missing features
@@ -531,22 +505,16 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: get MSRV
         id: msrv
         run: |
           msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
           echo "msrv=$msrv" >> $GITHUB_OUTPUT
       - name: Install toolchain
-        run: |
-          rustup toolchain install "$MSRV" --no-self-update --profile=minimal
-          rustup override set "$MSRV"
-          cargo -V
-        env:
-          MSRV: ${{ steps.msrv.outputs.msrv }}
+        uses: ./.github/actions/install-rust
+        with:
+          channel: ${{ steps.msrv.outputs.msrv }}
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # key won't match, will rely on restore-keys
@@ -609,10 +577,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: Check Release Content
         shell: bash
         run: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -30,10 +30,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for security advisories and unmaintained crates
@@ -46,10 +43,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for banned and duplicated dependencies
@@ -62,10 +56,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for unauthorized licenses
@@ -78,10 +69,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Checked for unauthorized crate sources

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -29,8 +29,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for security advisories and unmaintained crates
@@ -42,8 +41,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for banned and duplicated dependencies
@@ -55,8 +53,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Check for unauthorized licenses
@@ -68,8 +65,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: Install cargo-deny
         run: cargo install cargo-deny
       - name: Checked for unauthorized crate sources

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,8 +37,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
         with:
           channel: nightly
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTDOCFLAGS: --html-in-header header.html
-  # If nightly is breaking CI, modify this variable to target a specific nightly version.
-  NIGHTLY_TOOLCHAIN: nightly
 
 # Sets the permissions to allow deploying to Github pages.
 permissions:
@@ -40,10 +38,9 @@ jobs:
           persist-credentials: false
 
       - name: Install toolchain
-        run: |
-          rustup toolchain install ${{ env.NIGHTLY_TOOLCHAIN }} --no-self-update --profile=minimal
-          rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
-          cargo -V
+        uses: ./.github/actions/install-rust
+        with:
+          channel: nightly
 
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps

--- a/.github/workflows/example-run.yml
+++ b/.github/workflows/example-run.yml
@@ -29,10 +29,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: Disable audio
         # Disable audio through a patch. on github m1 runners, audio timeouts after 15 minutes
         run: git apply --ignore-whitespace tools/example-showcase/disable-audio.patch
@@ -127,10 +124,7 @@ jobs:
             sudo apt-get install --no-install-recommends libgl1-mesa-dri mesa-vulkan-drivers
           fi
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # key won't match, will rely on restore-keys
@@ -198,10 +192,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # key won't match, will rely on restore-keys

--- a/.github/workflows/example-run.yml
+++ b/.github/workflows/example-run.yml
@@ -28,8 +28,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: Disable audio
         # Disable audio through a patch. on github m1 runners, audio timeouts after 15 minutes
         run: git apply --ignore-whitespace tools/example-showcase/disable-audio.patch
@@ -123,8 +122,7 @@ jobs:
             sudo add-apt-repository ppa:kisak/turtle -y
             sudo apt-get install --no-install-recommends libgl1-mesa-dri mesa-vulkan-drivers
           fi
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # key won't match, will rely on restore-keys
@@ -191,8 +189,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # key won't match, will rely on restore-keys

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -31,8 +31,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: get MSRV
         id: msrv
         run: |
@@ -120,8 +119,7 @@ jobs:
           ref: "main"
           persist-credentials: false
 
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
         with:
           channel: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}

--- a/.github/workflows/update-caches.yml
+++ b/.github/workflows/update-caches.yml
@@ -19,8 +19,6 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_TEST_DEBUG: 0
   CARGO_PROFILE_DEV_DEBUG: 0
-  # If nightly is breaking CI, modify this variable to target a specific nightly version.
-  NIGHTLY_TOOLCHAIN: nightly
   # Keep in sync between all workflows
   RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
@@ -28,26 +26,18 @@ jobs:
   env:
     runs-on: ubuntu-latest
     outputs:
-      NIGHTLY_TOOLCHAIN: ${{ steps.env.outputs.NIGHTLY_TOOLCHAIN }}
       MSRV: ${{ steps.msrv.outputs.MSRV }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: get MSRV
         id: msrv
         run: |
           msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
           echo "MSRV=$msrv" >> $GITHUB_OUTPUT
-      - name: Expose Env
-        id: env
-        run: |
-          echo "NIGHTLY_TOOLCHAIN=${{ env.NIGHTLY_TOOLCHAIN }}" >> $GITHUB_OUTPUT
 
   build-caches:
     name: Build Caches
@@ -67,17 +57,17 @@ jobs:
             toolchain: stable
             target: ""
           - os: ubuntu-latest
-            toolchain: ${{ needs.env.outputs.NIGHTLY_TOOLCHAIN }}
+            toolchain: nightly
             target: ""
           - os: ubuntu-latest
             toolchain: ${{ needs.env.outputs.MSRV }}
             target: ""
           - os: macos-latest
-            toolchain: ${{ needs.env.outputs.NIGHTLY_TOOLCHAIN }}
+            toolchain: nightly
             target: ""
           # ci.yml / build-wasm-atomics
           - os: ubuntu-latest
-            toolchain: ${{ needs.env.outputs.NIGHTLY_TOOLCHAIN }}
+            toolchain: nightly
             target: wasm32-unknown-unknown
             components: rust-src
             rustflags: '-C debuginfo=0 -D warnings -C target-feature=+atomics,+bulk-memory --cfg getrandom_backend="wasm_js"'
@@ -131,19 +121,11 @@ jobs:
           persist-credentials: false
 
       - name: Install toolchain
-        shell: bash
-        id: rust
-        run: |
-          rustup toolchain install "$RUST_TOOLCHAIN" --no-self-update --profile=minimal ${RUST_COMPONENTS:+--component "$RUST_COMPONENTS"}
-          if [ -n "$RUST_TARGET" ]; then
-            rustup target add "$RUST_TARGET" --toolchain "$RUST_TOOLCHAIN"
-          fi
-          rustup override set "$RUST_TOOLCHAIN"
-          cargo -V
-        env:
-          RUST_TOOLCHAIN: ${{ matrix.toolchain }}
-          RUST_TARGET: ${{ matrix.target }}
-          RUST_COMPONENTS: ${{ matrix.components }}
+        uses: ./.github/actions/install-rust
+        with:
+          channel: ${{ matrix.toolchain }}
+          target: ${{ matrix.target }}
+          components: ${{ matrix.components }}
 
       # prepare the lockfile - to have a complete image of the dependencies on the current platform
       - name: Create lock file

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -20,8 +20,6 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_TEST_DEBUG: 0
   CARGO_PROFILE_DEV_DEBUG: 0
-  # If nightly is breaking CI, modify this variable to target a specific nightly version.
-  NIGHTLY_TOOLCHAIN: nightly
   # Keep in sync between all workflows
   RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
@@ -36,10 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
 
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -72,10 +67,7 @@ jobs:
           persist-credentials: false
 
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
 
       - name: Set up JDK 17
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
@@ -120,11 +112,9 @@ jobs:
           persist-credentials: false
 
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup target add wasm32-unknown-unknown --toolchain stable
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
+        with:
+          target: wasm32-unknown-unknown
 
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -184,10 +174,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build
@@ -216,18 +203,17 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install ${{ env.NIGHTLY_TOOLCHAIN }} --no-self-update --profile=minimal
-          rustup override set ${{ env.NIGHTLY_TOOLCHAIN }}
-          cargo -V
+        uses: ./.github/actions/install-rust
+        with:
+          channel: nightly
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # key won't match, will rely on restore-keys
-          key: ${{ runner.os }}-${{ env.NIGHTLY_TOOLCHAIN }}--${{ hashFiles('**/Cargo.toml') }}-
+          key: ${{ runner.os }}-nightly--${{ hashFiles('**/Cargo.toml') }}-
           # See .github/workflows/update-caches.yml for how keys are generated
           restore-keys: |
-            ${{ runner.os }}-${{ env.NIGHTLY_TOOLCHAIN }}--${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-${{ env.NIGHTLY_TOOLCHAIN }}--
+            ${{ runner.os }}-nightly--${{ hashFiles('**/Cargo.toml') }}-
+            ${{ runner.os }}-nightly--
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
@@ -250,10 +236,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install toolchain
-        run: |
-          rustup toolchain install stable --no-self-update --profile=minimal
-          rustup override set stable
-          cargo -V
+        uses: ./.github/actions/install-rust
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # key won't match, will rely on restore-keys

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -33,8 +33,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
 
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -66,8 +65,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
 
       - name: Set up JDK 17
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
@@ -111,8 +109,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
         with:
           target: wasm32-unknown-unknown
 
@@ -173,8 +170,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Build
@@ -202,8 +198,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
         with:
           channel: nightly
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -235,8 +230,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Install toolchain
-        uses: ./.github/actions/install-rust
+      - uses: ./.github/actions/install-rust
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # key won't match, will rely on restore-keys


### PR DESCRIPTION
# Objective

- We want Rust update to be manual events instead of breaking CI (format or clippy) every 6 weeks

## Solution

- Set the Rust stable version used by CI manually
- Have it in a single place so that updates are simple
- Also do the same for nightly so that it's a single place to update instead of four env variables when we need to pin it

## Testing

- CI