### PR TITLE
Better system access conflict messages

### DIFF
--- a/_release-content/migration-guides/system_access_conflict_errors.md
+++ b/_release-content/migration-guides/system_access_conflict_errors.md
@@ -1,0 +1,65 @@
+---
+title: Better system access conflict errors
+pull_requests: [25507, 25731]
+---
+
+To provide better error messages,
+system access conflicts are now managed by returning `Result` instead of panicking.
+
+The signatures of `SystemParam::init_access` and `WorldQuery::init_nested_access`
+have been changed to return `Result`, and to remove the `world` and `system_name`
+parameters that were only used to build the panic message.
+Manual implementations and any manual calls will need to be changed.
+
+Manual implementations of `SystemParam` or `WorldQuery` that
+delegate to other implementations should propagate the `Err`,
+either by returning the value directly or using the `?` operator.
+
+Note that propagating the error will include the type name
+of the *inner* parameter in the panic message.
+Use `map_err(ParameterAccessConflict::with_param::<Self>)`
+to replace it with the wrapper's type name, if desired.
+
+Implementations that perform no access can simply return `Ok(())`.
+Note that performing metadata access using safe methods on `UnsafeWorldCell`
+requires registering metadata access to detect conflicts with `&mut World`.
+Use `SystemAccess::try_extend_metadata` if you call such methods in `get_param`.
+
+Implementations that need to register custom access
+should call one of the `SystemAccess::try_extend` methods to try to add the access,
+and then call `ParameterAccessConflict::new::<Self>` on an `Err`.
+
+```rust
+impl SystemParam for ExampleParameter {
+    // 0.19
+    fn init_access(
+        state: &Self::State,
+        system_meta: &mut SystemMeta,
+        component_access_set: &mut FilteredAccessSet,
+        world: &mut World,
+    ) {
+        let mut access: FilteredAccess = ...;
+        let conflicts = component_access_set.get_conflicts_single(&access);
+        if !conflicts.is_empty() {
+            panic!("...");
+        }
+        component_access_set.add(access);
+    }
+
+    // 0.20
+    fn init_access(
+        state: &Self::State,
+        system_meta: &mut SystemMeta,
+        system_access: &mut SystemAccess,
+    ) -> Result<(), Box<ParameterAccessConflict>> {
+        let mut access: FilteredAccess = ...;
+        system_access.try_extend_single(access).map_err(|access| {
+            ParameterAccessConflict::new::<Self>(access)
+                // If you have additional suggestions to display to the user on conflict,
+                // call `with_suggestion` or `with_suggestion_if_exclusive` to add them.
+                .with_suggestion("Suggestion on conflict")
+                .with_suggestion_if_exclusive(system_access, "Suggestion on conflict with `&mut World`")
+        })
+    }
+}
+```

