### PR TITLE
cache weak handles in SpriteMaterialCache

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -292,7 +292,7 @@ pub struct Assets<A: Asset> {
     queued_events: Vec<AssetEvent<A>>,
     /// Assets managed by the `Assets` struct with live strong `Handle`s
     /// originating from `get_strong_handle`.
-    duplicate_handles: HashMap<AssetIndex, u32>,
+    duplicate_handles: HashMap<AssetIndex, u16>,
 }
 
 impl<A: Asset> Default for Assets<A> {

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -292,7 +292,7 @@ pub struct Assets<A: Asset> {
     queued_events: Vec<AssetEvent<A>>,
     /// Assets managed by the `Assets` struct with live strong `Handle`s
     /// originating from `get_strong_handle`.
-    duplicate_handles: HashMap<AssetIndex, u16>,
+    duplicate_handles: HashMap<AssetIndex, u32>,
 }
 
 impl<A: Asset> Default for Assets<A> {

--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -1307,6 +1307,15 @@ where
             }),
         })
     }
+
+    fn unload_asset(
+        source_asset: AssetId<Self::SourceAsset>,
+        (_, _, _, _, bind_group_allocators, render_material_bindings, ..): &mut SystemParamItem<
+            Self::Param,
+        >,
+    ) {
+        render_material_bindings.unload_material(source_asset, bind_group_allocators);
+    }
 }
 
 /// Creates a [`Material2dPipelineSpecializer`] and uses it to specialize a

--- a/crates/bevy_sprite_render/src/mesh2d/material.rs
+++ b/crates/bevy_sprite_render/src/mesh2d/material.rs
@@ -1461,7 +1461,7 @@ where
 /// [`RenderMesh2dInstances`] might not be updated properly.  The easiest way to
 /// ensure that [`super::mesh::extract_2d_meshes`] re-extracts a mesh is to mark
 /// its [`Mesh2d`] as changed, so that's what this system does.
