### PR TITLE
fix many_animated_sprites

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -292,7 +292,7 @@ pub struct Assets<A: Asset> {
     queued_events: Vec<AssetEvent<A>>,
     /// Assets managed by the `Assets` struct with live strong `Handle`s
     /// originating from `get_strong_handle`.
-    duplicate_handles: HashMap<AssetIndex, u16>,
+    duplicate_handles: HashMap<AssetIndex, u32>,
 }
 
 impl<A: Asset> Default for Assets<A> {

--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -1307,6 +1307,15 @@ where
             }),
         })
     }
+
+    fn unload_asset(
+        source_asset: AssetId<Self::SourceAsset>,
+        (_, _, _, _, bind_group_allocators, render_material_bindings, ..): &mut SystemParamItem<
+            Self::Param,
+        >,
+    ) {
+        render_material_bindings.unload_material(source_asset, bind_group_allocators);
+    }
 }
 
 /// Creates a [`Material2dPipelineSpecializer`] and uses it to specialize a

--- a/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
@@ -157,21 +157,25 @@ impl<M: Asset> SpriteMaterialCache<M> {
         get: impl FnOnce() -> M,
     ) -> Handle<M> {
         let key = SpriteMeshMaterialBucketKey::new(sprite, &anchor);
-        let bucket = self.map.entry(key).or_default();
-        let maybe_handle = bucket
-            .iter()
-            .find(|(cached_sprite, _)| cached_sprite == sprite)
-            .and_then(|(_, id)| materials.get_strong_handle(*id));
-
-        match maybe_handle {
-            Some(handle) => handle,
-            None => {
-                let handle = materials.add(get());
-                bucket.push((sprite.clone(), handle.id()));
-                self.reversed.insert(handle.id(), key);
-                handle
+        if let Some(bucket) = self.map.get(&key)
+            && let Some(&(_, id)) = bucket
+                .iter()
+                .find(|(cached_sprite, _)| cached_sprite == sprite)
+        {
+            if let Some(handle) = materials.get_strong_handle(id) {
+                return handle;
             }
+            // Dropped, but the `Removed` event hasn't arrived yet.
+            self.clean(id);
         }
+
+        let handle = materials.add(get());
+        self.map
+            .entry(key)
+            .or_default()
+            .push((sprite.clone(), handle.id()));
+        self.reversed.insert(handle.id(), key);
+        handle
     }
 }
 
@@ -300,5 +304,40 @@ mod tests {
         cache.clean(handle3.id());
         assert_eq!(cache.map.len(), 0);
         assert_eq!(cache.reversed.len(), 0);
+    }
+
+    #[test]
+    fn sprite_material_cache_replaces_dropped_entry() {
+        let mut cache = SpriteMaterialCache::<SpriteMeshMaterial>::default();
+        let mut assets = Assets::default();
+        let handle = cache.get_or_insert_with(
+            &Sprite::default(),
+            Anchor::default(),
+            &mut assets,
+            SpriteMeshMaterial::default,
+        );
+
+        assets.remove(handle.id());
+
+        let handle2 = cache.get_or_insert_with(
+            &Sprite::default(),
+            Anchor::default(),
+            &mut assets,
+            SpriteMeshMaterial::default,
+        );
+        let handle3 = cache.get_or_insert_with(
+            &Sprite::default(),
+            Anchor::default(),
+            &mut assets,
+            SpriteMeshMaterial::default,
+        );
+        assert_ne!(handle, handle2);
+        assert_eq!(handle2, handle3);
+        assert_eq!(cache.map.values().map(Vec::len).sum::<usize>(), 1);
+
+        // late `Removed` event shouldn't evict the replacement
+        cache.clean(handle.id());
+        assert_eq!(cache.map.len(), 1);
+        assert_eq!(cache.reversed.len(), 1);
     }
 }


### PR DESCRIPTION
note: this is an alternative to #25735

# Objective

- `many_animated_sprites` runs at ~1.4fps and memory grows every frame
- In debug it panics on startup (`attempt to add with overflow` in `get_strong_handle`).

## Solution

3 independent fixes:

- `Assets::duplicate_handles` was a `u16`. `SpriteMaterialCache` calls `get_strong_handle` once per changed sprite, and all 102k sprites start on texture atlas index 0, so one material gets all the handles in the first frame. The counter panics in debug and wraps in release, so once enough sprites drop their handle the counter hits zero and the material is removed while ~65k sprites are still using it. After that every changed sprite creates its own material, which is where all the time and memory go. Changing the counter to `u32` alone fixes the example.
- When a material is dropped, `add_material` doesn't see the `Removed` event until the next frame, so for one frame the cache still points at it. Any sprite that matched that material during that frame got a brand new material, one per sprite. `SpriteMaterialCache::get_or_insert_with` now drops the stale entry and reuses one replacement for all of them.
- `MeshMaterial2d<M>` had no `unload_asset`, so dropped 2D materials leaked their bindless slot. Added the same override `bevy_pbr` has.

## Testing

- `many_animated_sprites --release`: 1.4fps -> ~190fps, memory flat instead of climbing ~3MB/s.
- Added `sprite_material_cache_replaces_dropped_entry`.

---

Built by me w/ help from Claude (Fable 5.1).  Had claude run an ultracode workflow asking it to track down the performance and memory leak issues, and it found the overflow quickly and then later the other parts, testing each part along the way.  Once the fixes were settled on, I read through all the code to validate the approaches, made some minor improvements to the code, added comments, and then opened this PR