### PR TITLE
Eliminate some unnecessary allocations in AssetPath

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -317,7 +317,7 @@ impl<'a> AssetPath<'a> {
         let path = match &self.path {
             CowArc::Borrowed(path) => CowArc::Borrowed(path.parent()?),
             CowArc::Static(path) => CowArc::Static(path.parent()?),
-            CowArc::Owned(path) => path.parent()?.to_path_buf().into(),
+            CowArc::Owned(path) => CowArc::Owned(path.parent()?.into()),
         };
         Some(AssetPath {
             source: self.source.clone(),
@@ -568,17 +568,16 @@ impl<'a> AssetPath<'a> {
     /// ```
     pub fn is_unapproved(&self) -> bool {
         use std::path::Component;
-        let mut simplified = PathBuf::new();
+
+        let mut component_count: usize = 0;
+
         for component in self.path.components() {
             match component {
                 Component::Prefix(_) | Component::RootDir => return true,
                 Component::CurDir => {}
-                Component::ParentDir => {
-                    if !simplified.pop() {
-                        return true;
-                    }
-                }
-                Component::Normal(os_str) => simplified.push(os_str),
+                Component::ParentDir if component_count == 0 => return true,
+                Component::ParentDir => component_count -= 1,
+                Component::Normal(_) => component_count += 1,
             }
         }
 


### PR DESCRIPTION
# Objective

Eliminate some unnecessary memory allocations in AssetPath's methods (bevy_asset).

## AssetPath::parent

Converting `&Path` directly to `Arc<Path>` is the fastest approach, requiring only one allocation.
But the current implementation is `&Path -> PathBuf -> Arc<Path>`, which requires two.

*The `PathBuf -> Arc<Path>` step requires an allocation and a copy; see the standard library implementation for details.*

## AssetPath::is_unapproved

Currently, using PathBuf as a stack is unnecessary. Switching to an integer counter is sufficient.

## Solution

See `FileChanged` for details — the change is minimal.

## Testing

None