-fn mark_2d_meshes_as_changed_if_their_materials_changed<M>(
+pub fn mark_2d_meshes_as_changed_if_their_materials_changed<M>(
     mut queries: ParamSet<(
         Query<&mut Mesh2d, Or<(Changed<MeshMaterial2d<M>>, AssetChanged<MeshMaterial2d<M>>)>>,
         Query<&mut Mesh2d>,

--- a/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
@@ -144,24 +144,23 @@ fn get_or_insert_material<M: Asset>(
     let bucket = cache
         .entry(SpriteMeshMaterialBucketKey::new(sprite, &anchor))
         .or_default();
-    let slot = match bucket
+    let found = bucket
         .iter()
-        .position(|(cached_sprite, _)| cached_sprite == sprite)
-    {
-        Some(i) => &mut bucket[i].1,
-        None => {
-            bucket.push((sprite.clone(), Weak::new()));
-            &mut bucket.last_mut().unwrap().1
-        }
+        .position(|(cached_sprite, _)| cached_sprite == sprite);
+    if let Some(handle) = found.and_then(|i| bucket[i].1.upgrade()) {
+        return Handle::Strong(handle);
+    }
+
+    let handle = materials.add(get());
+    let Handle::Strong(strong) = &handle else {
+        unreachable!("`Assets::add` returns a strong handle");
     };
-    let handle = slot.upgrade().unwrap_or_else(|| {
-        let Handle::Strong(handle) = materials.add(get()) else {
-            unreachable!("`Assets::add` returns a strong handle");
-        };
-        *slot = Arc::downgrade(&handle);
-        handle
-    });
-    Handle::Strong(handle)
+    let weak = Arc::downgrade(strong);
+    match found {
+        Some(i) => bucket[i].1 = weak,
+        None => bucket.push((sprite.clone(), weak)),
+    }
+    handle
 }
 
 /// Change the material when [`Sprite`] is added / changed.
@@ -250,10 +249,6 @@ mod tests {
                 || material.clone(),
             )
         }
-
-        fn entries(&self) -> usize {
-            self.cache.values().map(Vec::len).sum()
-        }
     }
 
     #[test]
@@ -300,8 +295,8 @@ mod tests {
         let default = SpriteMeshMaterial::default();
 
         let id = fx.get(Anchor::default(), &default).id();
-        let handle = fx.get(Anchor::default(), &default);
-        assert_ne!(handle.id(), id);
-        assert_eq!(fx.entries(), 1);
+        let id2 = fx.get(Anchor::default(), &default).id();
+        assert_ne!(id, id2);
+        assert_eq!(fx.cache.values().map(Vec::len).sum::<usize>(), 1);
     }
 }

--- a/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
@@ -157,21 +157,25 @@ impl<M: Asset> SpriteMaterialCache<M> {
         get: impl FnOnce() -> M,
     ) -> Handle<M> {
         let key = SpriteMeshMaterialBucketKey::new(sprite, &anchor);
-        let bucket = self.map.entry(key).or_default();
-        let maybe_handle = bucket
-            .iter()
-            .find(|(cached_sprite, _)| cached_sprite == sprite)
-            .and_then(|(_, id)| materials.get_strong_handle(*id));
-
-        match maybe_handle {
-            Some(handle) => handle,
-            None => {
-                let handle = materials.add(get());
-                bucket.push((sprite.clone(), handle.id()));
-                self.reversed.insert(handle.id(), key);
-                handle
+        if let Some(bucket) = self.map.get(&key)
+            && let Some(&(_, id)) = bucket
+                .iter()
+                .find(|(cached_sprite, _)| cached_sprite == sprite)
+        {
+            if let Some(handle) = materials.get_strong_handle(id) {
+                return handle;
             }
+            // Dropped, but the `Removed` event hasn't arrived yet.
+            self.clean(id);
         }
+
+        let handle = materials.add(get());
+        self.map
+            .entry(key)
+            .or_default()
+            .push((sprite.clone(), handle.id()));
+        self.reversed.insert(handle.id(), key);
+        handle
     }
 }
 
@@ -300,5 +304,40 @@ mod tests {
         cache.clean(handle3.id());
         assert_eq!(cache.map.len(), 0);
         assert_eq!(cache.reversed.len(), 0);
+    }
+
+    #[test]
+    fn sprite_material_cache_replaces_dropped_entry() {
+        let mut cache = SpriteMaterialCache::<SpriteMeshMaterial>::default();
+        let mut assets = Assets::default();
+        let handle = cache.get_or_insert_with(
+            &Sprite::default(),
+            Anchor::default(),
+            &mut assets,
+            SpriteMeshMaterial::default,
+        );
+
+        assets.remove(handle.id());
+
+        let handle2 = cache.get_or_insert_with(
+            &Sprite::default(),
+            Anchor::default(),
+            &mut assets,
+            SpriteMeshMaterial::default,
+        );
+        let handle3 = cache.get_or_insert_with(
+            &Sprite::default(),
+            Anchor::default(),
+            &mut assets,
+            SpriteMeshMaterial::default,
+        );
+        assert_ne!(handle, handle2);
+        assert_eq!(handle2, handle3);
+        assert_eq!(cache.map.values().map(Vec::len).sum::<usize>(), 1);
+
+        // late `Removed` event shouldn't evict the replacement
+        cache.clean(handle.id());
+        assert_eq!(cache.map.len(), 1);
+        assert_eq!(cache.reversed.len(), 1);
     }
 }

--- a/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
@@ -1,9 +1,10 @@
+use alloc::sync::Arc;
+
 use bevy_app::{Plugin, PostUpdate};
-use bevy_asset::{Asset, AssetEvent, AssetEventSystems, AssetId, Assets, Handle};
+use bevy_asset::{Asset, AssetEventSystems, AssetId, Assets, Handle};
 use bevy_color::ColorToComponents;
 use bevy_ecs::{
     entity::Entity,
-    message::MessageReader,
     query::{Added, Changed, Or},
     schedule::IntoScheduleConfigs,
     system::{Commands, Local, Query, Res, ResMut},
@@ -17,7 +18,7 @@ use bevy_mesh::{
 };
 use bevy_shape::Rectangle;
 
-use bevy_platform::collections::{hash_map::Entry, HashMap};
+use bevy_platform::collections::HashMap;
 use bevy_shader::load_shader_library;
 use bevy_sprite::{prelude::Sprite, Anchor, SpriteAlphaMode};
 
@@ -27,7 +28,10 @@ pub use sprite_extended_material::*;
 mod sprite_mesh_material;
 pub use sprite_mesh_material::*;
 
-use crate::{check_entities_needing_specialization, MeshMaterial2d};
+use crate::{
+    check_entities_needing_specialization, mark_2d_meshes_as_changed_if_their_materials_changed,
+    MeshMaterial2d,
+};
 
 /// Plugin used to render a Sprite using a [`Mesh2d`] and a [`SpriteMaterial`]
 pub struct SpriteMeshPlugin;
@@ -45,6 +49,7 @@ impl Plugin for SpriteMeshPlugin {
             (add_mesh, add_material)
                 .chain()
                 .before(check_entities_needing_specialization::<SpriteMeshMaterial>)
+                .before(mark_2d_meshes_as_changed_if_their_materials_changed::<SpriteMeshMaterial>)
                 .before(mark_2d_meshes_as_changed_if_their_assets_changed)
                 .before(AssetEventSystems),
         );
@@ -120,63 +125,37 @@ impl SpriteMeshMaterialBucketKey {
     }
 }
 
-struct SpriteMaterialCache<M: Asset> {
-    map: HashMap<SpriteMeshMaterialBucketKey, Vec<(Sprite, AssetId<M>)>>,
-    reversed: HashMap<AssetId<M>, SpriteMeshMaterialBucketKey>,
+type SpriteMaterialCache<M> = HashMap<SpriteMeshMaterialBucketKey, Vec<(Sprite, Handle<M>)>>;
+
+fn evict_unused_materials<M: Asset>(cache: &mut SpriteMaterialCache<M>) {
+    cache.retain(|_, bucket| {
+        bucket.retain(|(_, handle)| {
+            !matches!(handle, Handle::Strong(handle) if Arc::strong_count(handle) == 1)
+        });
+        !bucket.is_empty()
+    });
 }
 
-impl<M: Asset> Default for SpriteMaterialCache<M> {
-    fn default() -> Self {
-        Self {
-            map: Default::default(),
-            reversed: Default::default(),
-        }
-    }
-}
-
-impl<M: Asset> SpriteMaterialCache<M> {
-    fn clean(&mut self, id: AssetId<M>) {
-        if let Some(key) = self.reversed.remove(&id)
-            && let Entry::Occupied(mut bucket) = self.map.entry(key)
-        {
-            bucket
-                .get_mut()
-                .retain(|(_, cached_material_id)| *cached_material_id != id);
-
-            if bucket.get().is_empty() {
-                bucket.remove();
-            }
-        }
+fn get_or_insert_material<M: Asset>(
+    cache: &mut SpriteMaterialCache<M>,
+    sprite: &Sprite,
+    anchor: Anchor,
+    materials: &mut Assets<M>,
+    get: impl FnOnce() -> M,
+) -> Handle<M> {
+    let bucket = cache
+        .entry(SpriteMeshMaterialBucketKey::new(sprite, &anchor))
+        .or_default();
+    if let Some((_, handle)) = bucket
+        .iter()
+        .find(|(cached_sprite, _)| cached_sprite == sprite)
+    {
+        return handle.clone();
     }
 
-    fn get_or_insert_with(
-        &mut self,
-        sprite: &Sprite,
-        anchor: Anchor,
-        materials: &mut Assets<M>,
-        get: impl FnOnce() -> M,
-    ) -> Handle<M> {
-        let key = SpriteMeshMaterialBucketKey::new(sprite, &anchor);
-        if let Some(bucket) = self.map.get(&key)
-            && let Some(&(_, id)) = bucket
-                .iter()
-                .find(|(cached_sprite, _)| cached_sprite == sprite)
-        {
-            if let Some(handle) = materials.get_strong_handle(id) {
-                return handle;
-            }
-            // Dropped, but the `Removed` event hasn't arrived yet.
-            self.clean(id);
-        }
-
-        let handle = materials.add(get());
-        self.map
-            .entry(key)
-            .or_default()
-            .push((sprite.clone(), handle.id()));
-        self.reversed.insert(handle.id(), key);
-        handle
-    }
+    let handle = materials.add(get());
+    bucket.push((sprite.clone(), handle.clone()));
+    handle
 }
 
 /// Change the material when [`Sprite`] is added / changed.
@@ -203,26 +182,23 @@ fn add_material(
     texture_atlas_layouts: Res<Assets<TextureAtlasLayout>>,
     mut cached_materials: Local<SpriteMaterialCache<SpriteMeshMaterial>>,
     mut materials: ResMut<Assets<SpriteMeshMaterial>>,
-    mut material_events: MessageReader<AssetEvent<SpriteMeshMaterial>>,
 ) {
-    for event in material_events.read() {
-        if let AssetEvent::Removed { id } = event {
-            cached_materials.clean(*id);
-        }
-    }
+    evict_unused_materials(&mut cached_materials);
 
     for (entity, sprite, anchor, count) in sprites {
         if count.is_some_and(|c| c.0 != 0) {
             continue;
         }
 
-        let handle = cached_materials.get_or_insert_with(sprite, *anchor, &mut materials, || {
-            make_sprite_mesh_material(&texture_atlas_layouts, sprite, *anchor)
-        });
+        let handle = get_or_insert_material(
+            &mut cached_materials,
+            sprite,
+            *anchor,
+            &mut materials,
+            || make_sprite_mesh_material(&texture_atlas_layouts, sprite, *anchor),
+        );
 
-        commands
-            .entity(entity)
-            .insert(MeshMaterial2d(handle.clone()));
+        commands.entity(entity).insert(MeshMaterial2d(handle));
     }
 }
 
@@ -248,96 +224,63 @@ fn make_sprite_mesh_material(
 mod tests {
     use super::*;
 
-    #[test]
-    fn sprite_material_cache() {
-        let mut cache = SpriteMaterialCache::<SpriteMeshMaterial>::default();
-        let mut assets = Assets::default();
-        let handle = cache.get_or_insert_with(
-            &Sprite::default(),
-            Anchor::default(),
-            &mut assets,
-            SpriteMeshMaterial::default,
-        );
-        assert_eq!(cache.map.len(), 1);
-        assert_eq!(cache.reversed.len(), 1);
-        assert_eq!(
-            assets.get(&handle).cloned(),
-            Some(SpriteMeshMaterial::default())
-        );
+    #[derive(Default)]
+    struct Fixture {
+        cache: SpriteMaterialCache<SpriteMeshMaterial>,
+        assets: Assets<SpriteMeshMaterial>,
+    }
 
-        let handle2 = cache.get_or_insert_with(
-            &Sprite::default(),
-            Anchor::default(),
-            &mut assets,
-            SpriteMeshMaterial::default,
-        );
-        assert_eq!(handle, handle2);
-        assert_eq!(cache.reversed.len(), 1);
-        assert_eq!(cache.map.len(), 1);
-
-        let mat = SpriteMeshMaterial {
-            flip_x: true,
-            ..Default::default()
-        };
-        let handle3 =
-            cache.get_or_insert_with(&Sprite::default(), Anchor::BOTTOM_LEFT, &mut assets, || {
-                mat.clone()
-            });
-        assert_eq!(cache.map.len(), 2);
-        assert_eq!(cache.map.len(), 2);
-        assert_ne!(handle, handle3);
-        assert_eq!(assets.get(&handle3).cloned(), Some(mat.clone()));
-
-        let handle4 =
-            cache.get_or_insert_with(&Sprite::default(), Anchor::BOTTOM_LEFT, &mut assets, || {
-                mat.clone()
-            });
-        assert_eq!(cache.map.len(), 2);
-        assert_eq!(cache.map.len(), 2);
-        assert_eq!(handle3, handle4);
-        assert_eq!(assets.get(&handle4).cloned(), Some(mat.clone()));
-
-        cache.clean(handle.id());
-        assert_eq!(cache.map.len(), 1);
-        assert_eq!(cache.reversed.len(), 1);
-
-        cache.clean(handle3.id());
-        assert_eq!(cache.map.len(), 0);
-        assert_eq!(cache.reversed.len(), 0);
+    impl Fixture {
+        fn get(
+            &mut self,
+            anchor: Anchor,
+            material: &SpriteMeshMaterial,
+        ) -> Handle<SpriteMeshMaterial> {
+            get_or_insert_material(
+                &mut self.cache,
+                &Sprite::default(),
+                anchor,
+                &mut self.assets,
+                || material.clone(),
+            )
+        }
     }
 
     #[test]
-    fn sprite_material_cache_replaces_dropped_entry() {
-        let mut cache = SpriteMaterialCache::<SpriteMeshMaterial>::default();
-        let mut assets = Assets::default();
-        let handle = cache.get_or_insert_with(
-            &Sprite::default(),
-            Anchor::default(),
-            &mut assets,
-            SpriteMeshMaterial::default,
-        );
+    fn sprite_material_cache() {
+        let mut fx = Fixture::default();
+        let default = SpriteMeshMaterial::default();
+        let flipped = SpriteMeshMaterial {
+            flip_x: true,
+            ..Default::default()
+        };
 
-        assets.remove(handle.id());
+        let handle = fx.get(Anchor::default(), &default);
+        assert_eq!(fx.cache.len(), 1);
+        assert_eq!(fx.assets.get(&handle), Some(&default));
 
-        let handle2 = cache.get_or_insert_with(
-            &Sprite::default(),
-            Anchor::default(),
-            &mut assets,
-            SpriteMeshMaterial::default,
-        );
-        let handle3 = cache.get_or_insert_with(
-            &Sprite::default(),
-            Anchor::default(),
-            &mut assets,
-            SpriteMeshMaterial::default,
-        );
-        assert_ne!(handle, handle2);
-        assert_eq!(handle2, handle3);
-        assert_eq!(cache.map.values().map(Vec::len).sum::<usize>(), 1);
+        let handle2 = fx.get(Anchor::default(), &default);
+        assert_eq!(handle, handle2);
+        assert_eq!(fx.cache.len(), 1);
 
-        // late `Removed` event shouldn't evict the replacement
-        cache.clean(handle.id());
-        assert_eq!(cache.map.len(), 1);
-        assert_eq!(cache.reversed.len(), 1);
+        let handle3 = fx.get(Anchor::BOTTOM_LEFT, &flipped);
+        assert_ne!(handle, handle3);
+        assert_eq!(fx.cache.len(), 2);
+        assert_eq!(fx.assets.get(&handle3), Some(&flipped));
+
+        let handle4 = fx.get(Anchor::BOTTOM_LEFT, &flipped);
+        assert_eq!(handle3, handle4);
+        assert_eq!(fx.cache.len(), 2);
+
+        evict_unused_materials(&mut fx.cache);
+        assert_eq!(fx.cache.len(), 2);
+
+        drop((handle, handle2));
+        evict_unused_materials(&mut fx.cache);
+        assert_eq!(fx.cache.len(), 1);
+
+        drop((handle3, handle4));
+        evict_unused_materials(&mut fx.cache);
+        assert_eq!(fx.cache.len(), 0);
     }
 }

--- a/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/mod.rs
@@ -1,7 +1,7 @@
-use alloc::sync::Arc;
+use alloc::sync::{Arc, Weak};
 
 use bevy_app::{Plugin, PostUpdate};
-use bevy_asset::{Asset, AssetEventSystems, AssetId, Assets, Handle};
+use bevy_asset::{Asset, AssetEventSystems, AssetId, Assets, Handle, StrongHandle};
 use bevy_color::ColorToComponents;
 use bevy_ecs::{
     entity::Entity,
@@ -125,19 +125,17 @@ impl SpriteMeshMaterialBucketKey {
     }
 }
 
-type SpriteMaterialCache<M> = HashMap<SpriteMeshMaterialBucketKey, Vec<(Sprite, Handle<M>)>>;
+type SpriteMaterialCache = HashMap<SpriteMeshMaterialBucketKey, Vec<(Sprite, Weak<StrongHandle>)>>;
 
-fn evict_unused_materials<M: Asset>(cache: &mut SpriteMaterialCache<M>) {
+fn evict_unused_materials(cache: &mut SpriteMaterialCache) {
     cache.retain(|_, bucket| {
-        bucket.retain(|(_, handle)| {
-            !matches!(handle, Handle::Strong(handle) if Arc::strong_count(handle) == 1)
-        });
+        bucket.retain(|(_, handle)| handle.upgrade().is_some());
         !bucket.is_empty()
     });
 }
 
 fn get_or_insert_material<M: Asset>(
-    cache: &mut SpriteMaterialCache<M>,
+    cache: &mut SpriteMaterialCache,
     sprite: &Sprite,
     anchor: Anchor,
     materials: &mut Assets<M>,
@@ -146,16 +144,24 @@ fn get_or_insert_material<M: Asset>(
     let bucket = cache
         .entry(SpriteMeshMaterialBucketKey::new(sprite, &anchor))
         .or_default();
-    if let Some((_, handle)) = bucket
+    let slot = match bucket
         .iter()
-        .find(|(cached_sprite, _)| cached_sprite == sprite)
+        .position(|(cached_sprite, _)| cached_sprite == sprite)
     {
-        return handle.clone();
-    }
-
-    let handle = materials.add(get());
-    bucket.push((sprite.clone(), handle.clone()));
-    handle
+        Some(i) => &mut bucket[i].1,
+        None => {
+            bucket.push((sprite.clone(), Weak::new()));
+            &mut bucket.last_mut().unwrap().1
+        }
+    };
+    let handle = slot.upgrade().unwrap_or_else(|| {
+        let Handle::Strong(handle) = materials.add(get()) else {
+            unreachable!("`Assets::add` returns a strong handle");
+        };
+        *slot = Arc::downgrade(&handle);
+        handle
+    });
+    Handle::Strong(handle)
 }
 
 /// Change the material when [`Sprite`] is added / changed.
@@ -180,7 +186,7 @@ fn add_material(
         )>,
     >,
     texture_atlas_layouts: Res<Assets<TextureAtlasLayout>>,
-    mut cached_materials: Local<SpriteMaterialCache<SpriteMeshMaterial>>,
+    mut cached_materials: Local<SpriteMaterialCache>,
     mut materials: ResMut<Assets<SpriteMeshMaterial>>,
 ) {
     evict_unused_materials(&mut cached_materials);
@@ -226,7 +232,7 @@ mod tests {
 
     #[derive(Default)]
     struct Fixture {
-        cache: SpriteMaterialCache<SpriteMeshMaterial>,
+        cache: SpriteMaterialCache,
         assets: Assets<SpriteMeshMaterial>,
     }
 
@@ -243,6 +249,10 @@ mod tests {
                 &mut self.assets,
                 || material.clone(),
             )
+        }
+
+        fn entries(&self) -> usize {
+            self.cache.values().map(Vec::len).sum()
         }
     }
 
@@ -282,5 +292,16 @@ mod tests {
         drop((handle3, handle4));
         evict_unused_materials(&mut fx.cache);
         assert_eq!(fx.cache.len(), 0);
+    }
+
+    #[test]
+    fn sprite_material_cache_replaces_dropped_material() {
+        let mut fx = Fixture::default();
+        let default = SpriteMeshMaterial::default();
+
+        let id = fx.get(Anchor::default(), &default).id();
+        let handle = fx.get(Anchor::default(), &default);
+        assert_ne!(handle.id(), id);
+        assert_eq!(fx.entries(), 1);
     }
 }

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_extended_material.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_extended_material.rs
@@ -1,7 +1,7 @@
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_asset::{
-    asset_changed::AssetChanged, AsAssetId, Asset, AssetApp, AssetEvent, AssetEventSystems,
-    AssetId, Assets, Handle,
+    asset_changed::AssetChanged, AsAssetId, Asset, AssetApp, AssetEventSystems, AssetId, Assets,
+    Handle,
 };
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
@@ -32,8 +32,9 @@ use bevy_sprite::{Anchor, Sprite};
 use core::hash::Hash;
 
 use crate::{
-    check_entities_needing_specialization, AlphaMode2d, ExtendedMaterial2d, Material2dKey,
-    Material2dPlugin, MaterialExtension2d, MeshMaterial2d, SpriteMeshMaterial,
+    check_entities_needing_specialization, mark_2d_meshes_as_changed_if_their_materials_changed,
+    AlphaMode2d, ExtendedMaterial2d, Material2dKey, Material2dPlugin, MaterialExtension2d,
+    MeshMaterial2d, SpriteMeshMaterial,
 };
 
 /// Adds the necessary systems and resources for a [`SpriteMaterial`] of type `M`.
@@ -62,15 +63,12 @@ where
                 PostUpdate,
                 add_material::<M>
                     .before(check_entities_needing_specialization::<SpriteExt<M>>)
+                    .before(mark_2d_meshes_as_changed_if_their_materials_changed::<SpriteExt<M>>)
                     .before(AssetEventSystems),
             )
             .add_systems(
                 PostUpdate,
-                (
-                    update_changed_material_extensions::<M>,
-                    clean_sprite_material_cache::<M>,
-                )
-                    .after(AssetEventSystems),
+                update_changed_material_extensions::<M>.after(AssetEventSystems),
             );
     }
 }
@@ -106,20 +104,26 @@ fn add_material<M>(
     M: Asset + MaterialExtension2d,
     M::Data: Clone,
 {
+    cache.retain(|_, inner| {
+        super::evict_unused_materials(inner);
+        !inner.is_empty()
+    });
+
     for (entity, sprite, anchor, sprite_material) in sprites {
         let Some(instance) = sprite_materials.get(&sprite_material.0) else {
             continue;
         };
 
         let sprite_cache = cache.entry(sprite_material.id()).or_default();
-        let handle = sprite_cache.get_or_insert_with(sprite, *anchor, &mut materials, || {
-            let material =
-                super::make_sprite_mesh_material(&texture_atlas_layouts, sprite, *anchor);
-            ExtendedMaterial2d {
-                base: material,
-                extension: SpriteMaterialExtension::new(sprite_material.id(), instance),
-            }
-        });
+        let handle =
+            super::get_or_insert_material(sprite_cache, sprite, *anchor, &mut materials, || {
+                let material =
+                    super::make_sprite_mesh_material(&texture_atlas_layouts, sprite, *anchor);
+                ExtendedMaterial2d {
+                    base: material,
+                    extension: SpriteMaterialExtension::new(sprite_material.id(), instance),
+                }
+            });
 
         commands
             .entity(entity)
@@ -443,31 +447,6 @@ where
 {
     fn default() -> Self {
         Self(Default::default())
-    }
-}
-
-fn clean_sprite_material_cache<M>(
-    mut cache: ResMut<SpriteMaterialCache<M>>,
-    mut asset_events: MessageReader<AssetEvent<M>>,
-    mut ext_events: MessageReader<AssetEvent<SpriteExt<M>>>,
-) where
-    M::Data: Clone,
-    M: Asset + MaterialExtension2d,
-{
-    for message in asset_events.read() {
-        if let AssetEvent::Removed { id } = *message {
-            cache.remove(&id);
-        }
-    }
-
-    for event in ext_events.read() {
-        let AssetEvent::Removed { id } = *event else {
-            continue;
-        };
-
-        for el in cache.values_mut() {
-            el.clean(id);
-        }
     }
 }
 

--- a/crates/bevy_sprite_render/src/sprite_mesh/sprite_extended_material.rs
+++ b/crates/bevy_sprite_render/src/sprite_mesh/sprite_extended_material.rs
@@ -435,7 +435,7 @@ where
 
 /// Keeps an index of cached `SpriteExt` handles based on the [`Sprite`], [`Anchor`], and the asset id of the material
 #[derive(Resource, Deref, DerefMut)]
-struct SpriteMaterialCache<M>(HashMap<AssetId<M>, super::SpriteMaterialCache<SpriteExt<M>>>)
+struct SpriteMaterialCache<M>(HashMap<AssetId<M>, super::SpriteMaterialCache>)
 where
     M::Data: Clone,
     M: Asset + MaterialExtension2d;


### PR DESCRIPTION
# Objective

- Improve performance of sprites that change often. Forked off from #25734
- fix many_animated_sprites bad fps and memory leak

## Solution

- The cache keeps a weak handle per material and upgrades it on lookup, so a changed sprite is an `Arc` bump instead of a new handle + drop event + `duplicate_handles` update. If the upgrade fails the material is gone and gets recreated, so the cache doesn't need to watch `AssetEvent::Removed` anymore (which showed up a frame late anyway).
- A material swap was also marking the mesh changed a frame late. `add_material` now runs before `mark_2d_meshes_as_changed_if_their_materials_changed`
- `MeshMaterial2d<M>` had no `unload_asset`, so dropped 2D materials leaked their bindless slot. Added the same override `bevy_pbr` has.

## Testing
- `many_animated_sprites --release`: ~1.4fps -> ~340fps. w/ memory flat

---

Built by me w/ help from Claude (Fable 5.1). This came out of the follow-ups Claude suggested while working on #25734. Had it build the change, measure it, and run a couple of cleanup passes over the result, then I read through the code to validate the approach before opening this PR.
