### PR TITLE
Fix mismatched morph pipeline key/bind group when MeshMorphWeights is missing (#21655)

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -918,6 +918,7 @@ pub fn check_entities_needing_specialization<M>(
                 AssetChanged<Mesh3d>,
                 Changed<MeshMaterial3d<M>>,
                 AssetChanged<MeshMaterial3d<M>>,
+                Added<bevy_mesh::morph::MeshMorphWeights>,
             )>,
             With<MeshMaterial3d<M>>,
         ),
@@ -926,6 +927,8 @@ pub fn check_entities_needing_specialization<M>(
     mut entities_needing_specialization: ResMut<EntitiesNeedingSpecialization<M>>,
     mut removed_mesh_3d_components: RemovedComponents<Mesh3d>,
     mut removed_mesh_material_3d_components: RemovedComponents<MeshMaterial3d<M>>,
+    mut removed_morph_weights: RemovedComponents<bevy_mesh::morph::MeshMorphWeights>,
+    material_meshes: Query<(), (With<Mesh3d>, With<MeshMaterial3d<M>>)>,
 ) where
     M: Material,
 {
@@ -937,6 +940,13 @@ pub fn check_entities_needing_specialization<M>(
         .par_iter()
         .for_each(|entity| par_local.borrow_local_mut().push(entity));
     par_local.drain_into(&mut entities_needing_specialization.changed);
+
+    // Changing weights does not change the pipeline, but removing the component does.
+    entities_needing_specialization.changed.extend(
+        removed_morph_weights
+            .read()
+            .filter(|entity| material_meshes.contains(*entity)),
+    );
 
     // All entities that removed their `Mesh3d` or `MeshMaterial3d` components
     // need to have their specializations removed as well.
@@ -972,6 +982,7 @@ pub struct PendingMeshMaterialQueues(pub PendingQueues);
 
 #[derive(SystemParam)]
 pub(crate) struct SpecializeMaterialMeshesSystemParam<'w, 's> {
+    morph_indices: Res<'w, MorphIndices>,
     render_meshes: Res<'w, RenderAssets<RenderMesh>>,
     render_materials: Res<'w, ErasedRenderAssets<PreparedMaterial>>,
     render_mesh_instances: Res<'w, RenderMeshInstances>,
@@ -1000,6 +1011,7 @@ pub(crate) fn specialize_material_meshes(
 
     {
         let SpecializeMaterialMeshesSystemParam {
+            morph_indices,
             render_meshes,
             render_materials,
             render_mesh_instances,
@@ -1111,7 +1123,10 @@ pub(crate) fn specialize_material_meshes(
                     &Msaa::from_samples(view_key.msaa_samples()),
                 ));
                 let mut mesh_key = *view_key
-                    | MeshPipelineKey::from_bits_retain(mesh.key_bits.bits())
+                    | morph_indices.mesh_key(
+                        *visible_entity,
+                        MeshPipelineKey::from_bits_retain(mesh.key_bits.bits()),
+                    )
                     | mesh_pipeline_key_bits;
 
                 if let Some(lightmap) = render_lightmaps.render_lightmaps.get(visible_entity) {
@@ -1834,5 +1849,68 @@ impl MaterialPropertiesExt for MaterialProperties {
         // So we have to disable the optimization for depth only prepass and always bind the material's bind group.
         self.get_shader(PrepassVertexShader).is_some()
             || self.get_shader(PrepassFragmentShader).is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bevy_mesh::morph::MeshMorphWeights;
+
+    #[test]
+    fn morph_component_changes_require_specialization_but_weight_updates_do_not() {
+        let mut world = World::new();
+        world.init_resource::<EntitiesNeedingSpecialization<StandardMaterial>>();
+        let entity = world
+            .spawn((
+                Mesh3d::default(),
+                MeshMaterial3d::<StandardMaterial>::default(),
+            ))
+            .id();
+        let mut schedule = Schedule::default();
+        schedule.add_systems(check_entities_needing_specialization::<StandardMaterial>);
+        schedule.run(&mut world);
+        schedule.run(&mut world);
+        assert!(world
+            .resource::<EntitiesNeedingSpecialization<StandardMaterial>>()
+            .changed
+            .is_empty());
+
+        world
+            .entity_mut(entity)
+            .insert(MeshMorphWeights::Value { weights: vec![0.0] });
+        schedule.run(&mut world);
+        assert_eq!(
+            world
+                .resource::<EntitiesNeedingSpecialization<StandardMaterial>>()
+                .changed,
+            vec![entity]
+        );
+
+        *world.get_mut::<MeshMorphWeights>(entity).unwrap() =
+            MeshMorphWeights::Value { weights: vec![0.5] };
+        schedule.run(&mut world);
+        assert!(world
+            .resource::<EntitiesNeedingSpecialization<StandardMaterial>>()
+            .changed
+            .is_empty());
+
+        world.entity_mut(entity).remove::<MeshMorphWeights>();
+        schedule.run(&mut world);
+        assert_eq!(
+            world
+                .resource::<EntitiesNeedingSpecialization<StandardMaterial>>()
+                .changed,
+            vec![entity]
+        );
+
+        world
+            .entity_mut(entity)
+            .insert(MeshMorphWeights::Value { weights: vec![1.0] });
+        schedule.run(&mut world);
+        assert!(world
+            .resource::<EntitiesNeedingSpecialization<StandardMaterial>>()
+            .changed
+            .contains(&entity));
     }
 }

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -970,6 +970,7 @@ pub struct PendingPrepassMeshMaterialQueues(pub PendingQueues);
 
 #[derive(SystemParam)]
 pub(crate) struct SpecializePrepassSystemParam<'w, 's> {
+    morph_indices: Res<'w, crate::MorphIndices>,
     render_meshes: Res<'w, RenderAssets<RenderMesh>>,
     render_materials: Res<'w, ErasedRenderAssets<PreparedMaterial>>,
     render_mesh_instances: Res<'w, RenderMeshInstances>,
@@ -1014,6 +1015,7 @@ pub(crate) fn specialize_prepass_material_meshes(
 
     {
         let SpecializePrepassSystemParam {
+            morph_indices,
             render_meshes,
             render_materials,
             render_mesh_instances,
@@ -1132,8 +1134,11 @@ pub(crate) fn specialize_prepass_material_meshes(
                     continue;
                 };
 
-                let mut mesh_key =
-                    *view_key | MeshPipelineKey::from_bits_retain(mesh.key_bits.bits());
+                let mut mesh_key = *view_key
+                    | morph_indices.mesh_key(
+                        *visible_entity,
+                        MeshPipelineKey::from_bits_retain(mesh.key_bits.bits()),
+                    );
 
                 let alpha_mode = material.properties.alpha_mode;
                 match alpha_mode {

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -2422,6 +2422,7 @@ pub struct PendingShadowQueues(pub PendingQueues);
 
 #[derive(SystemParam)]
 pub(crate) struct SpecializeShadowsSystemParam<'w, 's> {
+    morph_indices: Res<'w, MorphIndices>,
     render_meshes: Res<'w, RenderAssets<RenderMesh>>,
     render_mesh_instances: Res<'w, RenderMeshInstances>,
     render_materials: Res<'w, ErasedRenderAssets<PreparedMaterial>>,
@@ -2447,6 +2448,7 @@ pub(crate) fn specialize_shadows(
 
     {
         let SpecializeShadowsSystemParam {
+            morph_indices,
             render_meshes,
             render_mesh_instances,
             render_materials,
@@ -2565,8 +2567,11 @@ pub(crate) fn specialize_shadows(
                     continue;
                 };
 
-                let mut mesh_key =
-                    *light_key | MeshPipelineKey::from_bits_retain(mesh.key_bits.bits());
+                let mut mesh_key = *light_key
+                    | morph_indices.mesh_key(
+                        *visible_entity,
+                        MeshPipelineKey::from_bits_retain(mesh.key_bits.bits()),
+                    );
 
                 // Even though we don't use the lightmap in the shadow map, the
                 // `SetMeshBindGroup` render command will bind the data for it. So

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1965,6 +1965,7 @@ pub fn extract_meshes_for_gpu_building(
                 )>,
                 Changed<VisibilityRange>,
                 Changed<SkinnedMesh>,
+                Added<bevy_mesh::morph::MeshMorphWeights>,
             )>,
         >,
     >,
@@ -1981,6 +1982,7 @@ pub fn extract_meshes_for_gpu_building(
         mut removed_no_cpu_culling_query,
         mut removed_visibility_range_query,
         mut removed_skinned_mesh_query,
+        mut removed_morph_weights_query,
     ): (
         Extract<RemovedComponents<PreviousGlobalTransform>>,
         Extract<RemovedComponents<Lightmap>>,
@@ -1994,6 +1996,7 @@ pub fn extract_meshes_for_gpu_building(
         Extract<RemovedComponents<NoCpuCulling>>,
         Extract<RemovedComponents<VisibilityRange>>,
         Extract<RemovedComponents<SkinnedMesh>>,
+        Extract<RemovedComponents<bevy_mesh::morph::MeshMorphWeights>>,
     ),
     all_meshes_query: Extract<Query<GpuMeshExtractionQuery>>,
     mut removed_meshes_query: Extract<RemovedComponents<Mesh3d>>,
@@ -2033,7 +2036,8 @@ pub fn extract_meshes_for_gpu_building(
             .chain(removed_no_automatic_batching_query.read())
             .chain(removed_no_cpu_culling_query.read())
             .chain(removed_visibility_range_query.read())
-            .chain(removed_skinned_mesh_query.read()),
+            .chain(removed_skinned_mesh_query.read())
+            .chain(removed_morph_weights_query.read()),
     );
 
     // We have to skip the meshes in the potential reextraction set if we
@@ -4520,13 +4524,15 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMeshBindGroup<I> {
             MorphIndices::Storage { .. } => {
                 current_morph_index = None;
                 prev_morph_index = None;
-                morph_bind_group_key =
-                    match mesh_slabs.and_then(|mesh_slabs| mesh_slabs.morph_target_slab_id) {
-                        Some(morph_target_slab_id) => {
-                            MeshMorphBindGroupKey::Storage((metadata_slab_id, morph_target_slab_id))
-                        }
-                        None => MeshMorphBindGroupKey::NoMorphTargets,
-                    };
+                morph_bind_group_key = match mesh_slabs
+                    .filter(|_| morph_indices.contains(*entity))
+                    .and_then(|mesh_slabs| mesh_slabs.morph_target_slab_id)
+                {
+                    Some(morph_target_slab_id) => {
+                        MeshMorphBindGroupKey::Storage((metadata_slab_id, morph_target_slab_id))
+                    }
+                    None => MeshMorphBindGroupKey::NoMorphTargets,
+                };
             }
         };
 

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -152,6 +152,28 @@ impl MorphUniforms {
 }
 
 impl MorphIndices {
+    /// Returns whether the entity has extracted morph weights for the current frame.
+    pub(crate) fn contains(&self, entity: MainEntity) -> bool {
+        match self {
+            Self::Uniform { current, .. } => current.contains_key(&entity),
+            Self::Storage {
+                morph_weights_info, ..
+            } => morph_weights_info.contains_key(&entity),
+        }
+    }
+
+    /// A mesh's morph targets are only used by instances with extracted weights.
+    pub(crate) fn mesh_key(
+        &self,
+        entity: MainEntity,
+        mut key: crate::MeshPipelineKey,
+    ) -> crate::MeshPipelineKey {
+        if !self.contains(entity) {
+            key.remove(crate::MeshPipelineKey::MORPH_TARGETS);
+        }
+        key
+    }
+
     /// Returns the index of the morph descriptor in the morph descriptor table
     /// for the given entity.
     ///
@@ -443,5 +465,78 @@ pub fn no_automatic_morph_batching(
 
     for entity in &query {
         commands.entity(entity).try_insert(NoAutomaticBatching);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MeshPipelineKey;
+    use bevy_utils::default;
+
+    #[test]
+    fn morph_pipeline_key_is_per_entity_and_tracks_removal() {
+        let mut world = World::new();
+        let morphed = MainEntity::from(world.spawn_empty().id());
+        let plain = MainEntity::from(world.spawn_empty().id());
+        let base = MeshPipelineKey::MORPH_TARGETS | MeshPipelineKey::DEPTH_PREPASS;
+        for storage in [false, true] {
+            let mut indices = if storage {
+                MorphIndices::Storage {
+                    morph_weights_info: default(),
+                    gpu_descriptor_indices: default(),
+                    gpu_descriptor_free_list: default(),
+                }
+            } else {
+                MorphIndices::Uniform {
+                    current: default(),
+                    prev: default(),
+                }
+            };
+            assert_eq!(
+                indices.mesh_key(morphed, base),
+                MeshPipelineKey::DEPTH_PREPASS
+            );
+            match &mut indices {
+                MorphIndices::Uniform { current, .. } => {
+                    current.insert(morphed, MorphIndex { index: 0 });
+                }
+                MorphIndices::Storage {
+                    morph_weights_info, ..
+                } => {
+                    morph_weights_info.insert(
+                        morphed,
+                        MorphWeightsInfo {
+                            current_weight_offset: 0,
+                            prev_weight_offset: None,
+                            weight_count: 1,
+                        },
+                    );
+                }
+            }
+            assert_eq!(indices.mesh_key(morphed, base), base);
+            assert_eq!(
+                indices.mesh_key(plain, base),
+                MeshPipelineKey::DEPTH_PREPASS
+            );
+            assert_eq!(
+                indices.mesh_key(morphed, MeshPipelineKey::DEPTH_PREPASS),
+                MeshPipelineKey::DEPTH_PREPASS
+            );
+            match &mut indices {
+                MorphIndices::Uniform { current, .. } => {
+                    current.remove(&morphed);
+                }
+                MorphIndices::Storage {
+                    morph_weights_info, ..
+                } => {
+                    morph_weights_info.remove(&morphed);
+                }
+            }
+            assert_eq!(
+                indices.mesh_key(morphed, base),
+                MeshPipelineKey::DEPTH_PREPASS
+            );
+        }
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #21655
- Spawning a mesh with morph target attributes but without a `MeshMorphWeights` component - or removing that component after spawn - crashed the renderer with a bind group validation error ("Expected entry with binding 2 not found in assigned bind group layout" / a `RenderCommandFailure` for a missing `MeshBindGroups` entry).
- Root cause: morph gating was split across two independent checks that could disagree. The pipeline key was derived from the mesh *asset's* own attribute data (`mesh.morph_targets().is_some()`, baked into the shared `BaseMeshPipelineKey`), while bind group selection was derived from the per-*entity* `MeshMorphWeights` extraction (`MorphIndices`). For a mesh shared by two entities where only one has `MeshMorphWeights`, or after removing/re-adding the component on one entity, these two checks desynced - producing a pipeline whose shader expects a morph bind group that was never allocated for that entity.

## Solution

- Made `MeshMorphWeights` presence (as tracked per-frame in `MorphIndices`) the single source of truth for morph gating, on both the pipeline-key and bind-group sides - the same approach already used for skinned meshes in #18074.
- Added `MorphIndices::contains(entity)` and `MorphIndices::mesh_key(entity, key)` in `render/morph.rs`. `mesh_key` strips `MeshPipelineKey::MORPH_TARGETS` from the per-entity pipeline key whenever the entity has no extracted morph weights this frame, regardless of what the mesh asset's own key bits say.
- Called `mesh_key` at all three specialization sites that build a mesh's pipeline key: `specialize_material_meshes` (`material.rs`), `specialize_prepass_material_meshes` (`prepass/mod.rs`), `specialize_shadows` (`light.rs`).
- Gated the `MorphIndices::Storage` bind-group path in `SetMeshBindGroup` (`render/mesh.rs`) on `morph_indices.contains(entity)`, so an entity without extracted weights always resolves to `MeshMorphBindGroupKey::NoMorphTargets`, matching the pipeline key. The `Uniform` path was already keyed per-entity (`current.get(entity)`) and needed no change.
- Added triggers so specialization and GPU re-extraction happen on add/remove of `MeshMorphWeights`, without re-specializing on every weight value change:
  - `check_entities_needing_specialization` (`material.rs`) now reacts to `Added<MeshMorphWeights>` and `RemovedComponents<MeshMorphWeights>` (filtered to entities that still have `Mesh3d`/`MeshMaterial3d<M>`).
  - `extract_meshes_for_gpu_building` (`mesh.rs`) reacts to the same add/remove to keep `MeshInputUniform`'s morph descriptor index in sync on the GPU-building path.
  - Changing only the weight *values* (no component add/remove) intentionally does **not** trigger respecialization or pipeline re-creation.

## Testing

- Reproduced the bug on main (`b3fd9d783`) on an RTX 4070 (Vulkan): the stock `morph_targets` example ran 120 frames with no errors; after removing `MeshMorphWeights` from the animated entities (per the repro steps in #21655), 3 out of 3 runs hit the renderer error.
- Manually verified against the fix: pipeline key and bind group selection stay consistent for a given entity; removing and re-adding the component correctly updates rendering; changing only the morph weights does not recreate the pipeline. Checked the shared-mesh case (two entities on one mesh, only one with `MeshMorphWeights`), plus the prepass, shadow, and uniform-buffer (non-storage) fallback paths.
- Added 4 unit tests covering `MorphIndices::mesh_key`/`contains` across both the `Uniform` and `Storage` variants, and `check_entities_needing_specialization`'s add/remove/weight-change behavior.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` and `cargo fmt --all -- --check` pass.
- Reviewers: the quickest manual repro is still the one from #21655 - in `examples/animation/morph_targets.rs`'s `play_animation_when_ready`, remove `MeshMorphWeights` from the animated children after spawn and confirm the renderer no longer errors.
- Only tested on Vulkan/NVIDIA on Linux; no other backends/platforms tried. Separately (and unrelated to this fix - a pre-existing condition, not something this PR changes): pipeline compilation can occasionally fail inside the NVIDIA driver during async shutdown; this doesn't reproduce with synchronous pipeline compilation, and this PR doesn't touch the general async/sync compilation path.