--- a/_release-content/migration-guides/world_query_no_default_impls.md
+++ b/_release-content/migration-guides/world_query_no_default_impls.md
@@ -20,10 +20,9 @@ impl WorldQuery {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn update_archetypes(_state: &mut Self::State, _world: UnsafeWorldCell) {}

--- a/crates/bevy_asset/src/asset_changed.rs
+++ b/crates/bevy_asset/src/asset_changed.rs
@@ -16,7 +16,6 @@ use bevy_ecs::{
     world::unsafe_world_cell::UnsafeWorldCell,
 };
 use bevy_platform::collections::HashMap;
-use bevy_utils::prelude::DebugName;
 use core::marker::PhantomData;
 use disqualified::ShortName;
 use tracing::error;
@@ -242,20 +241,18 @@ unsafe impl<A: AsAssetId> WorldQuery for AssetChanged<A> {
     // In order to access two different entities we implement init_nested_access.
     fn init_nested_access(
         state: &Self::State,
-        system_name: Option<&str>,
         component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
         let mut filter = FilteredAccess::default();
         filter.add_read(state.resource_id);
         filter.and_with(IS_RESOURCE);
 
-        let conflicts = component_access_set.get_conflicts_single(&filter);
-        if conflicts.is_empty() {
-            component_access_set.add(filter);
-            return;
+        if !component_access_set.is_compatible_single(&filter) {
+            return Err(filter.into());
         }
-        panic!("error[B0002]: AssetChanged<{}> in system {:?} conflicts with a previous system parameter. Consider removing the duplicate access. See: https://bevy.org/learn/errors/b0002", DebugName::type_name::<A>(), system_name);
+
+        component_access_set.add(filter);
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> AssetChangedState<A> {

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -19,7 +19,7 @@ use bevy_ecs_macro_logic::{
 };
 use bevy_macro_utils::{
     derive_label, ensure_no_collision,
-    fq_std::{FQDefault, FQIterator, FQOption, FQResult},
+    fq_std::{FQBox, FQDefault, FQIterator, FQOption, FQResult},
     get_struct_fields, pascal_to_snake_case, BevyManifest,
 };
 use proc_macro::TokenStream;
@@ -455,7 +455,7 @@ fn derive_system_param_impl(
                     state: &Self::State,
                     system_meta: &mut #path::system::SystemMeta,
                     system_access: &mut #path::system::SystemAccess,
-                ) -> Result<(), #path::system::ParameterAccessConflict> {
+                ) -> Result<(), #FQBox<#path::system::ParameterAccessConflict>> {
                     <#fields_alias::<'_, '_, #punctuated_generic_idents> as #path::system::SystemParam>::init_access(&state.state, system_meta, system_access)?;
                     Ok(())
                 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -455,9 +455,9 @@ fn derive_system_param_impl(
                     state: &Self::State,
                     system_meta: &mut #path::system::SystemMeta,
                     system_access: &mut #path::system::SystemAccess,
-                    world: &mut #path::world::World
-                ) {
-                    <#fields_alias::<'_, '_, #punctuated_generic_idents> as #path::system::SystemParam>::init_access(&state.state, system_meta, system_access, world);
+                ) -> Result<(), #path::system::ParameterAccessConflict> {
+                    <#fields_alias::<'_, '_, #punctuated_generic_idents> as #path::system::SystemParam>::init_access(&state.state, system_meta, system_access)?;
+                    Ok(())
                 }
 
                 fn apply(state: &mut Self::State, system_meta: &#path::system::SystemMeta, world: &mut #path::world::World) {

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -19,7 +19,7 @@ use bevy_ecs_macro_logic::{
 };
 use bevy_macro_utils::{
     derive_label, ensure_no_collision,
-    fq_std::{FQBox, FQDefault, FQIterator, FQOption, FQResult},
+    fq_std::{FQDefault, FQIterator, FQOption, FQResult},
     get_struct_fields, pascal_to_snake_case, BevyManifest,
 };
 use proc_macro::TokenStream;
@@ -455,7 +455,7 @@ fn derive_system_param_impl(
                     state: &Self::State,
                     system_meta: &mut #path::system::SystemMeta,
                     system_access: &mut #path::system::SystemAccess,
-                ) -> Result<(), #FQBox<#path::system::ParameterAccessConflict>> {
+                ) -> Result<(), #path::system::BoxedParameterAccessConflict> {
                     <#fields_alias::<'_, '_, #punctuated_generic_idents> as #path::system::SystemParam>::init_access(&state.state, system_meta, system_access)?;
                     Ok(())
                 }

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -1,4 +1,4 @@
-use bevy_macro_utils::fq_std::{FQClone, FQOption};
+use bevy_macro_utils::fq_std::{FQClone, FQOption, FQResult};
 use proc_macro2::Ident;
 use quote::quote;
 use syn::{Attribute, Fields, ImplGenerics, Member, Type, TypeGenerics, Visibility, WhereClause};
@@ -159,11 +159,10 @@ pub(crate) fn world_query_impl(
 
             fn init_nested_access(
                 state: &Self::State,
-                _system_name: #FQOption<&str>,
                 _component_access_set: &mut #path::query::FilteredAccessSet,
-                _world: #path::world::unsafe_world_cell::UnsafeWorldCell,
-            ) {
-                #( <#field_types>::init_nested_access(&state.#field_aliases, _system_name, _component_access_set, _world); )*
+            ) -> #FQResult<(), #path::query::FilteredAccessSet> {
+                #( <#field_types>::init_nested_access(&state.#field_aliases, _component_access_set)?; )*
+                Ok(())
             }
 
             fn init_state(world: &mut #path::world::World) -> #state_struct_name #user_ty_generics {

--- a/crates/bevy_ecs/src/lifecycle.rs
+++ b/crates/bevy_ecs/src/lifecycle.rs
@@ -68,6 +68,7 @@ use crate::{
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
 };
 
+use alloc::boxed::Box;
 use derive_more::derive::Into;
 
 #[cfg(feature = "bevy_reflect")]
@@ -703,7 +704,7 @@ unsafe impl<'a> SystemParam for &'a RemovedComponentMessages {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_access.try_extend_metadata().map_err(|access| {
             ParameterAccessConflict::new::<Self>(access).with_suggestion_if_exclusive(
                 system_access,

--- a/crates/bevy_ecs/src/lifecycle.rs
+++ b/crates/bevy_ecs/src/lifecycle.rs
@@ -62,7 +62,7 @@ use crate::{
     relationship::RelationshipHookMode,
     storage::SparseSet,
     system::{
-        Local, ReadOnlySystemParam, SystemAccess, SystemMeta, SystemParam,
+        Local, ParameterAccessConflict, ReadOnlySystemParam, SystemAccess, SystemMeta, SystemParam,
         SystemParamValidationError,
     },
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
@@ -701,11 +701,15 @@ unsafe impl<'a> SystemParam for &'a RemovedComponentMessages {
 
     fn init_access(
         _state: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
-        system_access.require_shared_access::<Self>(system_meta);
+    ) -> Result<(), ParameterAccessConflict> {
+        system_access.try_extend_metadata().map_err(|access| {
+            ParameterAccessConflict::new::<Self>(access).with_suggestion_if_exclusive(
+                system_access,
+                "Calling `World::removed_components()`",
+            )
+        })
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/message/message_reader.rs
+++ b/crates/bevy_ecs/src/message/message_reader.rs
@@ -171,6 +171,7 @@ unsafe impl<'w, 's, M: Message> SystemParam for PopulatedMessageReader<'w, 's, M
         system_access: &mut crate::system::SystemAccess,
     ) -> Result<(), Box<ParameterAccessConflict>> {
         MessageReader::<M>::init_access(state, system_meta, system_access)
+            .map_err(ParameterAccessConflict::with_param::<Self>)
     }
 
     unsafe fn get_param<'world, 'state>(

--- a/crates/bevy_ecs/src/message/message_reader.rs
+++ b/crates/bevy_ecs/src/message/message_reader.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 #[cfg(feature = "multi_threaded")]
 use crate::message::MessageParIter;
 use crate::{
@@ -167,7 +169,7 @@ unsafe impl<'w, 's, M: Message> SystemParam for PopulatedMessageReader<'w, 's, M
         state: &Self::State,
         system_meta: &mut crate::system::SystemMeta,
         system_access: &mut crate::system::SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         MessageReader::<M>::init_access(state, system_meta, system_access)
     }
 

--- a/crates/bevy_ecs/src/message/message_reader.rs
+++ b/crates/bevy_ecs/src/message/message_reader.rs
@@ -2,7 +2,7 @@
 use crate::message::MessageParIter;
 use crate::{
     message::{Message, MessageCursor, MessageIterator, MessageIteratorWithId, Messages},
-    system::{Local, Res, SystemParam, SystemParamValidationError},
+    system::{Local, ParameterAccessConflict, Res, SystemParam, SystemParamValidationError},
 };
 
 /// Reads [`Message`]s of type `T` in order and tracks which messages have already been read.
@@ -167,9 +167,8 @@ unsafe impl<'w, 's, M: Message> SystemParam for PopulatedMessageReader<'w, 's, M
         state: &Self::State,
         system_meta: &mut crate::system::SystemMeta,
         system_access: &mut crate::system::SystemAccess,
-        world: &mut crate::prelude::World,
-    ) {
-        MessageReader::<M>::init_access(state, system_meta, system_access, world);
+    ) -> Result<(), ParameterAccessConflict> {
+        MessageReader::<M>::init_access(state, system_meta, system_access)
     }
 
     unsafe fn get_param<'world, 'state>(

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -1029,6 +1029,19 @@ impl FilteredAccessSet {
         true
     }
 
+    /// Returns `true` if this and `other` can be active at the same time.
+    pub fn is_compatible_single(&self, other: &FilteredAccess) -> bool {
+        if self.combined_access.is_compatible(other.access()) {
+            return true;
+        }
+        for filtered in &self.filtered_accesses {
+            if !filtered.is_compatible(other) {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Returns a vector of elements that this set and `other` cannot access at the same time.
     pub fn get_conflicts(&self, other: &FilteredAccessSet) -> AccessConflicts {
         // if the unfiltered access is incompatible, must check each pair

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -2983,7 +2983,7 @@ impl<'__w, T: Component<Mutability = Mutable>> ContiguousQueryData for Mut<'__w,
 ///         <ParentInner<D, F> as WorldQuery>::update_component_access(state, access)
 ///     }
 ///
-///     fn init_nested_access(state: &Self::State, component_access_set: &mut FilteredAccessSet) {
+///     fn init_nested_access(state: &Self::State, component_access_set: &mut FilteredAccessSet) -> Result<(), FilteredAccessSet> {
 ///         <ParentInner<D, F> as WorldQuery>::init_nested_access(state, component_access_set)
 ///     }
 ///

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -540,10 +540,9 @@ unsafe impl WorldQuery for Entity {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(_world: &mut World) {}
@@ -666,10 +665,9 @@ unsafe impl WorldQuery for EntityLocation {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(_world: &mut World) {}
@@ -857,10 +855,9 @@ unsafe impl WorldQuery for SpawnDetails {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(_world: &mut World) {}
@@ -1001,10 +998,9 @@ unsafe impl<'a> WorldQuery for EntityRef<'a> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(_world: &mut World) {}
@@ -1127,10 +1123,9 @@ unsafe impl<'a> WorldQuery for EntityMut<'a> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(_world: &mut World) {}
@@ -1250,10 +1245,9 @@ unsafe impl WorldQuery for FilteredEntityRef<'_, '_> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(_world: &mut World) -> Self::State {
@@ -1391,10 +1385,9 @@ unsafe impl WorldQuery for FilteredEntityMut<'_, '_> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(_world: &mut World) -> Self::State {
@@ -1527,10 +1520,9 @@ where
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> Self::State {
@@ -1660,10 +1652,9 @@ where
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> Self::State {
@@ -1785,10 +1776,9 @@ unsafe impl WorldQuery for &Archetype {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(_world: &mut World) {}
@@ -1958,10 +1948,9 @@ unsafe impl<T: Component> WorldQuery for &T {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> ComponentId {
@@ -2203,10 +2192,9 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> ComponentId {
@@ -2490,10 +2478,9 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> ComponentId {
@@ -2719,10 +2706,9 @@ unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     // Forwarded to `&mut T`
@@ -2997,8 +2983,8 @@ impl<'__w, T: Component<Mutability = Mutable>> ContiguousQueryData for Mut<'__w,
 ///         <ParentInner<D, F> as WorldQuery>::update_component_access(state, access)
 ///     }
 ///
-///     fn init_nested_access(state: &Self::State, system_name: Option<&str>, component_access_set: &mut FilteredAccessSet, world: UnsafeWorldCell) {
-///         <ParentInner<D, F> as WorldQuery>::init_nested_access(state, system_name, component_access_set, world)
+///     fn init_nested_access(state: &Self::State, component_access_set: &mut FilteredAccessSet) {
+///         <ParentInner<D, F> as WorldQuery>::init_nested_access(state, component_access_set)
 ///     }
 ///
 ///     fn init_state(world: &mut World) -> Self::State {
@@ -3095,11 +3081,9 @@ unsafe impl<D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> WorldQuery
 
     fn init_nested_access(
         state: &Self::State,
-        system_name: Option<&str>,
         component_access_set: &mut FilteredAccessSet,
-        world: UnsafeWorldCell,
-    ) {
-        state.init_access(system_name, component_access_set, world);
+    ) -> Result<(), FilteredAccessSet> {
+        state.init_access(component_access_set)
     }
 
     fn init_state(world: &mut World) -> Self::State {
@@ -3287,11 +3271,9 @@ unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
 
     fn init_nested_access(
         state: &Self::State,
-        system_name: Option<&str>,
         component_access_set: &mut FilteredAccessSet,
-        world: UnsafeWorldCell,
-    ) {
-        T::init_nested_access(state, system_name, component_access_set, world);
+    ) -> Result<(), FilteredAccessSet> {
+        T::init_nested_access(state, component_access_set)
     }
 
     fn init_state(world: &mut World) -> T::State {
@@ -3509,10 +3491,9 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> ComponentId {
@@ -3832,11 +3813,9 @@ macro_rules! impl_anytuple_fetch {
 
             fn init_nested_access(
                 state: &Self::State,
-                system_name: Option<&str>,
                 component_access_set: &mut FilteredAccessSet,
-                world: UnsafeWorldCell,
-            ) {
-                <($(Option<$name>,)*)>::init_nested_access(state, system_name, component_access_set, world);
+            ) -> Result<(), FilteredAccessSet> {
+                <($(Option<$name>,)*)>::init_nested_access(state, component_access_set)
             }
 
             fn init_state(world: &mut World) -> Self::State {
@@ -4051,10 +4030,9 @@ unsafe impl<D: QueryData> WorldQuery for NopWorldQuery<D> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> Self::State {
@@ -4161,10 +4139,9 @@ unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(_world: &mut World) -> Self::State {}
@@ -4395,10 +4372,9 @@ mod tests {
 
             fn init_nested_access(
                 _state: &Self::State,
-                _system_name: Option<&str>,
                 _component_access_set: &mut FilteredAccessSet,
-                _world: UnsafeWorldCell,
-            ) {
+            ) -> Result<(), FilteredAccessSet> {
+                Ok(())
             }
 
             fn init_state(_world: &mut World) {}

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -187,10 +187,9 @@ unsafe impl<T: Component> WorldQuery for With<T> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> ComponentId {
@@ -298,10 +297,9 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> ComponentId {
@@ -499,12 +497,11 @@ macro_rules! impl_or_query_filter {
 
             fn init_nested_access(
                 state: &Self::State,
-                _system_name: Option<&str>,
                 _component_access_set: &mut FilteredAccessSet,
-                _world: UnsafeWorldCell,
-            ) {
+            ) -> Result<(), FilteredAccessSet>  {
                 let ($($state,)*) = state;
-                $($filter::init_nested_access($state, _system_name, _component_access_set, _world);)*
+                $($filter::init_nested_access($state, _component_access_set)?;)*
+                Ok(())
             }
 
             fn init_state(world: &mut World) -> Self::State {
@@ -653,10 +650,9 @@ unsafe impl<T: Component> WorldQuery for Allow<T> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> ComponentId {
@@ -864,10 +860,9 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> ComponentId {
@@ -1101,10 +1096,9 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(world: &mut World) -> ComponentId {
@@ -1271,10 +1265,9 @@ unsafe impl WorldQuery for Spawned {
 
     fn init_nested_access(
         _state: &Self::State,
-        _system_name: Option<&str>,
         _component_access_set: &mut FilteredAccessSet,
-        _world: UnsafeWorldCell,
-    ) {
+    ) -> Result<(), FilteredAccessSet> {
+        Ok(())
     }
 
     fn init_state(_world: &mut World) {}

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -18,7 +18,7 @@ use crate::{
 #[cfg(all(not(target_arch = "wasm32"), feature = "multi_threaded"))]
 use crate::entity::UniqueEntityEquivalentSlice;
 
-use alloc::{format, vec::Vec};
+use alloc::vec::Vec;
 use bevy_utils::prelude::DebugName;
 use core::{fmt, ptr};
 use fixedbitset::FixedBitSet;
@@ -197,35 +197,23 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// or with any previous access.
     pub fn init_access(
         &self,
-        system_name: Option<&str>,
         component_access_set: &mut FilteredAccessSet,
-        world: UnsafeWorldCell,
-    ) {
-        let conflicts = component_access_set.get_conflicts_single(&self.component_access);
-        if !conflicts.is_empty() {
-            let mut accesses = conflicts.format_conflict_list(world);
-            // Access list may be empty (if access to all components requested)
-            if !accesses.is_empty() {
-                accesses.push(' ');
-            }
-            let type_name = DebugName::type_name::<Query<D, F>>();
-            let type_name = type_name.shortname();
-            let system = system_name
-                .map(|name| format!(" in system {name}"))
-                .unwrap_or_default();
-            panic!("error[B0001]: {type_name}{system} accesses component(s) {accesses}in a way that conflicts with a previous system parameter. Consider using `Without<T>` to create disjoint Queries or merging conflicting Queries into a `ParamSet`. See: https://bevy.org/learn/errors/b0001",);
+    ) -> Result<(), FilteredAccessSet> {
+        let component_access = self.component_access.clone();
+        if !component_access_set.is_compatible_single(&component_access) {
+            return Err(component_access.into());
         }
-
-        component_access_set.add(self.component_access.clone());
-        D::init_nested_access(&self.fetch_state, system_name, component_access_set, world);
-        F::init_nested_access(&self.filter_state, system_name, component_access_set, world);
+        component_access_set.add(component_access);
+        D::init_nested_access(&self.fetch_state, component_access_set)?;
+        F::init_nested_access(&self.filter_state, component_access_set)?;
+        Ok(())
     }
 
     /// Creates a new [`QueryState`] from a given [`World`] and inherits the result of `world.id()`.
     pub fn new(world: &mut World) -> Self {
         // SAFETY: We immediately call `init_access`
         let state = unsafe { Self::new_unchecked(world) };
-        state.init_access(None, &mut FilteredAccessSet::new(), world.into());
+        state.assert_no_conflicts_with_nested_queries(world.into());
         state
     }
 
@@ -239,7 +227,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         // SAFETY: We immediately call `init_access`
         let mut state =
             unsafe { Self::from_states_uninitialized(world, fetch_state, filter_state) };
-        state.init_access(None, &mut FilteredAccessSet::new(), world.into());
+        state.assert_no_conflicts_with_nested_queries(world.into());
         state.update_archetypes(world);
         Some(state)
     }
@@ -343,9 +331,32 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
                 filter = core::any::type_name::<F>(),
             ),
         };
-        state.init_access(None, &mut FilteredAccessSet::new(), builder.world().into());
+        state.assert_no_conflicts_with_nested_queries(builder.world().into());
         state.update_archetypes(builder.world());
         state
+    }
+
+    fn assert_no_conflicts_with_nested_queries(&self, world: UnsafeWorldCell<'_>) {
+        self.init_access(&mut FilteredAccessSet::new())
+            .unwrap_or_else(|access2| {
+                // Find the other conflicting query.
+                // By initializing `access` with the access of the later query,
+                // the earlier one will detect the conflict instead.
+                let mut access = access2.clone();
+                let access1 = self.init_access(&mut access).expect_err(
+                    "Query with internal access conflict must always report a conflict",
+                );
+                let conflicts = access1.get_conflicts(&access2);
+                let mut accesses = conflicts.format_conflict_list(world);
+                // Access list may be empty (if access to all components requested)
+                if !accesses.is_empty() {
+                    accesses.insert_str(0, " on component(s) ");
+                }
+                panic!(
+                    "`{}` has access conflicts between nested queries{accesses}.",
+                    DebugName::type_name::<Self>().shortname()
+                );
+            });
     }
 
     /// Creates a [`Query`] from the given [`QueryState`] and [`World`].

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -69,7 +69,7 @@ pub unsafe trait WorldQuery {
     /// - [`WorldQuery::init_nested_access`] must not request conflicting access.
     ///   If `Self` is [`ReadOnlyQueryData`](crate::query::ReadOnlyQueryData) or [`QueryFilter`](crate::query::QueryFilter), the access is read-only and can never conflict.
     ///   If `Self` is [`SingleEntityQueryData`](crate::query::SingleEntityQueryData), there is no external access and it cannot conflict.
-    ///   Otherwise, [`WorldQuery::init_nested_access`] must be called to ensure it does not panic.
+    ///   Otherwise, [`WorldQuery::init_nested_access`] must be called to ensure it does not return [`Err`].
     unsafe fn init_fetch<'w, 's>(
         world: UnsafeWorldCell<'w>,
         state: &'s Self::State,
@@ -124,7 +124,7 @@ pub unsafe trait WorldQuery {
 
     /// Adds any component accesses to other entities used by this [`WorldQuery`].
     ///
-    /// This method must return `Err` if the access would conflict with any existing access in the [`FilteredAccessSet`].
+    /// This method must return [`Err`] if the access would conflict with any existing access in the [`FilteredAccessSet`].
     ///
     /// This is used for queries to request access to entities other than the current one,
     /// such as to read resources or to follow relations.

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -124,16 +124,14 @@ pub unsafe trait WorldQuery {
 
     /// Adds any component accesses to other entities used by this [`WorldQuery`].
     ///
-    /// This method must panic if the access would conflict with any existing access in the [`FilteredAccessSet`].
+    /// This method must return `Err` if the access would conflict with any existing access in the [`FilteredAccessSet`].
     ///
     /// This is used for queries to request access to entities other than the current one,
     /// such as to read resources or to follow relations.
     fn init_nested_access(
         state: &Self::State,
-        system_name: Option<&str>,
         component_access_set: &mut FilteredAccessSet,
-        world: UnsafeWorldCell,
-    );
+    ) -> Result<(), FilteredAccessSet>;
 
     /// Creates and initializes a [`State`](WorldQuery::State) for this [`WorldQuery`] type.
     fn init_state(world: &mut World) -> Self::State;
@@ -232,12 +230,11 @@ macro_rules! impl_tuple_world_query {
 
             fn init_nested_access(
                 state: &Self::State,
-                _system_name: Option<&str>,
                 _component_access_set: &mut FilteredAccessSet,
-                _world: UnsafeWorldCell,
-            ) {
+            ) -> Result<(), FilteredAccessSet> {
                 let ($($state,)*) = state;
-                $($name::init_nested_access($state, _system_name, _component_access_set, _world);)*
+                $($name::init_nested_access($state, _component_access_set)?;)*
+                Ok(())
             }
 
             fn init_state(world: &mut World) -> Self::State {

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -585,9 +585,9 @@ mod validation_tests {
         prelude::{Component, In, IntoSystem, Resource, Schedule},
         schedule::{MultiThreadedExecutor, SingleThreadedExecutor},
         system::{
-            DynParamBuilder, DynSystemParam, Local, ParamBuilder, ParamSet, Query, Res, ResMut,
-            RunSystemError, RunSystemOnce, Single, SystemAccess, SystemMeta, SystemParam,
-            SystemParamBuilder, SystemParamValidationError,
+            DynParamBuilder, DynSystemParam, Local, ParamBuilder, ParamSet,
+            ParameterAccessConflict, Query, Res, ResMut, RunSystemError, RunSystemOnce, Single,
+            SystemAccess, SystemMeta, SystemParam, SystemParamBuilder, SystemParamValidationError,
         },
         world::World,
     };
@@ -616,8 +616,8 @@ mod validation_tests {
             _state: &Self::State,
             _system_meta: &mut SystemMeta,
             _system_access: &mut SystemAccess,
-            _world: &mut World,
-        ) {
+        ) -> Result<(), ParameterAccessConflict> {
+            Ok(())
         }
 
         unsafe fn get_param<'world, 'state>(

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -581,6 +581,8 @@ mod tests {
 
 #[cfg(test)]
 mod validation_tests {
+    use alloc::boxed::Box;
+
     use crate::{
         prelude::{Component, In, IntoSystem, Resource, Schedule},
         schedule::{MultiThreadedExecutor, SingleThreadedExecutor},
@@ -616,7 +618,7 @@ mod validation_tests {
             _state: &Self::State,
             _system_meta: &mut SystemMeta,
             _system_access: &mut SystemAccess,
-        ) -> Result<(), ParameterAccessConflict> {
+        ) -> Result<(), Box<ParameterAccessConflict>> {
             Ok(())
         }
 

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -898,7 +898,7 @@ impl MainThreadExecutor {
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::String;
+    use alloc::{boxed::Box, string::String};
     use core::{
         panic::AssertUnwindSafe,
         sync::atomic::{AtomicBool, Ordering::Relaxed},
@@ -933,7 +933,7 @@ mod tests {
             _state: &Self::State,
             _system_meta: &mut SystemMeta,
             system_access: &mut SystemAccess,
-        ) -> Result<(), ParameterAccessConflict> {
+        ) -> Result<(), Box<ParameterAccessConflict>> {
             system_access
                 .try_extend_exclusive()
                 .map_err(ParameterAccessConflict::new::<Self>)

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -911,7 +911,8 @@ mod tests {
         prelude::Resource,
         schedule::{IntoScheduleConfigs, MultiThreadedExecutor, Schedule},
         system::{
-            Commands, NonSendMut, SystemAccess, SystemMeta, SystemParam, SystemParamValidationError,
+            Commands, NonSendMut, ParameterAccessConflict, SystemAccess, SystemMeta, SystemParam,
+            SystemParamValidationError,
         },
         world::{unsafe_world_cell::UnsafeWorldCell, World},
     };
@@ -930,11 +931,12 @@ mod tests {
 
         fn init_access(
             _state: &Self::State,
-            system_meta: &mut SystemMeta,
+            _system_meta: &mut SystemMeta,
             system_access: &mut SystemAccess,
-            _world: &mut World,
-        ) {
-            system_access.require_exclusive_access::<Self>(system_meta);
+        ) -> Result<(), ParameterAccessConflict> {
+            system_access
+                .try_extend_exclusive()
+                .map_err(ParameterAccessConflict::new::<Self>)
         }
 
         unsafe fn get_param<'world, 'state>(

--- a/crates/bevy_ecs/src/system/access.rs
+++ b/crates/bevy_ecs/src/system/access.rs
@@ -57,7 +57,7 @@ impl SystemAccess {
         Ok(())
     }
 
-    /// Tries to add set the current access to [`Exclusive`].
+    /// Tries to set the current access to [`Exclusive`].
     /// If the provided [`SystemAccess`] is not [`None`],
     /// this will instead return an [`Err`] with [`Exclusive`].
     ///
@@ -65,7 +65,7 @@ impl SystemAccess {
     ///
     /// # Errors
     ///
-    /// If `self` is not compatible with `other`, this will return an [`Err`] wrapping `other`.
+    /// If `self` is not compatible with [`Exclusive`], this will return an [`Err`] wrapping [`Exclusive`].
     ///
     /// [`None`]: SystemAccess::None
     /// [`Shared`]: SystemAccess::Shared

--- a/crates/bevy_ecs/src/system/access.rs
+++ b/crates/bevy_ecs/src/system/access.rs
@@ -1,10 +1,6 @@
 use alloc::borrow::Cow;
-use bevy_utils::prelude::ShortName;
 
-use crate::{
-    query::{AccessConflicts, FilteredAccess, FilteredAccessSet},
-    system::SystemMeta,
-};
+use crate::query::{AccessConflicts, FilteredAccess, FilteredAccessSet};
 
 /// Represents the access a [`System`] requires to the [`World`].
 ///
@@ -44,6 +40,84 @@ impl SystemAccess {
     /// Returns true if the system requires exclusive access to the world.
     pub fn is_exclusive(&self) -> bool {
         matches!(self, Self::Exclusive)
+    }
+
+    /// Tries to add the provided [`SystemAccess`] to the current access.
+    /// If the provided [`SystemAccess`] is not compatible,
+    /// this will instead return an [`Err`] with the provided [`SystemAccess`].
+    ///
+    /// # Errors
+    ///
+    /// If `self` is not compatible with `other`, this will return an [`Err`] wrapping `other`.
+    pub fn try_extend(&mut self, other: Self) -> Result<(), Self> {
+        if !self.is_compatible(&other) {
+            return Err(other);
+        }
+        self.extend(other);
+        Ok(())
+    }
+
+    /// Tries to add set the current access to [`Exclusive`].
+    /// If the provided [`SystemAccess`] is not [`None`],
+    /// this will instead return an [`Err`] with [`Exclusive`].
+    ///
+    /// This is equivalent to `self.try_extend(SystemAccess::Exclusive)`.
+    ///
+    /// # Errors
+    ///
+    /// If `self` is not compatible with `other`, this will return an [`Err`] wrapping `other`.
+    ///
+    /// [`None`]: SystemAccess::None
+    /// [`Shared`]: SystemAccess::Shared
+    /// [`Exclusive`]: SystemAccess::Exclusive
+    pub fn try_extend_exclusive(&mut self) -> Result<(), Self> {
+        self.try_extend(Self::Exclusive)
+    }
+
+    /// Tries to add access to [`World`] metadata (e.g. [`Archetypes`], [`Components`]) to the current access.
+    /// If the current access is [`Exclusive`],
+    /// this will instead return an [`Err`] with an empty [`Shared`].
+    ///
+    /// On success, `self` is guaranteed to be `Shared`.
+    ///
+    /// This is equivalent to `self.try_extend(SystemAccess::Shared(FilteredAccessSet::new()))`.
+    ///
+    /// # Errors
+    ///
+    /// If `self` is [`Exclusive`], this will return an [`Err`] with an empty [`Shared`].
+    ///
+    /// [`World`]: crate::world::World
+    /// [`Archetypes`]: crate::archetype::Archetypes
+    /// [`Components`]: crate::component::Components
+    /// [`Shared`]: SystemAccess::Shared
+    /// [`Exclusive`]: SystemAccess::Exclusive
+    pub fn try_extend_metadata(&mut self) -> Result<(), Self> {
+        self.try_extend(Self::Shared(FilteredAccessSet::new()))
+    }
+
+    /// Tries to add the provided [`FilteredAccess`] to the current access.
+    /// If the provided [`SystemAccess`] is not compatible,
+    /// this will instead return an [`Err`] with a [`Shared`] that includes the provided [`FilteredAccess`].
+    ///
+    /// This is equivalent to `self.try_extend(SystemAccess::Shared(other.into()))`.
+    ///
+    /// # Errors
+    ///
+    /// If `self` is not compatible with `other`, this will return an [`Err`] with a [`Shared`] wrapping `other`.
+    ///
+    /// [`Shared`]: SystemAccess::Shared
+    pub fn try_extend_single(&mut self, other: FilteredAccess) -> Result<(), Self> {
+        if let Self::None = self {
+            *self = Self::Shared(FilteredAccessSet::new());
+        }
+        if let Self::Shared(access) = self
+            && access.is_compatible_single(&other)
+        {
+            access.add(other);
+            Ok(())
+        } else {
+            Err(Self::Shared(other.into()))
+        }
     }
 
     /// Returns true if this system's access is compatible with the other
@@ -118,157 +192,6 @@ impl SystemAccess {
         }
     }
 
-    /// Marks the system as requiring shared access to the world, which means it
-    /// can run in parallel with other systems that also require shared access,
-    /// as long as they don't require exclusive access to the same components.
-    ///
-    /// The provided type `T` is used for error reporting in case of access conflicts;
-    /// it should be the type of the system parameter that is requesting shared access.
-    ///
-    /// # Panics
-    ///
-    /// If the system already has exclusive access, this method will panic with
-    /// an error message indicating the conflict.
-    ///
-    /// # Examples
-    ///
-    /// ## Only metadata access required
-    ///
-    /// If a system parameter requires access to world metadata but not any
-    /// particular components, you may call this function without modifying the
-    /// returned [`FilteredAccessSet`]:
-    ///
-    /// ```rust,no_run
-    /// # use bevy_ecs::system::{SystemAccess, SystemMeta, SystemParam, SystemParamValidationError};
-    /// # use bevy_ecs::world::{unsafe_world_cell::UnsafeWorldCell, World, WorldId};
-    /// # use bevy_ecs::change_detection::Tick;
-    /// pub struct MyWorldId(WorldId);
-    ///
-    /// // SAFETY: World metadata is registered and accessed.
-    /// unsafe impl SystemParam for MyWorldId {
-    ///     type State = ();
-    ///     type Item<'world, 'state> = MyWorldId;
-    ///
-    ///     fn init_state(_: &mut World) -> Self::State {}
-    ///
-    ///     fn init_access(
-    ///         _state: &Self::State,
-    ///         system_meta: &mut SystemMeta,
-    ///         system_access: &mut SystemAccess,
-    ///         _world: &mut World,
-    ///     ) {
-    ///         system_access.require_shared_access::<Self>(system_meta);
-    ///     }
-    ///
-    ///     unsafe fn get_param<'world, 'state>(
-    ///         _: &'state mut Self::State,
-    ///         _: &SystemMeta,
-    ///         world: UnsafeWorldCell<'world>,
-    ///         _: Tick,
-    ///     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError> {
-    ///         Ok(MyWorldId(world.id()))
-    ///     }
-    /// }
-    /// ```
-    pub fn require_shared_access<T>(&mut self, system_meta: &SystemMeta) -> &mut FilteredAccessSet {
-        match self {
-            this @ Self::None => {
-                *this = Self::Shared(FilteredAccessSet::new());
-                if let Self::Shared(access) = this {
-                    access
-                } else {
-                    unreachable!()
-                }
-            }
-            Self::Shared(access) => access,
-            Self::Exclusive => panic!(
-                "error[B0002]: {} in system {} conflicts with a previous system parameter.",
-                ShortName::of::<T>(),
-                system_meta.name()
-            ),
-        }
-    }
-
-    /// Marks the system as requiring exclusive access to the world, meaning no
-    /// other [`Shared`] or [`Exclusive`] system can run in parallel with it.
-    ///
-    /// The provided type `T` is used for error reporting in case of access conflicts;
-    /// it should be the type of the system parameter that is requesting exclusive access.
-    ///
-    /// # Panics
-    ///
-    /// If the system already has shared or exclusive access, this method will
-    /// panic with an error message indicating the conflict.
-    ///
-    /// [`Shared`]: SystemAccess::Shared
-    /// [`Exclusive`]: SystemAccess::Exclusive
-    pub fn require_exclusive_access<T>(&mut self, system_meta: &SystemMeta) {
-        if !matches!(self, Self::None) {
-            panic!(
-                "error[B0002]: {} in system {} conflicts with a previous system parameter.",
-                ShortName::of::<T>(),
-                system_meta.name()
-            );
-        }
-        *self = Self::Exclusive;
-    }
-
-    /// Attempts to add the provided [`FilteredAccess`] to the system's current access.
-    ///
-    /// - If the system currently has [`None`] access, it will change this access
-    ///   to [`Shared`] and add the provided [`FilteredAccess`].
-    /// - If the system currently has [`Shared`] access, it will check for conflicts
-    ///   with the provided [`FilteredAccess`]. If there are no conflicts, it will
-    ///   add the provided [`FilteredAccess`]. If there are conflicts, it will return
-    ///   an [`AccessConflicts`] error.
-    /// - If the system currently has [`Exclusive`] access, it will error
-    ///   with [`AccessConflicts::All`].
-    ///
-    /// # Errors
-    ///
-    /// If there are conflicts with the system's current access, an
-    /// [`AccessConflicts`] error will be returned.
-    ///
-    /// [`None`]: SystemAccess::None
-    /// [`Shared`]: SystemAccess::Shared
-    /// [`Exclusive`]: SystemAccess::Exclusive
-    pub fn try_add(&mut self, filtered_access: FilteredAccess) -> Result<(), AccessConflicts> {
-        let conflicts = self.get_conflicts_single(&filtered_access);
-        self.ensure_filtered_access(filtered_access);
-        if conflicts.is_empty() {
-            Ok(())
-        } else {
-            Err(conflicts)
-        }
-    }
-
-    /// Marks the system as requiring access to certain or all components or
-    /// resources in the [`World`].
-    ///
-    /// [`World`]: crate::world::World
-    pub fn ensure_filtered_access(&mut self, filtered_access: FilteredAccess) {
-        self.ensure_metadata_access();
-        // If the system is `Exclusive` then we already have access to everything,
-        // so we don't need to add anything.
-        if let Self::Shared(access) = self {
-            access.add(filtered_access);
-        }
-    }
-
-    /// Marks the system as requiring access to [`World`] metadata
-    /// (e.g. [`Archetypes`], [`Components`], etc.).
-    ///
-    /// [`World`]: crate::world::World
-    /// [`Archetypes`]: crate::archetype::Archetypes
-    /// [`Components`]: crate::component::Components
-    pub fn ensure_metadata_access(&mut self) {
-        // If the system is `Shared` or `Exclusive` then we already have access
-        // to metadata, so we don't need to add anything.
-        if let Self::None = self {
-            *self = Self::Shared(FilteredAccessSet::new());
-        }
-    }
-
     /// Merges the provided [`SystemAccess`] into the system's current access.
     pub fn extend(&mut self, other: Self) {
         match (&mut *self, other) {
@@ -296,63 +219,8 @@ mod tests {
     use crate::{
         component::ComponentId,
         query::{FilteredAccess, FilteredAccessSet},
-        system::{SystemAccess, SystemMeta},
+        system::SystemAccess,
     };
-
-    #[test]
-    fn check_default_access() {
-        let mut access = SystemAccess::default();
-
-        assert_eq!(access, SystemAccess::None);
-        assert!(access.is_none());
-        assert_ne!(access, SystemAccess::Shared(FilteredAccessSet::default()));
-        assert!(!access.is_shared());
-        assert_ne!(access, SystemAccess::Exclusive);
-        assert!(!access.is_exclusive());
-
-        access.ensure_metadata_access();
-
-        assert!(access.is_shared());
-        assert_eq!(access, SystemAccess::Shared(FilteredAccessSet::default()));
-    }
-
-    #[test]
-    fn check_shared_access() {
-        let mut access = SystemAccess::Shared(FilteredAccessSet::default());
-
-        assert_ne!(access, SystemAccess::None);
-        assert!(!access.is_none());
-        assert!(access.is_shared());
-        assert_ne!(access, SystemAccess::Exclusive);
-        assert!(!access.is_exclusive());
-
-        access.ensure_metadata_access();
-
-        assert!(access.is_shared());
-
-        access.ensure_filtered_access(FilteredAccess::default());
-
-        assert!(access.is_shared());
-    }
-
-    #[test]
-    fn check_exclusive_access() {
-        let mut access = SystemAccess::Exclusive;
-
-        assert_ne!(access, SystemAccess::None);
-        assert!(!access.is_none());
-        assert_ne!(access, SystemAccess::Shared(FilteredAccessSet::default()));
-        assert!(!access.is_shared());
-        assert!(access.is_exclusive());
-
-        access.ensure_metadata_access();
-
-        assert!(access.is_exclusive());
-
-        access.ensure_filtered_access(FilteredAccess::default());
-
-        assert!(access.is_exclusive());
-    }
 
     #[test]
     fn check_compatibility() {
@@ -407,42 +275,6 @@ mod tests {
             access_exclusive.get_conflicts(&access_exclusive),
             crate::query::AccessConflicts::All
         );
-    }
-
-    #[test]
-    #[should_panic]
-    fn require_shared_access_panics_on_exclusive() {
-        let mut access = SystemAccess::Exclusive;
-        access.require_shared_access::<()>(&SystemMeta::new::<()>());
-    }
-
-    #[test]
-    #[should_panic]
-    fn require_exclusive_access_panics_on_shared() {
-        let mut access = SystemAccess::Shared(FilteredAccessSet::default());
-        access.require_exclusive_access::<()>(&SystemMeta::new::<()>());
-    }
-
-    #[test]
-    #[should_panic]
-    fn require_exclusive_access_panics_on_exclusive() {
-        let mut access = SystemAccess::Exclusive;
-        access.require_exclusive_access::<()>(&SystemMeta::new::<()>());
-    }
-
-    #[test]
-    fn try_add_returns_correctly() {
-        let mut access = SystemAccess::None;
-        let filtered_access = FilteredAccess::default();
-
-        assert!(access.try_add(filtered_access.clone()).is_ok());
-        assert!(access.is_shared());
-
-        let mut access_shared = SystemAccess::Shared(FilteredAccessSet::default());
-        assert!(access_shared.try_add(filtered_access.clone()).is_ok());
-
-        let mut access_exclusive = SystemAccess::Exclusive;
-        assert!(access_exclusive.try_add(filtered_access).is_err());
     }
 
     #[test]

--- a/crates/bevy_ecs/src/system/access.rs
+++ b/crates/bevy_ecs/src/system/access.rs
@@ -223,6 +223,63 @@ mod tests {
     };
 
     #[test]
+    fn check_default_access() {
+        let mut access = SystemAccess::default();
+
+        assert_eq!(access, SystemAccess::None);
+        assert!(access.is_none());
+        assert_ne!(access, SystemAccess::Shared(FilteredAccessSet::default()));
+        assert!(!access.is_shared());
+        assert_ne!(access, SystemAccess::Exclusive);
+        assert!(!access.is_exclusive());
+
+        access.try_extend_metadata().unwrap();
+
+        assert!(access.is_shared());
+        assert_eq!(access, SystemAccess::Shared(FilteredAccessSet::default()));
+    }
+
+    #[test]
+    fn check_shared_access() {
+        let mut access = SystemAccess::Shared(FilteredAccessSet::default());
+
+        assert_ne!(access, SystemAccess::None);
+        assert!(!access.is_none());
+        assert!(access.is_shared());
+        assert_ne!(access, SystemAccess::Exclusive);
+        assert!(!access.is_exclusive());
+
+        access.try_extend_metadata().unwrap();
+
+        assert!(access.is_shared());
+
+        access.try_extend_single(FilteredAccess::default()).unwrap();
+
+        assert!(access.is_shared());
+    }
+
+    #[test]
+    fn check_exclusive_access() {
+        let mut access = SystemAccess::Exclusive;
+
+        assert_ne!(access, SystemAccess::None);
+        assert!(!access.is_none());
+        assert_ne!(access, SystemAccess::Shared(FilteredAccessSet::default()));
+        assert!(!access.is_shared());
+        assert!(access.is_exclusive());
+
+        access.try_extend_metadata().unwrap_err();
+
+        assert!(access.is_exclusive());
+
+        access
+            .try_extend_single(FilteredAccess::default())
+            .unwrap_err();
+
+        assert!(access.is_exclusive());
+    }
+
+    #[test]
     fn check_compatibility() {
         let access_none = SystemAccess::None;
         let access_shared = SystemAccess::Shared({
@@ -275,6 +332,41 @@ mod tests {
             access_exclusive.get_conflicts(&access_exclusive),
             crate::query::AccessConflicts::All
         );
+    }
+
+    #[test]
+    fn try_extend_metadata_err_on_exclusive() {
+        let mut access = SystemAccess::Exclusive;
+        access.try_extend_metadata().unwrap_err();
+    }
+
+    #[test]
+    fn try_extend_exclusive_err_on_shared() {
+        let mut access = SystemAccess::Shared(FilteredAccessSet::default());
+        access.try_extend_exclusive().unwrap_err();
+    }
+
+    #[test]
+    fn try_extend_exclusive_err_on_exclusive() {
+        let mut access = SystemAccess::Exclusive;
+        access.try_extend_exclusive().unwrap_err();
+    }
+
+    #[test]
+    fn try_extend_single_returns_correctly() {
+        let mut access = SystemAccess::None;
+        let filtered_access = FilteredAccess::default();
+
+        assert!(access.try_extend_single(filtered_access.clone()).is_ok());
+        assert!(access.is_shared());
+
+        let mut access_shared = SystemAccess::Shared(FilteredAccessSet::default());
+        assert!(access_shared
+            .try_extend_single(filtered_access.clone())
+            .is_ok());
+
+        let mut access_exclusive = SystemAccess::Exclusive;
+        assert!(access_exclusive.try_extend_single(filtered_access).is_err());
     }
 
     #[test]

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -240,7 +240,7 @@ where
         let error_resource = world.register_component::<crate::error::FallbackErrorHandler>();
         let mut error_resource_access = FilteredAccess::default();
         error_resource_access.add_read(error_resource);
-        a_access.ensure_filtered_access(error_resource_access);
+        a_access.extend(SystemAccess::Shared(error_resource_access.into()));
 
         a_access
     }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -5,13 +5,13 @@ use crate::{
     prelude::FromWorld,
     schedule::{InternedSystemSet, SystemSet},
     system::{
-        check_system_change_tick, FromInput, ReadOnlySystemParam, System, SystemAccess, SystemIn,
-        SystemInput, SystemParam, SystemParamItem,
+        check_system_change_tick, FromInput, ParameterAccessConflict, ReadOnlySystemParam, System,
+        SystemAccess, SystemIn, SystemInput, SystemParam, SystemParamItem,
     },
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World, WorldId},
 };
 
-use alloc::{borrow::Cow, vec, vec::Vec};
+use alloc::{borrow::Cow, format, string::String, vec, vec::Vec};
 use bevy_utils::prelude::DebugName;
 use core::marker::PhantomData;
 use variadics_please::all_tuples;
@@ -302,10 +302,9 @@ impl<Param: SystemParam> SystemState<Param> {
         let mut meta = SystemMeta::new::<Param>();
         meta.last_run = world.change_tick().relative_to(Tick::MAX);
         let param_state = Param::init_state(world);
-        let mut access = SystemAccess::default();
         // We need to call `init_access` to ensure there are no panics from conflicts within `Param`,
         // even though we don't use the calculated access.
-        Param::init_access(&param_state, &mut meta, &mut access, world);
+        init_param_or_panic::<Param>(&param_state, &mut meta, world.into());
         Self {
             meta,
             param_state,
@@ -318,10 +317,9 @@ impl<Param: SystemParam> SystemState<Param> {
         let mut meta = SystemMeta::new::<Param>();
         meta.last_run = world.change_tick().relative_to(Tick::MAX);
         let param_state = builder.build(world);
-        let mut access = SystemAccess::default();
         // We need to call `init_access` to ensure there are no panics from conflicts within `Param`,
         // even though we don't use the calculated access.
-        Param::init_access(&param_state, &mut meta, &mut access, world);
+        init_param_or_panic::<Param>(&param_state, &mut meta, world.into());
         Self {
             meta,
             param_state,
@@ -563,6 +561,120 @@ where
     }
 }
 
+/// Registers any [`World`] access used by the given [`SystemParam`].
+///
+/// This method will panic with a descriptive message if [`SystemParam::init_access`] returns [`Err`].
+fn init_param_or_panic<P: SystemParam>(
+    state: &P::State,
+    system_meta: &mut SystemMeta,
+    world: UnsafeWorldCell,
+) -> SystemAccess {
+    let mut access = SystemAccess::default();
+    P::init_access(state, system_meta, &mut access).unwrap_or_else(|err2| {
+        if DebugName::ENABLED {
+            // Find the other conflicting parameter.
+            // By initializing `access` with the access of the later parameter,
+            // the earlier one will detect the conflict instead.
+            let mut access = err2.access.clone();
+            let err1 = P::init_access(state, system_meta, &mut access).err();
+            panic_for_param_conflict(system_meta.name(), world, err1, err2);
+        } else {
+            // The ordinary panic message includes multiple `DebugName`s,
+            // each of which would be replaced with an "Enable the debug feature" message.
+            // Don't even bother calling `init_access` again if we can't use the parameter name.
+            panic_for_param_conflict_no_debug(err2);
+        }
+    });
+    access
+}
+
+/// Formats a helpful panic message for conflicting [`SystemParam`] access.
+///
+/// This is separate from [`init_param_or_panic`] so that it is not monomorphized for each [`SystemParam`] type.
+#[cold]
+fn panic_for_param_conflict(
+    system_name: &DebugName,
+    world: UnsafeWorldCell<'_>,
+    err1: Option<ParameterAccessConflict>,
+    err2: ParameterAccessConflict,
+) -> ! {
+    let err1 =
+        err1.expect("System param with internal access conflict must always report a conflict");
+
+    let conflicts = err1.access.get_conflicts(&err2.access);
+    let mut accesses = conflicts.format_conflict_list(world);
+    // Access list may be empty (if access to all components requested)
+    if !accesses.is_empty() {
+        accesses.insert_str(0, " on component(s) ");
+    }
+
+    let code = if let Some(code) = err1.code
+        && Some(code) == err2.code
+    {
+        code
+    } else if err1.access.is_exclusive() || err2.access.is_exclusive() {
+        "B0008"
+    } else {
+        "B0007"
+    };
+    let code_lower = code.to_ascii_lowercase();
+
+    // Check if both parameters were the same.
+    // Only consider parameters duplicates if the name *and* access matches.
+    // Just checking the name will give false positives with nested queries.
+    let remove_duplicate = (err1.param == err2.param && err1.access == err2.access)
+        .then_some(DebugName::borrowed("Removing the duplicate parameter"));
+
+    let mut suggestions = err1
+        .suggestions
+        .iter()
+        .chain(&err2.suggestions)
+        .collect::<Vec<_>>();
+    // Remove duplicate suggestions so that we don't suggest "Using `Without<T>`" twice for conflicting queries.
+    suggestions.sort_by_key(|s| &***s);
+    suggestions.dedup();
+
+    let suggestions = suggestions
+        .into_iter()
+        .chain(&remove_duplicate)
+        .map(|s| format!("* {s}\n"))
+        .collect::<String>();
+
+    panic!(
+        concat!(
+            "error[{}]: `{}` and `{}` parameters in system `{}` conflict{}.\n",
+            "Consider:\n",
+            "{}",
+            "* Merging conflicting parameters into a `ParamSet`\n",
+            "See: https://bevy.org/learn/errors/{}",
+        ),
+        code,
+        err1.param.shortname(),
+        err2.param.shortname(),
+        system_name,
+        accesses,
+        suggestions,
+        code_lower,
+    );
+}
+
+/// Formats a simple panic message for conflicting [`SystemParam`] access when debug strings are not available.
+///
+/// This is separate from [`init_param_or_panic`] so that it is not monomorphized for each [`SystemParam`] type.
+#[cold]
+fn panic_for_param_conflict_no_debug(err2: ParameterAccessConflict) -> ! {
+    let code = err2.code.unwrap_or("B0007");
+    let code_lower = code.to_ascii_lowercase();
+    panic!(
+        concat!(
+            "error[{}]: System parameter access conflict.\n",
+            "Enable the `debug` feature to see the system and parameter names.\n",
+            "See: https://bevy.org/learn/errors/{}"
+        ),
+        code, code_lower
+    );
+}
+
 /// A marker type used to distinguish regular function systems from exclusive function systems.
 #[doc(hidden)]
 pub struct IsFunctionSystem;
@@ -729,14 +841,7 @@ where
             world_id: world.id(),
         });
         self.system_meta.last_run = world.change_tick().relative_to(Tick::MAX);
-        let mut system_access = SystemAccess::default();
-        F::Param::init_access(
-            &state.param,
-            &mut self.system_meta,
-            &mut system_access,
-            world,
-        );
-        system_access
+        init_param_or_panic::<F::Param>(&state.param, &mut self.system_meta, world.into())
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -11,7 +11,7 @@ use crate::{
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World, WorldId},
 };
 
-use alloc::{borrow::Cow, format, string::String, vec, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, format, string::String, vec, vec::Vec};
 use bevy_utils::prelude::DebugName;
 use core::marker::PhantomData;
 use variadics_please::all_tuples;
@@ -577,12 +577,12 @@ fn init_param_or_panic<P: SystemParam>(
             // the earlier one will detect the conflict instead.
             let mut access = err2.access.clone();
             let err1 = P::init_access(state, system_meta, &mut access).err();
-            panic_for_param_conflict(system_meta.name(), world, err1, err2);
+            panic_for_param_conflict(system_meta.name(), world, err1, *err2);
         } else {
             // The ordinary panic message includes multiple `DebugName`s,
             // each of which would be replaced with an "Enable the debug feature" message.
             // Don't even bother calling `init_access` again if we can't use the parameter name.
-            panic_for_param_conflict_no_debug(err2);
+            panic_for_param_conflict_no_debug(*err2);
         }
     });
     access
@@ -595,7 +595,7 @@ fn init_param_or_panic<P: SystemParam>(
 fn panic_for_param_conflict(
     system_name: &DebugName,
     world: UnsafeWorldCell<'_>,
-    err1: Option<ParameterAccessConflict>,
+    err1: Option<Box<ParameterAccessConflict>>,
     err2: ParameterAccessConflict,
 ) -> ! {
     let err1 =

--- a/crates/bevy_ecs/src/system/system_name.rs
+++ b/crates/bevy_ecs/src/system/system_name.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     world::unsafe_world_cell::UnsafeWorldCell,
 };
+use alloc::boxed::Box;
 use bevy_utils::prelude::DebugName;
 use derive_more::derive::{Display, Into};
 
@@ -62,7 +63,7 @@ unsafe impl SystemParam for SystemName {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         Ok(())
     }
 

--- a/crates/bevy_ecs/src/system/system_name.rs
+++ b/crates/bevy_ecs/src/system/system_name.rs
@@ -2,7 +2,8 @@ use crate::{
     change_detection::Tick,
     prelude::World,
     system::{
-        ReadOnlySystemParam, SystemAccess, SystemMeta, SystemParam, SystemParamValidationError,
+        ParameterAccessConflict, ReadOnlySystemParam, SystemAccess, SystemMeta, SystemParam,
+        SystemParamValidationError,
     },
     world::unsafe_world_cell::UnsafeWorldCell,
 };
@@ -61,8 +62,8 @@ unsafe impl SystemParam for SystemName {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
+        Ok(())
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -816,7 +816,7 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
         change_tick: Tick,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         let (ptr, ticks) = world.get_resource_with_ticks(component_id).ok_or_else(|| {
-            SystemParamValidationError::invalid::<Self>("Resource does not exist,")
+            SystemParamValidationError::invalid::<Self>("Resource does not exist")
         })?;
         Ok(Res {
             value: ptr.deref(),

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -3389,7 +3389,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "error[B0002]")]
+    #[should_panic(expected = "error[B0008]")]
     fn mutable_world_conflicts_with_optional_query() {
         #[derive(Component)]
         struct A;
@@ -3398,7 +3398,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "error[B0002]")]
+    #[should_panic(expected = "error[B0008]")]
     fn mutable_world_conflicts_with_query() {
         #[derive(Component)]
         struct A;
@@ -3407,7 +3407,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "error[B0002]")]
+    #[should_panic(expected = "error[B0008]")]
     fn mutable_world_conflicts_with_empty_query() {
         fn system(_: &mut World, _: Query<()>) {}
         assert_is_system(system);

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -310,6 +310,11 @@ pub struct ParameterAccessConflict {
     pub code: Option<&'static str>,
 }
 
+/// An error returned from [`SystemParam::init_access`].
+// This type alias exists because it is hard to reference `Box` in a macro,
+// since `std::` is not available in no_std and `alloc::` is not available by default.
+pub type BoxedParameterAccessConflict = Box<ParameterAccessConflict>;
+
 impl ParameterAccessConflict {
     /// Constructs a new [`ParameterAccessConflict`] with the provided [`SystemAccess`]
     /// and the parameter name initialized from the type name of `T`.

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -237,7 +237,7 @@ pub unsafe trait SystemParam: Sized {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict>;
+    ) -> Result<(), Box<ParameterAccessConflict>>;
 
     /// Applies any deferred mutations stored in this [`SystemParam`]'s state.
     /// This is used to apply [`Commands`] during [`ApplyDeferred`](crate::prelude::ApplyDeferred).
@@ -313,17 +313,17 @@ pub struct ParameterAccessConflict {
 impl ParameterAccessConflict {
     /// Constructs a new [`ParameterAccessConflict`] with the provided [`SystemAccess`]
     /// and the parameter name initialized from the type name of `T`.
-    pub fn new<T>(access: SystemAccess) -> Self {
-        Self {
+    pub fn new<T>(access: SystemAccess) -> Box<Self> {
+        Box::new(Self {
             access,
             param: DebugName::type_name::<T>(),
             suggestions: Vec::new(),
             code: None,
-        }
+        })
     }
 
     /// Update the parameter name to the type name of `T`.
-    pub fn with_param<T>(mut self) -> Self {
+    pub fn with_param<T>(mut self: Box<Self>) -> Box<Self> {
         self.param = DebugName::type_name::<T>();
         self
     }
@@ -331,7 +331,7 @@ impl ParameterAccessConflict {
     /// Adds a suggestion that will be reported in the panic message.
     ///
     /// The suggestion should be a gerund phrase, like `"Using a different parameter"`.
-    pub fn with_suggestion(mut self, suggestion: &'static str) -> Self {
+    pub fn with_suggestion(mut self: Box<Self>, suggestion: &'static str) -> Box<Self> {
         self.suggestions.push(DebugName::borrowed(suggestion));
         self
     }
@@ -343,10 +343,10 @@ impl ParameterAccessConflict {
     ///
     /// The suggestion should be a gerund phrase, like `"Calling ``World::resource()``"`.
     pub fn with_suggestion_if_exclusive(
-        mut self,
+        mut self: Box<Self>,
         access: &SystemAccess,
         suggestion: &'static str,
-    ) -> Self {
+    ) -> Box<Self> {
         if let SystemAccess::Exclusive = access {
             self.suggestions.push(DebugName::borrowed(suggestion));
         }
@@ -359,7 +359,7 @@ impl ParameterAccessConflict {
     /// it will be included in the error message.
     /// If either parameter has `None`, or the values differ,
     /// the generic `B0007` will be used instead.
-    pub fn with_code(mut self, code: &'static str) -> Self {
+    pub fn with_code(mut self: Box<Self>, code: &'static str) -> Box<Self> {
         self.code = Some(code);
         self
     }
@@ -397,7 +397,7 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
         state: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_access
             .try_extend_metadata()
             // When conflicting with `Exclusive` access, report the main query access and ignore nested queries
@@ -461,7 +461,7 @@ unsafe impl<'a, 'b, D: IterQueryData + 'static, F: QueryFilter + 'static> System
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         Query::init_access(state, system_meta, system_access)
             .map_err(ParameterAccessConflict::with_param::<Self>)
     }
@@ -514,7 +514,7 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         Query::init_access(state, system_meta, system_access)
             .map_err(ParameterAccessConflict::with_param::<Self>)
     }
@@ -700,7 +700,7 @@ macro_rules! impl_param_set {
                 non_snake_case,
                 reason = "Certain variable names are provided by the caller, not by us."
             )]
-            fn init_access(state: &Self::State, system_meta: &mut SystemMeta, system_access: &mut SystemAccess) -> Result<(), ParameterAccessConflict> {
+            fn init_access(state: &Self::State, system_meta: &mut SystemMeta, system_access: &mut SystemAccess) -> Result<(), Box<ParameterAccessConflict>> {
                 let ($($param,)*) = state;
                 $(
                     // Call `init_access` on a clone of the original access set to check for conflicts
@@ -791,7 +791,7 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
         &component_id: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         let mut filter = FilteredAccess::default();
         filter.add_read(component_id);
         filter.and_with(IS_RESOURCE);
@@ -840,7 +840,7 @@ unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T>
         &component_id: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         let mut filter = FilteredAccess::default();
         filter.add_write(component_id);
         filter.and_with(IS_RESOURCE);
@@ -890,7 +890,7 @@ unsafe impl SystemParam for &'_ World {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         let mut filtered_access = FilteredAccess::default();
         filtered_access.read_all();
 
@@ -922,7 +922,7 @@ unsafe impl SystemParam for &'_ mut World {
         _state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         // Exclusive systems must be ran on the main thread.
         system_meta.set_non_send();
 
@@ -959,7 +959,7 @@ unsafe impl<'w> SystemParam for DeferredWorld<'w> {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         let mut filtered_access = FilteredAccess::default();
         filtered_access.write_all();
 
@@ -1154,7 +1154,7 @@ unsafe impl<'a, T: FromWorld + Send + 'static> SystemParam for Local<'a, T> {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         Ok(())
     }
 
@@ -1349,7 +1349,7 @@ unsafe impl<T: SystemBuffer> SystemParam for Deferred<'_, T> {
         _state: &Self::State,
         system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_meta.set_has_deferred();
         Ok(())
     }
@@ -1388,7 +1388,7 @@ unsafe impl SystemParam for NonSendMarker {
         _state: &Self::State,
         system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_meta.set_non_send();
         Ok(())
     }
@@ -1424,7 +1424,7 @@ unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
         &component_id: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_meta.set_non_send();
 
         let mut filtered_access = FilteredAccess::default();
@@ -1470,7 +1470,7 @@ unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
         &component_id: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_meta.set_non_send();
 
         let mut filtered_access = FilteredAccess::default();
@@ -1516,7 +1516,7 @@ unsafe impl<'a> SystemParam for &'a Archetypes {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_access.try_extend_metadata().map_err(|access| {
             ParameterAccessConflict::new::<Self>(access)
                 .with_suggestion_if_exclusive(system_access, "Calling `World::archetypes()`")
@@ -1548,7 +1548,7 @@ unsafe impl<'a> SystemParam for &'a ResourceEntities {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_access.try_extend_metadata().map_err(|access| {
             ParameterAccessConflict::new::<Self>(access)
                 .with_suggestion_if_exclusive(system_access, "Calling `World::resource_entities()`")
@@ -1580,7 +1580,7 @@ unsafe impl<'a> SystemParam for &'a Components {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_access.try_extend_metadata().map_err(|access| {
             ParameterAccessConflict::new::<Self>(access)
                 .with_suggestion_if_exclusive(system_access, "Calling `World::components()`")
@@ -1612,7 +1612,7 @@ unsafe impl<'a> SystemParam for &'a Entities {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_access.try_extend_metadata().map_err(|access| {
             ParameterAccessConflict::new::<Self>(access)
                 .with_suggestion_if_exclusive(system_access, "Calling `World::entities()`")
@@ -1644,7 +1644,7 @@ unsafe impl<'a> SystemParam for &'a EntityAllocator {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_access.try_extend_metadata().map_err(|access| {
             ParameterAccessConflict::new::<Self>(access)
                 .with_suggestion_if_exclusive(system_access, "Calling `World::entity_allocator()`")
@@ -1676,7 +1676,7 @@ unsafe impl<'a> SystemParam for &'a Bundles {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_access.try_extend_metadata().map_err(|access| {
             ParameterAccessConflict::new::<Self>(access)
                 .with_suggestion_if_exclusive(system_access, "Calling `World::bundles()`")
@@ -1737,7 +1737,7 @@ unsafe impl SystemParam for SystemChangeTick {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         Ok(())
     }
 
@@ -1769,7 +1769,7 @@ unsafe impl<T: SystemParam> SystemParam for Option<T> {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         T::init_access(state, system_meta, system_access)
     }
 
@@ -1810,7 +1810,7 @@ unsafe impl<T: SystemParam> SystemParam for Result<T, SystemParamValidationError
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         T::init_access(state, system_meta, system_access)
     }
 
@@ -1904,7 +1904,7 @@ unsafe impl<T: SystemParam> SystemParam for If<T> {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         T::init_access(state, system_meta, system_access)
     }
 
@@ -1951,7 +1951,7 @@ unsafe impl<T: SystemParam> SystemParam for Vec<T> {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         for state in state {
             T::init_access(state, system_meta, system_access)?;
         }
@@ -2003,7 +2003,7 @@ unsafe impl<T: SystemParam> SystemParam for ParamSet<'_, '_, Vec<T>> {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         for state in state {
             // Call `init_access` on a clone of the original access set to check for conflicts
             let system_access_clone = &mut system_access.clone();
@@ -2106,7 +2106,7 @@ unsafe impl<T: SystemParam, const N: usize> SystemParam for SmallVec<[T; N]> {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         for state in state {
             T::init_access(state, system_meta, system_access)?;
         }
@@ -2173,7 +2173,7 @@ macro_rules! impl_system_param_tuple {
                 ($($param::init_state(world),)*)
             }
 
-            fn init_access(state: &Self::State, _system_meta: &mut SystemMeta, _system_access: &mut SystemAccess) -> Result<(), ParameterAccessConflict> {
+            fn init_access(state: &Self::State, _system_meta: &mut SystemMeta, _system_access: &mut SystemAccess) -> Result<(), Box<ParameterAccessConflict>> {
                 let ($($param,)*) = state;
                 $($param::init_access($param, _system_meta, _system_access)?;)*
                 Ok(())
@@ -2349,7 +2349,7 @@ unsafe impl<P: SystemParam + 'static> SystemParam for StaticSystemParam<'_, '_, 
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         P::init_access(state, system_meta, system_access)
     }
 
@@ -2384,7 +2384,7 @@ unsafe impl<T: ?Sized> SystemParam for PhantomData<T> {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         Ok(())
     }
 
@@ -2417,7 +2417,7 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         Ok(())
     }
 
@@ -2450,7 +2450,7 @@ unsafe impl<P: SystemParam + 'static> SystemParam for &'_ mut SystemState<P> {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         Ok(())
     }
 
@@ -2668,7 +2668,7 @@ trait DynParamState: Sync + Send + Any {
         &self,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict>;
+    ) -> Result<(), Box<ParameterAccessConflict>>;
 
     /// Validates the inner parameter by calling [`SystemParam::get_param`] and discarding the value.
     ///
@@ -2698,7 +2698,7 @@ impl<T: SystemParam + 'static> DynParamState for ParamState<T> {
         &self,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         T::init_access(&self.0, system_meta, system_access)
     }
 
@@ -2727,7 +2727,7 @@ unsafe impl SystemParam for DynSystemParam<'_, '_> {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         state.0.init_access(system_meta, system_access)
     }
 
@@ -2777,7 +2777,7 @@ unsafe impl SystemParam for FilteredResources<'_, '_> {
         access: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         let mut filtered_access = FilteredAccess::default();
         filtered_access.access_mut().extend(access);
         filtered_access.and_with(IS_RESOURCE);
@@ -2823,7 +2823,7 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
         access: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         let mut filtered_access = FilteredAccess::default();
         filtered_access.access_mut().extend(access);
         filtered_access.and_with(IS_RESOURCE);

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -231,14 +231,13 @@ pub unsafe trait SystemParam: Sized {
 
     /// Registers any [`World`] access used by this [`SystemParam`].
     ///
-    /// This method must panic if the access would conflict with any existing
+    /// This method must return [`Err`] if the access would conflict with any existing
     /// access in the [`SystemAccess`].
     fn init_access(
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    );
+    ) -> Result<(), ParameterAccessConflict>;
 
     /// Applies any deferred mutations stored in this [`SystemParam`]'s state.
     /// This is used to apply [`Commands`] during [`ApplyDeferred`](crate::prelude::ApplyDeferred).
@@ -288,6 +287,84 @@ pub unsafe trait SystemParam: Sized {
     ) -> Result<Self::Item<'world, 'state>, SystemParamValidationError>;
 }
 
+/// An error returned from [`SystemParam::init_access`].
+///
+/// This contains information about the parameter that had an access conflict,
+/// and can be used to construct a panic message.
+pub struct ParameterAccessConflict {
+    /// The access requested by the conflicting parameter.
+    pub access: SystemAccess,
+
+    /// The type name of the conflicting parameter.
+    pub param: DebugName,
+
+    /// A list of suggestions to display to the user.
+    pub suggestions: Vec<DebugName>,
+
+    /// The error code used by this parameter.
+    ///
+    /// If both conflicting parameters have the same `code`,
+    /// it will be included in the error message.
+    /// If either parameter has `None`, or the values differ,
+    /// the generic `B0007` will be used instead.
+    pub code: Option<&'static str>,
+}
+
+impl ParameterAccessConflict {
+    /// Constructs a new [`ParameterAccessConflict`] with the provided [`SystemAccess`]
+    /// and the parameter name initialized from the type name of `T`.
+    pub fn new<T>(access: SystemAccess) -> Self {
+        Self {
+            access,
+            param: DebugName::type_name::<T>(),
+            suggestions: Vec::new(),
+            code: None,
+        }
+    }
+
+    /// Update the parameter name to the type name of `T`.
+    pub fn with_param<T>(mut self) -> Self {
+        self.param = DebugName::type_name::<T>();
+        self
+    }
+
+    /// Adds a suggestion that will be reported in the panic message.
+    ///
+    /// The suggestion should be a gerund phrase, like `"Using a different parameter"`.
+    pub fn with_suggestion(mut self, suggestion: &'static str) -> Self {
+        self.suggestions.push(DebugName::borrowed(suggestion));
+        self
+    }
+
+    /// Adds a suggestion that will be reported in the panic message
+    /// if the provided `access` is [`SystemAccess::Exclusive`].
+    ///
+    /// This can be used to suggest APIs on `World` that will have the same effect as the parameter.
+    ///
+    /// The suggestion should be a gerund phrase, like `"Calling ``World::resource()``"`.
+    pub fn with_suggestion_if_exclusive(
+        mut self,
+        access: &SystemAccess,
+        suggestion: &'static str,
+    ) -> Self {
+        if let SystemAccess::Exclusive = access {
+            self.suggestions.push(DebugName::borrowed(suggestion));
+        }
+        self
+    }
+
+    /// Sets the error code for this parameter.
+    ///
+    /// If both conflicting parameters have the same `code`,
+    /// it will be included in the error message.
+    /// If either parameter has `None`, or the values differ,
+    /// the generic `B0007` will be used instead.
+    pub fn with_code(mut self, code: &'static str) -> Self {
+        self.code = Some(code);
+        self
+    }
+}
+
 /// A [`SystemParam`] that only reads a given [`World`].
 ///
 /// # Safety
@@ -318,12 +395,39 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
 
     fn init_access(
         state: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
-        let component_access_set = system_access.require_shared_access::<Self>(system_meta);
-        state.init_access(Some(system_meta.name()), component_access_set, world.into());
+    ) -> Result<(), ParameterAccessConflict> {
+        system_access
+            .try_extend_metadata()
+            // When conflicting with `Exclusive` access, report the main query access and ignore nested queries
+            .map_err(|_| state.component_access().clone().into())
+            .and_then(|()| {
+                let SystemAccess::Shared(component_access_set) = system_access else {
+                    unreachable!()
+                };
+                state.init_access(component_access_set)
+            })
+            .map_err(|access| {
+                let suggestion = match system_access {
+                    SystemAccess::None => unreachable!(),
+                    SystemAccess::Exclusive => "Using a `&mut QueryState` parameter",
+                    SystemAccess::Shared(access) => {
+                        // If `Without<IsResource>` will solve the conflict, suggest that directly,
+                        // as it's hard to discover otherwise.
+                        let mut without_isresource = state.component_access.clone();
+                        without_isresource.and_without(IS_RESOURCE);
+                        if access.is_compatible_single(&without_isresource) {
+                            "Using `Without<IsResource>` to exclude resources from the query."
+                        } else {
+                            "Using `Without<T>` to create disjoint queries."
+                        }
+                    }
+                };
+                ParameterAccessConflict::new::<Self>(SystemAccess::Shared(access))
+                    .with_suggestion(suggestion)
+                    .with_code("B0001")
+            })
     }
 
     #[inline]
@@ -357,9 +461,9 @@ unsafe impl<'a, 'b, D: IterQueryData + 'static, F: QueryFilter + 'static> System
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
-        Query::init_access(state, system_meta, system_access, world);
+    ) -> Result<(), ParameterAccessConflict> {
+        Query::init_access(state, system_meta, system_access)
+            .map_err(ParameterAccessConflict::with_param::<Self>)
     }
 
     #[inline]
@@ -410,9 +514,9 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
-        Query::init_access(state, system_meta, system_access, world);
+    ) -> Result<(), ParameterAccessConflict> {
+        Query::init_access(state, system_meta, system_access)
+            .map_err(ParameterAccessConflict::with_param::<Self>)
     }
 
     #[inline]
@@ -596,20 +700,21 @@ macro_rules! impl_param_set {
                 non_snake_case,
                 reason = "Certain variable names are provided by the caller, not by us."
             )]
-            fn init_access(state: &Self::State, system_meta: &mut SystemMeta, system_access: &mut SystemAccess, world: &mut World) {
+            fn init_access(state: &Self::State, system_meta: &mut SystemMeta, system_access: &mut SystemAccess) -> Result<(), ParameterAccessConflict> {
                 let ($($param,)*) = state;
                 $(
                     // Call `init_access` on a clone of the original access set to check for conflicts
                     let system_access_clone = &mut system_access.clone();
-                    $param::init_access($param, system_meta, system_access_clone, world);
+                    $param::init_access($param, system_meta, system_access_clone)?;
                 )*
                 $(
                     // Pretend to add the param to the system alone to gather the new access,
                     // then merge its access into the system.
                     let mut param_access = SystemAccess::default();
-                    $param::init_access($param, system_meta, &mut param_access, world);
+                    $param::init_access($param, system_meta, &mut param_access)?;
                     system_access.extend(param_access);
                 )*
+                Ok(())
             }
 
             fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
@@ -684,22 +789,18 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
 
     fn init_access(
         &component_id: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         let mut filter = FilteredAccess::default();
         filter.add_read(component_id);
         filter.and_with(IS_RESOURCE);
 
-        if let Err(conflicts) = system_access.try_add(filter) {
-            let mut accesses = conflicts.format_conflict_list(world.as_unsafe_world_cell());
-            // Access list may be empty (if access to all components requested)
-            if !accesses.is_empty() {
-                accesses.push(' ');
-            }
-            panic!("error[B0002]: Res<{}> in system {} conflicts with a previous system parameter. Consider removing the duplicate access using `Without<IsResource>` to create disjoint Queries or merging conflicting Queries into a `ParamSet`. See: https://bevy.org/learn/errors/b0002", DebugName::type_name::<T>(), system_meta.name);
-        }
+        system_access.try_extend_single(filter).map_err(|access| {
+            ParameterAccessConflict::new::<Self>(access)
+                .with_suggestion_if_exclusive(system_access, "Calling `World::resource()`")
+                .with_code("B0002")
+        })
     }
 
     #[inline]
@@ -710,7 +811,7 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
         change_tick: Tick,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         let (ptr, ticks) = world.get_resource_with_ticks(component_id).ok_or_else(|| {
-            SystemParamValidationError::invalid::<Self>("Resource does not exist")
+            SystemParamValidationError::invalid::<Self>("Resource does not exist,")
         })?;
         Ok(Res {
             value: ptr.deref(),
@@ -737,22 +838,18 @@ unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T>
 
     fn init_access(
         &component_id: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         let mut filter = FilteredAccess::default();
         filter.add_write(component_id);
         filter.and_with(IS_RESOURCE);
 
-        if let Err(conflicts) = system_access.try_add(filter) {
-            let mut accesses = conflicts.format_conflict_list(world.as_unsafe_world_cell());
-            // Access list may be empty (if access to all components requested)
-            if !accesses.is_empty() {
-                accesses.push(' ');
-            }
-            panic!("error[B0002]: ResMut<{}> in system {} conflicts with a previous system parameter. Consider removing the duplicate access or using `Without<IsResource>` to create disjoint Queries or merging conflicting Queries into a `ParamSet`. See: https://bevy.org/learn/errors/b0002", DebugName::type_name::<T>(), system_meta.name);
-        }
+        system_access.try_extend_single(filter).map_err(|access| {
+            ParameterAccessConflict::new::<Self>(access)
+                .with_suggestion_if_exclusive(system_access, "Calling `World::resource_mut()`")
+                .with_code("B0002")
+        })
     }
 
     #[inline]
@@ -791,19 +888,15 @@ unsafe impl SystemParam for &'_ World {
 
     fn init_access(
         _state: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         let mut filtered_access = FilteredAccess::default();
         filtered_access.read_all();
 
-        if system_access.try_add(filtered_access).is_err() {
-            panic!(
-                "&World in system {} conflicts with a previous system parameter's access.",
-                system_meta.name,
-            );
-        }
+        system_access
+            .try_extend_single(filtered_access)
+            .map_err(ParameterAccessConflict::new::<Self>)
     }
 
     #[inline]
@@ -829,12 +922,18 @@ unsafe impl SystemParam for &'_ mut World {
         _state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         // Exclusive systems must be ran on the main thread.
         system_meta.set_non_send();
 
-        system_access.require_exclusive_access::<Self>(system_meta);
+        system_access.try_extend_exclusive().map_err(|access| {
+            ParameterAccessConflict::new::<Self>(access)
+                .with_suggestion("Using a `&mut SystemState` parameter")
+                .with_suggestion(
+                    "Using a `Commands` parameter instead of `&mut World` to defer changes",
+                )
+                .with_code("B0008")
+        })
     }
 
     #[inline]
@@ -858,19 +957,15 @@ unsafe impl<'w> SystemParam for DeferredWorld<'w> {
 
     fn init_access(
         _state: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         let mut filtered_access = FilteredAccess::default();
         filtered_access.write_all();
 
-        if system_access.try_add(filtered_access).is_err() {
-            panic!(
-                "DeferredWorld in system {} conflicts with a previous system parameter's access.",
-                system_meta.name,
-            );
-        }
+        system_access
+            .try_extend_single(filtered_access)
+            .map_err(ParameterAccessConflict::new::<Self>)
     }
 
     unsafe fn get_param<'world, 'state>(
@@ -1059,8 +1154,8 @@ unsafe impl<'a, T: FromWorld + Send + 'static> SystemParam for Local<'a, T> {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
+        Ok(())
     }
 
     #[inline]
@@ -1254,9 +1349,9 @@ unsafe impl<T: SystemBuffer> SystemParam for Deferred<'_, T> {
         _state: &Self::State,
         system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         system_meta.set_has_deferred();
+        Ok(())
     }
 
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
@@ -1293,9 +1388,9 @@ unsafe impl SystemParam for NonSendMarker {
         _state: &Self::State,
         system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         system_meta.set_non_send();
+        Ok(())
     }
 
     #[inline]
@@ -1329,19 +1424,19 @@ unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
         &component_id: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         system_meta.set_non_send();
 
         let mut filtered_access = FilteredAccess::default();
         filtered_access.add_read(component_id);
 
-        if system_access.try_add(filtered_access).is_err() {
-            panic!(
-                "error[B0002]: NonSend<{}> in system {} conflicts with a previous system parameter's access. Consider removing the duplicate access. See: https://bevy.org/learn/errors/b0002",
-                DebugName::type_name::<T>(), system_meta.name,
-            );
-        }
+        system_access
+            .try_extend_single(filtered_access)
+            .map_err(|access| {
+                ParameterAccessConflict::new::<Self>(access)
+                    .with_suggestion_if_exclusive(system_access, "Calling `World::non_send()`")
+                    .with_code("B0002")
+            })
     }
 
     #[inline]
@@ -1375,19 +1470,19 @@ unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
         &component_id: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         system_meta.set_non_send();
 
         let mut filtered_access = FilteredAccess::default();
         filtered_access.add_write(component_id);
 
-        if system_access.try_add(filtered_access).is_err() {
-            panic!(
-                "error[B0002]: NonSendMut<{}> in system {} conflicts with a previous system parameter's access. Consider removing the duplicate access. See: https://bevy.org/learn/errors/b0002",
-                DebugName::type_name::<T>(), system_meta.name,
-            );
-        }
+        system_access
+            .try_extend_single(filtered_access)
+            .map_err(|access| {
+                ParameterAccessConflict::new::<Self>(access)
+                    .with_suggestion_if_exclusive(system_access, "Calling `World::non_send_mut()`")
+                    .with_code("B0002")
+            })
     }
 
     #[inline]
@@ -1419,11 +1514,13 @@ unsafe impl<'a> SystemParam for &'a Archetypes {
 
     fn init_access(
         _state: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
-        system_access.require_shared_access::<Self>(system_meta);
+    ) -> Result<(), ParameterAccessConflict> {
+        system_access.try_extend_metadata().map_err(|access| {
+            ParameterAccessConflict::new::<Self>(access)
+                .with_suggestion_if_exclusive(system_access, "Calling `World::archetypes()`")
+        })
     }
 
     #[inline]
@@ -1449,11 +1546,13 @@ unsafe impl<'a> SystemParam for &'a ResourceEntities {
 
     fn init_access(
         _state: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
-        system_access.require_shared_access::<Self>(system_meta);
+    ) -> Result<(), ParameterAccessConflict> {
+        system_access.try_extend_metadata().map_err(|access| {
+            ParameterAccessConflict::new::<Self>(access)
+                .with_suggestion_if_exclusive(system_access, "Calling `World::resource_entities()`")
+        })
     }
 
     #[inline]
@@ -1479,11 +1578,13 @@ unsafe impl<'a> SystemParam for &'a Components {
 
     fn init_access(
         _state: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
-        system_access.require_shared_access::<Self>(system_meta);
+    ) -> Result<(), ParameterAccessConflict> {
+        system_access.try_extend_metadata().map_err(|access| {
+            ParameterAccessConflict::new::<Self>(access)
+                .with_suggestion_if_exclusive(system_access, "Calling `World::components()`")
+        })
     }
 
     #[inline]
@@ -1509,11 +1610,13 @@ unsafe impl<'a> SystemParam for &'a Entities {
 
     fn init_access(
         _state: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
-        system_access.require_shared_access::<Self>(system_meta);
+    ) -> Result<(), ParameterAccessConflict> {
+        system_access.try_extend_metadata().map_err(|access| {
+            ParameterAccessConflict::new::<Self>(access)
+                .with_suggestion_if_exclusive(system_access, "Calling `World::entities()`")
+        })
     }
 
     #[inline]
@@ -1539,11 +1642,13 @@ unsafe impl<'a> SystemParam for &'a EntityAllocator {
 
     fn init_access(
         _state: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
-        system_access.require_shared_access::<Self>(system_meta);
+    ) -> Result<(), ParameterAccessConflict> {
+        system_access.try_extend_metadata().map_err(|access| {
+            ParameterAccessConflict::new::<Self>(access)
+                .with_suggestion_if_exclusive(system_access, "Calling `World::entity_allocator()`")
+        })
     }
 
     #[inline]
@@ -1569,11 +1674,13 @@ unsafe impl<'a> SystemParam for &'a Bundles {
 
     fn init_access(
         _state: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
-        system_access.require_shared_access::<Self>(system_meta);
+    ) -> Result<(), ParameterAccessConflict> {
+        system_access.try_extend_metadata().map_err(|access| {
+            ParameterAccessConflict::new::<Self>(access)
+                .with_suggestion_if_exclusive(system_access, "Calling `World::bundles()`")
+        })
     }
 
     #[inline]
@@ -1630,8 +1737,8 @@ unsafe impl SystemParam for SystemChangeTick {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
+        Ok(())
     }
 
     #[inline]
@@ -1662,9 +1769,8 @@ unsafe impl<T: SystemParam> SystemParam for Option<T> {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
-        T::init_access(state, system_meta, system_access, world);
+    ) -> Result<(), ParameterAccessConflict> {
+        T::init_access(state, system_meta, system_access)
     }
 
     #[inline]
@@ -1704,9 +1810,8 @@ unsafe impl<T: SystemParam> SystemParam for Result<T, SystemParamValidationError
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
-        T::init_access(state, system_meta, system_access, world);
+    ) -> Result<(), ParameterAccessConflict> {
+        T::init_access(state, system_meta, system_access)
     }
 
     #[inline]
@@ -1799,9 +1904,8 @@ unsafe impl<T: SystemParam> SystemParam for If<T> {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
-        T::init_access(state, system_meta, system_access, world);
+    ) -> Result<(), ParameterAccessConflict> {
+        T::init_access(state, system_meta, system_access)
     }
 
     #[inline]
@@ -1847,11 +1951,11 @@ unsafe impl<T: SystemParam> SystemParam for Vec<T> {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         for state in state {
-            T::init_access(state, system_meta, system_access, world);
+            T::init_access(state, system_meta, system_access)?;
         }
+        Ok(())
     }
 
     #[inline]
@@ -1899,20 +2003,20 @@ unsafe impl<T: SystemParam> SystemParam for ParamSet<'_, '_, Vec<T>> {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         for state in state {
             // Call `init_access` on a clone of the original access set to check for conflicts
             let system_access_clone = &mut system_access.clone();
-            T::init_access(state, system_meta, system_access_clone, world);
+            T::init_access(state, system_meta, system_access_clone)?;
         }
         for state in state {
             // Pretend to add the param to the system alone to gather the new access,
             // then merge its access into the system.
             let mut param_access = SystemAccess::default();
-            T::init_access(state, system_meta, &mut param_access, world);
+            T::init_access(state, system_meta, &mut param_access)?;
             system_access.extend(param_access);
         }
+        Ok(())
     }
 
     #[inline]
@@ -2002,11 +2106,11 @@ unsafe impl<T: SystemParam, const N: usize> SystemParam for SmallVec<[T; N]> {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         for state in state {
-            T::init_access(state, system_meta, system_access, world);
+            T::init_access(state, system_meta, system_access)?;
         }
+        Ok(())
     }
 
     #[inline]
@@ -2069,9 +2173,10 @@ macro_rules! impl_system_param_tuple {
                 ($($param::init_state(world),)*)
             }
 
-            fn init_access(state: &Self::State, _system_meta: &mut SystemMeta, _system_access: &mut SystemAccess, _world: &mut World) {
+            fn init_access(state: &Self::State, _system_meta: &mut SystemMeta, _system_access: &mut SystemAccess) -> Result<(), ParameterAccessConflict> {
                 let ($($param,)*) = state;
-                $($param::init_access($param, _system_meta, _system_access, _world);)*
+                $($param::init_access($param, _system_meta, _system_access)?;)*
+                Ok(())
             }
 
 
@@ -2244,9 +2349,8 @@ unsafe impl<P: SystemParam + 'static> SystemParam for StaticSystemParam<'_, '_, 
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
-        P::init_access(state, system_meta, system_access, world);
+    ) -> Result<(), ParameterAccessConflict> {
+        P::init_access(state, system_meta, system_access)
     }
 
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {
@@ -2280,8 +2384,8 @@ unsafe impl<T: ?Sized> SystemParam for PhantomData<T> {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
+        Ok(())
     }
 
     #[inline]
@@ -2313,8 +2417,8 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
+        Ok(())
     }
 
     unsafe fn get_param<'world, 'state>(
@@ -2346,8 +2450,8 @@ unsafe impl<P: SystemParam + 'static> SystemParam for &'_ mut SystemState<P> {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         _system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
+        Ok(())
     }
 
     unsafe fn get_param<'world, 'state>(
@@ -2564,8 +2668,7 @@ trait DynParamState: Sync + Send + Any {
         &self,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    );
+    ) -> Result<(), ParameterAccessConflict>;
 
     /// Validates the inner parameter by calling [`SystemParam::get_param`] and discarding the value.
     ///
@@ -2595,9 +2698,8 @@ impl<T: SystemParam + 'static> DynParamState for ParamState<T> {
         &self,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
-        T::init_access(&self.0, system_meta, system_access, world);
+    ) -> Result<(), ParameterAccessConflict> {
+        T::init_access(&self.0, system_meta, system_access)
     }
 
     unsafe fn validate(
@@ -2625,9 +2727,8 @@ unsafe impl SystemParam for DynSystemParam<'_, '_> {
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
-        state.0.init_access(system_meta, system_access, world);
+    ) -> Result<(), ParameterAccessConflict> {
+        state.0.init_access(system_meta, system_access)
     }
 
     #[inline]
@@ -2674,19 +2775,20 @@ unsafe impl SystemParam for FilteredResources<'_, '_> {
 
     fn init_access(
         access: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         let mut filtered_access = FilteredAccess::default();
         filtered_access.access_mut().extend(access);
         filtered_access.and_with(IS_RESOURCE);
 
-        if let Err(conflicts) = system_access.try_add(filtered_access) {
-            let accesses = conflicts.format_conflict_list(world.into());
-            let system_name = &system_meta.name;
-            panic!("error[B0002]: FilteredResources in system {system_name} accesses resources(s){accesses} in a way that conflicts with a previous system parameter. Consider removing the duplicate access. See: https://bevy.org/learn/errors/b0002");
-        }
+        system_access
+            .try_extend_single(filtered_access)
+            .map_err(|access| {
+                ParameterAccessConflict::new::<Self>(access)
+                    .with_suggestion_if_exclusive(system_access, "Calling `World::resource()`")
+                    .with_code("B0002")
+            })
     }
 
     unsafe fn get_param<'world, 'state>(
@@ -2719,19 +2821,20 @@ unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
 
     fn init_access(
         access: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
+    ) -> Result<(), ParameterAccessConflict> {
         let mut filtered_access = FilteredAccess::default();
         filtered_access.access_mut().extend(access);
         filtered_access.and_with(IS_RESOURCE);
 
-        if let Err(conflicts) = system_access.try_add(filtered_access) {
-            let accesses = conflicts.format_conflict_list(world.into());
-            let system_name = &system_meta.name;
-            panic!("error[B0002]: FilteredResourcesMut in system {system_name} accesses resources(s){accesses} in a way that conflicts with a previous system parameter. Consider removing the duplicate access. See: https://bevy.org/learn/errors/b0002");
-        }
+        system_access
+            .try_extend_single(filtered_access)
+            .map_err(|access| {
+                ParameterAccessConflict::new::<Self>(access)
+                    .with_suggestion_if_exclusive(system_access, "Calling `World::resource_mut()`")
+                    .with_code("B0002")
+            })
     }
 
     unsafe fn get_param<'world, 'state>(

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -277,7 +277,7 @@ pub unsafe trait SystemParam: Sized {
     ///   access was registered in [`init_access`](SystemParam::init_access).
     /// - [`SystemParam::init_access`] must not request conflicting access.
     ///   If `Self` is `ReadOnlySystemParam`, the access is read-only and can never conflict.
-    ///   Otherwise, [`SystemParam::init_access`] must be called to ensure it does not panic.
+    ///   Otherwise, [`SystemParam::init_access`] must be called to ensure it does not return [`Err`].
     /// - `world` must be the same [`World`] that was used to initialize [`state`](SystemParam::init_state).
     unsafe fn get_param<'world, 'state>(
         state: &'state mut Self::State,
@@ -386,7 +386,7 @@ unsafe impl<'w, 's, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> Re
 }
 
 // SAFETY: Relevant query ComponentId access is applied to SystemMeta. If
-// this Query conflicts with any prior access, a panic will occur.
+// this Query conflicts with any prior access, an `Err` will be returned.
 unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Query<'_, '_, D, F> {
     type State = QueryState<D, F>;
     type Item<'w, 's> = Query<'w, 's, D, F>;
@@ -451,7 +451,7 @@ unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam for Qu
 }
 
 // SAFETY: Relevant query ComponentId access is applied to SystemMeta. If
-// this Query conflicts with any prior access, a panic will occur.
+// this Query conflicts with any prior access, an `Err` will be returned.
 unsafe impl<'a, 'b, D: IterQueryData + 'static, F: QueryFilter + 'static> SystemParam
     for Single<'a, 'b, D, F>
 {
@@ -504,7 +504,7 @@ unsafe impl<'a, 'b, D: ReadOnlyQueryData + 'static, F: QueryFilter + 'static> Re
 }
 
 // SAFETY: Relevant query ComponentId access is applied to SystemMeta. If
-// this Query conflicts with any prior access, a panic will occur.
+// this Query conflicts with any prior access, an `Err` will be returned.
 unsafe impl<D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
     for Populated<'_, '_, D, F>
 {
@@ -679,7 +679,7 @@ macro_rules! impl_param_set {
         { }
 
         // SAFETY: Relevant parameter ComponentId access is applied to SystemMeta. If any ParamState conflicts
-        // with any prior access, a panic will occur.
+        // with any prior access, an `Err` will be returned.
         unsafe impl<'_w, '_s, $($param: SystemParam,)*> SystemParam for ParamSet<'_w, '_s, ($($param,)*)>
         {
             type State = ($($param::State,)*);
@@ -783,7 +783,7 @@ all_tuples_enumerated!(impl_param_set, 1, 8, P, p);
 unsafe impl<'a, T: Resource> ReadOnlySystemParam for Res<'a, T> {}
 
 // SAFETY: Res ComponentId access is applied to SystemMeta. If this Res
-// conflicts with any prior access, a panic will occur.
+// conflicts with any prior access, an `Err` will be returned.
 unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
     type State = ComponentId;
     type Item<'w, 's> = Res<'w, T>;
@@ -832,7 +832,7 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
 }
 
 // SAFETY: Res ComponentId access is applied to SystemMeta. If this Res
-// conflicts with any prior access, a panic will occur.
+// conflicts with any prior access, an `Err` will be returned.
 unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T> {
     type State = ComponentId;
     type Item<'w, 's> = ResMut<'w, T>;
@@ -884,7 +884,7 @@ unsafe impl<'a, T: Resource<Mutability = Mutable>> SystemParam for ResMut<'a, T>
 // SAFETY: only reads world
 unsafe impl<'w> ReadOnlySystemParam for &'w World {}
 
-// SAFETY: `read_all` access is set and conflicts result in a panic
+// SAFETY: `read_all` access is set and conflicts result in an `Err`
 unsafe impl SystemParam for &'_ World {
     type State = ();
     type Item<'w, 's> = &'w World;
@@ -916,7 +916,7 @@ unsafe impl SystemParam for &'_ World {
     }
 }
 
-// SAFETY: `write_all` access is set and conflicts result in a panic
+// SAFETY: `write_all` access is set and conflicts result in an `Err`
 unsafe impl SystemParam for &'_ mut World {
     type State = ();
     type Item<'world, 'state> = &'world mut World;
@@ -1416,7 +1416,7 @@ unsafe impl ReadOnlySystemParam for NonSendMarker {}
 unsafe impl<'w, T> ReadOnlySystemParam for NonSend<'w, T> {}
 
 // SAFETY: NonSendComponentId access is applied to SystemMeta. If this
-// NonSend conflicts with any prior access, a panic will occur.
+// NonSend conflicts with any prior access, an `Err` will be returned.
 unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
     type State = ComponentId;
     type Item<'w, 's> = NonSend<'w, T>;
@@ -1462,7 +1462,7 @@ unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
 }
 
 // SAFETY: NonSendMut ComponentId access is applied to SystemMeta. If this
-// NonSendMut conflicts with any prior access, a panic will occur.
+// NonSendMut conflicts with any prior access, an `Err` will be returned.
 unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
     type State = ComponentId;
     type Item<'w, 's> = NonSendMut<'w, T>;
@@ -1942,7 +1942,7 @@ unsafe impl<T: SystemParam> SystemParam for If<T> {
 unsafe impl<T: ReadOnlySystemParam> ReadOnlySystemParam for If<T> {}
 
 // SAFETY: Registers access for each element of `state`.
-// If any one conflicts, it will panic.
+// If any one conflicts, it will return an `Err`.
 unsafe impl<T: SystemParam> SystemParam for Vec<T> {
     type State = Vec<T::State>;
 
@@ -1994,7 +1994,7 @@ unsafe impl<T: SystemParam> SystemParam for Vec<T> {
 
 // SAFETY: Registers access for each element of `state`.
 // If any one conflicts with a previous parameter,
-// the call passing a copy of the current access will panic.
+// the call passing a copy of the current access will return `Err`.
 unsafe impl<T: SystemParam> SystemParam for ParamSet<'_, '_, Vec<T>> {
     type State = Vec<T::State>;
 
@@ -2097,7 +2097,7 @@ impl<T: SystemParam> ParamSet<'_, '_, Vec<T>> {
 }
 
 // SAFETY: Registers access for each element of `state`.
-// If any one conflicts, it will panic.
+// If any one conflicts, it will return `Err`.
 unsafe impl<T: SystemParam, const N: usize> SystemParam for SmallVec<[T; N]> {
     type State = SmallVec<[T::State; N]>;
 
@@ -2767,7 +2767,7 @@ unsafe impl SystemParam for DynSystemParam<'_, '_> {
 }
 
 // SAFETY: Resource ComponentId access is applied to the access. If this FilteredResources
-// conflicts with any prior access, a panic will occur.
+// conflicts with any prior access, an `Err` will be returned.
 #[expect(deprecated, reason = "`FilteredResources` will be removed.")]
 unsafe impl SystemParam for FilteredResources<'_, '_> {
     type State = Access;
@@ -2813,7 +2813,7 @@ unsafe impl SystemParam for FilteredResources<'_, '_> {
 unsafe impl ReadOnlySystemParam for FilteredResources<'_, '_> {}
 
 // SAFETY: Resource ComponentId access is applied to the access. If this FilteredResourcesMut
-// conflicts with any prior access, a panic will occur.
+// conflicts with any prior access, an `Err` will be returned.
 #[expect(deprecated, reason = "`FilteredResourcesMut` will be removed.")]
 unsafe impl SystemParam for FilteredResourcesMut<'_, '_> {
     type State = Access;

--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -6,6 +6,7 @@ use crate::{
     },
     world::{unsafe_world_cell::UnsafeWorldCell, FromWorld, World},
 };
+use alloc::boxed::Box;
 use bevy_platform::sync::atomic::{AtomicUsize, Ordering};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
@@ -72,7 +73,7 @@ unsafe impl SystemParam for WorldId {
         _state: &Self::State,
         _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         system_access.try_extend_metadata().map_err(|access| {
             ParameterAccessConflict::new::<Self>(access)
                 .with_suggestion_if_exclusive(system_access, "Calling `World::id()`")

--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -1,7 +1,9 @@
 use crate::{
     change_detection::Tick,
     storage::SparseSetIndex,
-    system::{SystemAccess, SystemMeta, SystemParam, SystemParamValidationError},
+    system::{
+        ParameterAccessConflict, SystemAccess, SystemMeta, SystemParam, SystemParamValidationError,
+    },
     world::{unsafe_world_cell::UnsafeWorldCell, FromWorld, World},
 };
 use bevy_platform::sync::atomic::{AtomicUsize, Ordering};
@@ -68,11 +70,13 @@ unsafe impl SystemParam for WorldId {
 
     fn init_access(
         _state: &Self::State,
-        system_meta: &mut SystemMeta,
+        _system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        _world: &mut World,
-    ) {
-        system_access.require_shared_access::<Self>(system_meta);
+    ) -> Result<(), ParameterAccessConflict> {
+        system_access.try_extend_metadata().map_err(|access| {
+            ParameterAccessConflict::new::<Self>(access)
+                .with_suggestion_if_exclusive(system_access, "Calling `World::id()`")
+        })
     }
 
     #[inline]

--- a/crates/bevy_extract/src/extract_param.rs
+++ b/crates/bevy_extract/src/extract_param.rs
@@ -3,8 +3,8 @@ use bevy_ecs::{
     change_detection::Tick,
     prelude::*,
     system::{
-        ReadOnlySystemParam, SystemAccess, SystemMeta, SystemParam, SystemParamItem,
-        SystemParamValidationError, SystemState,
+        ParameterAccessConflict, ReadOnlySystemParam, SystemAccess, SystemMeta, SystemParam,
+        SystemParamItem, SystemParamValidationError, SystemState,
     },
     world::unsafe_world_cell::UnsafeWorldCell,
 };
@@ -85,9 +85,8 @@ where
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
-        Res::<MainWorld>::init_access(&state.main_world_state, system_meta, system_access, world);
+    ) -> Result<(), ParameterAccessConflict> {
+        Res::<MainWorld>::init_access(&state.main_world_state, system_meta, system_access)
     }
 
     #[inline]

--- a/crates/bevy_extract/src/extract_param.rs
+++ b/crates/bevy_extract/src/extract_param.rs
@@ -85,7 +85,7 @@ where
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         Res::<MainWorld>::init_access(&state.main_world_state, system_meta, system_access)
     }
 

--- a/crates/bevy_extract/src/sync_world.rs
+++ b/crates/bevy_extract/src/sync_world.rs
@@ -351,10 +351,9 @@ mod sub_entities_world_query_impls {
 
         fn init_nested_access(
             _state: &Self::State,
-            _system_name: Option<&str>,
             _component_access_set: &mut FilteredAccessSet,
-            _world: UnsafeWorldCell,
-        ) {
+        ) -> Result<(), FilteredAccessSet> {
+            Ok(())
         }
 
         fn init_state(world: &mut World) -> ComponentId {
@@ -482,10 +481,9 @@ mod sub_entities_world_query_impls {
 
         fn init_nested_access(
             _state: &Self::State,
-            _system_name: Option<&str>,
             _component_access_set: &mut FilteredAccessSet,
-            _world: UnsafeWorldCell,
-        ) {
+        ) -> Result<(), FilteredAccessSet> {
+            Ok(())
         }
 
         fn init_state(world: &mut World) -> ComponentId {

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -12,8 +12,8 @@ use bevy_ecs::{
     change_detection::Tick,
     resource::Resource,
     system::{
-        Deferred, ReadOnlySystemParam, Res, SystemAccess, SystemBuffer, SystemMeta, SystemParam,
-        SystemParamValidationError,
+        Deferred, ParameterAccessConflict, ReadOnlySystemParam, Res, SystemAccess, SystemBuffer,
+        SystemMeta, SystemParam, SystemParamValidationError,
     },
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld, World},
 };
@@ -210,9 +210,8 @@ where
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
-        GizmosState::<Config, Clear>::init_access(&state.state, system_meta, system_access, world);
+    ) -> Result<(), ParameterAccessConflict> {
+        GizmosState::<Config, Clear>::init_access(&state.state, system_meta, system_access)
     }
 
     fn apply(state: &mut Self::State, system_meta: &SystemMeta, world: &mut World) {

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -210,7 +210,7 @@ where
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         GizmosState::<Config, Clear>::init_access(&state.state, system_meta, system_access)
     }
 

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -356,7 +356,7 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-    ) -> Result<(), ParameterAccessConflict> {
+    ) -> Result<(), Box<ParameterAccessConflict>> {
         Res::<CurrentView>::init_access(&state.resource_id, system_meta, system_access)?;
         Query::init_access(&state.query_state, system_meta, system_access)?;
         Ok(())

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -9,8 +9,8 @@ use bevy_ecs::component::ComponentId;
 use bevy_ecs::prelude::*;
 use bevy_ecs::query::{QueryData, QueryFilter, QueryState};
 use bevy_ecs::system::{
-    Deferred, SystemAccess, SystemBuffer, SystemMeta, SystemName, SystemParam,
-    SystemParamValidationError,
+    Deferred, ParameterAccessConflict, SystemAccess, SystemBuffer, SystemMeta, SystemName,
+    SystemParam, SystemParamValidationError,
 };
 use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_ecs::world::DeferredWorld;
@@ -356,10 +356,10 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         state: &Self::State,
         system_meta: &mut SystemMeta,
         system_access: &mut SystemAccess,
-        world: &mut World,
-    ) {
-        Res::<CurrentView>::init_access(&state.resource_id, system_meta, system_access, world);
-        Query::init_access(&state.query_state, system_meta, system_access, world);
+    ) -> Result<(), ParameterAccessConflict> {
+        Res::<CurrentView>::init_access(&state.resource_id, system_meta, system_access)?;
+        Query::init_access(&state.query_state, system_meta, system_access)?;
+        Ok(())
     }
 
     #[inline]

--- a/crates/bevy_render/src/renderer/render_context.rs
+++ b/crates/bevy_render/src/renderer/render_context.rs
@@ -347,10 +347,8 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
 
     fn init_state(world: &mut World) -> Self::State {
         ViewQueryState {
-            resource_id: world
-                .components_registrator()
-                .register_component::<CurrentView>(),
-            query_state: QueryState::new(world),
+            resource_id: Res::<CurrentView>::init_state(world),
+            query_state: Query::init_state(world),
         }
     }
 
@@ -360,38 +358,32 @@ unsafe impl<'a, D: QueryData + 'static, F: QueryFilter + 'static> SystemParam
         system_access: &mut SystemAccess,
         world: &mut World,
     ) {
-        let component_access_set = system_access.require_shared_access::<Self>(system_meta);
-        component_access_set.add_resource_read(state.resource_id);
-
-        <Query<'_, '_, D, F> as SystemParam>::init_access(
-            &state.query_state,
-            system_meta,
-            system_access,
-            world,
-        );
+        Res::<CurrentView>::init_access(&state.resource_id, system_meta, system_access, world);
+        Query::init_access(&state.query_state, system_meta, system_access, world);
     }
 
     #[inline]
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
-        _system_meta: &SystemMeta,
+        system_meta: &SystemMeta,
         world: UnsafeWorldCell<'w>,
-        _change_tick: Tick,
+        change_tick: Tick,
     ) -> Result<Self::Item<'w, 's>, SystemParamValidationError> {
         // SAFETY: We have registered resource read access in init_access
-        let current_view = unsafe { world.get_resource::<CurrentView>() };
-
-        let Some(current_view) = current_view else {
-            return Err(SystemParamValidationError::skipped::<Self>(
-                "CurrentView resource not present",
-            ));
-        };
+        let current_view = unsafe {
+            Res::<CurrentView>::get_param(&mut state.resource_id, system_meta, world, change_tick)
+        }
+        .map_err(|_| {
+            SystemParamValidationError::skipped::<Self>("CurrentView resource not present")
+        })?;
 
         let entity = current_view.entity();
 
         // SAFETY: Query state access is properly registered in init_access.
         // The caller ensures the world matches the one used in init_state.
-        let item = unsafe { state.query_state.get_unchecked(world, entity) }.map_err(|_| {
+        let query =
+            unsafe { Query::get_param(&mut state.query_state, system_meta, world, change_tick) }?;
+        let item = query.get_inner(entity).map_err(|_| {
             SystemParamValidationError::skipped::<Self>("Current view entity does not match query")
         })?;
 

--- a/crates/bevy_utils/src/debug_info.rs
+++ b/crates/bevy_utils/src/debug_info.rs
@@ -37,6 +37,12 @@ cfg::alloc! {
 }
 
 impl DebugName {
+    /// Whether the `debug` feature is enabled.
+    ///
+    /// If this is `false`, [`DebugName`] will be a zero-sized type
+    /// and will return a generic message when used as a string.
+    pub const ENABLED: bool = cfg!(feature = "debug");
+
     /// Create a new `DebugName` from a `&str`
     ///
     /// The value will be ignored if the `debug` feature is not enabled

--- a/errors/B0006.md
+++ b/errors/B0006.md
@@ -10,7 +10,13 @@ Bevy's renderer is designed to be used with hardware acceleration. When initiali
 - It is possible that the hardware itself is too old.
 - You could try using a different backend for the `RenderPlugin`, for example the OpenGL backend. However, please be aware that this could reduce the renderer's performance on other systems that don't have this problem. Here's an example of how to do this:
 
-```rust
+```rust,no_run
+use bevy::prelude::*;
+use bevy::render::{
+    settings::{Backends, WgpuSettings},
+    RenderPlugin,
+};
+
 fn main() {
     App::new()
         .add_plugins(

--- a/errors/B0007.md
+++ b/errors/B0007.md
@@ -1,0 +1,7 @@
+# B0007
+
+A runtime warning.
+
+TODO: Write error page for access conflict between different kinds of parameters.
+
+This includes `Query`/`Res` conflicts where we should suggest `Without<IsResource>`, as well as things like `MessageWriter<M>`/`ResMut<Messages<M>>`.

--- a/errors/B0008.md
+++ b/errors/B0008.md
@@ -1,0 +1,9 @@
+# B0008
+
+A runtime warning.
+
+TODO: Write error page for access conflicts with exclusive parameters.
+
+This should suggest `Commands` in case a user added `&mut World` just to spawn an entity.
+
+This is also where we should show how `&mut ParamState` and `&mut QueryState` can be used.

--- a/errors/B0009.md
+++ b/errors/B0009.md
@@ -1,4 +1,4 @@
-# B0007
+# B0009
 
 A runtime warning.
 

--- a/errors/B0009.md
+++ b/errors/B0009.md
@@ -1,0 +1,7 @@
+# B0007
+
+A runtime warning.
+
+TODO: Write error page for access conflicts with `MessageReader`/`MessageWriter`.
+
+This should suggest `MessageMutator` for both reading and writing messages.

--- a/errors/src/lib.rs
+++ b/errors/src/lib.rs
@@ -13,3 +13,18 @@ pub struct B0003;
 
 #[doc = include_str!("../B0004.md")]
 pub struct B0004;
+
+#[doc = include_str!("../B0005.md")]
+pub struct B0005;
+
+#[doc = include_str!("../B0006.md")]
+pub struct B0006;
+
+#[doc = include_str!("../B0007.md")]
+pub struct B0007;
+
+#[doc = include_str!("../B0008.md")]
+pub struct B0008;
+
+#[doc = include_str!("../B0009.md")]
+pub struct B0009;

--- a/errors/src/lib.rs
+++ b/errors/src/lib.rs
@@ -17,6 +17,10 @@ pub struct B0004;
 #[doc = include_str!("../B0005.md")]
 pub struct B0005;
 
+#[expect(
+    clippy::needless_doctest_main,
+    reason = "The example is emphasizing that the code should go in the user's `fn main()`."
+)]
 #[doc = include_str!("../B0006.md")]
 pub struct B0006;
 

--- a/errors/src/lib.rs
+++ b/errors/src/lib.rs
@@ -17,10 +17,6 @@ pub struct B0004;
 #[doc = include_str!("../B0005.md")]
 pub struct B0005;
 
-#[expect(
-    clippy::needless_doctest_main,
-    reason = "The example is emphasizing that the code should go in the user's `fn main()`."
-)]
 #[doc = include_str!("../B0006.md")]
 pub struct B0006;
 


### PR DESCRIPTION
# Objective

Provide better error messages for access conflicts between system parameters.  

The messages currently have useful messages for conflicts between two `Query`s and between two `Res`/`ResMut`s, but have fairly generic text for other combinations.  This used to be enough to cover everything, except that conflicts with `MessageReader`/`MessageWriter` were reported as though the user had written `Res`/`ResMut`.  With resources-as-entities, it started working less well, as conflicts between a `Query` and `Res` would give different messages depending on the order of the parameters, and did not suggest `Without<IsResource>`.  And now that `&mut World` is a `SystemParam`, access conflicts between any parameter and `&mut World` gives a fairly generic message with no extra help.  

## Solution

Change `SystemParam::init_access` to return a `Result` instead of panicking, and centralize the creation of the panic message for conflicts.  

Use this to get information about *both* conflicting parameters!  Calling `init_access` a second time with the access from the second parameter already included will cause the failure at the first parameter, instead.  

Also use this to replace the parameter name for wrapper parameters.  In particular, the error for `Single` can now mention `Single` instead of `Query`.  

Provide a way to add context-sensitive suggestions to the `Err` payload.  This lets us recommend alternative APIs when using `&mut World`, and lets us recommend `Without<IsResource>` for queries in exactly the cases where it will help.  

Add some additional error codes to https://bevy.org/learn/errors/.  There are existing ones for `Query` conflicts and resource conflicts.  Add new codes for `&mut World` conflicts and `Message` conflicts, plus a generic page for conflicts between different parameter types.  

## Help needed writing documentation

I have included stubs for new https://bevy.org/learn/errors pages, but I have not written content in them.  I'm not really sure how to write these myself, and would appreciate help.  Feel free to make PRs to my branch!  

## Future work

I plan to provide a way to configure errors when using `#[derive(SystemParam)]`, but will leave it for a follow-up PR.  

In particular, I want to configure the errors for `MessageReader` and `MessageWriter` so that they can suggest using `MessageMutator` instead of giving an error message about resources.  

## Showcase

Here are some examples of systems with conflicts, along with the old and new error message.  

Note that these all use disqualified 1.1 to shorten the type names, which has not yet finished releasing.  

### Two queries

```rust
fn queries(_: Query<&C>, _: Query<&mut C>)
```

Before:
```
error[B0001]: Query<&mut C> in system queries accesses component(s) C in a way that conflicts with a previous system parameter. Consider using `Without<T>` to create disjoint Queries or merging conflicting Queries into a `ParamSet`. See: https://bevy.org/learn/errors/b0001
```

After:
```
error[B0001]: `Query<&C>` and `Query<&mut C>` parameters in system `queries` conflict on component(s) C.
Consider:
* Using `Without<T>` to create disjoint queries.
* Merging conflicting parameters into a `ParamSet`
See: https://bevy.org/learn/errors/b0001
```

### Two resources
```rust
resources(_: Res<R>, _: ResMut<R>)
```

Before:
```
error[B0002]: ResMut<bevy_ecs::system::system_param::tests::R> in system resources conflicts with a previous system parameter. Consider removing the duplicate access or using `Without<IsResource>` to create disjoint Queries or merging conflicting Queries into a `ParamSet`. See: https://bevy.org/learn/errors/b0002
```

After:
```
error[B0002]: `Res<R>` and `ResMut<R>` parameters in system `resources` conflict on component(s) R.
Consider:
* Merging conflicting parameters into a `ParamSet`
See: https://bevy.org/learn/errors/b0002
```

### Two `Single`s

```rust
fn singles(_: Single<&C>, _: Single<&mut C>)
```

Before:
```
error[B0001]: Query<&mut C> in system singles accesses component(s) C in a way that conflicts with a previous system parameter. Consider using `Without<T>` to create disjoint Queries or merging conflicting Queries into a `ParamSet`. See: https://bevy.org/learn/errors/b0001
```

After:
```
error[B0001]: `Single<&C>` and `Single<&mut C>` parameters in system `singles` conflict on component(s) C.
Consider:
* Using `Without<T>` to create disjoint queries.
* Merging conflicting parameters into a `ParamSet`
See: https://bevy.org/learn/errors/b0001
```

### Query and resource
```rust
fn query_resource(_: Query<EntityMut>, _: ResMut<R>)
```

Before:
```
error[B0002]: ResMut<bevy_ecs::system::system_param::tests::R> in system query_resource conflicts with a previous system parameter. Consider removing the duplicate access or using `Without<IsResource>` to create disjoint Queries or merging conflicting Queries into a `ParamSet`. See: https://bevy.org/learn/errors/b0002
```

After:
```
error[B0007]: `Query<EntityMut>` and `ResMut<R>` parameters in system `query_resource` conflict on component(s) R.
Consider:
* Using `Without<IsResource>` to exclude resources from the query.
* Merging conflicting parameters into a `ParamSet`
See: https://bevy.org/learn/errors/b0007
```

### Resource and query
```rust
fn resource_query(_: ResMut<R>, _: Query<EntityMut>)
```

Before:
```
error[B0001]: Query<EntityMut> in system resource_query accesses component(s) R in a way that conflicts with a previous system parameter. Consider using `Without<T>` to create disjoint Queries or merging conflicting Queries into a `ParamSet`. See: https://bevy.org/learn/errors/b0001
```

After:
```
error[B0007]: `ResMut<R>` and `Query<EntityMut>` parameters in system `resource_query` conflict on component(s) R.
Consider:
* Using `Without<IsResource>` to exclude resources from the query.
* Merging conflicting parameters into a `ParamSet`
See: https://bevy.org/learn/errors/b0007
```

### Query and `&mut World`
```rust
fn query_world(_: Query<&C>,_: &mut World)
```

Before:
```
error[B0002]: &mut World in system query_world conflicts with a previous system parameter.
```

After:
```
error[B0008]: `Query<&C>` and `&mut World` parameters in system `query_world` conflict.
Consider:
* Using a `&mut QueryState` parameter
* Using a `&mut SystemState` parameter
* Using a `Commands` parameter instead of `&mut World` to defer changes
* Merging conflicting parameters into a `ParamSet`
See: https://bevy.org/learn/errors/b0008
```

### `&mut World` and resource
```rust
fn world_resource(_: &mut World, _: Res<R>)
```

Before:

```
error[B0002]: Res<bevy_ecs::system::system_param::tests::R> in system world_resource conflicts with a previous system parameter. Consider removing the duplicate access using `Without<IsResource>` to create disjoint Queries or merging conflicting Queries into a `ParamSet`. See: https://bevy.org/learn/errors/b0002
```

After:

```
error[B0008]: `&mut World` and `Res<R>` parameters in system `world_resource` conflict.
Consider:
* Calling `World::resource()`
* Using a `&mut SystemState` parameter
* Using a `Commands` parameter instead of `&mut World` to defer changes
* Merging conflicting parameters into a `ParamSet`
See: https://bevy.org/learn/errors/b0008
```