### PR TITLE
Fix duplicated log output on Android

### DIFF
--- a/crates/bevy_log/src/android_tracing.rs
+++ b/crates/bevy_log/src/android_tracing.rs
@@ -10,15 +10,28 @@ use tracing_subscriber::{field::Visit, layer::Context, registry::LookupSpan, Lay
 #[derive(Default)]
 pub(crate) struct AndroidLayer;
 
-struct StringRecorder(String, bool);
+/// Accumulates the fields of a span or event into a single string for the
+/// Android log output.
+///
+/// The first element holds the recorded message and fields. The second element
+/// holds the value of the synthesized `log.target` field, if present (see
+/// `record_debug`).
+struct StringRecorder(String, Option<String>);
 impl StringRecorder {
     fn new() -> Self {
-        StringRecorder(String::new(), false)
+        StringRecorder(String::new(), None)
     }
 }
 
 impl Visit for StringRecorder {
     fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+        // `tracing-log` emits events forwarded from the `log` crate with a fixed
+        // metadata target of "log"; the record's real target is only available in
+        // the synthesized `log.target` field. Capture it so it can be used as the
+        // logcat tag.
+        if field.name() == "log.target" {
+            self.1 = Some(format!("{:?}", value).trim_matches('"').to_owned());
+        }
         if field.name() == "message" {
             if !self.0.is_empty() {
                 self.0 = format!("{:?}\n{}", value, self.0)
@@ -26,12 +39,10 @@ impl Visit for StringRecorder {
                 self.0 = format!("{:?}", value)
             }
         } else {
-            if self.1 {
-                // following args
+            // Separate fields from anything already recorded (e.g. the message),
+            // so that the first field does not get glued to it.
+            if !self.0.is_empty() {
                 write!(self.0, " ").unwrap();
-            } else {
-                // first arg
-                self.1 = true;
             }
             write!(self.0, "{} = {:?};", field.name(), value).unwrap();
         }
@@ -86,12 +97,18 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for AndroidLayer {
             Level::WARN => android_log_sys::LogPriority::WARN,
             Level::ERROR => android_log_sys::LogPriority::ERROR,
         };
+        // Use the record's target as the logcat tag so that logs are grouped by the
+        // crate or module that emitted them. Prefer the target captured from the
+        // synthesized `log.target` field, because `tracing-log` emits events forwarded
+        // from the `log` crate with a fixed metadata target of "log". The event name
+        // would be useless as a tag too: it is "log event" for all bridged records.
+        let tag = recorder.1.as_deref().unwrap_or(meta.target());
         // SAFETY: Called only on Android platforms. priority is guaranteed to be in range of c_int.
         // The provided tag and message are null terminated properly.
         unsafe {
             android_log_sys::__android_log_write(
                 priority as android_log_sys::c_int,
-                sanitize(meta.name()).as_ptr(),
+                sanitize(tag).as_ptr(),
                 sanitize(&recorder.0).as_ptr(),
             );
         }

--- a/crates/bevy_log/src/android_tracing.rs
+++ b/crates/bevy_log/src/android_tracing.rs
@@ -15,7 +15,7 @@ pub(crate) struct AndroidLayer;
 ///
 /// The first element holds the recorded message and fields. The second element
 /// holds the value of the synthesized `log.target` field, if present (see
-/// `record_debug`).
+/// `record_str`).
 struct StringRecorder(String, Option<String>);
 impl StringRecorder {
     fn new() -> Self {
@@ -24,14 +24,19 @@ impl StringRecorder {
 }
 
 impl Visit for StringRecorder {
-    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+    fn record_str(&mut self, field: &Field, value: &str) {
         // `tracing-log` emits events forwarded from the `log` crate with a fixed
         // metadata target of "log"; the record's real target is only available in
         // the synthesized `log.target` field. Capture it so it can be used as the
-        // logcat tag.
+        // logcat tag. `str` values are dispatched to `record_str`, so this captures
+        // the target exactly as-is.
         if field.name() == "log.target" {
-            self.1 = Some(format!("{:?}", value).trim_matches('"').to_owned());
+            self.1 = Some(value.to_owned());
         }
+        self.record_debug(field, &value);
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
         if field.name() == "message" {
             if !self.0.is_empty() {
                 self.0 = format!("{:?}\n{}", value, self.0)

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -247,14 +247,11 @@ pub struct LogPlugin {
     ///
     /// Please see the `examples/app/log_layers.rs` for a complete example.
     ///
-    /// Note: the behavior of this hook differs by platform:
-    /// - On desktop platforms, returning `None` installs the default
-    ///   [`tracing_subscriber::fmt::Layer`], which writes to `stderr`.
-    /// - On Android, returning `None` installs no formatter layer: logs are written to logcat
-    ///   by `LogPlugin` itself. A layer returned from this hook is still added.
-    /// - On iOS and Wasm, the hook is not called at all: those platforms write logs through
-    ///   their own layers (`tracing-oslog` / `tracing-wasm`), so a layer returned from this
-    ///   hook would be ignored.
+    /// Note: this hook is only used on desktop platforms. On Android, iOS and Wasm,
+    /// `LogPlugin` writes logs directly to the platform's native logging system (logcat,
+    /// the unified logging system, the browser console) and does not call this hook; use
+    /// [`custom_layer`](Self::custom_layer) if you need an additional layer on those
+    /// platforms.
     pub fmt_layer: fn(app: &mut App) -> Option<BoxedFmtLayer>,
 
     /// Whether to stream events to the Tracy profiler or collector. Only enable
@@ -369,17 +366,13 @@ impl Plugin for LogPlugin {
                 None
             };
 
-            let fmt_layer = (self.fmt_layer)(app);
-
-            // On Android the default formatter layer is not installed when no custom
-            // layer is provided (`None` simply passes through: `Option` implements
-            // `Layer`, so it contributes nothing). Every log event is already written
-            // to the Android logging system (logcat) by `AndroidLayer` below, and
-            // `stderr` is separately forwarded to logcat by the Android activity glue,
-            // so writing to stderr too would duplicate every log line in logcat (with
-            // ANSI escape codes and under the `RustStdoutStderr` tag).
+            // The formatter layer hook is not used on Android, mirroring the iOS and Wasm
+            // behavior: logs are written to the Android logging system (logcat) by
+            // `AndroidLayer` below, and `stderr` is separately forwarded to logcat by the
+            // Android activity glue, so a formatter layer writing to stderr would
+            // duplicate every log line.
             #[cfg(not(target_os = "android"))]
-            let fmt_layer = fmt_layer.unwrap_or_else(|| {
+            let fmt_layer = (self.fmt_layer)(app).unwrap_or_else(|| {
                 // note: the implementation of `Default` reads from the env var NO_COLOR
                 // to decide whether to use ANSI color codes, which is common convention
                 // https://no-color.org/
@@ -388,12 +381,13 @@ impl Plugin for LogPlugin {
 
             // bevy_render::renderer logs a `tracy.frame_mark` event every frame
             // at Level::INFO. Formatted logs should omit it.
-            #[cfg(feature = "tracing-tracy")]
+            #[cfg(all(feature = "tracing-tracy", not(target_os = "android")))]
             let fmt_layer =
                 fmt_layer.with_filter(tracing_subscriber::filter::FilterFn::new(|meta| {
                     meta.fields().field("tracy.frame_mark").is_none()
                 }));
 
+            #[cfg(not(target_os = "android"))]
             let subscriber = subscriber.with(fmt_layer);
 
             #[cfg(all(feature = "tracing-chrome", not(target_os = "android")))]

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -246,6 +246,13 @@ pub struct LogPlugin {
     /// timestamp from the log output.
     ///
     /// Please see the `examples/app/log_layers.rs` for a complete example.
+    ///
+    /// Note: on iOS this hook is not called at all, because no formatter layer is used
+    /// there (logs are written to the unified logging system by `tracing-oslog`). On
+    /// Android the hook is called, but no default formatter layer is installed when it
+    /// returns `None`: `LogPlugin` already writes every log event to the Android logging
+    /// system (logcat), and the Android activity glue separately forwards `stderr` to
+    /// logcat, so the default `stderr` writer would duplicate every log line.
     pub fmt_layer: fn(app: &mut App) -> Option<BoxedFmtLayer>,
 
     /// Whether to stream events to the Tracy profiler or collector. Only enable
@@ -360,7 +367,17 @@ impl Plugin for LogPlugin {
                 None
             };
 
-            let fmt_layer = (self.fmt_layer)(app).unwrap_or_else(|| {
+            let fmt_layer = (self.fmt_layer)(app);
+
+            // On Android the default formatter layer is not installed when no custom
+            // layer is provided (`None` simply passes through: `Option` implements
+            // `Layer`, so it contributes nothing). Every log event is already written
+            // to the Android logging system (logcat) by `AndroidLayer` below, and
+            // `stderr` is separately forwarded to logcat by the Android activity glue,
+            // so writing to stderr too would duplicate every log line in logcat (with
+            // ANSI escape codes and under the `RustStdoutStderr` tag).
+            #[cfg(not(target_os = "android"))]
+            let fmt_layer = fmt_layer.unwrap_or_else(|| {
                 // note: the implementation of `Default` reads from the env var NO_COLOR
                 // to decide whether to use ANSI color codes, which is common convention
                 // https://no-color.org/

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -247,12 +247,11 @@ pub struct LogPlugin {
     ///
     /// Please see the `examples/app/log_layers.rs` for a complete example.
     ///
-    /// Note: on iOS this hook is not called at all, because no formatter layer is used
-    /// there (logs are written to the unified logging system by `tracing-oslog`). On
-    /// Android the hook is called, but no default formatter layer is installed when it
-    /// returns `None`: `LogPlugin` already writes every log event to the Android logging
-    /// system (logcat), and the Android activity glue separately forwards `stderr` to
-    /// logcat, so the default `stderr` writer would duplicate every log line.
+    /// Note: on some platforms logs are written to the platform's native logging system
+    /// (e.g. logcat on Android, the unified logging system on iOS) rather than through a
+    /// formatter layer; on those platforms no default formatter layer is installed when
+    /// this hook returns `None` (on iOS the hook isn't called at all), while a layer
+    /// returned from this hook is still used.
     pub fmt_layer: fn(app: &mut App) -> Option<BoxedFmtLayer>,
 
     /// Whether to stream events to the Tracy profiler or collector. Only enable

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -247,11 +247,14 @@ pub struct LogPlugin {
     ///
     /// Please see the `examples/app/log_layers.rs` for a complete example.
     ///
-    /// Note: on some platforms logs are written to the platform's native logging system
-    /// (e.g. logcat on Android, the unified logging system on iOS) rather than through a
-    /// formatter layer; on those platforms no default formatter layer is installed when
-    /// this hook returns `None` (on iOS the hook isn't called at all), while a layer
-    /// returned from this hook is still used.
+    /// Note: the behavior of this hook differs by platform:
+    /// - On desktop platforms, returning `None` installs the default
+    ///   [`tracing_subscriber::fmt::Layer`], which writes to `stderr`.
+    /// - On Android, returning `None` installs no formatter layer: logs are written to logcat
+    ///   by `LogPlugin` itself. A layer returned from this hook is still added.
+    /// - On iOS and Wasm, the hook is not called at all: those platforms write logs through
+    ///   their own layers (`tracing-oslog` / `tracing-wasm`), so a layer returned from this
+    ///   hook would be ignored.
     pub fmt_layer: fn(app: &mut App) -> Option<BoxedFmtLayer>,
 
     /// Whether to stream events to the Tracy profiler or collector. Only enable


### PR DESCRIPTION
# Objective

The default formatter layer writes to stderr, which the Android activity glue forwards to logcat under the `RustStdoutStderr` tag, while `AndroidLayer` simultaneously wrote every event to logcat directly, so each log line showed up twice on Android.

## Solution

Don't install the default formatter layer on Android (`fmt_layer` is ignored), mirroring the existing iOS and Wasm behavior.

Also make `AndroidLayer` use the record's target as the logcat tag instead of the event name. For records forwarded from the `log` crate, `tracing-log` fixes the event's metadata target to "log" and only carries the record's real target in the synthesized `log.target` field, so that field is preferred when present.

Additionally, always separate recorded fields from the message with a space so that they don't get glued to it.

## Testing

Run android example.

Before:
```
2026-09-10 03:47:53.164 18548-18575 RustStdoutStderr        org.bevyengine.example               I  [2m2026-09-09T19:47:53.164794Z[0m [34mDEBUG[0m [2mbevy_app::plugin_group[0m[2m:[0m added plugin: bevy_app::task_pool_plugin::TaskPoolPlugin
2026-09-10 03:47:53.164 18548-18576 log event               org.bevyengine.example               D  added plugin: bevy_app::task_pool_plugin::TaskPoolPluginlog.target = "bevy_app::plugin_group"; log.module_path = "bevy_app::plugin_group"; log.file = "examples/mobile/src/lib.rs"; log.line = 22;
2026-09-10 03:47:53.165 18548-18575 RustStdoutStderr        org.bevyengine.example               I  [2m2026-09-09T19:47:53.164990Z[0m [34mDEBUG[0m [2mbevy_app::app[0m[2m:[0m added plugin: bevy_app::task_pool_plugin::TaskPoolPlugin
2026-09-10 03:47:53.165 18548-18576 log event               org.bevyengine.example               D  added plugin: bevy_app::task_pool_plugin::TaskPoolPluginlog.target = "bevy_app::app"; log.module_path = "bevy_app::app"; log.file = "crates/bevy_app/src/app.rs"; log.line = 528;
2026-09-10 03:47:53.166 18548-18575 RustStdoutStderr        org.bevyengine.example               I  [2m2026-09-09T19:47:53.166266Z[0m [34mDEBUG[0m [2mbevy_app::plugin_group[0m[2m:[0m added plugin: bevy_diagnostic::frame_count::FrameCountPlugin
2026-09-10 03:47:53.166 18548-18576 log event               org.bevyengine.example               D  added plugin: bevy_diagnostic::frame_count::FrameCountPluginlog.target = "bevy_app::plugin_group"; log.module_path = "bevy_app::plugin_group"; log.file = "examples/mobile/src/lib.rs"; log.line = 22;
2026-09-10 03:47:53.166 18548-18575 RustStdoutStderr        org.bevyengine.example               I  [2m2026-09-09T19:47:53.166361Z[0m [34mDEBUG[0m [2mbevy_app::app[0m[2m:[0m added plugin: bevy_diagnostic::frame_count::FrameCountPlugin
2026-09-10 03:47:53.166 18548-18576 log event               org.bevyengine.example               D  added plugin: bevy_diagnostic::frame_count::FrameCountPluginlog.target = "bevy_app::app"; log.module_path = "bevy_app::app"; log.file = "crates/bevy_app/src/app.rs"; log.line = 528;
```

After:
```
2026-09-10 03:42:37.654 17458-17488 bevy_app::plugin_group  org.bevyengine.example               D  added plugin: bevy_app::task_pool_plugin::TaskPoolPlugin log.target = "bevy_app::plugin_group"; log.module_path = "bevy_app::plugin_group"; log.file = "examples/mobile/src/lib.rs"; log.line = 22;
2026-09-10 03:42:37.654 17458-17488 bevy_app::app           org.bevyengine.example               D  added plugin: bevy_app::task_pool_plugin::TaskPoolPlugin log.target = "bevy_app::app"; log.module_path = "bevy_app::app"; log.file = "crates/bevy_app/src/app.rs"; log.line = 528;
2026-09-10 03:42:37.655 17458-17488 bevy_app::plugin_group  org.bevyengine.example               D  added plugin: bevy_diagnostic::frame_count::FrameCountPlugin log.target = "bevy_app::plugin_group"; log.module_path = "bevy_app::plugin_group"; log.file = "examples/mobile/src/lib.rs"; log.line = 22;
2026-09-10 03:42:37.655 17458-17488 bevy_app::app           org.bevyengine.example               D  added plugin: bevy_diagnostic::frame_count::FrameCountPlugin log.target = "bevy_app::app"; log.module_path = "bevy_app::app"; log.file = "crates/bevy_app/src/app.rs"; log.line = 528;
```