### PR TITLE
Switch back to separate `bsn!` and `bsn_list!` macros. Warn when `[]` or `()` is used in a macro block 

### DIFF
--- a/_release-content/migration-guides/bsn_syntax_improvements.md
+++ b/_release-content/migration-guides/bsn_syntax_improvements.md
@@ -171,7 +171,7 @@ bsn! {
 
 This gives us the best of all worlds: entities are visually distinct, and there is no over-indentation, line noise, or syntax noise. Both `()` and `,` have been deprecated in this context.
 
-Using `[]` and `()` for `bsn_list!` (and `bsn!`) is now discouraged / warned against (ex: `bsn_list []`), as it can result in poor rustfmt autoformatting. Instead, use `bsn_list! {}`, which is the only syntax that `rustfmt` won't touch. Don't worry, we
+Using `[]` and `()` for `bsn_list!` (and `bsn!`) is now discouraged / warned against (ex: `bsn_list! []`), as it can result in poor rustfmt autoformatting. Instead, use `bsn_list! {}`, which is the only syntax that `rustfmt` won't touch. Don't worry, we
 plan to build a BSN auto-formatter!
 
 ```rust

--- a/_release-content/migration-guides/bsn_syntax_improvements.md
+++ b/_release-content/migration-guides/bsn_syntax_improvements.md
@@ -171,10 +171,11 @@ bsn! {
 
 This gives us the best of all worlds: entities are visually distinct, and there is no over-indentation, line noise, or syntax noise. Both `()` and `,` have been deprecated in this context.
 
-`bsn_list! []` has also been deprecated. Instead, just use `bsn! {}`, which now supports list expressions:
+Using `[]` and `()` for `bsn_list!` (and `bsn!`) is now discouraged / warned against (ex: `bsn_list []`), as it can result in poor rustfmt autoformatting. Instead, use `bsn_list! {}`, which is the only syntax that `rustfmt` won't touch. Don't worry, we
+plan to build a BSN auto-formatter!
 
 ```rust
-bsn! {
+bsn_list! {
     #Ok @button("Ok")
     --
     #Cancel @button("Cancel")

--- a/_release-content/release-notes/bsn_syntax_improvements.md
+++ b/_release-content/release-notes/bsn_syntax_improvements.md
@@ -171,7 +171,7 @@ bsn! {
 
 This gives us the best of all worlds: entities are visually distinct, and there is no over-indentation, line noise, or syntax noise. Both `()` and `,` have been deprecated in this context.
 
-Using `[]` and `()` for `bsn_list!` (and `bsn!`) is now discouraged (ex: `bsn_list []`), as it can result in poor rustfmt autoformatting. Instead, use `bsn_list! {}`, which is the only syntax that `rustfmt` won't touch. Don't worry, we
+Using `[]` and `()` for `bsn_list!` (and `bsn!`) is now discouraged / warned against (ex: `bsn_list []`), as it can result in poor rustfmt autoformatting. Instead, use `bsn_list! {}`, which is the only syntax that `rustfmt` won't touch. Don't worry, we
 plan to build a BSN auto-formatter!
 
 ```rust

--- a/_release-content/release-notes/bsn_syntax_improvements.md
+++ b/_release-content/release-notes/bsn_syntax_improvements.md
@@ -171,10 +171,11 @@ bsn! {
 
 This gives us the best of all worlds: entities are visually distinct, and there is no over-indentation, line noise, or syntax noise. Both `()` and `,` have been deprecated in this context.
 
-`bsn_list! []` has also been deprecated. Instead, just use `bsn! {}`, which now supports list expressions:
+Using `[]` and `()` for `bsn_list!` (and `bsn!`) is now discouraged (ex: `bsn_list []`), as it can result in poor rustfmt autoformatting. Instead, use `bsn_list! {}`, which is the only syntax that `rustfmt` won't touch. Don't worry, we
+plan to build a BSN auto-formatter!
 
 ```rust
-bsn! {
+bsn_list! {
     #Ok @button("Ok")
     --
     #Cancel @button("Cancel")

--- a/crates/bevy_feathers/src/controls/button.rs
+++ b/crates/bevy_feathers/src/controls/button.rs
@@ -83,7 +83,7 @@ pub struct FeathersButtonProps {
 impl Default for FeathersButtonProps {
     fn default() -> Self {
         Self {
-            caption: Box::new(bsn! {}),
+            caption: Box::new(bsn_list! {}),
             variant: ButtonVariant::default(),
             corners: Default::default(),
         }

--- a/crates/bevy_feathers/src/controls/checkbox.rs
+++ b/crates/bevy_feathers/src/controls/checkbox.rs
@@ -58,7 +58,7 @@ pub struct FeathersCheckboxProps {
 impl Default for FeathersCheckboxProps {
     fn default() -> Self {
         Self {
-            caption: Box::new(bsn! {}),
+            caption: Box::new(bsn_list! {}),
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/color_input.rs
+++ b/crates/bevy_feathers/src/controls/color_input.rs
@@ -340,7 +340,7 @@ impl FeathersColorInput {
 
 // Lazily-constructed menu popup
 fn color_input_popup() -> Box<dyn Scene> {
-    Box::new(bsn!(
+    Box::new(bsn! {
         @FeathersMenuPopup
         PopupEntityRefs {
             mode_wheel: #mode_wheel,
@@ -729,7 +729,7 @@ fn color_input_popup() -> Box<dyn Scene> {
             }
             on(recent_color_selected)
         ]
-    ))
+    })
 }
 
 fn color_wheel_value_change(

--- a/crates/bevy_feathers/src/controls/dialog.rs
+++ b/crates/bevy_feathers/src/controls/dialog.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     system::Commands,
 };
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
-use bevy_scene::{bsn, on, Scene, SceneComponent, SceneList};
+use bevy_scene::{bsn, bsn_list, on, Scene, SceneComponent, SceneList};
 use bevy_text::FontWeight;
 use bevy_ui::{
     px, vh, vw, widget::Text, AlignItems, BorderRadius, BoxShadow, Display, FixedNode,
@@ -38,7 +38,7 @@ pub struct FeathersDialogProps {
 impl Default for FeathersDialogProps {
     fn default() -> Self {
         Self {
-            contents: Box::new(bsn! {}),
+            contents: Box::new(bsn_list! {}),
             width: Val::Auto,
         }
     }
@@ -117,7 +117,7 @@ impl Default for FeathersFloatingDialogProps {
     fn default() -> Self {
         Self {
             title: String::new(),
-            contents: Box::new(bsn! {}),
+            contents: Box::new(bsn_list! {}),
             width: Val::Auto,
             left: px(120),
             top: px(120),

--- a/crates/bevy_feathers/src/controls/listview.rs
+++ b/crates/bevy_feathers/src/controls/listview.rs
@@ -17,7 +17,7 @@ use bevy_input_focus::{
 };
 use bevy_picking::{cursor::EntityCursor, hover::Hovered, PickingSystems};
 use bevy_reflect::{prelude::ReflectDefault, Reflect};
-use bevy_scene::{bsn, Scene, SceneComponent, SceneList};
+use bevy_scene::{bsn, bsn_list, Scene, SceneComponent, SceneList};
 use bevy_text::{FontSize, FontWeight};
 use bevy_ui::{
     px, AlignItems, BorderRadius, Display, FlexDirection, InteractionDisabled, JustifyContent,
@@ -53,7 +53,7 @@ pub struct FeathersListViewProps {
 impl Default for FeathersListViewProps {
     fn default() -> Self {
         Self {
-            rows: Box::new(bsn! {}),
+            rows: Box::new(bsn_list! {}),
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/menu.rs
+++ b/crates/bevy_feathers/src/controls/menu.rs
@@ -272,7 +272,7 @@ pub struct FeathersMenuButtonProps {
 impl Default for FeathersMenuButtonProps {
     fn default() -> Self {
         Self {
-            caption: Box::new(bsn! {}),
+            caption: Box::new(bsn_list! {}),
             corners: Default::default(),
             arrow: true,
         }
@@ -292,7 +292,7 @@ impl FeathersMenuButton {
             // Additional children for menu chevron
             Children [
                 {
-                    props.arrow.then(|| bsn! {
+                    props.arrow.then(|| bsn_list! {
                         Node {
                             flex_grow: 1.0,
                         }
@@ -329,7 +329,7 @@ impl FeathersMenuToolButton {
             // Additional children for menu chevron
             Children [
                 {
-                    props.arrow.then(|| bsn! {
+                    props.arrow.then(|| bsn_list! {
                         Node { min_width: px(2) }
                         --
                         @icon(icons::CHEVRON_DOWN)
@@ -410,7 +410,7 @@ pub struct FeathersMenuItemProps {
 impl Default for FeathersMenuItemProps {
     fn default() -> Self {
         Self {
-            caption: Box::new(bsn! {}),
+            caption: Box::new(bsn_list! {}),
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/number_input.rs
+++ b/crates/bevy_feathers/src/controls/number_input.rs
@@ -151,7 +151,7 @@ impl FeathersNumberInput {
                 {
                     // Label section
                     props.label_text.map(|text| {
-                        bsn! {
+                        bsn_list! {
                             Node {
                                 display: Display::Flex,
                                 align_items: AlignItems::Center,

--- a/crates/bevy_feathers/src/controls/radio.rs
+++ b/crates/bevy_feathers/src/controls/radio.rs
@@ -57,7 +57,7 @@ pub struct FeathersRadioProps {
 impl Default for FeathersRadioProps {
     fn default() -> Self {
         Self {
-            caption: Box::new(bsn! {}),
+            caption: Box::new(bsn_list! {}),
         }
     }
 }

--- a/crates/bevy_feathers/src/controls/select.rs
+++ b/crates/bevy_feathers/src/controls/select.rs
@@ -83,7 +83,7 @@ pub struct FeathersSelectProps {
 impl Default for FeathersSelectProps {
     fn default() -> Self {
         Self {
-            options: Box::new(bsn! {}),
+            options: Box::new(bsn_list! {}),
             corners: Default::default(),
             max_visible: 8,
         }

--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -71,6 +71,44 @@ impl<'a> BsnCodegenCtx<'a> {
         let string = ident.to_string();
         (ident.to_string(), self.entity_refs.get(string))
     }
+
+    fn validate_macro_uses_braces(&mut self) {
+        let span = Span::call_site();
+        let Some(source_text) = span.source_text() else {
+            return;
+        };
+
+        const BSN_LIST: &str = "bsn_list!";
+        const BSN: &str = "bsn!";
+
+        let (name, remaining) = if let Some(remaining) = source_text.strip_prefix(BSN_LIST) {
+            (BSN_LIST, remaining)
+        } else if let Some(remaining) = source_text.strip_prefix(BSN) {
+            (BSN, remaining)
+        } else {
+            eprintln!("Unknown macro root! {}", source_text);
+            return;
+        };
+
+        for character in remaining.chars() {
+            if character.is_whitespace() {
+                continue;
+            }
+
+            match character {
+                '(' | '[' => {
+                    self.deprecations.push(deprecation_warning(
+                        span,
+                        "USE_BRACE_FOR_BSN_MACRO",
+                        &format!("'{name} {character}' should not be used, as rustfmt can mangle the outputs. Use '{name} {{ }}' instead"),
+                    ));
+                }
+                _ => {
+                    break;
+                }
+            }
+        }
+    }
 }
 
 pub trait BsnTokenStream: Parse {
@@ -79,6 +117,7 @@ pub trait BsnTokenStream: Parse {
 
 impl BsnTokenStream for BsnRoot {
     fn into_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+        ctx.validate_macro_uses_braces();
         let tokens = self.0.into_tokens(ctx);
         let errors = ctx.errors.iter().map(|e| e.to_compile_error());
         let bevy_scene = ctx.bevy_scene;
@@ -112,6 +151,7 @@ impl BsnTokenStream for BsnRoot {
 
 impl BsnTokenStream for BsnListRoot {
     fn into_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
+        ctx.validate_macro_uses_braces();
         let tokens = self.0.into_tokens(ctx);
         let errors = ctx.errors.iter().map(|e| e.to_compile_error());
         let bevy_scene = ctx.bevy_scene;

--- a/crates/bevy_scene/macros/src/bsn/codegen.rs
+++ b/crates/bevy_scene/macros/src/bsn/codegen.rs
@@ -79,40 +79,33 @@ pub trait BsnTokenStream: Parse {
 
 impl BsnTokenStream for BsnRoot {
     fn into_tokens(self, ctx: &mut BsnCodegenCtx) -> TokenStream {
-        match self {
-            BsnRoot::Bsn(bsn) => {
-                let tokens = bsn.into_tokens(ctx);
-                let errors = ctx.errors.iter().map(|e| e.to_compile_error());
-                let bevy_scene = ctx.bevy_scene;
-                let hoisted_exprs = ctx.hoisted_expressions.expressions.drain(..);
-                let call_id = if !ctx.entity_refs.refs.is_empty() {
-                    quote! {
-                        static _CALL_ID: #bevy_scene::macro_utils::CallCounter = #bevy_scene::macro_utils::CallCounter::new();
-                        let _call_id = _CALL_ID.increment();
-                    }
-                } else {
-                    quote! {}
-                };
+        let tokens = self.0.into_tokens(ctx);
+        let errors = ctx.errors.iter().map(|e| e.to_compile_error());
+        let bevy_scene = ctx.bevy_scene;
+        let hoisted_exprs = ctx.hoisted_expressions.expressions.drain(..);
+        let call_id = if !ctx.entity_refs.refs.is_empty() {
+            quote! {
+                static _CALL_ID: #bevy_scene::macro_utils::CallCounter = #bevy_scene::macro_utils::CallCounter::new();
+                let _call_id = _CALL_ID.increment();
+            }
+        } else {
+            quote! {}
+        };
 
-                let deprecations = ctx.deprecations.iter();
-                // NOTE: Assigning the result to a variable first so that the LSP's
-                // type inference can see assignments before it encounters
-                // any compile errors. This keeps autocomplete working in broken states,
-                // e.g. when typing the name of a field but no value yet.
-                quote! {
-                    #bevy_scene::SceneScope({
-                        #(#deprecations)*
-                        #call_id
-                        #(#hoisted_exprs)*
-                        let _res = #tokens;
-                        #(#errors)*
-                        _res
-                    })
-                }
-            }
-            BsnRoot::BsnList(bsn_scene_list_items) => {
-                BsnListRoot(bsn_scene_list_items).into_tokens(ctx)
-            }
+        let deprecations = ctx.deprecations.iter();
+        // NOTE: Assigning the result to a variable first so that the LSP's
+        // type inference can see assignments before it encounters
+        // any compile errors. This keeps autocomplete working in broken states,
+        // e.g. when typing the name of a field but no value yet.
+        quote! {
+            #bevy_scene::SceneScope({
+                #(#deprecations)*
+                #call_id
+                #(#hoisted_exprs)*
+                let _res = #tokens;
+                #(#errors)*
+                _res
+            })
         }
     }
 }
@@ -1131,7 +1124,7 @@ mod tests {
             proc_macro2::Span::call_site(),
             "Test Error",
         ));
-        let root = BsnRoot::Bsn(Bsn {
+        let root = BsnRoot(Bsn {
             entries: vec![],
             used_parens: None,
         });

--- a/crates/bevy_scene/macros/src/bsn/parse.rs
+++ b/crates/bevy_scene/macros/src/bsn/parse.rs
@@ -47,15 +47,7 @@ macro_rules! parse_punctuated_vec_autocomplete_friendly {
 
 impl Parse for BsnRoot {
     fn parse(input: ParseStream) -> Result<Self> {
-        let bsn = input.parse::<Bsn>()?;
-        Ok(if input.peek(TwoMinus) || input.peek(Comma) {
-            let _ = input.parse::<CommaOrTwoMinus>()?;
-            let mut items = input.parse::<BsnSceneListItems>()?;
-            items.0.insert(0, BsnSceneListItem::Scene(bsn));
-            BsnRoot::BsnList(items)
-        } else {
-            BsnRoot::Bsn(bsn)
-        })
+        Ok(BsnRoot(input.parse::<Bsn>()?))
     }
 }
 
@@ -69,7 +61,6 @@ impl Parse for Bsn {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut entries = Vec::new();
         let mut used_parens = None;
-        // TODO: remove this case when parens are fully deprecated
         if input.peek(Paren) {
             used_parens = Some(input.span());
             let content;

--- a/crates/bevy_scene/macros/src/bsn/types.rs
+++ b/crates/bevy_scene/macros/src/bsn/types.rs
@@ -2,10 +2,7 @@ use proc_macro2::{Span, TokenStream};
 use syn::{Ident, Lit, LitStr, Member, Path};
 
 #[derive(Debug)]
-pub enum BsnRoot {
-    Bsn(Bsn),
-    BsnList(BsnSceneListItems),
-}
+pub struct BsnRoot(pub Bsn);
 
 #[derive(Debug)]
 pub struct BsnListRoot(pub BsnSceneListItems);

--- a/crates/bevy_scene/macros/src/lib.rs
+++ b/crates/bevy_scene/macros/src/lib.rs
@@ -61,12 +61,12 @@ use syn::{parse_macro_input, DeriveInput};
 ///
 /// ### Scene Lists
 ///
-/// Scene list syntax appears in Relationships (surrounded by []) and the [`bsn!`] macro.
+/// Scene list syntax appears inside "relationship" syntax (ex: `Relationship []`) and the [`bsn_list!`] macro.
 ///
 /// Unlike parts of a scene, which are whitespace-separated, the scenes in a scene list are `--` separated.
 /// Each `--` separated single-entity scene uses the same syntax as a single [`bsn!`] macro call.
 ///
-/// Note: The examples below omit the relationship or macro call, `Children [<scene list>]` or `bsn!{<scene list>}`
+/// Note: The examples below omit the relationship or macro call, `Children [<scene list>]` or `bsn_list! { <scene list> }`
 ///
 /// | Example                      | Meaning                                                                                                               |
 /// | ---------------------------- | --------------------------------------------------------------------------------------------------------------------- |
@@ -139,11 +139,11 @@ use syn::{parse_macro_input, DeriveInput};
 ///         }
 ///         ComponentB({some_var + 3.})   // values can be expressions, when wrapped in {}
 ///         @Container {
-///             @items: bsn! {        // sometimes you may need to nest macro calls
+///             @items: bsn_list! {       // sometimes you may need to nest macro calls
 ///                 #Item1 SomeComponent  // note: the name #Item1 here is in its own scope
 ///                 --
 ///                 #Item2 @some_scene()
-///             }
+///             ]
 ///         }
 ///     ]
 /// };
@@ -190,10 +190,6 @@ pub fn bsn(input: TokenStream) -> TokenStream {
 ///
 /// [`SceneList`]: https://docs.rs/bevy/latest/bevy/prelude/trait.SceneList.html
 /// [`bevy_scene`]: https://docs.rs/bevy/latest/bevy/scene/index.html
-#[deprecated(
-    since = "0.20.0",
-    note = "use bsn! {} instead, which now supports lists"
-)]
 #[proc_macro]
 pub fn bsn_list(input: TokenStream) -> TokenStream {
     crate::_bsn::bsn_list(input)

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -112,7 +112,7 @@
 //! ## Entity Hierarchies and Relationships
 //!
 //! Use `Children [scene1 -- scene2]` inside [`bsn!`] to spawn child entities.
-//! [`Children`] (and a list of entities at the root of [`bsn!`]) are separated by `--`;
+//! [`Children`] (and entities within [`bsn_list!`]) are separated by `--`;
 //! add multiple components to the same entity by listing them without a `--`:
 //!
 //! ```ignore
@@ -200,14 +200,14 @@
 //! If both a parent and a composed child define the same name (e.g. both use `#X`),
 //! each scope's `#X` resolves to its own entity, avoiding conflicts or potentially unintuitive shadowing.
 //!
-//! In a list defined in [`bsn!`], all root entities share a single name scope, so sibling scenes
+//! In a [`bsn_list!`], all root entities share a single name scope, so sibling scenes
 //! can reference each other by name. This is useful for wiring up relationships between
 //! entities that are spawned together. For example, a group of UI panels where each
 //! panel needs a relationship to its neighbor:
 //!
 //! ```ignore
 //! fn linked_pair() -> impl SceneList {
-//!     bsn! {
+//!     bsn_list! {
 //!         #Left Link(#Right)
 //!         --
 //!         #Right Link(#Left)
@@ -520,7 +520,7 @@
 //!     }
 //! }
 //!
-//! let items = bsn!{ #A -- #B -- #C};
+//! let items = bsn_list! { #A -- #B -- #C }; // or bsn! if container takes a `impl Scene`
 //! commands.spawn_scene(container(items));
 //! ```
 //!
@@ -539,7 +539,7 @@
 //!     }
 //! }
 //!
-//! let items = bsn! { #A -- #B -- #C }; // or bsn! if container takes a `impl Scene`
+//! let items = bsn_list! { #A -- #B -- #C }; // or bsn! if container takes a `impl Scene`
 //! commands.spawn_scene(container(items));
 //! ```
 //!
@@ -1417,7 +1417,7 @@ mod tests {
         }
 
         fn a() -> impl SceneList {
-            bsn! {
+            bsn_list! {
                 #X
                 Reference(#Y)
                 Children [
@@ -1649,7 +1649,7 @@ mod tests {
         let mut app = test_app();
         let world = app.world_mut();
         let entities = world
-            .spawn_scene_list(bsn! {
+            .spawn_scene_list(bsn_list! {
                 #A
                 --
                 target(#A)
@@ -1953,7 +1953,7 @@ mod tests {
         }
         let mut app = test_app();
         let world = app.world_mut();
-        let items = bsn! {
+        let items = bsn_list! {
             #Second
             --
             #Third
@@ -2198,7 +2198,7 @@ mod tests {
         let mut app = test_app();
         let world = app.world_mut();
         let entities = world
-            .spawn_scene_list(bsn! {
+            .spawn_scene_list(bsn_list! {
                 #A
                 --
                 Foo::Entity(#A)
@@ -2354,7 +2354,7 @@ mod tests {
         let world = app.world_mut();
 
         fn scene(root: Entity) -> impl SceneList {
-            bsn! {
+            bsn_list! {
                 #Child1 ChildOf(root)
                 --
                 #Child2 ChildOf(#Child1)
@@ -2393,7 +2393,7 @@ mod tests {
             }
         }
 
-        let children = bsn! {
+        let children = bsn_list! {
             #B
             --
             #C
@@ -3067,7 +3067,7 @@ mod tests {
         impl Default for Props2 {
             fn default() -> Self {
                 Self {
-                    items: Box::new(bsn! {}),
+                    items: Box::new(bsn_list! {}),
                 }
             }
         }
@@ -3104,7 +3104,7 @@ mod tests {
                 }
                 ComponentB({some_var + 3.})  // values can be expressions, when wrapped in {}
                 @Container {
-                    @items: bsn! {                // sometimes you may need to nest macro calls
+                    @items: bsn_list! {               // sometimes you may need to nest macro calls
                         #Item1 SomeComponent          // note: the name #item1 here is in its own scope
                         --
                         #Item2 @some_scene()
@@ -3373,8 +3373,8 @@ mod tests {
             ]
         };
 
-        let root = bsn! {
-            #Root @{patch}
+        let root = bsn_list! {
+            #root @{patch}
         };
 
         let expected_id = Some(world.spawn_scene_list(root).unwrap()[0]);

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1982,10 +1982,10 @@ mod tests {
         }
         let mut app = test_app();
         let world = app.world_mut();
-        let items = bsn![
+        let item = bsn! {
             #Second
-        ];
-        let id = world.spawn_scene(container(items)).unwrap().id();
+        };
+        let id = world.spawn_scene(container(item)).unwrap().id();
         let children = world.entity(id).get::<Children>().unwrap();
         let names: Vec<_> = children
             .iter()

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -165,7 +165,7 @@ pub trait WorldSceneExt {
     /// }
     /// // This scene list includes the "player.bsn" asset (note that the `.bsn` file format is not yet released). It will be spawned on the frame that "player.bsn"
     /// // is loaded.
-    /// world.queue_spawn_scene_list(bsn! {
+    /// world.queue_spawn_scene_list(bsn_list! {
     ///     :"player.bsn"
     ///     #Player1
     ///     Team::Red

--- a/crates/bevy_scene/src/spawn.rs
+++ b/crates/bevy_scene/src/spawn.rs
@@ -128,7 +128,7 @@ pub trait WorldSceneExt {
     ///     Blue,
     /// }
     ///
-    /// world.spawn_scene_list(bsn! {
+    /// world.spawn_scene_list(bsn_list! {
     ///     #Player1
     ///     Team::Red
     ///     --
@@ -313,7 +313,7 @@ pub trait CommandsSceneExt {
     /// }
     ///
     /// // Note that the .bsn file format is not yet released.
-    /// commands.spawn_scene_list(bsn! {
+    /// commands.spawn_scene_list(bsn_list! {
     ///     :"player.bsn"
     ///     #Player1
     ///     Team::Red
@@ -344,7 +344,7 @@ pub trait CommandsSceneExt {
     ///
     /// // This scene list includes the "player.bsn" asset (note that the `.bsn` file format is not yet released). It will be spawned on the frame that "player.bsn"
     /// // is loaded.
-    /// commands.queue_spawn_scene_list(bsn! {
+    /// commands.queue_spawn_scene_list(bsn_list! {
     ///     :"player.bsn"
     ///     #Player1
     ///     Team::Red
@@ -426,7 +426,7 @@ pub trait EntityWorldMutSceneExt {
     ///     Blue,
     /// }
     ///
-    /// world.spawn_empty().queue_spawn_related_scenes::<Children>(bsn! {
+    /// world.spawn_empty().queue_spawn_related_scenes::<Children>(bsn_list! {
     ///     #Player1
     ///     Team::Red
     ///     --
@@ -527,7 +527,7 @@ pub trait EntityCommandsSceneExt {
     ///     Blue,
     /// }
     ///
-    /// commands.spawn_empty().queue_spawn_related_scenes::<Children>(bsn! {
+    /// commands.spawn_empty().queue_spawn_related_scenes::<Children>(bsn_list! {
     ///     #Player1
     ///     Team::Red
     ///     --

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -11,7 +11,7 @@ fn main() {
 
 /// set up a simple 3D scene
 fn scene() -> impl SceneList {
-    bsn! {
+    bsn_list! {
         #CircularBase
         Mesh3d(asset_value(Circle::new(4.0)))
         MeshMaterial3d::<StandardMaterial>(asset_value(Color::WHITE))

--- a/examples/asset/compressed_image_saver.rs
+++ b/examples/asset/compressed_image_saver.rs
@@ -62,7 +62,7 @@ fn spawn_scene(
             .unwrap(),
     );
 
-    commands.spawn_scene_list(bsn! {
+    commands.spawn_scene_list(bsn_list! {
         Mesh3d(floor_mesh)
         MeshMaterial3d::<StandardMaterial>(asset_value(Color::WHITE))
         Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2))

--- a/examples/large_scenes/bevy_city/src/main.rs
+++ b/examples/large_scenes/bevy_city/src/main.rs
@@ -133,7 +133,7 @@ fn main() {
 }
 
 fn scene() -> impl SceneList {
-    bsn! {
+    bsn_list! {
         @camera()
         --
         @sun()

--- a/examples/scene/bsn.rs
+++ b/examples/scene/bsn.rs
@@ -9,7 +9,7 @@ fn main() {
 }
 
 fn scene() -> impl SceneList {
-    bsn! { Camera2d -- @ui() }
+    bsn_list! { Camera2d -- @ui() }
 }
 
 fn ui() -> impl Scene {

--- a/examples/ui/layout/display_and_visibility.rs
+++ b/examples/ui/layout/display_and_visibility.rs
@@ -327,7 +327,7 @@ fn feathers_select_display(target: EntityTemplate) -> impl Scene {
         @select_base::<NodeDisplaySetting>(target)
         @FeathersSelect {
             @options: {
-                bsn! {
+                bsn_list! {
                     @FeathersListRow Selected OptionIndex(0) NodeDisplaySetting::Flex Children[@caption(format!("Display::{:?}", Display::Flex))]
                     --
                     @FeathersListRow OptionIndex(1) NodeDisplaySetting::None Children[@caption(format!("Display::{:?}", Display::None))]
@@ -344,7 +344,7 @@ fn feathers_select_visibility(target: EntityTemplate) -> impl Scene {
         @select_base::<NodeVisibilitySetting>(target)
         @FeathersSelect {
             @options: {
-                bsn! {
+                bsn_list! {
                     @FeathersListRow Selected OptionIndex(0) NodeVisibilitySetting::Inherited Children[@caption(format!("Visibility::{:?}", Visibility::Inherited))]
                     --
                     @FeathersListRow OptionIndex(1) NodeVisibilitySetting::Visible Children[@caption(format!("Visibility::{:?}", Visibility::Visible))]

--- a/examples/ui/layout/ghost_nodes.rs
+++ b/examples/ui/layout/ghost_nodes.rs
@@ -27,7 +27,7 @@ fn main() {
 struct Counter(i32);
 
 fn scene() -> impl SceneList {
-    bsn! { Camera2d -- @ghost_root() -- @normal_root() }
+    bsn_list! { Camera2d -- @ghost_root() -- @normal_root() }
 }
 
 /// Ghost UI root

--- a/examples/ui/navigation/directional_navigation_overrides.rs
+++ b/examples/ui/navigation/directional_navigation_overrides.rs
@@ -439,7 +439,7 @@ fn grid_page_text_entities_scene_list(page_num: usize) -> impl SceneList {
         ),
         _ => Text::default()
     };
-    bsn! {
+    bsn_list! {
         // Text describing current page
         @helper_text_node_scene(format!("Currently on Page {}", page_num + 1), 650, 10, Justify::Center)
         --
@@ -502,7 +502,7 @@ fn setup_buttons_for_triangle_page(commands: &mut Commands, page_num: usize) -> 
 /// Scene list containing all the text entities regarding button/page navigation for the triangle page.
 fn triangle_page_text_entities_scene_list(page_num: usize) -> impl SceneList {
     let previous_page = if page_num == 0 { 3 } else { page_num };
-    bsn! {
+    bsn_list! {
         // Text describing current page
         @helper_text_node_scene(format!("Currently on Page {}", page_num + 1), 650, 20, Justify::Center)
         --

--- a/examples/ui/styling/box_shadow.rs
+++ b/examples/ui/styling/box_shadow.rs
@@ -190,7 +190,7 @@ fn setup(mut commands: Commands, app_settings: Res<AppSettings>) {
     };
     app_settings.shape.change_node(&mut node);
 
-    commands.spawn_scene_list(bsn! {
+    commands.spawn_scene_list(bsn_list! {
         // Camera
         Camera2d
         BoxShadowSamples({app_settings.samples})

--- a/examples/ui/widgets/feathers_counter.rs
+++ b/examples/ui/widgets/feathers_counter.rs
@@ -40,7 +40,7 @@ fn main() {
 }
 
 fn scene() -> impl SceneList {
-    bsn! { Camera2d -- @demo_root() }
+    bsn_list! { Camera2d -- @demo_root() }
 }
 
 fn demo_root() -> impl Scene {

--- a/examples/ui/widgets/feathers_gallery.rs
+++ b/examples/ui/widgets/feathers_gallery.rs
@@ -84,7 +84,7 @@ fn main() {
 }
 
 fn scene() -> impl SceneList {
-    bsn! {
+    bsn_list! {
         Camera2d
         --
         @demo_root()
@@ -962,7 +962,7 @@ fn demo_column_2() -> impl Scene {
                 --
                 @subpane_body() Children [
                     @FeathersListView {
-                        @rows: bsn! {
+                        @rows: bsn_list! {
                             @FeathersListRow Children [ @caption("First World") ]
                             --
                             @FeathersListRow Selected Children [ @caption("Second Nature") ]
@@ -1213,10 +1213,10 @@ fn handle_hex_color_change(
 fn spawn_quit_dialog(activate: On<Activate>, mut commands: Commands) {
     commands
         .entity(activate.event_target())
-        .queue_spawn_related_scenes::<Children>(bsn! {
+        .queue_spawn_related_scenes::<Children>(bsn_list! {
             @FeathersDialog {
                 @width: px(320),
-                @contents: bsn! {
+                @contents: bsn_list! {
                     @FeathersDialogHeader Children [
                         @caption("Quit Feathers Gallery")
                         --
@@ -1267,7 +1267,7 @@ fn toggle_demo_dialog(
             @FeathersFloatingDialog {
                 @title: {"Hello".to_string()},
                 @width: px(280),
-                @contents: bsn! {
+                @contents: bsn_list! {
                     @caption("Close this dialog to unset the toggle.")
                 }
             }

--- a/examples/ui/widgets/feathers_number_input.rs
+++ b/examples/ui/widgets/feathers_number_input.rs
@@ -26,7 +26,7 @@ fn main() {
 }
 
 fn scene() -> impl SceneList {
-    bsn! { Camera2d -- @demo_root() }
+    bsn_list! { Camera2d -- @demo_root() }
 }
 
 fn demo_root() -> impl Scene {

--- a/examples/ui/widgets/headless_tabs.rs
+++ b/examples/ui/widgets/headless_tabs.rs
@@ -31,7 +31,7 @@ fn main() {
 }
 
 fn showcase() -> impl SceneList {
-    bsn! {
+    bsn_list! {
         Camera2d
         --
         Node {
@@ -74,7 +74,8 @@ fn showcase() -> impl SceneList {
             @selected_tab(#manual_scene)
             on(tablist_self_update)
             Children [
-                #manual_scene @tab_header("Scene")
+                #manual_scene
+                @tab_header("Scene")
                 --
                 @tab_header("Assets")
                 --
@@ -91,7 +92,8 @@ fn showcase() -> impl SceneList {
             @selected_tab(#vertical_transform)
             on(tablist_self_update)
             Children [
-                #vertical_transform @tab_header("Transform")
+                #vertical_transform
+                @tab_header("Transform")
                 --
                 @tab_header("Visibility")
                 --
@@ -105,7 +107,8 @@ fn showcase() -> impl SceneList {
             @selected_tab(#controlled_a)
             on(controlled_selection)
             Children [
-                #controlled_a @tab_header("External A")
+                #controlled_a
+                @tab_header("External A")
                 --
                 @tab_header("External B")
             ]

--- a/examples/ui/widgets/headless_tabs.rs
+++ b/examples/ui/widgets/headless_tabs.rs
@@ -70,12 +70,11 @@ fn showcase() -> impl SceneList {
             @section_label("Horizontal manual - focus and selection are separate")
             --
             @tab_strip(ControlOrientation::Horizontal)
-            TabList::default()
+            TabList
             @selected_tab(#manual_scene)
             on(tablist_self_update)
             Children [
-                #manual_scene
-                @tab_header("Scene")
+                #manual_scene @tab_header("Scene")
                 --
                 @tab_header("Assets")
                 --
@@ -92,8 +91,7 @@ fn showcase() -> impl SceneList {
             @selected_tab(#vertical_transform)
             on(tablist_self_update)
             Children [
-                #vertical_transform
-                @tab_header("Transform")
+                #vertical_transform @tab_header("Transform")
                 --
                 @tab_header("Visibility")
                 --
@@ -103,12 +101,11 @@ fn showcase() -> impl SceneList {
             @section_label("Controlled - observer updates external state")
             --
             @tab_strip(ControlOrientation::Horizontal)
-            TabList::default()
+            TabList
             @selected_tab(#controlled_a)
             on(controlled_selection)
             Children [
-                #controlled_a
-                @tab_header("External A")
+                #controlled_a @tab_header("External A")
                 --
                 @tab_header("External B")
             ]

--- a/examples/ui/widgets/virtual_keyboard.rs
+++ b/examples/ui/widgets/virtual_keyboard.rs
@@ -51,7 +51,7 @@ fn on_virtual_key_pressed(
 }
 
 fn scene() -> impl SceneList {
-    bsn! { Camera2d -- @text_input() -- @keyboard() }
+    bsn_list! { Camera2d -- @text_input() -- @keyboard() }
 }
 
 fn keyboard() -> impl Scene {

--- a/examples/usage/character_creation.rs
+++ b/examples/usage/character_creation.rs
@@ -52,7 +52,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, character: Res<Character>) {
-    commands.spawn_scene_list(bsn! {
+    commands.spawn_scene_list(bsn_list! {
         Camera2d
         --
         // This scene will serve as one half of our "View"


### PR DESCRIPTION
# Objective

In the interest of discouraging the use of `[]` (which rustfmt can badly mangle the contents of), #25626 merged the two macros into `bsn! {}`:

```rust
// One entity, implements Scene
bsn! {
  A
  B
}

// Two entities, implements SceneList
bsn! {
  A B
  --
  C D
}
```

In practice, this was generally pretty good, but it has a fatal flaw: defining an empty list (or an empty entity) is ambiguous:

```rust
bsn! { } // is this an empty list or an empty entity? 
```

This is a "conceptual ambiguity", in addition to being  a practical one (there is currently no way to define an empty list). We teach people rules, but they break down in the empty case. This isn't good enough.

## Solution

Switch back to the `bsn!` and `bsn_list!` split. Strongly encourage people to use `bsn_list! {}` instead of `bsn_list! []` or `bsn_list! ()` by detecting and warning against these cases.

This restriction _is_ necessary / correct from my perspective, as we were always going to need to write a BSN auto-formatter, and this was always going to conflict with rustfmt. We should be getting ahead of this now. 

Due to the nature of `Span::call_site`, we can only detect this for root macros (nested macros will not warn). This is "fine" because `rustfmt` won't touch the nested macro calls if they are inside of `bsn! {}`. I think it is more than good enough to curb the behavior.