### PR TITLE
Opt collection reflection subtrait methods out of lsp completions.

### DIFF
--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -50,6 +50,8 @@ use core::{
 /// [`GetTypeRegistration`]: crate::GetTypeRegistration
 /// [limitation]: https://github.com/serde-rs/serde/issues/1937
 /// [`Deserialize`]: ::serde::Deserialize
+// Prevents unexpectedly importing this trait when trying to call, for example, `array::map`
+#[rust_analyzer::completions(ignore_flyimport_methods)]
 pub trait Array: PartialReflect {
     /// Returns a reference to the element at `index`, or `None` if out of bounds.
     fn get(&self, index: usize) -> Option<&dyn PartialReflect>;

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -54,6 +54,8 @@ use crate::{
 /// [list-like]: https://doc.rust-lang.org/book/ch08-01-vectors.html
 /// [reflection]: crate
 /// [type-erasing]: https://doc.rust-lang.org/book/ch17-02-trait-objects.html
+// Prevents unexpectedly importing this trait when trying to call, for example, `Vec::iter`
+#[rust_analyzer::completions(ignore_flyimport_methods)]
 pub trait List: PartialReflect {
     /// Returns a reference to the element at `index`, or `None` if out of bounds.
     fn get(&self, index: usize) -> Option<&dyn PartialReflect>;

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -48,6 +48,8 @@ use alloc::{boxed::Box, vec::Vec};
 /// [`BTreeMap`]: alloc::collections::BTreeMap
 /// [map-like]: https://doc.rust-lang.org/book/ch08-03-hash-maps.html
 /// [reflection]: crate
+// Prevents unexpectedly importing this trait when trying to call, for example, `HashMap::get`
+#[rust_analyzer::completions(ignore_flyimport_methods)]
 pub trait Map: PartialReflect {
     /// Returns a reference to the value associated with the given key.
     ///

--- a/crates/bevy_reflect/src/set.rs
+++ b/crates/bevy_reflect/src/set.rs
@@ -48,6 +48,8 @@ use crate::{
 /// [`BTreeSet`]: alloc::collections::BTreeSet
 /// [set-like]: https://doc.rust-lang.org/stable/std/collections/struct.HashSet.html
 /// [reflection]: crate
+// Prevents unexpectedly importing this trait when trying to call, for example, `HashSet::iter`
+#[rust_analyzer::completions(ignore_flyimport_methods)]
 pub trait Set: PartialReflect {
     /// Returns a reference to the value.
     ///


### PR DESCRIPTION
# Objective

I've been looking at older issues and this one seemed like a simple fix.
Closes #15088

TL;DR: 
`List::iter` and friends have the same names as the likes of `Vec::iter`. Rust analyzer may auto-import the reflection subtraits when a user is trying use the original methods.

## Solution

Hide the methods of `bevy_reflect::{List, Array, Map, Set}` from showing up in completions if the trait isn't imported.

## Testing

Wrote some code and tried to make `List::iter` show up in completions. It would show up before these changes and now doesn't until the trait is imported.
