### PR TITLE
Prevent directional light shadow views from leaking

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -401,7 +401,6 @@ impl Plugin for PbrPlugin {
             .init_gpu_resource::<LightMeta>()
             .init_resource::<RenderShadowLodOrigin>();
 
-        render_app.world_mut().add_observer(add_light_view_entities);
         render_app
             .world_mut()
             .add_observer(remove_light_view_entities);

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -107,6 +107,7 @@ pub struct ExtractedRectLight {
 }
 
 #[derive(Component, Debug)]
+#[require(DirectionalLightViewEntities)]
 pub struct ExtractedDirectionalLight {
     pub color: LinearRgba,
     pub illuminance: f32,
@@ -952,16 +953,6 @@ pub fn extract_lights(
 /// Component automatically attached to a light entity to track light-view entities
 /// for each view.
 pub struct DirectionalLightViewEntities(EntityHashMap<Vec<Entity>>);
-
-// TODO: using required component
-pub(crate) fn add_light_view_entities(
-    add: On<Add<ExtractedDirectionalLight>>,
-    mut commands: Commands,
-) {
-    if let Ok(mut v) = commands.get_entity(add.entity) {
-        v.insert(DirectionalLightViewEntities::default());
-    }
-}
 
 pub(crate) fn remove_light_view_entities(
     remove: On<Remove<DirectionalLightViewEntities>>,


### PR DESCRIPTION
# Objective

Fix #25132.

Hiding a directional light removes `ExtractedDirectionalLight`, but `DirectionalLightViewEntities` never gets cleaned up (since #23790) and so its cascade views persist. Re-showing the light then overwrites the views and orphans the old ones (`remove_light_view_entities` doesn't run because we're emitting a `Discard` and not a `Remove`), so you end up with multiple views resolving to the same `RetainedViewEntity`, and `queue_shadows` tries to bin into it twice.

## Solution

Just make `DirectionalLightViewEntities` a required component instead of using an observer, matching what point and spot lights already do. It was also suggested in a TODO :)

## Testing

- Tried and failed at reproducing #25132 with the PR applied

---
I've used a llm to help with the debugging.