### PR TITLE
Fix 2D cameras with different MSAA sharing a depth texture (#25501)

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -441,7 +441,7 @@ pub fn prepare_core_2d_depth_textures(
         };
 
         let cached_texture = textures
-            .entry(camera.target.clone())
+            .entry((camera.target.clone(), msaa))
             .or_insert_with(|| {
                 let descriptor = TextureDescriptor {
                     label: Some("view_depth_texture"),

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -25,7 +25,6 @@ fn main() {
     let mut app = App::new();
     app.add_plugins((DefaultPlugins,))
         .add_systems(OnEnter(Scene::Shapes), shapes::setup)
-        .add_systems(OnEnter(Scene::MixedMsaa), mixed_msaa::setup)
         .add_systems(OnEnter(Scene::Bloom), bloom::setup)
         .add_systems(OnEnter(Scene::Text), text::setup)
         .add_systems(OnEnter(Scene::Sprite), sprite::setup)
@@ -55,7 +54,6 @@ fn main() {
 enum Scene {
     #[default]
     Shapes,
-    MixedMsaa,
     Bloom,
     Text,
     Sprite,
@@ -68,7 +66,6 @@ enum Scene {
 impl Scene {
     const ALL_ORDERED: &'static [Scene] = &[
         Scene::Shapes,
-        Scene::MixedMsaa,
         Scene::Bloom,
         Scene::Text,
         Scene::Sprite,
@@ -162,37 +159,6 @@ mod shapes {
                 DespawnOnExit(super::Scene::Shapes),
             ));
         }
-    }
-}
-
-mod mixed_msaa {
-    use bevy::prelude::*;
-
-    pub fn setup(
-        mut commands: Commands,
-        mut meshes: ResMut<Assets<Mesh>>,
-        mut materials: ResMut<Assets<ColorMaterial>>,
-    ) {
-        // Cameras sharing a render target must not share depth textures when their
-        // sample counts differ. Use 1 and 4 samples for WebGPU compatibility.
-        for (order, msaa) in [Msaa::Off, Msaa::Sample4].into_iter().enumerate() {
-            commands.spawn((
-                Camera2d,
-                Camera {
-                    order: order as isize,
-                    ..default()
-                },
-                msaa,
-                DespawnOnExit(super::Scene::MixedMsaa),
-            ));
-        }
-
-        commands.spawn((
-            Mesh2d(meshes.add(Triangle2d::default())),
-            MeshMaterial2d(materials.add(Color::WHITE)),
-            Transform::from_scale(Vec3::splat(150.0)),
-            DespawnOnExit(super::Scene::MixedMsaa),
-        ));
     }
 }
 

--- a/examples/testbed/2d.rs
+++ b/examples/testbed/2d.rs
@@ -25,6 +25,7 @@ fn main() {
     let mut app = App::new();
     app.add_plugins((DefaultPlugins,))
         .add_systems(OnEnter(Scene::Shapes), shapes::setup)
+        .add_systems(OnEnter(Scene::MixedMsaa), mixed_msaa::setup)
         .add_systems(OnEnter(Scene::Bloom), bloom::setup)
         .add_systems(OnEnter(Scene::Text), text::setup)
         .add_systems(OnEnter(Scene::Sprite), sprite::setup)
@@ -54,6 +55,7 @@ fn main() {
 enum Scene {
     #[default]
     Shapes,
+    MixedMsaa,
     Bloom,
     Text,
     Sprite,
@@ -66,6 +68,7 @@ enum Scene {
 impl Scene {
     const ALL_ORDERED: &'static [Scene] = &[
         Scene::Shapes,
+        Scene::MixedMsaa,
         Scene::Bloom,
         Scene::Text,
         Scene::Sprite,
@@ -159,6 +162,37 @@ mod shapes {
                 DespawnOnExit(super::Scene::Shapes),
             ));
         }
+    }
+}
+
+mod mixed_msaa {
+    use bevy::prelude::*;
+
+    pub fn setup(
+        mut commands: Commands,
+        mut meshes: ResMut<Assets<Mesh>>,
+        mut materials: ResMut<Assets<ColorMaterial>>,
+    ) {
+        // Cameras sharing a render target must not share depth textures when their
+        // sample counts differ. Use 1 and 4 samples for WebGPU compatibility.
+        for (order, msaa) in [Msaa::Off, Msaa::Sample4].into_iter().enumerate() {
+            commands.spawn((
+                Camera2d,
+                Camera {
+                    order: order as isize,
+                    ..default()
+                },
+                msaa,
+                DespawnOnExit(super::Scene::MixedMsaa),
+            ));
+        }
+
+        commands.spawn((
+            Mesh2d(meshes.add(Triangle2d::default())),
+            MeshMaterial2d(materials.add(Color::WHITE)),
+            Transform::from_scale(Vec3::splat(150.0)),
+            DespawnOnExit(super::Scene::MixedMsaa),
+        ));
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #25501.
- Two `Camera2d` entities rendering to the same target with different `Msaa` values would incorrectly share a single depth texture. `prepare_core_2d_depth_textures` cached the depth texture keyed only by render target, so the second camera reused the first camera's depth texture - created with the first camera's sample count. This caused a sample-count mismatch between the render pass and its depth attachment (a wgpu validation error).

## Solution

- Key the depth texture cache by `(camera.target, msaa)` instead of `camera.target` alone, so each distinct MSAA sample count sharing a target gets its own depth texture.
- This mirrors the existing `prepare_core_3d_depth_textures` in `core_3d/mod.rs`, which already keys its depth texture cache the same way - 2D was simply missing the same treatment 3D already had.

## Testing

- Added a `mixed_msaa` scene to `examples/testbed/2d.rs`: two `Camera2ds` targeting the same window with `Msaa::Off` and `Msaa::Sample4` respectively. This reproduces the exact failure before the fix and passes after.
- Manually tested on RTX 4070 / Vulkan:
  - Before the fix: reproduced the validation error from the issue.
  - After the fix: ran 6 scenarios of 60 frames each, including changing MSAA on a camera at runtime.
- `cargo clippy` and `cargo fmt` are clean on the changed files.
- Not tested: other backends (DX12, Metal, WebGPU) and other platforms - the fix is backend-agnostic (it only changes a CPU-side cache key), so I don't expect platform-specific behavior, but reviewers on other platforms/backends are welcome to double-check.
- The crate has no unit tests for this system; verification is via the GPU-driven testbed scene above - reviewers can run `cargo run --example testbed_2d` and cycle to the "MixedMsaa" scene.