### PR TITLE
Add commands to despawn all entities matching specific filters.

### DIFF
--- a/benches/benches/bevy_ecs/world/commands.rs
+++ b/benches/benches/bevy_ecs/world/commands.rs
@@ -2,6 +2,8 @@ use core::hint::black_box;
 
 use bevy_ecs::{
     component::Component,
+    entity::Entity,
+    query::With,
     system::{Command, Commands},
     world::{CommandQueue, World},
 };
@@ -9,7 +11,7 @@ use criterion::Criterion;
 
 use crate::world_builder::WorldBuilder;
 
-#[derive(Component)]
+#[derive(Component, Clone, Copy)]
 struct A;
 #[derive(Component)]
 struct B;
@@ -93,6 +95,56 @@ pub fn nonempty_spawn_commands(criterion: &mut Criterion) {
     }
 
     group.finish();
+}
+
+pub fn despawn_commands(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("despawn_commands");
+    group.warm_up_time(core::time::Duration::from_millis(500));
+    group.measurement_time(core::time::Duration::from_secs(4));
+
+    for entity_count in [100, 1_000, 10_000] {
+        let input_setup = || {
+            let mut world = WorldBuilder::new()
+                .with_max_expected_entities(entity_count)
+                .warm_up_entity_allocator()
+                .build();
+            let command_queue = CommandQueue::default();
+            let query = world.query_filtered::<Entity, With<A>>();
+
+            // we must iterate the iterator to force the spawn.
+            world
+                .spawn_batch(core::iter::repeat_n(A, entity_count as usize))
+                .for_each(|_| {});
+
+            (world, command_queue, query)
+        };
+
+        group.bench_function(format!("despawn_{entity_count}"), |bencher| {
+            bencher.iter_batched(
+                input_setup,
+                |(mut world, mut command_queue, mut query)| {
+                    let mut commands = Commands::new(&mut command_queue, &world);
+                    for entity in query.iter(&world) {
+                        commands.entity(entity).despawn();
+                    }
+                    command_queue.apply(&mut world);
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        });
+
+        group.bench_function(format!("despawn_all_{entity_count}"), |bencher| {
+            bencher.iter_batched(
+                input_setup,
+                |(mut world, mut command_queue, _)| {
+                    let mut commands = Commands::new(&mut command_queue, &world);
+                    commands.despawn_all::<With<A>>();
+                    command_queue.apply(&mut world);
+                },
+                criterion::BatchSize::LargeInput,
+            );
+        });
+    }
 }
 
 #[derive(Default, Component)]

--- a/benches/benches/bevy_ecs/world/mod.rs
+++ b/benches/benches/bevy_ecs/world/mod.rs
@@ -21,6 +21,7 @@ criterion_group!(
     benches,
     empty_commands,
     spawn_commands,
+    despawn_commands,
     nonempty_spawn_commands,
     insert_commands,
     fake_commands,

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -284,12 +284,20 @@ pub(crate) fn play_queued_audio_system<Source: Asset + Decodable>(
 pub(crate) fn cleanup_finished_audio<T: Decodable + Asset>(
     mut commands: Commands,
     query_nonspatial_despawn: Query<
-        (Entity, &AudioSink),
-        (With<PlaybackDespawnMarker>, With<AudioPlayer<T>>),
+        (),
+        (
+            With<PlaybackDespawnMarker>,
+            With<AudioPlayer<T>>,
+            With<AudioSink>,
+        ),
     >,
     query_spatial_despawn: Query<
-        (Entity, &SpatialAudioSink),
-        (With<PlaybackDespawnMarker>, With<AudioPlayer<T>>),
+        (),
+        (
+            With<PlaybackDespawnMarker>,
+            With<AudioPlayer<T>>,
+            With<SpatialAudioSink>,
+        ),
     >,
     query_nonspatial_remove: Query<
         (Entity, &AudioSink),
@@ -300,16 +308,17 @@ pub(crate) fn cleanup_finished_audio<T: Decodable + Asset>(
         (With<PlaybackRemoveMarker>, With<AudioPlayer<T>>),
     >,
 ) {
-    for (entity, sink) in &query_nonspatial_despawn {
-        if sink.sink.empty() {
-            commands.entity(entity).despawn();
-        }
+    if !query_nonspatial_despawn.is_empty() {
+        commands
+            .despawn_all_where::<&AudioSink, (With<PlaybackDespawnMarker>, With<AudioPlayer<T>>)>(
+                |_, sink| sink.empty(),
+            );
     }
-    for (entity, sink) in &query_spatial_despawn {
-        if sink.sink.empty() {
-            commands.entity(entity).despawn();
-        }
+
+    if !query_spatial_despawn.is_empty() {
+        commands.despawn_all_where::<&SpatialAudioSink, (With<PlaybackDespawnMarker>, With<AudioPlayer<T>>)>(|_, sink| sink.empty());
     }
+
     for (entity, sink) in &query_nonspatial_remove {
         if sink.sink.empty() {
             commands.entity(entity).remove::<(

--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -14,7 +14,7 @@ use crate::{
     error::{BevyError, CommandOutput, ErrorContext, Result},
     event::Event,
     message::{Message, Messages},
-    query::QueryFilter,
+    query::{QueryData, QueryFilter},
     resource::Resource,
     schedule::ScheduleLabel,
     system::{IntoSystem, SystemId, SystemInput},
@@ -322,6 +322,14 @@ pub fn write_message<M: Message>(message: M) -> impl Command {
 /// A [`Command`] that despawns all entities matching a specific [`QueryFilter`].
 #[track_caller]
 pub fn despawn_all<F: QueryFilter>() -> impl Command {
+    despawn_all_where::<(), F>(|_, _| true)
+}
+
+/// A [`Command`] that despawns all entities matching a specific [`QueryFilter`] and condition.
+#[track_caller]
+pub fn despawn_all_where<D: QueryData, F: QueryFilter>(
+    mut cond: impl FnMut(Entity, D::Item<'_, '_>) -> bool + Send + 'static,
+) -> impl Command {
     // We can't both be iterating over entities in a world and despawning them.
     // So we collect the entities into batches which we then despawn. Batches
     // are sized we're not constructing new queries to often while limiting the
@@ -330,14 +338,26 @@ pub fn despawn_all<F: QueryFilter>() -> impl Command {
 
     let caller = MaybeLocation::caller();
     move |world: &mut World| {
-        let mut query = world.query_filtered::<Entity, F>();
+        let mut query = world.query_filtered::<(Entity, D), F>();
 
         let mut batch: ArrayVec<Entity, BATCH_SIZE> = ArrayVec::new();
 
         loop {
-            for entity in query.iter(world).take(BATCH_SIZE) {
+            let mut entities = query.iter_mut(world);
+
+            while !batch.is_full() {
+                let Some((entity, data)) = entities.fetch_next() else {
+                    break;
+                };
+
+                if !cond(entity, data) {
+                    continue;
+                }
+
                 batch.push(entity);
             }
+            // We need to explicitly drop to release the world borrow.
+            drop(entities);
 
             if batch.is_empty() {
                 break;

--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -4,7 +4,6 @@
 //! It also contains functions that return closures for use with
 //! [`Commands`](crate::system::Commands).
 
-use alloc::collections::VecDeque;
 use bevy_utils::prelude::DebugName;
 
 use crate::{
@@ -319,71 +318,22 @@ pub fn write_message<M: Message>(message: M) -> impl Command {
     }
 }
 
-/// A [`Command`] that despawns all entities matching a specific [`QueryFilter`].
+/// A [`Command`] that [despawns](crate::system::entity_command::despawn) all entities matching a specific [`QueryFilter`].
 #[track_caller]
 pub fn despawn_all<F: QueryFilter>() -> impl Command {
-    despawn_all_where::<(), F>(|_, _| true)
+    let caller = MaybeLocation::caller();
+    move |world: &mut World| {
+        world.despawn_all_with_caller::<F>(caller);
+    }
 }
 
-/// A [`Command`] that despawns all entities matching a specific [`QueryFilter`] and condition.
+/// A [`Command`] that [despawns](crate::system::entity_command::despawn) all entities matching a specific [`QueryFilter`] and condition.
 #[track_caller]
 pub fn despawn_all_where<D: QueryData, F: QueryFilter>(
-    mut cond: impl FnMut(Entity, D::Item<'_, '_>) -> bool + Send + 'static,
+    cond: impl FnMut(Entity, D::Item<'_, '_>) -> bool + Send + 'static,
 ) -> impl Command {
     let caller = MaybeLocation::caller();
     move |world: &mut World| {
-        let mut query = world.query_filtered::<(Entity, D), F>();
-        let mut query = query.iter_mut(world);
-
-        let mut entities_to_despawn = VecDeque::new();
-
-        while let Some((entity, data)) = query.fetch_next() {
-            if cond(entity, data) {
-                // We want to despawn the entities backwards since we're
-                // less likely to leave holes.
-                entities_to_despawn.push_front(entity);
-            }
-        }
-        // We have to explicitly drop the query to release the world borrow.
-        drop(query);
-
-        // This part of the closure does not need to be generic.
-        // Compiling it once saves a bit of compile time.
-        fn despawn_entities(
-            world: &mut World,
-            mut entities_to_despawn: VecDeque<Entity>,
-            caller: MaybeLocation,
-        ) {
-            entities_to_despawn.retain(|entity| {
-                let _ = world.despawn_no_free_with_caller(*entity, caller);
-
-                // Check if the entity wasn't already freed or reconstructed.
-                matches!(world.entities.get(*entity), Ok(None))
-            });
-
-            // We free the entities in batches so other threads can sneak in allocations.
-            // The batches should be larger than the local buffer size (128) since we
-            // want to optimize away the attempt at pushing into the local buffer.
-            const BATCH_SIZE: usize = 256;
-            let (first, second) = entities_to_despawn.as_slices();
-
-            let (first_chunks, tail) = first.as_chunks::<BATCH_SIZE>();
-
-            for chunk in first_chunks {
-                world.entity_allocator.free_many(chunk);
-            }
-
-            world.entity_allocator.free_many(tail);
-
-            let (second_chunks, tail) = second.as_chunks::<BATCH_SIZE>();
-
-            for chunk in second_chunks {
-                world.entity_allocator.free_many(chunk);
-            }
-
-            world.entity_allocator.free_many(tail);
-        }
-
-        despawn_entities(world, entities_to_despawn, caller);
+        world.despawn_all_where_with_caller::<D, F>(cond, caller);
     }
 }

--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -4,7 +4,7 @@
 //! It also contains functions that return closures for use with
 //! [`Commands`](crate::system::Commands).
 
-use arrayvec::ArrayVec;
+use alloc::collections::VecDeque;
 use bevy_utils::prelude::DebugName;
 
 use crate::{
@@ -330,56 +330,60 @@ pub fn despawn_all<F: QueryFilter>() -> impl Command {
 pub fn despawn_all_where<D: QueryData, F: QueryFilter>(
     mut cond: impl FnMut(Entity, D::Item<'_, '_>) -> bool + Send + 'static,
 ) -> impl Command {
-    // We can't both be iterating over entities in a world and despawning them.
-    // So we collect the entities into batches which we then despawn. Batches
-    // are sized we're not constructing new queries to often while limiting the
-    // chance of a stack overflow (currently about half a page on x86_64).
-    const BATCH_SIZE: usize = 256;
-
     let caller = MaybeLocation::caller();
     move |world: &mut World| {
         let mut query = world.query_filtered::<(Entity, D), F>();
+        let mut query = query.iter_mut(world);
 
-        let mut batch: ArrayVec<Entity, BATCH_SIZE> = ArrayVec::new();
+        let mut entities_to_despawn = VecDeque::new();
 
-        loop {
-            let mut entities = query.iter_mut(world);
-
-            while !batch.is_full() {
-                let Some((entity, data)) = entities.fetch_next() else {
-                    break;
-                };
-
-                if !cond(entity, data) {
-                    continue;
-                }
-
-                batch.push(entity);
+        while let Some((entity, data)) = query.fetch_next() {
+            if cond(entity, data) {
+                // We want to despawn the entities backwards since we're
+                // less likely to leave holes.
+                entities_to_despawn.push_front(entity);
             }
-            // We need to explicitly drop to release the world borrow.
-            drop(entities);
-
-            if batch.is_empty() {
-                break;
-            }
-
-            let mut i = 0;
-            while i < batch.len() {
-                let entity = batch[i];
-
-                let _ = world.despawn_no_free_with_caller(entity, caller);
-
-                if let Ok(None) = world.entities.get(entity) {
-                    i += 1;
-                } else {
-                    // It may have already been despawned or a command may have reconstructed it.
-                    // See the comment in `despawn_with_caller` on `World`;
-                    batch.swap_remove(i);
-                }
-            }
-
-            world.entity_allocator.free_many(&batch);
-            batch.clear();
         }
+        // We have to explicitly drop the query to release the world borrow.
+        drop(query);
+
+        // This part of the closure does not need to be generic.
+        // Compiling it once saves a bit of compile time.
+        fn despawn_entities(
+            world: &mut World,
+            mut entities_to_despawn: VecDeque<Entity>,
+            caller: MaybeLocation,
+        ) {
+            entities_to_despawn.retain(|entity| {
+                let _ = world.despawn_no_free_with_caller(*entity, caller);
+
+                // Check if the entity wasn't already freed or reconstructed.
+                matches!(world.entities.get(*entity), Ok(None))
+            });
+
+            // We free the entities in batches so other threads can sneak in allocations.
+            // The batches should be larger than the local buffer size (128) since we
+            // want to optimize away the attempt at pushing into the local buffer.
+            const BATCH_SIZE: usize = 256;
+            let (first, second) = entities_to_despawn.as_slices();
+
+            let (first_chunks, tail) = first.as_chunks::<BATCH_SIZE>();
+
+            for chunk in first_chunks {
+                world.entity_allocator.free_many(chunk);
+            }
+
+            world.entity_allocator.free_many(tail);
+
+            let (second_chunks, tail) = second.as_chunks::<BATCH_SIZE>();
+
+            for chunk in second_chunks {
+                world.entity_allocator.free_many(chunk);
+            }
+
+            world.entity_allocator.free_many(tail);
+        }
+
+        despawn_entities(world, entities_to_despawn, caller);
     }
 }

--- a/crates/bevy_ecs/src/system/commands/command.rs
+++ b/crates/bevy_ecs/src/system/commands/command.rs
@@ -4,6 +4,7 @@
 //! It also contains functions that return closures for use with
 //! [`Commands`](crate::system::Commands).
 
+use arrayvec::ArrayVec;
 use bevy_utils::prelude::DebugName;
 
 use crate::{
@@ -13,6 +14,7 @@ use crate::{
     error::{BevyError, CommandOutput, ErrorContext, Result},
     event::Event,
     message::{Message, Messages},
+    query::QueryFilter,
     resource::Resource,
     schedule::ScheduleLabel,
     system::{IntoSystem, SystemId, SystemInput},
@@ -314,5 +316,50 @@ pub fn write_message<M: Message>(message: M) -> impl Command {
     move |world: &mut World| {
         let mut messages = world.resource_mut::<Messages<M>>();
         messages.write_with_caller(message, caller);
+    }
+}
+
+/// A [`Command`] that despawns all entities matching a specific [`QueryFilter`].
+#[track_caller]
+pub fn despawn_all<F: QueryFilter>() -> impl Command {
+    // We can't both be iterating over entities in a world and despawning them.
+    // So we collect the entities into batches which we then despawn. Batches
+    // are sized we're not constructing new queries to often while limiting the
+    // chance of a stack overflow (currently about half a page on x86_64).
+    const BATCH_SIZE: usize = 256;
+
+    let caller = MaybeLocation::caller();
+    move |world: &mut World| {
+        let mut query = world.query_filtered::<Entity, F>();
+
+        let mut batch: ArrayVec<Entity, BATCH_SIZE> = ArrayVec::new();
+
+        loop {
+            for entity in query.iter(world).take(BATCH_SIZE) {
+                batch.push(entity);
+            }
+
+            if batch.is_empty() {
+                break;
+            }
+
+            let mut i = 0;
+            while i < batch.len() {
+                let entity = batch[i];
+
+                let _ = world.despawn_no_free_with_caller(entity, caller);
+
+                if let Ok(None) = world.entities.get(entity) {
+                    i += 1;
+                } else {
+                    // It may have already been despawned or a command may have reconstructed it.
+                    // See the comment in `despawn_with_caller` on `World`;
+                    batch.swap_remove(i);
+                }
+            }
+
+            world.entity_allocator.free_many(&batch);
+            batch.clear();
+        }
     }
 }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     event::{EntityEvent, Event},
     message::Message,
     observer::{IntoEntityObserver, IntoObserver},
-    query::QueryFilter,
+    query::{QueryData, QueryFilter},
     relationship::RelationshipHookMode,
     resource::Resource,
     schedule::ScheduleLabel,
@@ -482,6 +482,31 @@ impl<'w, 's> Commands<'w, 's> {
     /// ```
     pub fn despawn_all<F: QueryFilter>(&mut self) {
         self.queue(command::despawn_all::<F>());
+    }
+
+    /// Despawns all entities matching the given [`QueryFilter`] and condition.
+    ///
+    /// This method is equivalent to iterating over all the filtered entities
+    /// and [despawning](EntityCommands::despawn) them one by one, but is faster by allocating far fewer commands.
+    ///
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    ///
+    ///
+    /// #[derive(Component)]
+    /// struct Health(f32);
+    ///
+    /// fn despawn_dead(mut commands: Commands) {
+    ///     commands.despawn_all_where::<&Health, ()>(|_, health| health.0 <= 0.0);
+    /// }
+    ///
+    /// # bevy_ecs::system::assert_is_system(despawn_dead);
+    /// ```
+    pub fn despawn_all_where<D: QueryData, F: QueryFilter>(
+        &mut self,
+        cond: impl FnMut(Entity, D::Item<'_, '_>) -> bool + Send + 'static,
+    ) {
+        self.queue(command::despawn_all_where::<D, F>(cond));
     }
 
     /// Pushes a generic [`Command`] to the command queue.
@@ -3113,5 +3138,28 @@ mod tests {
         assert!(world.get_entity(c).is_err());
 
         assert!(world.get_entity(a_b).is_ok());
+    }
+
+    #[test]
+    fn despawn_all_where_command_checks() {
+        let mut world = World::default();
+
+        #[derive(Component)]
+        struct ComponentA(usize);
+
+        let a_1 = world.spawn(ComponentA(1)).id();
+        let a_2 = world.spawn(ComponentA(2)).id();
+        let a_3 = world.spawn(ComponentA(3)).id();
+
+        let mut commands = world.commands();
+
+        commands.despawn_all_where::<&ComponentA, ()>(|_, data| data.0 < 3);
+
+        world.flush_commands();
+
+        assert!(world.get_entity(a_1).is_err());
+        assert!(world.get_entity(a_2).is_err());
+
+        assert!(world.get_entity(a_3).is_ok());
     }
 }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     event::{EntityEvent, Event},
     message::Message,
     observer::{IntoEntityObserver, IntoObserver},
+    query::QueryFilter,
     relationship::RelationshipHookMode,
     resource::Resource,
     schedule::ScheduleLabel,
@@ -459,6 +460,28 @@ impl<'w, 's> Commands<'w, 's> {
         I::Item: Bundle<Effect: NoBundleEffect>,
     {
         self.queue(command::spawn_batch(batch));
+    }
+
+    /// Despawns all entities matching the given [`QueryFilter`].
+    ///
+    /// This method is equivalent to iterating over all the filtered entities
+    /// and [despawning](EntityCommands::despawn) them one by one, but is faster by allocating far fewer commands.
+    ///
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    ///
+    ///
+    /// #[derive(Component)]
+    /// struct PleaseDespawn;
+    ///
+    /// fn despawn_entities(mut commands: Commands) {
+    ///     commands.despawn_all::<With<PleaseDespawn>>();
+    /// }
+    ///
+    /// # bevy_ecs::system::assert_is_system(despawn_entities);
+    /// ```
+    pub fn despawn_all<F: QueryFilter>(&mut self) {
+        self.queue(command::despawn_all::<F>());
     }
 
     /// Pushes a generic [`Command`] to the command queue.
@@ -2440,6 +2463,7 @@ impl<'a, T: Component> EntityEntryCommands<'a, T> {
 mod tests {
     use crate::{
         component::Component,
+        query::{Or, With, Without},
         resource::Resource,
         system::Commands,
         world::{CommandQueue, FromWorld, World},
@@ -3058,5 +3082,36 @@ mod tests {
             Some(expected),
             world.entities().entity_get_spawn_or_despawn_tick(id)
         );
+    }
+
+    #[test]
+    fn despawn_all_command_despawns() {
+        let mut world = World::default();
+
+        #[derive(Component)]
+        struct ComponentA;
+
+        #[derive(Component)]
+        struct ComponentB;
+
+        #[derive(Component)]
+        struct ComponentC;
+
+        let a_1 = world.spawn(ComponentA).id();
+        let a_2 = world.spawn(ComponentA).id();
+        let a_b = world.spawn((ComponentA, ComponentB)).id();
+        let c = world.spawn(ComponentC).id();
+
+        let mut commands = world.commands();
+
+        commands.despawn_all::<Or<(With<ComponentC>, (With<ComponentA>, Without<ComponentB>))>>();
+
+        world.flush_commands();
+
+        assert!(world.get_entity(a_1).is_err());
+        assert!(world.get_entity(a_2).is_err());
+        assert!(world.get_entity(c).is_err());
+
+        assert!(world.get_entity(a_b).is_ok());
     }
 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -65,7 +65,7 @@ use crate::{
         },
     },
 };
-use alloc::vec::Vec;
+use alloc::{collections::VecDeque, vec::Vec};
 use bevy_platform::{
     cell::SyncUnsafeCell,
     sync::atomic::{AtomicU32, Ordering},
@@ -1669,6 +1669,73 @@ impl World {
         })?;
         entity.despawn_no_free_with_caller(caller);
         Ok(entity.id())
+    }
+
+    /// [`Despawns`](Self::despawn) all entities matching the [`QueryFilter`].
+    #[track_caller]
+    #[inline]
+    pub fn despawn_all<F: QueryFilter>(&mut self) {
+        self.despawn_all_with_caller::<F>(MaybeLocation::caller());
+    }
+
+    /// [`Despawns`](Self::despawn) all entities matching a specific [`QueryFilter`] and condition.
+    #[track_caller]
+    #[inline]
+    pub fn despawn_all_where<D: QueryData, F: QueryFilter>(
+        &mut self,
+        cond: impl FnMut(Entity, D::Item<'_, '_>) -> bool,
+    ) {
+        self.despawn_all_where_with_caller::<D, F>(cond, MaybeLocation::caller());
+    }
+
+    /// [`despawn_all`](Self::despawn_all) that takes a caller explicitly.
+    #[inline]
+    pub(crate) fn despawn_all_with_caller<F: QueryFilter>(&mut self, caller: MaybeLocation) {
+        self.despawn_all_where_with_caller::<(), F>(|_, _| true, caller);
+    }
+
+    /// [`despawn_all_where`](Self::despawn_all_where) that takes a caller explicitly.
+    pub(crate) fn despawn_all_where_with_caller<D: QueryData, F: QueryFilter>(
+        &mut self,
+        mut cond: impl FnMut(Entity, D::Item<'_, '_>) -> bool,
+        caller: MaybeLocation,
+    ) {
+        let mut query = self.query_filtered::<(Entity, D), F>();
+        let mut query = query.iter_mut(self);
+
+        let mut entities_to_despawn = VecDeque::new();
+
+        while let Some((entity, data)) = query.fetch_next() {
+            if cond(entity, data) {
+                // We want to despawn the entities backwards since we're
+                // less likely to leave holes.
+                entities_to_despawn.push_front(entity);
+            }
+        }
+        // We have to explicitly drop the query to release the world borrow.
+        drop(query);
+
+        // This part of the closure does not need to be generic.
+        // Compiling it once saves a bit of compile time.
+        fn despawn_entities(
+            world: &mut World,
+            mut entities_to_despawn: VecDeque<Entity>,
+            caller: MaybeLocation,
+        ) {
+            entities_to_despawn.retain(|entity| {
+                let _ = world.despawn_no_free_with_caller(*entity, caller);
+
+                // Check if the entity wasn't already freed or reconstructed.
+                matches!(world.entities.get(*entity), Ok(None))
+            });
+
+            let (head, tail) = entities_to_despawn.as_slices();
+
+            world.entity_allocator.free_many(head);
+            world.entity_allocator.free_many(tail);
+        }
+
+        despawn_entities(self, entities_to_despawn, caller);
     }
 
     /// Clears the internal component tracker state.

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -252,9 +252,9 @@ pub fn save_to_disk(path: impl AsRef<Path>) -> impl FnMut(On<ScreenshotCaptured>
     }
 }
 
-fn clear_screenshots(mut commands: Commands, screenshots: Query<Entity, With<Captured>>) {
-    for entity in screenshots.iter() {
-        commands.entity(entity).despawn();
+fn clear_screenshots(mut commands: Commands, screenshots: Query<(), With<Captured>>) {
+    if !screenshots.is_empty() {
+        commands.despawn_all::<With<Captured>>();
     }
 }
 

--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -178,10 +178,11 @@ pub fn despawn_entities_on_exit_state<S: States>(
     let Some(exited) = &transition.exited else {
         return;
     };
-    for (entity, exit) in &query {
-        if exit.0 == *exited {
-            commands.entity(entity).try_despawn();
-        }
+    if !query.is_empty() {
+        let exited = exited.clone();
+        commands.despawn_all_where::<&DespawnOnExit<S>, Allow<Disabled>>(move |_, exit| {
+            exit.0 == exited
+        });
     }
 }
 
@@ -257,10 +258,11 @@ pub fn despawn_entities_on_enter_state<S: States>(
         return;
     };
 
-    for (entity, enter) in &query {
-        if enter.0 == *entered {
-            commands.entity(entity).try_despawn();
-        }
+    if !query.is_empty() {
+        let entered = entered.clone();
+        commands.despawn_all_where::<&DespawnOnEnter<S>, Allow<Disabled>>(move |_, enter| {
+            enter.0 == entered
+        });
     }
 }
 

--- a/crates/bevy_state/src/state_scoped.rs
+++ b/crates/bevy_state/src/state_scoped.rs
@@ -256,6 +256,7 @@ pub fn despawn_entities_on_enter_state<S: States>(
     let Some(entered) = &transition.entered else {
         return;
     };
+
     for (entity, enter) in &query {
         if enter.0 == *entered {
             commands.entity(entity).try_despawn();


### PR DESCRIPTION
# Objective

Closes #4044

Add `despawn_all` and `despawn_all_where`. Commands that mass despawn entities based on a query filter. The current implementation is currently mostly useful to limit the number commands issued to the world

## Testing

Doc tests to check if it compiles and 2 test cases to check if it works.

For benchmarking I didn't create 1 benchmark where I swapped out the implementation. I added 2 benchmarks: one for the standard solution of querying over all the entities and submitting despawn commands for each, and one for just submitting a single despawn_all command. This way we can measure both implementations separately if we're improving them.

Here are the numbers:
```
despawn_commands/despawn_100
                        time:   [5.0155 µs 5.0290 µs 5.0423 µs]
despawn_commands/despawn_all_100
                        time:   [4.3340 µs 4.3549 µs 4.3724 µs]
despawn_commands/despawn_1000
                        time:   [37.328 µs 37.375 µs 37.433 µs]
despawn_commands/despawn_all_1000
                        time:   [28.509 µs 28.566 µs 28.615 µs]
despawn_commands/despawn_10000
                        time:   [388.62 µs 389.31 µs 390.19 µs]
despawn_commands/despawn_all_10000
                        time:   [286.75 µs 287.36 µs 288.02 µs]
```
 `despawn_{entity count}` is for the standard implementation. `despawn_all_{entity count}` is for the new command. We see a 15-30% speed improvement that grows the more entities we try to delete.