### PR TITLE
Make downsample.wesl valid WESL

### DIFF
--- a/_release-content/migration-guides/downsample_shader_specialization.md
+++ b/_release-content/migration-guides/downsample_shader_specialization.md
@@ -16,5 +16,5 @@ let pipelines = create_downsampling_pipelines(
     true, // array_texture
     combine_bind_groups,
 )
-.unwrap();
+.expect("a downsample shader is available for the texture format, `rgba16float`");
 ```

--- a/_release-content/migration-guides/downsample_shader_specialization.md
+++ b/_release-content/migration-guides/downsample_shader_specialization.md
@@ -1,0 +1,20 @@
+---
+title: "`DownsampleShaders::general` is now a `Handle<Shader>`"
+pull_requests: [25744]
+---
+
+`DownsampleShaders::general` is now a single `Handle<Shader>` instead of a `HashMap<TextureFormat, Handle<Shader>>`.
+
+Code that looked up a shader in the map and queued its own compute pipelines should call `bevy_core_pipeline::mip_generation::create_downsampling_pipelines` instead. It returns the bind group layouts and pipelines for a texture format, and adds the required shader defs itself:
+
+```rust
+let pipelines = create_downsampling_pipelines(
+    &render_device,
+    &pipeline_cache,
+    &downsample_shaders,
+    TextureFormat::Rgba16Float,
+    true, // array_texture
+    combine_bind_groups,
+)
+.unwrap();
+```

--- a/_release-content/migration-guides/downsample_shader_specialization.md
+++ b/_release-content/migration-guides/downsample_shader_specialization.md
@@ -5,16 +5,21 @@ pull_requests: [25744]
 
 `DownsampleShaders::general` is now a single `Handle<Shader>` instead of a `HashMap<TextureFormat, Handle<Shader>>`.
 
-Code that looked up a shader in the map and queued its own compute pipelines should call `bevy_core_pipeline::mip_generation::create_downsampling_pipelines` instead. It returns the bind group layouts and pipelines for a texture format, and adds the required shader defs itself:
+Code that looked up a shader in `DownsampleShaders::general` and queued its own compute pipelines should specialize the new `DownsamplePipeline` resource instead. It adds the required shader defs itself. Build a `DownsamplePipelineKey` for each pass, then get the pipeline from `SpecializedComputePipelines<DownsamplePipeline>` and the bind group layout from the key:
 
 ```rust
-let pipelines = create_downsampling_pipelines(
-    &render_device,
-    &pipeline_cache,
-    &downsample_shaders,
-    TextureFormat::Rgba16Float,
-    true, // array_texture
-    combine_bind_groups,
-)
-.expect("a downsample shader is available for the texture format, `rgba16float`");
+let first = DownsamplePipelineKey {
+    texture_format: TextureFormat::Rgba16Float,
+    array_texture: true, // for cubemaps and other 2D array textures
+    combine_bind_groups: can_combine_downsampling_bind_groups(&render_adapter, &render_device),
+    pass: DownsamplePass::First,
+};
+let second = DownsamplePipelineKey { pass: DownsamplePass::Second, ..first };
+
+let first_pipeline = specialized_pipelines.specialize(&pipeline_cache, &downsample_pipeline, first);
+let first_layout = first.bind_group_layout();
 ```
+
+If you do this in a `RenderStartup` system, order it after `init_gpu_resource::<DownsamplePipeline>` and `init_gpu_resource::<SpecializedComputePipelines<DownsamplePipeline>>`, since both resources are created there.
+
+The `FIRST_PASS` and `SECOND_PASS` shader defs in `downsample.wesl` are now `SPLIT_BIND_GROUP_FIRST` and `SPLIT_BIND_GROUP_SECOND`.

--- a/crates/bevy_core_pipeline/src/mip_generation/downsample.wesl
+++ b/crates/bevy_core_pipeline/src/mip_generation/downsample.wesl
@@ -4,76 +4,186 @@
 @group(0) @binding(0) var sampler_linear_clamp: sampler;
 @group(0) @binding(1) var<uniform> constants: Constants;
 
-@if(ARRAY_TEXTURE && COMBINE_BIND_GROUP) {
-@group(0) @binding(2) var mip_0: texture_2d_array<f32>;
-@group(0) @binding(3) var mip_1: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(4) var mip_2: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(5) var mip_3: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(6) var mip_4: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(7) var mip_5: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(8) var mip_6: texture_storage_2d_array<##TEXTURE_FORMAT##, read_write>;
-@group(0) @binding(9) var mip_7: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(10) var mip_8: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(11) var mip_9: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(12) var mip_10: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(13) var mip_11: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(14) var mip_12: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
+@if(TEXTURE_FORMAT_RGBA8UNORM) {
+alias MipWrite2d = texture_storage_2d<rgba8unorm, write>;
+alias MipReadWrite2d = texture_storage_2d<rgba8unorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rgba8unorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rgba8unorm, read_write>;
 }
 
-@if(ARRAY_TEXTURE && FIRST_PASS) {
-@group(0) @binding(2) var mip_0: texture_2d_array<f32>;
-@group(0) @binding(3) var mip_1: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(4) var mip_2: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(5) var mip_3: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(6) var mip_4: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(7) var mip_5: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(8) var mip_6: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
+@if(TEXTURE_FORMAT_RGBA8SNORM) {
+alias MipWrite2d = texture_storage_2d<rgba8snorm, write>;
+alias MipReadWrite2d = texture_storage_2d<rgba8snorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rgba8snorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rgba8snorm, read_write>;
 }
 
-@if(ARRAY_TEXTURE && SECOND_PASS) {
-@group(0) @binding(2) var mip_6: texture_2d_array<f32>;
-@group(0) @binding(3) var mip_7: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(4) var mip_8: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(5) var mip_9: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(6) var mip_10: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(7) var mip_11: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(8) var mip_12: texture_storage_2d_array<##TEXTURE_FORMAT##, write>;
+@if(TEXTURE_FORMAT_RGBA16UNORM) {
+alias MipWrite2d = texture_storage_2d<rgba16unorm, write>;
+alias MipReadWrite2d = texture_storage_2d<rgba16unorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rgba16unorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rgba16unorm, read_write>;
 }
 
-@if(!ARRAY_TEXTURE && COMBINE_BIND_GROUP) {
-@group(0) @binding(2) var mip_0: texture_2d<f32>;
-@group(0) @binding(3) var mip_1: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(4) var mip_2: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(5) var mip_3: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(6) var mip_4: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(7) var mip_5: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(8) var mip_6: texture_storage_2d<##TEXTURE_FORMAT##, read_write>;
-@group(0) @binding(9) var mip_7: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(10) var mip_8: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(11) var mip_9: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(12) var mip_10: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(13) var mip_11: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(14) var mip_12: texture_storage_2d<##TEXTURE_FORMAT##, write>;
+@if(TEXTURE_FORMAT_RGBA16SNORM) {
+alias MipWrite2d = texture_storage_2d<rgba16snorm, write>;
+alias MipReadWrite2d = texture_storage_2d<rgba16snorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rgba16snorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rgba16snorm, read_write>;
 }
 
-@if(!ARRAY_TEXTURE && FIRST_PASS) {
-@group(0) @binding(2) var mip_0: texture_2d<f32>;
-@group(0) @binding(3) var mip_1: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(4) var mip_2: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(5) var mip_3: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(6) var mip_4: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(7) var mip_5: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(8) var mip_6: texture_storage_2d<##TEXTURE_FORMAT##, write>;
+@if(TEXTURE_FORMAT_RGBA16FLOAT) {
+alias MipWrite2d = texture_storage_2d<rgba16float, write>;
+alias MipReadWrite2d = texture_storage_2d<rgba16float, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rgba16float, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rgba16float, read_write>;
 }
 
-@if(!ARRAY_TEXTURE && SECOND_PASS) {
-@group(0) @binding(2) var mip_6: texture_2d<f32>;
-@group(0) @binding(3) var mip_7: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(4) var mip_8: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(5) var mip_9: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(6) var mip_10: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(7) var mip_11: texture_storage_2d<##TEXTURE_FORMAT##, write>;
-@group(0) @binding(8) var mip_12: texture_storage_2d<##TEXTURE_FORMAT##, write>;
+@if(TEXTURE_FORMAT_RG8UNORM) {
+alias MipWrite2d = texture_storage_2d<rg8unorm, write>;
+alias MipReadWrite2d = texture_storage_2d<rg8unorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rg8unorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rg8unorm, read_write>;
+}
+
+@if(TEXTURE_FORMAT_RG8SNORM) {
+alias MipWrite2d = texture_storage_2d<rg8snorm, write>;
+alias MipReadWrite2d = texture_storage_2d<rg8snorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rg8snorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rg8snorm, read_write>;
+}
+
+@if(TEXTURE_FORMAT_RG16UNORM) {
+alias MipWrite2d = texture_storage_2d<rg16unorm, write>;
+alias MipReadWrite2d = texture_storage_2d<rg16unorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rg16unorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rg16unorm, read_write>;
+}
+
+@if(TEXTURE_FORMAT_RG16SNORM) {
+alias MipWrite2d = texture_storage_2d<rg16snorm, write>;
+alias MipReadWrite2d = texture_storage_2d<rg16snorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rg16snorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rg16snorm, read_write>;
+}
+
+@if(TEXTURE_FORMAT_RG16FLOAT) {
+alias MipWrite2d = texture_storage_2d<rg16float, write>;
+alias MipReadWrite2d = texture_storage_2d<rg16float, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rg16float, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rg16float, read_write>;
+}
+
+@if(TEXTURE_FORMAT_R32FLOAT) {
+alias MipWrite2d = texture_storage_2d<r32float, write>;
+alias MipReadWrite2d = texture_storage_2d<r32float, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<r32float, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<r32float, read_write>;
+}
+
+@if(TEXTURE_FORMAT_RG32FLOAT) {
+alias MipWrite2d = texture_storage_2d<rg32float, write>;
+alias MipReadWrite2d = texture_storage_2d<rg32float, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rg32float, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rg32float, read_write>;
+}
+
+@if(TEXTURE_FORMAT_RGBA32FLOAT) {
+alias MipWrite2d = texture_storage_2d<rgba32float, write>;
+alias MipReadWrite2d = texture_storage_2d<rgba32float, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rgba32float, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rgba32float, read_write>;
+}
+
+@if(TEXTURE_FORMAT_BGRA8UNORM) {
+alias MipWrite2d = texture_storage_2d<bgra8unorm, write>;
+alias MipReadWrite2d = texture_storage_2d<bgra8unorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<bgra8unorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<bgra8unorm, read_write>;
+}
+
+@if(TEXTURE_FORMAT_R8UNORM) {
+alias MipWrite2d = texture_storage_2d<r8unorm, write>;
+alias MipReadWrite2d = texture_storage_2d<r8unorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<r8unorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<r8unorm, read_write>;
+}
+
+@if(TEXTURE_FORMAT_R8SNORM) {
+alias MipWrite2d = texture_storage_2d<r8snorm, write>;
+alias MipReadWrite2d = texture_storage_2d<r8snorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<r8snorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<r8snorm, read_write>;
+}
+
+@if(TEXTURE_FORMAT_R16UNORM) {
+alias MipWrite2d = texture_storage_2d<r16unorm, write>;
+alias MipReadWrite2d = texture_storage_2d<r16unorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<r16unorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<r16unorm, read_write>;
+}
+
+@if(TEXTURE_FORMAT_R16SNORM) {
+alias MipWrite2d = texture_storage_2d<r16snorm, write>;
+alias MipReadWrite2d = texture_storage_2d<r16snorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<r16snorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<r16snorm, read_write>;
+}
+
+@if(TEXTURE_FORMAT_R16FLOAT) {
+alias MipWrite2d = texture_storage_2d<r16float, write>;
+alias MipReadWrite2d = texture_storage_2d<r16float, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<r16float, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<r16float, read_write>;
+}
+
+@if(TEXTURE_FORMAT_RGB10A2UNORM) {
+alias MipWrite2d = texture_storage_2d<rgb10a2unorm, write>;
+alias MipReadWrite2d = texture_storage_2d<rgb10a2unorm, read_write>;
+alias MipWrite2dArray = texture_storage_2d_array<rgb10a2unorm, write>;
+alias MipReadWrite2dArray = texture_storage_2d_array<rgb10a2unorm, read_write>;
+}
+
+@if(ARRAY_TEXTURE) {
+alias SourceTexture = texture_2d_array<f32>;
+alias MipWrite = MipWrite2dArray;
+alias MipReadWrite = MipReadWrite2dArray;
+} @else {
+alias SourceTexture = texture_2d<f32>;
+alias MipWrite = MipWrite2d;
+alias MipReadWrite = MipReadWrite2d;
+}
+@if(COMBINE_BIND_GROUP || FIRST_PASS) {
+@group(0) @binding(2) var mip_0: SourceTexture;
+@group(0) @binding(3) var mip_1: MipWrite;
+@group(0) @binding(4) var mip_2: MipWrite;
+@group(0) @binding(5) var mip_3: MipWrite;
+@group(0) @binding(6) var mip_4: MipWrite;
+@group(0) @binding(7) var mip_5: MipWrite;
+}
+
+@if(COMBINE_BIND_GROUP) {
+@group(0) @binding(8) var mip_6: MipReadWrite;
+@group(0) @binding(9) var mip_7: MipWrite;
+@group(0) @binding(10) var mip_8: MipWrite;
+@group(0) @binding(11) var mip_9: MipWrite;
+@group(0) @binding(12) var mip_10: MipWrite;
+@group(0) @binding(13) var mip_11: MipWrite;
+@group(0) @binding(14) var mip_12: MipWrite;
+}
+
+@if(FIRST_PASS) {
+@group(0) @binding(8) var mip_6: MipWrite;
+}
+
+@if(SECOND_PASS) {
+@group(0) @binding(2) var mip_6: SourceTexture;
+@group(0) @binding(3) var mip_7: MipWrite;
+@group(0) @binding(4) var mip_8: MipWrite;
+@group(0) @binding(5) var mip_9: MipWrite;
+@group(0) @binding(6) var mip_10: MipWrite;
+@group(0) @binding(7) var mip_11: MipWrite;
+@group(0) @binding(8) var mip_12: MipWrite;
 }
 
 struct Constants { mips: u32, inverse_input_size: vec2f }

--- a/crates/bevy_core_pipeline/src/mip_generation/downsample.wesl
+++ b/crates/bevy_core_pipeline/src/mip_generation/downsample.wesl
@@ -153,7 +153,8 @@ alias SourceTexture = texture_2d<f32>;
 alias MipWrite = MipWrite2d;
 alias MipReadWrite = MipReadWrite2d;
 }
-@if(COMBINE_BIND_GROUP || FIRST_PASS) {
+
+@if(COMBINE_BIND_GROUP || SPLIT_BIND_GROUP_FIRST) {
 @group(0) @binding(2) var mip_0: SourceTexture;
 @group(0) @binding(3) var mip_1: MipWrite;
 @group(0) @binding(4) var mip_2: MipWrite;
@@ -172,11 +173,11 @@ alias MipReadWrite = MipReadWrite2d;
 @group(0) @binding(14) var mip_12: MipWrite;
 }
 
-@if(FIRST_PASS) {
+@if(SPLIT_BIND_GROUP_FIRST) {
 @group(0) @binding(8) var mip_6: MipWrite;
 }
 
-@if(SECOND_PASS) {
+@if(SPLIT_BIND_GROUP_SECOND) {
 @group(0) @binding(2) var mip_6: SourceTexture;
 @group(0) @binding(3) var mip_7: MipWrite;
 @group(0) @binding(4) var mip_8: MipWrite;
@@ -468,9 +469,9 @@ fn spd_reduce_load_source_image(uv: vec2u, slice: u32) -> vec4f {
 
     @if(COMBINE_BIND_GROUP)
     let result = textureSampleLevel(mip_0, sampler_linear_clamp, texture_coord, slice, 0.0);
-    @if(FIRST_PASS)
+    @if(SPLIT_BIND_GROUP_FIRST)
     let result = textureSampleLevel(mip_0, sampler_linear_clamp, texture_coord, slice, 0.0);
-    @if(SECOND_PASS)
+    @if(SPLIT_BIND_GROUP_SECOND)
     let result = textureSampleLevel(mip_6, sampler_linear_clamp, texture_coord, slice, 0.0);
 
 @if(SRGB_CONVERSION)
@@ -491,9 +492,9 @@ fn spd_reduce_load_source_image(uv: vec2u, slice: u32) -> vec4f {
 
     @if(COMBINE_BIND_GROUP)
     let result = textureSampleLevel(mip_0, sampler_linear_clamp, texture_coord, 0.0);
-    @if(FIRST_PASS)
+    @if(SPLIT_BIND_GROUP_FIRST)
     let result = textureSampleLevel(mip_0, sampler_linear_clamp, texture_coord, 0.0);
-    @if(SECOND_PASS)
+    @if(SPLIT_BIND_GROUP_SECOND)
     let result = textureSampleLevel(mip_6, sampler_linear_clamp, texture_coord, 0.0);
 
 @if(SRGB_CONVERSION)
@@ -536,29 +537,29 @@ fn spd_store(pix: vec2u, value: vec4f, mip: u32, slice: u32) {
         case 10u: { textureStore(mip_11, pix, slice, value); }
         @if(COMBINE_BIND_GROUP)
         case 11u: { textureStore(mip_12, pix, slice, value); }
-        @if(FIRST_PASS)
+        @if(SPLIT_BIND_GROUP_FIRST)
         case 0u: { textureStore(mip_1, pix, slice, value); }
-        @if(FIRST_PASS)
+        @if(SPLIT_BIND_GROUP_FIRST)
         case 1u: { textureStore(mip_2, pix, slice, value); }
-        @if(FIRST_PASS)
+        @if(SPLIT_BIND_GROUP_FIRST)
         case 2u: { textureStore(mip_3, pix, slice, value); }
-        @if(FIRST_PASS)
+        @if(SPLIT_BIND_GROUP_FIRST)
         case 3u: { textureStore(mip_4, pix, slice, value); }
-        @if(FIRST_PASS)
+        @if(SPLIT_BIND_GROUP_FIRST)
         case 4u: { textureStore(mip_5, pix, slice, value); }
-        @if(FIRST_PASS)
+        @if(SPLIT_BIND_GROUP_FIRST)
         case 5u: { textureStore(mip_6, pix, slice, value); }
-        @if(SECOND_PASS)
+        @if(SPLIT_BIND_GROUP_SECOND)
         case 6u: { textureStore(mip_7, pix, slice, value); }
-        @if(SECOND_PASS)
+        @if(SPLIT_BIND_GROUP_SECOND)
         case 7u: { textureStore(mip_8, pix, slice, value); }
-        @if(SECOND_PASS)
+        @if(SPLIT_BIND_GROUP_SECOND)
         case 8u: { textureStore(mip_9, pix, slice, value); }
-        @if(SECOND_PASS)
+        @if(SPLIT_BIND_GROUP_SECOND)
         case 9u: { textureStore(mip_10, pix, slice, value); }
-        @if(SECOND_PASS)
+        @if(SPLIT_BIND_GROUP_SECOND)
         case 10u: { textureStore(mip_11, pix, slice, value); }
-        @if(SECOND_PASS)
+        @if(SPLIT_BIND_GROUP_SECOND)
         case 11u: { textureStore(mip_12, pix, slice, value); }
         default: {}
     }
@@ -591,29 +592,29 @@ fn spd_store(pix: vec2u, value: vec4f, mip: u32, slice: u32) {
         case 10u: { textureStore(mip_11, pix, value); }
         @if(COMBINE_BIND_GROUP)
         case 11u: { textureStore(mip_12, pix, value); }
-        @if(FIRST_PASS)
+        @if(SPLIT_BIND_GROUP_FIRST)
         case 0u: { textureStore(mip_1, pix, value); }
-        @if(FIRST_PASS)
+        @if(SPLIT_BIND_GROUP_FIRST)
         case 1u: { textureStore(mip_2, pix, value); }
-        @if(FIRST_PASS)
+        @if(SPLIT_BIND_GROUP_FIRST)
         case 2u: { textureStore(mip_3, pix, value); }
-        @if(FIRST_PASS)
+        @if(SPLIT_BIND_GROUP_FIRST)
         case 3u: { textureStore(mip_4, pix, value); }
-        @if(FIRST_PASS)
+        @if(SPLIT_BIND_GROUP_FIRST)
         case 4u: { textureStore(mip_5, pix, value); }
-        @if(FIRST_PASS)
+        @if(SPLIT_BIND_GROUP_FIRST)
         case 5u: { textureStore(mip_6, pix, value); }
-        @if(SECOND_PASS)
+        @if(SPLIT_BIND_GROUP_SECOND)
         case 6u: { textureStore(mip_7, pix, value); }
-        @if(SECOND_PASS)
+        @if(SPLIT_BIND_GROUP_SECOND)
         case 7u: { textureStore(mip_8, pix, value); }
-        @if(SECOND_PASS)
+        @if(SPLIT_BIND_GROUP_SECOND)
         case 8u: { textureStore(mip_9, pix, value); }
-        @if(SECOND_PASS)
+        @if(SPLIT_BIND_GROUP_SECOND)
         case 9u: { textureStore(mip_10, pix, value); }
-        @if(SECOND_PASS)
+        @if(SPLIT_BIND_GROUP_SECOND)
         case 10u: { textureStore(mip_11, pix, value); }
-        @if(SECOND_PASS)
+        @if(SPLIT_BIND_GROUP_SECOND)
         case 11u: { textureStore(mip_12, pix, value); }
         default: {}
     }
@@ -647,9 +648,9 @@ fn spd_reduce_load_4(i0: vec2u, i1: vec2u, i2: vec2u, i3: vec2u, slice: u32) -> 
     let v3 = textureLoad(mip_6, i3, slice);
     return spd_reduce_4(v0, v1, v2, v3);
     }
-    @if(FIRST_PASS)
+    @if(SPLIT_BIND_GROUP_FIRST)
     return vec4(0.0, 0.0, 0.0, 0.0);
-    @if(SECOND_PASS) {
+    @if(SPLIT_BIND_GROUP_SECOND) {
     let v0 = textureLoad(mip_6, i0, slice, 0);
     let v1 = textureLoad(mip_6, i1, slice, 0);
     let v2 = textureLoad(mip_6, i2, slice, 0);
@@ -666,9 +667,9 @@ fn spd_reduce_load_4(i0: vec2u, i1: vec2u, i2: vec2u, i3: vec2u, slice: u32) -> 
     let v3 = textureLoad(mip_6, i3);
     return spd_reduce_4(v0, v1, v2, v3);
     }
-    @if(FIRST_PASS)
+    @if(SPLIT_BIND_GROUP_FIRST)
     return vec4(0.0, 0.0, 0.0, 0.0);
-    @if(SECOND_PASS) {
+    @if(SPLIT_BIND_GROUP_SECOND) {
     let v0 = textureLoad(mip_6, i0, 0);
     let v1 = textureLoad(mip_6, i1, 0);
     let v2 = textureLoad(mip_6, i2, 0);

--- a/crates/bevy_core_pipeline/src/mip_generation/mod.rs
+++ b/crates/bevy_core_pipeline/src/mip_generation/mod.rs
@@ -20,7 +20,7 @@ use crate::prepass::node::late_prepass;
 use crate::schedule::{Core3d, Core3dSystems};
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{embedded_asset, load_embedded_asset, AssetId, Assets, Handle};
+use bevy_asset::{embedded_asset, load_embedded_asset, AssetId, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     prelude::resource_exists,
@@ -37,7 +37,10 @@ use bevy_render::{
     diagnostic::RecordDiagnostics as _,
     render_asset::RenderAssets,
     render_resource::{
-        binding_types::{sampler, texture_2d, texture_storage_2d, uniform_buffer},
+        binding_types::{
+            sampler, texture_2d, texture_2d_array, texture_storage_2d, texture_storage_2d_array,
+            uniform_buffer,
+        },
         BindGroup, BindGroupEntries, BindGroupLayoutDescriptor, BindGroupLayoutEntries,
         CachedComputePipelineId, ComputePassDescriptor, ComputePipelineDescriptor, Extent3d,
         FilterMode, MipmapFilterMode, PipelineCache, Sampler, SamplerBindingType,
@@ -63,69 +66,47 @@ pub struct DownsampleShaders {
     /// The experimental shader that downsamples depth
     /// (`downsample_depth.wesl`).
     pub depth: Handle<Shader>,
-    /// The shaders that perform downsampling of color textures.
+    /// The shader that performs downsampling of color textures
+    /// (`downsample.wesl`).
     ///
-    /// This table maps a [`TextureFormat`] to the shader that performs
-    /// downsampling for textures in that format.
-    pub general: HashMap<TextureFormat, Handle<Shader>>,
+    /// Use [`create_downsampling_pipelines`] to specialize it for a texture
+    /// format.
+    pub general: Handle<Shader>,
 }
 
 // The number of storage textures required to combine the bind groups in the
 // downsampling shader.
 const REQUIRED_STORAGE_TEXTURES: u32 = 12;
 
-/// All texture formats that we can perform downsampling for.
-///
-/// This is a list of pairs, each of which consists of the [`TextureFormat`] and
-/// the WGSL name for that texture format.
-///
-/// The comprehensive list of WGSL names for texture formats can be found in
-/// [the relevant section of the WGSL specification].
-///
-/// [the relevant section of the WGSL specification]:
-/// https://www.w3.org/TR/WGSL/#texel-formats
-static TEXTURE_FORMATS: [(TextureFormat, &str); 40] = [
-    (TextureFormat::Rgba8Unorm, "rgba8unorm"),
-    (TextureFormat::Rgba8Snorm, "rgba8snorm"),
-    (TextureFormat::Rgba8Uint, "rgba8uint"),
-    (TextureFormat::Rgba8Sint, "rgba8sint"),
-    (TextureFormat::Rgba16Unorm, "rgba16unorm"),
-    (TextureFormat::Rgba16Snorm, "rgba16snorm"),
-    (TextureFormat::Rgba16Uint, "rgba16uint"),
-    (TextureFormat::Rgba16Sint, "rgba16sint"),
-    (TextureFormat::Rgba16Float, "rgba16float"),
-    (TextureFormat::Rg8Unorm, "rg8unorm"),
-    (TextureFormat::Rg8Snorm, "rg8snorm"),
-    (TextureFormat::Rg8Uint, "rg8uint"),
-    (TextureFormat::Rg8Sint, "rg8sint"),
-    (TextureFormat::Rg16Unorm, "rg16unorm"),
-    (TextureFormat::Rg16Snorm, "rg16snorm"),
-    (TextureFormat::Rg16Uint, "rg16uint"),
-    (TextureFormat::Rg16Sint, "rg16sint"),
-    (TextureFormat::Rg16Float, "rg16float"),
-    (TextureFormat::R32Uint, "r32uint"),
-    (TextureFormat::R32Sint, "r32sint"),
-    (TextureFormat::R32Float, "r32float"),
-    (TextureFormat::Rg32Uint, "rg32uint"),
-    (TextureFormat::Rg32Sint, "rg32sint"),
-    (TextureFormat::Rg32Float, "rg32float"),
-    (TextureFormat::Rgba32Uint, "rgba32uint"),
-    (TextureFormat::Rgba32Sint, "rgba32sint"),
-    (TextureFormat::Rgba32Float, "rgba32float"),
-    (TextureFormat::Bgra8Unorm, "bgra8unorm"),
-    (TextureFormat::R8Unorm, "r8unorm"),
-    (TextureFormat::R8Snorm, "r8snorm"),
-    (TextureFormat::R8Uint, "r8uint"),
-    (TextureFormat::R8Sint, "r8sint"),
-    (TextureFormat::R16Unorm, "r16unorm"),
-    (TextureFormat::R16Snorm, "r16snorm"),
-    (TextureFormat::R16Uint, "r16uint"),
-    (TextureFormat::R16Sint, "r16sint"),
-    (TextureFormat::R16Float, "r16float"),
-    (TextureFormat::Rgb10a2Unorm, "rgb10a2unorm"),
-    (TextureFormat::Rgb10a2Uint, "rgb10a2uint"),
-    (TextureFormat::Rg11b10Ufloat, "rg11b10ufloat"),
-];
+/// Returns the shader def that selects the output format of `downsample.wesl`,
+/// or `None` if the format isn't supported. Only float formats are supported
+/// because the shader stores `vec4f`.
+fn texture_format_shader_def(format: TextureFormat) -> Option<ShaderDefVal> {
+    let name = match format {
+        TextureFormat::Rgba8Unorm => "TEXTURE_FORMAT_RGBA8UNORM",
+        TextureFormat::Rgba8Snorm => "TEXTURE_FORMAT_RGBA8SNORM",
+        TextureFormat::Rgba16Unorm => "TEXTURE_FORMAT_RGBA16UNORM",
+        TextureFormat::Rgba16Snorm => "TEXTURE_FORMAT_RGBA16SNORM",
+        TextureFormat::Rgba16Float => "TEXTURE_FORMAT_RGBA16FLOAT",
+        TextureFormat::Rg8Unorm => "TEXTURE_FORMAT_RG8UNORM",
+        TextureFormat::Rg8Snorm => "TEXTURE_FORMAT_RG8SNORM",
+        TextureFormat::Rg16Unorm => "TEXTURE_FORMAT_RG16UNORM",
+        TextureFormat::Rg16Snorm => "TEXTURE_FORMAT_RG16SNORM",
+        TextureFormat::Rg16Float => "TEXTURE_FORMAT_RG16FLOAT",
+        TextureFormat::R32Float => "TEXTURE_FORMAT_R32FLOAT",
+        TextureFormat::Rg32Float => "TEXTURE_FORMAT_RG32FLOAT",
+        TextureFormat::Rgba32Float => "TEXTURE_FORMAT_RGBA32FLOAT",
+        TextureFormat::Bgra8Unorm => "TEXTURE_FORMAT_BGRA8UNORM",
+        TextureFormat::R8Unorm => "TEXTURE_FORMAT_R8UNORM",
+        TextureFormat::R8Snorm => "TEXTURE_FORMAT_R8SNORM",
+        TextureFormat::R16Unorm => "TEXTURE_FORMAT_R16UNORM",
+        TextureFormat::R16Snorm => "TEXTURE_FORMAT_R16SNORM",
+        TextureFormat::R16Float => "TEXTURE_FORMAT_R16FLOAT",
+        TextureFormat::Rgb10a2Unorm => "TEXTURE_FORMAT_RGB10A2UNORM",
+        _ => return None,
+    };
+    Some(name.into())
+}
 
 /// A render-world resource that stores a list of [`Image`]s that will have
 /// mipmaps generated for them.
@@ -210,15 +191,15 @@ pub struct MipGenerationPipelines {
 /// passes, not one. This is because WGSL doesn't presently support
 /// globally-coherent buffers; the only way to have a synchronization point is
 /// to issue a second dispatch.
-struct MipGenerationTextureFormatPipelines {
+pub struct MipGenerationTextureFormatPipelines {
     /// The bind group layout for the first pass of the downsampling shader.
-    downsampling_bind_group_layout_pass_1: BindGroupLayoutDescriptor,
+    pub downsampling_bind_group_layout_pass_1: BindGroupLayoutDescriptor,
     /// The bind group layout for the second pass of the downsampling shader.
-    downsampling_bind_group_layout_pass_2: BindGroupLayoutDescriptor,
+    pub downsampling_bind_group_layout_pass_2: BindGroupLayoutDescriptor,
     /// The compute pipeline for the first pass of the downsampling shader.
-    downsampling_pipeline_pass_1: CachedComputePipelineId,
+    pub downsampling_pipeline_pass_1: CachedComputePipelineId,
     /// The compute pipeline for the second pass of the downsampling shader.
-    downsampling_pipeline_pass_2: CachedComputePipelineId,
+    pub downsampling_pipeline_pass_2: CachedComputePipelineId,
 }
 
 /// Bind groups for the downsampling shader associated with a single texture.
@@ -258,30 +239,9 @@ impl Plugin for MipGenerationPlugin {
 
         let depth_shader = load_embedded_asset!(app, "experimental/downsample_depth.wesl");
 
-        // We don't have string-valued shader definitions, so we use a
-        // text-pasting hack. The `downsample.wesl` shader is eagerly
-        // specialized for each texture format by replacing `##TEXTURE_FORMAT##`
-        // with each possible format.
-        let mut shader_assets = app.world_mut().resource_mut::<Assets<Shader>>();
-        let shader_template_source = include_str!("downsample.wesl");
-        let general_shaders: HashMap<_, _> = TEXTURE_FORMATS
-            .iter()
-            .map(|(target_format, identifier)| {
-                let shader_source =
-                    shader_template_source.replace("##TEXTURE_FORMAT##", identifier);
-                (
-                    *target_format,
-                    shader_assets.add(Shader::from_wesl(
-                        shader_source,
-                        format!("downsample_{identifier}.wesl"),
-                    )),
-                )
-            })
-            .collect();
-
         let downsample_shaders = DownsampleShaders {
             depth: depth_shader,
-            general: general_shaders,
+            general: load_embedded_asset!(app, "downsample.wesl"),
         };
         app.insert_resource(downsample_shaders.clone());
 
@@ -579,7 +539,14 @@ fn get_or_create_mip_generation_pipelines<'a>(
 ) -> Option<&'a MipGenerationTextureFormatPipelines> {
     match mip_generation_pipelines.entry(target_format) {
         Entry::Vacant(vacant_entry) => {
-            let Some(downsample_shader) = downsample_shaders.general.get(&target_format) else {
+            let Some(pipelines) = create_downsampling_pipelines(
+                render_device,
+                pipeline_cache,
+                downsample_shaders,
+                target_format,
+                false,
+                combine_downsampling_bind_groups,
+            ) else {
                 error!(
                     "Attempted to generate mips for texture {:?} with format {:?}, but no \
                      downsample shader was available for that texture format",
@@ -588,29 +555,7 @@ fn get_or_create_mip_generation_pipelines<'a>(
                 return None;
             };
 
-            let (downsampling_bind_group_layout_pass_1, downsampling_bind_group_layout_pass_2) =
-                create_downsampling_bind_group_layouts(
-                    target_format,
-                    combine_downsampling_bind_groups,
-                );
-
-            let (downsampling_pipeline_pass_1, downsampling_pipeline_pass_2) =
-                create_downsampling_pipelines(
-                    render_device,
-                    pipeline_cache,
-                    &downsampling_bind_group_layout_pass_1,
-                    &downsampling_bind_group_layout_pass_2,
-                    downsample_shader,
-                    target_format,
-                    combine_downsampling_bind_groups,
-                );
-
-            Some(vacant_entry.insert(MipGenerationTextureFormatPipelines {
-                downsampling_bind_group_layout_pass_1,
-                downsampling_bind_group_layout_pass_2,
-                downsampling_pipeline_pass_1,
-                downsampling_pipeline_pass_2,
-            }))
+            Some(vacant_entry.insert(pipelines))
         }
 
         Entry::Occupied(occupied_entry) => Some(occupied_entry.into_mut()),
@@ -621,12 +566,25 @@ fn get_or_create_mip_generation_pipelines<'a>(
 /// shader for a single texture format.
 fn create_downsampling_bind_group_layouts(
     target_format: TextureFormat,
+    array_texture: bool,
     combine_downsampling_bind_groups: bool,
 ) -> (BindGroupLayoutDescriptor, BindGroupLayoutDescriptor) {
     let texture_sample_type = target_format.sample_type(None, None).expect(
         "Depth and multisample texture formats shouldn't have mip generation shaders to begin with",
     );
-    let mips_storage = texture_storage_2d(target_format, StorageTextureAccess::WriteOnly);
+    let (source_texture, mips_storage, mip6_storage) = if array_texture {
+        (
+            texture_2d_array(texture_sample_type),
+            texture_storage_2d_array(target_format, StorageTextureAccess::WriteOnly),
+            texture_storage_2d_array(target_format, StorageTextureAccess::ReadWrite),
+        )
+    } else {
+        (
+            texture_2d(texture_sample_type),
+            texture_storage_2d(target_format, StorageTextureAccess::WriteOnly),
+            texture_storage_2d(target_format, StorageTextureAccess::ReadWrite),
+        )
+    };
 
     if combine_downsampling_bind_groups {
         let bind_group_layout_descriptor = BindGroupLayoutDescriptor::new(
@@ -636,13 +594,13 @@ fn create_downsampling_bind_group_layouts(
                 (
                     sampler(SamplerBindingType::Filtering),
                     uniform_buffer::<DownsamplingConstants>(false),
-                    texture_2d(texture_sample_type),
+                    source_texture,
                     mips_storage, // 1
                     mips_storage, // 2
                     mips_storage, // 3
                     mips_storage, // 4
                     mips_storage, // 5
-                    texture_storage_2d(target_format, StorageTextureAccess::ReadWrite), // 6
+                    mip6_storage, // 6
                     mips_storage, // 7
                     mips_storage, // 8
                     mips_storage, // 9
@@ -669,7 +627,7 @@ fn create_downsampling_bind_group_layouts(
                 sampler(SamplerBindingType::Filtering),
                 uniform_buffer::<DownsamplingConstants>(false),
                 // Input mip 0
-                texture_2d(texture_sample_type),
+                source_texture,
                 mips_storage, // 1
                 mips_storage, // 2
                 mips_storage, // 3
@@ -688,7 +646,7 @@ fn create_downsampling_bind_group_layouts(
                 sampler(SamplerBindingType::Filtering),
                 uniform_buffer::<DownsamplingConstants>(false),
                 // Input mip 6
-                texture_2d(texture_sample_type),
+                source_texture,
                 mips_storage, // 7
                 mips_storage, // 8
                 mips_storage, // 9
@@ -804,19 +762,24 @@ fn create_downsampling_bind_groups(
 /// Creates the single-pass downsampling compute pipelines that perform
 /// downsampling on textures with a specific texture format.
 ///
+/// Returns `None` if the shader doesn't support `target_format`. Set
+/// `array_texture` to downsample a 2D array texture such as a cubemap.
+///
 /// Depending on whether the current platform can combine downsampling bind
 /// groups, this will either return two copies of the same pipeline or two
 /// different pipelines.
-fn create_downsampling_pipelines(
+pub fn create_downsampling_pipelines(
     render_device: &RenderDevice,
     pipeline_cache: &PipelineCache,
-    downsampling_bind_group_layout_pass_1: &BindGroupLayoutDescriptor,
-    downsampling_bind_group_layout_pass_2: &BindGroupLayoutDescriptor,
-    downsample_shader: &Handle<Shader>,
+    downsample_shaders: &DownsampleShaders,
     target_format: TextureFormat,
+    array_texture: bool,
     combine_downsampling_bind_groups: bool,
-) -> (CachedComputePipelineId, CachedComputePipelineId) {
-    let mut downsampling_shader_defs = vec![];
+) -> Option<MipGenerationTextureFormatPipelines> {
+    let mut downsampling_shader_defs = vec![
+        texture_format_shader_def(target_format)?,
+        ShaderDefVal::Bool("ARRAY_TEXTURE".into(), array_texture),
+    ];
     if render_device.features().contains(WgpuFeatures::SUBGROUP) {
         downsampling_shader_defs.push(ShaderDefVal::Int("SUBGROUP_SUPPORT".into(), 1));
     }
@@ -825,11 +788,18 @@ fn create_downsampling_pipelines(
     }
 
     let mut downsampling_first_shader_defs = downsampling_shader_defs.clone();
-    let mut downsampling_second_shader_defs = downsampling_shader_defs.clone();
+    let mut downsampling_second_shader_defs = downsampling_shader_defs;
     if !combine_downsampling_bind_groups {
         downsampling_first_shader_defs.push(ShaderDefVal::Int("FIRST_PASS".into(), 1));
         downsampling_second_shader_defs.push(ShaderDefVal::Int("SECOND_PASS".into(), 1));
     }
+
+    let (downsampling_bind_group_layout_pass_1, downsampling_bind_group_layout_pass_2) =
+        create_downsampling_bind_group_layouts(
+            target_format,
+            array_texture,
+            combine_downsampling_bind_groups,
+        );
 
     // Create the pipeline for the first pass, corresponding to mip levels [0,
     // 6].
@@ -838,7 +808,7 @@ fn create_downsampling_pipelines(
             label: Some(format!("mip generation pipeline, pass 1 ({:?})", target_format).into()),
             layout: vec![downsampling_bind_group_layout_pass_1.clone()],
             immediate_size: 0,
-            shader: downsample_shader.clone(),
+            shader: downsample_shaders.general.clone(),
             shader_defs: downsampling_first_shader_defs,
             entry_point: Some("downsample_first".into()),
             zero_initialize_workgroup_memory: false,
@@ -852,14 +822,19 @@ fn create_downsampling_pipelines(
             label: Some(format!("mip generation pipeline, pass 2 ({:?})", target_format).into()),
             layout: vec![downsampling_bind_group_layout_pass_2.clone()],
             immediate_size: 0,
-            shader: downsample_shader.clone(),
+            shader: downsample_shaders.general.clone(),
             shader_defs: downsampling_second_shader_defs,
             entry_point: Some("downsample_second".into()),
             zero_initialize_workgroup_memory: false,
             constants: vec![],
         });
 
-    (downsampling_first_pipeline, downsampling_second_pipeline)
+    Some(MipGenerationTextureFormatPipelines {
+        downsampling_bind_group_layout_pass_1,
+        downsampling_bind_group_layout_pass_2,
+        downsampling_pipeline_pass_1: downsampling_first_pipeline,
+        downsampling_pipeline_pass_2: downsampling_second_pipeline,
+    })
 }
 
 /// Creates the uniform buffer containing the [`DownsamplingConstants`] for a

--- a/crates/bevy_core_pipeline/src/mip_generation/mod.rs
+++ b/crates/bevy_core_pipeline/src/mip_generation/mod.rs
@@ -44,10 +44,10 @@ use bevy_render::{
         BindGroup, BindGroupEntries, BindGroupLayoutDescriptor, BindGroupLayoutEntries,
         CachedComputePipelineId, ComputePassDescriptor, ComputePipelineDescriptor, Extent3d,
         FilterMode, MipmapFilterMode, PipelineCache, Sampler, SamplerBindingType,
-        SamplerDescriptor, ShaderStages, ShaderType, SpecializedComputePipelines,
-        StorageTextureAccess, TextureAspect, TextureDescriptor, TextureDimension, TextureFormat,
-        TextureFormatFeatureFlags, TextureUsages, TextureView, TextureViewDescriptor,
-        TextureViewDimension, UniformBuffer,
+        SamplerDescriptor, ShaderStages, ShaderType, SpecializedComputePipeline,
+        SpecializedComputePipelines, StorageTextureAccess, TextureAspect, TextureDescriptor,
+        TextureDimension, TextureFormat, TextureFormatFeatureFlags, TextureUsages, TextureView,
+        TextureViewDescriptor, TextureViewDimension, UniformBuffer,
     },
     renderer::{RenderAdapter, RenderContext, RenderDevice, RenderQueue},
     settings::WgpuFeatures,
@@ -69,9 +69,120 @@ pub struct DownsampleShaders {
     /// The shader that performs downsampling of color textures
     /// (`downsample.wesl`).
     ///
-    /// Use [`create_downsampling_pipelines`] to specialize it for a texture
-    /// format.
+    /// [`DownsamplePipeline`] specializes it for a texture format.
     pub general: Handle<Shader>,
+}
+
+/// The single-pass downsampling compute pipeline for color textures.
+///
+/// Specialize it with [`SpecializedComputePipelines`] and a
+/// [`DownsamplePipelineKey`], once per [`DownsamplePass`].
+#[derive(Resource)]
+pub struct DownsamplePipeline {
+    /// The `downsample.wesl` shader.
+    shader: Handle<Shader>,
+    /// Whether the device supports subgroup operations.
+    subgroup_support: bool,
+}
+
+impl DownsamplePipeline {
+    /// Returns true if the shader can downsample textures in `format`.
+    ///
+    /// Only float formats are supported because the shader stores `vec4f`.
+    pub fn supports_texture_format(format: TextureFormat) -> bool {
+        texture_format_shader_def(format).is_some()
+    }
+}
+
+impl FromWorld for DownsamplePipeline {
+    fn from_world(world: &mut World) -> Self {
+        DownsamplePipeline {
+            shader: world.resource::<DownsampleShaders>().general.clone(),
+            subgroup_support: world
+                .resource::<RenderDevice>()
+                .features()
+                .contains(WgpuFeatures::SUBGROUP),
+        }
+    }
+}
+
+/// Selects a variant of the [`DownsamplePipeline`].
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct DownsamplePipelineKey {
+    /// The format of the texture to downsample.
+    ///
+    /// Must be a format that [`DownsamplePipeline::supports_texture_format`]
+    /// accepts.
+    pub texture_format: TextureFormat,
+    /// True if the texture is a 2D array texture, such as a cubemap.
+    pub array_texture: bool,
+    /// True if both passes share a single bind group.
+    ///
+    /// See [`can_combine_downsampling_bind_groups`].
+    pub combine_bind_groups: bool,
+    /// The pass that this pipeline runs.
+    pub pass: DownsamplePass,
+}
+
+/// One of the two dispatches of the single-pass downsampling shader.
+///
+/// Note that, despite the name, the single-pass downsampling shader has two
+/// passes, not one. This is because WGSL doesn't presently support
+/// globally-coherent buffers; the only way to have a synchronization point is
+/// to issue a second dispatch.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum DownsamplePass {
+    /// Produces mip levels 1 to 6.
+    First,
+    /// Produces mip levels 7 to 12.
+    Second,
+}
+
+impl SpecializedComputePipeline for DownsamplePipeline {
+    type Key = DownsamplePipelineKey;
+
+    fn specialize(&self, key: Self::Key) -> ComputePipelineDescriptor {
+        let mut shader_defs = vec![
+            texture_format_shader_def(key.texture_format).unwrap_or_else(|| {
+                panic!(
+                    "The downsample shader doesn't support texture format {:?}",
+                    key.texture_format
+                )
+            }),
+            ShaderDefVal::Bool("ARRAY_TEXTURE".into(), key.array_texture),
+        ];
+        if self.subgroup_support {
+            shader_defs.push("SUBGROUP_SUPPORT".into());
+        }
+        shader_defs.push(
+            match (key.combine_bind_groups, key.pass) {
+                (true, _) => "COMBINE_BIND_GROUP",
+                (false, DownsamplePass::First) => "SPLIT_BIND_GROUP_FIRST",
+                (false, DownsamplePass::Second) => "SPLIT_BIND_GROUP_SECOND",
+            }
+            .into(),
+        );
+
+        let (pass_number, entry_point) = match key.pass {
+            DownsamplePass::First => (1, "downsample_first"),
+            DownsamplePass::Second => (2, "downsample_second"),
+        };
+
+        ComputePipelineDescriptor {
+            label: Some(
+                format!(
+                    "mip generation pipeline, pass {pass_number} ({:?})",
+                    key.texture_format
+                )
+                .into(),
+            ),
+            layout: vec![key.bind_group_layout()],
+            shader: self.shader.clone(),
+            shader_defs,
+            entry_point: Some(entry_point.into()),
+            ..default()
+        }
+    }
 }
 
 // The number of storage textures required to combine the bind groups in the
@@ -164,49 +275,22 @@ pub struct MipGenerationPhase(pub Vec<AssetId<Image>>);
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MipGenerationPhaseId(pub u32);
 
-/// Stores all render pipelines and bind groups associated with the mipmap
-/// generation shader.
+/// Stores the pipelines and bind groups for each image that has mipmaps
+/// generated for it.
 ///
-/// The `prepare_mip_generator_pipelines` system populates this resource lazily
-/// as new textures are scheduled.
+/// The `prepare_mip_generator_pipelines` system adds an entry when an image is
+/// first scheduled and removes it on the first frame the image isn't.
 #[derive(Resource, Default)]
 pub struct MipGenerationPipelines {
-    /// The pipeline for each texture format.
-    ///
-    /// Note that pipelines can be shared among all images that use a single
-    /// texture format.
-    pipelines: HashMap<TextureFormat, MipGenerationTextureFormatPipelines>,
-
-    /// The bind group for each image.
-    ///
-    /// These are cached from frame to frame if the same image needs mips
-    /// generated for it on immediately-consecutive frames.
-    bind_groups: HashMap<AssetId<Image>, MipGenerationJobBindGroups>,
+    jobs: HashMap<AssetId<Image>, MipGenerationJobResources>,
 }
 
-/// The compute pipelines and bind group layouts for the single-pass
-/// downsampling shader for a single texture format.
-///
-/// Note that, despite the name, the single-pass downsampling shader has two
-/// passes, not one. This is because WGSL doesn't presently support
-/// globally-coherent buffers; the only way to have a synchronization point is
-/// to issue a second dispatch.
-pub struct MipGenerationTextureFormatPipelines {
-    /// The bind group layout for the first pass of the downsampling shader.
-    pub downsampling_bind_group_layout_pass_1: BindGroupLayoutDescriptor,
-    /// The bind group layout for the second pass of the downsampling shader.
-    pub downsampling_bind_group_layout_pass_2: BindGroupLayoutDescriptor,
-    /// The compute pipeline for the first pass of the downsampling shader.
-    pub downsampling_pipeline_pass_1: CachedComputePipelineId,
-    /// The compute pipeline for the second pass of the downsampling shader.
-    pub downsampling_pipeline_pass_2: CachedComputePipelineId,
-}
-
-/// Bind groups for the downsampling shader associated with a single texture.
-struct MipGenerationJobBindGroups {
-    /// The bind group for the first downsampling compute pass.
+/// Pipelines and bind groups for the downsampling shader associated with a
+/// single texture.
+struct MipGenerationJobResources {
+    downsampling_pipeline_pass_1: CachedComputePipelineId,
+    downsampling_pipeline_pass_2: CachedComputePipelineId,
     downsampling_bind_group_pass_1: BindGroup,
-    /// The bind group for the second downsampling compute pass.
     downsampling_bind_group_pass_2: BindGroup,
 }
 
@@ -251,8 +335,11 @@ impl Plugin for MipGenerationPlugin {
 
         render_app
             .init_gpu_resource::<SpecializedComputePipelines<DownsampleDepthPipeline>>()
+            .init_gpu_resource::<DownsamplePipeline>()
+            .init_gpu_resource::<SpecializedComputePipelines<DownsamplePipeline>>()
             .init_resource::<MipGenerationJobs>()
-            .init_resource::<MipGenerationPipelines>()
+            .init_gpu_resource::<MipGenerationPipelines>()
+            .init_gpu_resource::<MipGenerationResources>()
             .insert_resource(downsample_shaders)
             .add_systems(RenderStartup, depth::init_depth_pyramid_dummy_texture)
             .add_systems(
@@ -287,16 +374,6 @@ impl Plugin for MipGenerationPlugin {
                 Render,
                 reset_mip_generation_jobs.in_set(RenderSystems::Cleanup),
             );
-    }
-
-    fn finish(&self, app: &mut App) {
-        let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return;
-        };
-
-        // This needs to be done here so that we have access to the
-        // `RenderDevice`.
-        render_app.init_gpu_resource::<MipGenerationResources>();
     }
 }
 
@@ -340,7 +417,7 @@ pub fn generate_mips_for_phase(
     phase_id: MipGenerationPhaseId,
     mip_generation_jobs: &MipGenerationJobs,
     pipeline_cache: &PipelineCache,
-    mip_generation_bind_groups: &MipGenerationPipelines,
+    mip_generation_pipelines: &MipGenerationPipelines,
     gpu_images: &RenderAssets<GpuImage>,
     ctx: &mut RenderContext,
 ) {
@@ -359,25 +436,14 @@ pub fn generate_mips_for_phase(
         let Some(gpu_image) = gpu_images.get(*mip_generation_job) else {
             continue;
         };
-        let Some(mip_generation_job_bind_groups) = mip_generation_bind_groups
-            .bind_groups
-            .get(mip_generation_job)
-        else {
-            continue;
-        };
-        let Some(mip_generation_pipelines) = mip_generation_bind_groups
-            .pipelines
-            .get(&gpu_image.texture_descriptor.format)
-        else {
+        let Some(job_resources) = mip_generation_pipelines.jobs.get(mip_generation_job) else {
             continue;
         };
 
         // Fetch the mip generation pipelines.
         let (Some(mip_generation_pipeline_pass_1), Some(mip_generation_pipeline_pass_2)) = (
-            pipeline_cache
-                .get_compute_pipeline(mip_generation_pipelines.downsampling_pipeline_pass_1),
-            pipeline_cache
-                .get_compute_pipeline(mip_generation_pipelines.downsampling_pipeline_pass_2),
+            pipeline_cache.get_compute_pipeline(job_resources.downsampling_pipeline_pass_1),
+            pipeline_cache.get_compute_pipeline(job_resources.downsampling_pipeline_pass_2),
         ) else {
             continue;
         };
@@ -392,11 +458,7 @@ pub fn generate_mips_for_phase(
                     });
             let pass_span = diagnostics.pass_span(&mut compute_pass_1, "mip generation pass 1");
             compute_pass_1.set_pipeline(mip_generation_pipeline_pass_1);
-            compute_pass_1.set_bind_group(
-                0,
-                &mip_generation_job_bind_groups.downsampling_bind_group_pass_1,
-                &[],
-            );
+            compute_pass_1.set_bind_group(0, &job_resources.downsampling_bind_group_pass_1, &[]);
             compute_pass_1.dispatch_workgroups(
                 gpu_image.texture_descriptor.size.width.div_ceil(64),
                 gpu_image.texture_descriptor.size.height.div_ceil(64),
@@ -415,11 +477,7 @@ pub fn generate_mips_for_phase(
                     });
             let pass_span = diagnostics.pass_span(&mut compute_pass_2, "mip generation pass 2");
             compute_pass_2.set_pipeline(mip_generation_pipeline_pass_2);
-            compute_pass_2.set_bind_group(
-                0,
-                &mip_generation_job_bind_groups.downsampling_bind_group_pass_2,
-                &[],
-            );
+            compute_pass_2.set_bind_group(0, &job_resources.downsampling_bind_group_pass_2, &[]);
             compute_pass_2.dispatch_workgroups(
                 gpu_image.texture_descriptor.size.width.div_ceil(256),
                 gpu_image.texture_descriptor.size.height.div_ceil(256),
@@ -436,17 +494,18 @@ pub fn generate_mips_for_phase(
 /// Bind group layouts, bind groups, and pipelines are all cached for images
 /// that are being processed every frame.
 fn prepare_mip_generator_pipelines(
-    mip_generation_bind_groups: ResMut<MipGenerationPipelines>,
+    mip_generation_pipelines: ResMut<MipGenerationPipelines>,
     mip_generation_resources: Res<MipGenerationResources>,
     mip_generation_jobs: Res<MipGenerationJobs>,
     pipeline_cache: Res<PipelineCache>,
+    mut specialized_pipelines: ResMut<SpecializedComputePipelines<DownsamplePipeline>>,
+    downsample_pipeline: Res<DownsamplePipeline>,
     gpu_images: Res<RenderAssets<GpuImage>>,
-    downsample_shaders: Res<DownsampleShaders>,
     render_adapter: Res<RenderAdapter>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
 ) {
-    let mip_generation_pipelines = mip_generation_bind_groups.into_inner();
+    let mip_generation_pipelines = mip_generation_pipelines.into_inner();
 
     // Check to see whether we can combine downsampling bind groups on this
     // hardware and driver.
@@ -466,28 +525,32 @@ fn prepare_mip_generator_pipelines(
             // Note this job.
             all_source_images.insert(mip_generation_job);
 
-            // Create pipelines for this texture format if necessary. We have at
-            // most one pipeline per texture format, regardless of the number of
-            // jobs that use that texture format that there are.
-            let Some(pipelines) = get_or_create_mip_generation_pipelines(
-                &render_device,
-                &pipeline_cache,
-                &downsample_shaders,
-                &mut mip_generation_pipelines.pipelines,
-                gpu_image.texture_descriptor.format,
-                mip_generation_job,
-                combine_downsampling_bind_groups,
-            ) else {
+            // Create pipelines and bind groups for the job if it's new.
+            let Entry::Vacant(vacant_entry) =
+                mip_generation_pipelines.jobs.entry(*mip_generation_job)
+            else {
                 continue;
             };
 
-            // Create bind groups for the job if necessary.
-
-            let Entry::Vacant(vacant_entry) = mip_generation_pipelines
-                .bind_groups
-                .entry(*mip_generation_job)
-            else {
+            let target_format = gpu_image.texture_descriptor.format;
+            if !DownsamplePipeline::supports_texture_format(target_format) {
+                error!(
+                    "Attempted to generate mips for texture {:?} with format {:?}, but no \
+                     downsample shader was available for that texture format",
+                    mip_generation_job, target_format
+                );
                 continue;
+            }
+
+            let key_pass_1 = DownsamplePipelineKey {
+                texture_format: target_format,
+                array_texture: false,
+                combine_bind_groups: combine_downsampling_bind_groups,
+                pass: DownsamplePass::First,
+            };
+            let key_pass_2 = DownsamplePipelineKey {
+                pass: DownsamplePass::Second,
+                ..key_pass_1
             };
 
             let downsampling_constants_buffer =
@@ -499,12 +562,22 @@ fn prepare_mip_generator_pipelines(
                     &pipeline_cache,
                     &mip_generation_resources,
                     &downsampling_constants_buffer,
-                    pipelines,
                     gpu_image,
-                    combine_downsampling_bind_groups,
+                    key_pass_1,
+                    key_pass_2,
                 );
 
-            vacant_entry.insert(MipGenerationJobBindGroups {
+            vacant_entry.insert(MipGenerationJobResources {
+                downsampling_pipeline_pass_1: specialized_pipelines.specialize(
+                    &pipeline_cache,
+                    &downsample_pipeline,
+                    key_pass_1,
+                ),
+                downsampling_pipeline_pass_2: specialized_pipelines.specialize(
+                    &pipeline_cache,
+                    &downsample_pipeline,
+                    key_pass_2,
+                ),
                 downsampling_bind_group_pass_1,
                 downsampling_bind_group_pass_2,
             });
@@ -516,151 +589,80 @@ fn prepare_mip_generator_pipelines(
     // Note that this logic ensures that we don't recreate bind groups for
     // images that are updated every frame.
     mip_generation_pipelines
-        .bind_groups
+        .jobs
         .retain(|asset_id, _| all_source_images.contains(asset_id));
 }
 
-/// Returns the [`MipGenerationTextureFormatPipelines`] for a single texture
-/// format, creating it if necessary.
-///
-/// The [`MipGenerationTextureFormatPipelines`] that this function returns
-/// contains both the bind group layouts and pipelines for all invocations of
-/// the single-pass downsampling shader. Note that all images that share a
-/// texture format can share the same [`MipGenerationTextureFormatPipelines`]
-/// instance.
-fn get_or_create_mip_generation_pipelines<'a>(
-    render_device: &RenderDevice,
-    pipeline_cache: &PipelineCache,
-    downsample_shaders: &DownsampleShaders,
-    mip_generation_pipelines: &'a mut HashMap<TextureFormat, MipGenerationTextureFormatPipelines>,
-    target_format: TextureFormat,
-    mip_generation_job: &AssetId<Image>,
-    combine_downsampling_bind_groups: bool,
-) -> Option<&'a MipGenerationTextureFormatPipelines> {
-    match mip_generation_pipelines.entry(target_format) {
-        Entry::Vacant(vacant_entry) => {
-            let Some(pipelines) = create_downsampling_pipelines(
-                render_device,
-                pipeline_cache,
-                downsample_shaders,
-                target_format,
-                false,
-                combine_downsampling_bind_groups,
-            ) else {
-                error!(
-                    "Attempted to generate mips for texture {:?} with format {:?}, but no \
-                     downsample shader was available for that texture format",
-                    mip_generation_job, target_format
-                );
-                return None;
-            };
-
-            Some(vacant_entry.insert(pipelines))
-        }
-
-        Entry::Occupied(occupied_entry) => Some(occupied_entry.into_mut()),
-    }
-}
-
-/// Creates the [`BindGroupLayoutDescriptor`]s for the single-pass downsampling
-/// shader for a single texture format.
-fn create_downsampling_bind_group_layouts(
-    target_format: TextureFormat,
-    array_texture: bool,
-    combine_downsampling_bind_groups: bool,
-) -> (BindGroupLayoutDescriptor, BindGroupLayoutDescriptor) {
-    let texture_sample_type = target_format.sample_type(None, None).expect(
+impl DownsamplePipelineKey {
+    /// Returns the [`BindGroupLayoutDescriptor`] for the pipeline that this
+    /// key selects.
+    pub fn bind_group_layout(&self) -> BindGroupLayoutDescriptor {
+        let texture_sample_type = self.texture_format.sample_type(None, None).expect(
         "Depth and multisample texture formats shouldn't have mip generation shaders to begin with",
     );
-    let (source_texture, mips_storage, mip6_storage) = if array_texture {
-        (
-            texture_2d_array(texture_sample_type),
-            texture_storage_2d_array(target_format, StorageTextureAccess::WriteOnly),
-            texture_storage_2d_array(target_format, StorageTextureAccess::ReadWrite),
-        )
-    } else {
-        (
-            texture_2d(texture_sample_type),
-            texture_storage_2d(target_format, StorageTextureAccess::WriteOnly),
-            texture_storage_2d(target_format, StorageTextureAccess::ReadWrite),
-        )
-    };
+        let source_texture = if self.array_texture {
+            texture_2d_array(texture_sample_type)
+        } else {
+            texture_2d(texture_sample_type)
+        };
+        let storage = |access| {
+            if self.array_texture {
+                texture_storage_2d_array(self.texture_format, access)
+            } else {
+                texture_storage_2d(self.texture_format, access)
+            }
+        };
+        let mips_storage = storage(StorageTextureAccess::WriteOnly);
 
-    if combine_downsampling_bind_groups {
-        let bind_group_layout_descriptor = BindGroupLayoutDescriptor::new(
-            "combined mip generation bind group layout",
+        if self.combine_bind_groups {
+            let mip6_storage = storage(StorageTextureAccess::ReadWrite);
+            return BindGroupLayoutDescriptor::new(
+                "combined mip generation bind group layout",
+                &BindGroupLayoutEntries::sequential(
+                    ShaderStages::COMPUTE,
+                    (
+                        sampler(SamplerBindingType::Filtering),
+                        uniform_buffer::<DownsamplingConstants>(false),
+                        source_texture,
+                        mips_storage, // 1
+                        mips_storage, // 2
+                        mips_storage, // 3
+                        mips_storage, // 4
+                        mips_storage, // 5
+                        mip6_storage, // 6
+                        mips_storage, // 7
+                        mips_storage, // 8
+                        mips_storage, // 9
+                        mips_storage, // 10
+                        mips_storage, // 11
+                        mips_storage, // 12
+                    ),
+                ),
+            );
+        }
+
+        let label = match self.pass {
+            DownsamplePass::First => "mip generation bind group layout, pass 1",
+            DownsamplePass::Second => "mip generation bind group layout, pass 2",
+        };
+        BindGroupLayoutDescriptor::new(
+            label,
             &BindGroupLayoutEntries::sequential(
                 ShaderStages::COMPUTE,
                 (
                     sampler(SamplerBindingType::Filtering),
                     uniform_buffer::<DownsamplingConstants>(false),
-                    source_texture,
-                    mips_storage, // 1
-                    mips_storage, // 2
-                    mips_storage, // 3
-                    mips_storage, // 4
-                    mips_storage, // 5
-                    mip6_storage, // 6
-                    mips_storage, // 7
-                    mips_storage, // 8
-                    mips_storage, // 9
-                    mips_storage, // 10
-                    mips_storage, // 11
-                    mips_storage, // 12
+                    source_texture, // input mip
+                    mips_storage,   // output mip 1
+                    mips_storage,   // output mip 2
+                    mips_storage,   // output mip 3
+                    mips_storage,   // output mip 4
+                    mips_storage,   // output mip 5
+                    mips_storage,   // output mip 6
                 ),
             ),
-        );
-        return (
-            bind_group_layout_descriptor.clone(),
-            bind_group_layout_descriptor,
-        );
+        )
     }
-
-    // If we got here, we use a split layout. The first pass outputs mip levels
-    // [0, 6]; the second pass outputs mip levels [7, 12].
-
-    let bind_group_layout_descriptor_pass_1 = BindGroupLayoutDescriptor::new(
-        "mip generation bind group layout, pass 1",
-        &BindGroupLayoutEntries::sequential(
-            ShaderStages::COMPUTE,
-            (
-                sampler(SamplerBindingType::Filtering),
-                uniform_buffer::<DownsamplingConstants>(false),
-                // Input mip 0
-                source_texture,
-                mips_storage, // 1
-                mips_storage, // 2
-                mips_storage, // 3
-                mips_storage, // 4
-                mips_storage, // 5
-                mips_storage, // 6
-            ),
-        ),
-    );
-
-    let bind_group_layout_descriptor_pass_2 = BindGroupLayoutDescriptor::new(
-        "mip generation bind group layout, pass 2",
-        &BindGroupLayoutEntries::sequential(
-            ShaderStages::COMPUTE,
-            (
-                sampler(SamplerBindingType::Filtering),
-                uniform_buffer::<DownsamplingConstants>(false),
-                // Input mip 6
-                source_texture,
-                mips_storage, // 7
-                mips_storage, // 8
-                mips_storage, // 9
-                mips_storage, // 10
-                mips_storage, // 11
-                mips_storage, // 12
-            ),
-        ),
-    );
-
-    (
-        bind_group_layout_descriptor_pass_1,
-        bind_group_layout_descriptor_pass_2,
-    )
 }
 
 /// Creates the bind groups for the single-pass downsampling shader associated
@@ -674,9 +676,9 @@ fn create_downsampling_bind_groups(
     pipeline_cache: &PipelineCache,
     mip_generation_resources: &MipGenerationResources,
     downsampling_constants_buffer: &UniformBuffer<DownsamplingConstants>,
-    pipelines: &MipGenerationTextureFormatPipelines,
     gpu_image: &GpuImage,
-    combine_downsampling_bind_groups: bool,
+    key_pass_1: DownsamplePipelineKey,
+    key_pass_2: DownsamplePipelineKey,
 ) -> (BindGroup, BindGroup) {
     let input_texture_view_pass_1 = gpu_image.texture.create_view(&TextureViewDescriptor {
         label: Some("mip generation input texture view, pass 1"),
@@ -689,10 +691,10 @@ fn create_downsampling_bind_groups(
 
     // If we can combine downsampling bind groups on this platform, we only need
     // one bind group.
-    if combine_downsampling_bind_groups {
+    if key_pass_1.combine_bind_groups {
         let bind_group = render_device.create_bind_group(
             Some("combined mip generation bind group"),
-            &pipeline_cache.get_bind_group_layout(&pipelines.downsampling_bind_group_layout_pass_1),
+            &pipeline_cache.get_bind_group_layout(&key_pass_1.bind_group_layout()),
             &BindGroupEntries::sequential((
                 &mip_generation_resources.sampler,
                 downsampling_constants_buffer,
@@ -727,7 +729,7 @@ fn create_downsampling_bind_groups(
 
     let bind_group_pass_1 = render_device.create_bind_group(
         "mip generation bind group, pass 1",
-        &pipeline_cache.get_bind_group_layout(&pipelines.downsampling_bind_group_layout_pass_1),
+        &pipeline_cache.get_bind_group_layout(&key_pass_1.bind_group_layout()),
         &BindGroupEntries::sequential((
             &mip_generation_resources.sampler,
             downsampling_constants_buffer,
@@ -742,7 +744,7 @@ fn create_downsampling_bind_groups(
     );
     let bind_group_pass_2 = render_device.create_bind_group(
         "mip generation bind group, pass 2",
-        &pipeline_cache.get_bind_group_layout(&pipelines.downsampling_bind_group_layout_pass_2),
+        &pipeline_cache.get_bind_group_layout(&key_pass_2.bind_group_layout()),
         &BindGroupEntries::sequential((
             &mip_generation_resources.sampler,
             downsampling_constants_buffer,
@@ -757,84 +759,6 @@ fn create_downsampling_bind_groups(
     );
 
     (bind_group_pass_1, bind_group_pass_2)
-}
-
-/// Creates the single-pass downsampling compute pipelines that perform
-/// downsampling on textures with a specific texture format.
-///
-/// Returns `None` if the shader doesn't support `target_format`. Set
-/// `array_texture` to downsample a 2D array texture such as a cubemap.
-///
-/// Depending on whether the current platform can combine downsampling bind
-/// groups, this will either return two copies of the same pipeline or two
-/// different pipelines.
-pub fn create_downsampling_pipelines(
-    render_device: &RenderDevice,
-    pipeline_cache: &PipelineCache,
-    downsample_shaders: &DownsampleShaders,
-    target_format: TextureFormat,
-    array_texture: bool,
-    combine_downsampling_bind_groups: bool,
-) -> Option<MipGenerationTextureFormatPipelines> {
-    let mut downsampling_shader_defs = vec![
-        texture_format_shader_def(target_format)?,
-        ShaderDefVal::Bool("ARRAY_TEXTURE".into(), array_texture),
-    ];
-    if render_device.features().contains(WgpuFeatures::SUBGROUP) {
-        downsampling_shader_defs.push(ShaderDefVal::Int("SUBGROUP_SUPPORT".into(), 1));
-    }
-    if combine_downsampling_bind_groups {
-        downsampling_shader_defs.push(ShaderDefVal::Int("COMBINE_BIND_GROUP".into(), 1));
-    }
-
-    let mut downsampling_first_shader_defs = downsampling_shader_defs.clone();
-    let mut downsampling_second_shader_defs = downsampling_shader_defs;
-    if !combine_downsampling_bind_groups {
-        downsampling_first_shader_defs.push(ShaderDefVal::Int("FIRST_PASS".into(), 1));
-        downsampling_second_shader_defs.push(ShaderDefVal::Int("SECOND_PASS".into(), 1));
-    }
-
-    let (downsampling_bind_group_layout_pass_1, downsampling_bind_group_layout_pass_2) =
-        create_downsampling_bind_group_layouts(
-            target_format,
-            array_texture,
-            combine_downsampling_bind_groups,
-        );
-
-    // Create the pipeline for the first pass, corresponding to mip levels [0,
-    // 6].
-    let downsampling_first_pipeline =
-        pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-            label: Some(format!("mip generation pipeline, pass 1 ({:?})", target_format).into()),
-            layout: vec![downsampling_bind_group_layout_pass_1.clone()],
-            immediate_size: 0,
-            shader: downsample_shaders.general.clone(),
-            shader_defs: downsampling_first_shader_defs,
-            entry_point: Some("downsample_first".into()),
-            zero_initialize_workgroup_memory: false,
-            constants: vec![],
-        });
-
-    // Create the pipeline for the second pass, corresponding to mip levels [7,
-    // 12].
-    let downsampling_second_pipeline =
-        pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-            label: Some(format!("mip generation pipeline, pass 2 ({:?})", target_format).into()),
-            layout: vec![downsampling_bind_group_layout_pass_2.clone()],
-            immediate_size: 0,
-            shader: downsample_shaders.general.clone(),
-            shader_defs: downsampling_second_shader_defs,
-            entry_point: Some("downsample_second".into()),
-            zero_initialize_workgroup_memory: false,
-            constants: vec![],
-        });
-
-    Some(MipGenerationTextureFormatPipelines {
-        downsampling_bind_group_layout_pass_1,
-        downsampling_bind_group_layout_pass_2,
-        downsampling_pipeline_pass_1: downsampling_first_pipeline,
-        downsampling_pipeline_pass_2: downsampling_second_pipeline,
-    })
 }
 
 /// Creates the uniform buffer containing the [`DownsamplingConstants`] for a

--- a/crates/bevy_pbr/src/light_probe/generate.rs
+++ b/crates/bevy_pbr/src/light_probe/generate.rs
@@ -37,7 +37,6 @@ use bevy_render::{
         TextureViewDimension, UniformBuffer,
     },
     renderer::{RenderAdapter, RenderContext, RenderDevice, RenderQueue},
-    settings::WgpuFeatures,
     sync_component::{SyncComponent, SyncComponentPlugin},
     sync_world::RenderEntity,
     texture::{CachedTexture, GpuImage, TextureCache},
@@ -174,84 +173,17 @@ pub fn initialize_generated_environment_map_resources(
     let combine_bind_group =
         mip_generation::can_combine_downsampling_bind_groups(&render_adapter, &render_device);
 
-    // Output mips are write-only
-    let mips =
-        texture_storage_2d_array(TextureFormat::Rgba16Float, StorageTextureAccess::WriteOnly);
+    let downsampling = mip_generation::create_downsampling_pipelines(
+        &render_device,
+        &pipeline_cache,
+        &downsample_shaders,
+        TextureFormat::Rgba16Float,
+        true,
+        combine_bind_group,
+    )
+    .expect("The downsample shader should support Rgba16Float");
 
     // Bind group layouts
-    let (downsampling_first, downsampling_second) = if combine_bind_group {
-        // One big bind group layout containing all outputs 1–12
-        let downsampling = BindGroupLayoutDescriptor::new(
-            "downsampling_bind_group_layout_combined",
-            &BindGroupLayoutEntries::sequential(
-                ShaderStages::COMPUTE,
-                (
-                    sampler(SamplerBindingType::Filtering),
-                    uniform_buffer::<DownsamplingConstants>(false),
-                    texture_2d_array(TextureSampleType::Float { filterable: true }),
-                    mips, // 1
-                    mips, // 2
-                    mips, // 3
-                    mips, // 4
-                    mips, // 5
-                    texture_storage_2d_array(
-                        TextureFormat::Rgba16Float,
-                        StorageTextureAccess::ReadWrite,
-                    ), // 6
-                    mips, // 7
-                    mips, // 8
-                    mips, // 9
-                    mips, // 10
-                    mips, // 11
-                    mips, // 12
-                ),
-            ),
-        );
-
-        (downsampling.clone(), downsampling)
-    } else {
-        // Split layout: first pass outputs 1–6, second pass outputs 7–12 (input mip6 read-only)
-
-        let downsampling_first = BindGroupLayoutDescriptor::new(
-            "downsampling_first_bind_group_layout",
-            &BindGroupLayoutEntries::sequential(
-                ShaderStages::COMPUTE,
-                (
-                    sampler(SamplerBindingType::Filtering),
-                    uniform_buffer::<DownsamplingConstants>(false),
-                    // Input mip 0
-                    texture_2d_array(TextureSampleType::Float { filterable: true }),
-                    mips, // 1
-                    mips, // 2
-                    mips, // 3
-                    mips, // 4
-                    mips, // 5
-                    mips, // 6
-                ),
-            ),
-        );
-
-        let downsampling_second = BindGroupLayoutDescriptor::new(
-            "downsampling_second_bind_group_layout",
-            &BindGroupLayoutEntries::sequential(
-                ShaderStages::COMPUTE,
-                (
-                    sampler(SamplerBindingType::Filtering),
-                    uniform_buffer::<DownsamplingConstants>(false),
-                    // Input mip 6
-                    texture_2d_array(TextureSampleType::Float { filterable: true }),
-                    mips, // 7
-                    mips, // 8
-                    mips, // 9
-                    mips, // 10
-                    mips, // 11
-                    mips, // 12
-                ),
-            ),
-        );
-
-        (downsampling_first, downsampling_second)
-    };
     let radiance = BindGroupLayoutDescriptor::new(
         "radiance_bind_group_layout",
         &BindGroupLayoutEntries::sequential(
@@ -307,8 +239,8 @@ pub fn initialize_generated_environment_map_resources(
     );
 
     let layouts = GeneratorBindGroupLayouts {
-        downsampling_first,
-        downsampling_second,
+        downsampling_first: downsampling.downsampling_bind_group_layout_pass_1,
+        downsampling_second: downsampling.downsampling_bind_group_layout_pass_2,
         radiance,
         irradiance,
         copy,
@@ -329,62 +261,14 @@ pub fn initialize_generated_environment_map_resources(
     let samplers = GeneratorSamplers { linear };
 
     // Pipelines
-    let features = render_device.features();
-    let mut shader_defs = vec![];
-    if features.contains(WgpuFeatures::SUBGROUP) {
-        shader_defs.push(ShaderDefVal::Int("SUBGROUP_SUPPORT".into(), 1));
-    }
-    if combine_bind_group {
-        shader_defs.push(ShaderDefVal::Int("COMBINE_BIND_GROUP".into(), 1));
-    }
-    shader_defs.push(ShaderDefVal::Bool("ARRAY_TEXTURE".into(), true));
-    #[cfg(feature = "bluenoise_texture")]
-    {
-        shader_defs.push(ShaderDefVal::Int("HAS_BLUE_NOISE".into(), 1));
-    }
+    let shader_defs: Vec<ShaderDefVal> = if cfg!(feature = "bluenoise_texture") {
+        vec![ShaderDefVal::Int("HAS_BLUE_NOISE".into(), 1)]
+    } else {
+        vec![]
+    };
 
     let env_filter_shader = load_embedded_asset!(asset_server.as_ref(), "environment_filter.wesl");
     let copy_shader = load_embedded_asset!(asset_server.as_ref(), "copy.wesl");
-
-    let downsampling_shader = downsample_shaders
-        .general
-        .get(&TextureFormat::Rgba16Float)
-        .expect("Mip generation shader should exist in the general downsampling shader table");
-
-    // First pass for base mip Levels (0-5)
-    let downsample_first = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-        label: Some("downsampling_first_pipeline".into()),
-        layout: vec![layouts.downsampling_first.clone()],
-        immediate_size: 0,
-        shader: downsampling_shader.clone(),
-        shader_defs: {
-            let mut defs = shader_defs.clone();
-            if !combine_bind_group {
-                defs.push(ShaderDefVal::Int("FIRST_PASS".into(), 1));
-            }
-            defs
-        },
-        entry_point: Some("downsample_first".into()),
-        zero_initialize_workgroup_memory: false,
-        constants: vec![],
-    });
-
-    let downsample_second = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
-        label: Some("downsampling_second_pipeline".into()),
-        layout: vec![layouts.downsampling_second.clone()],
-        immediate_size: 0,
-        shader: downsampling_shader.clone(),
-        shader_defs: {
-            let mut defs = shader_defs.clone();
-            if !combine_bind_group {
-                defs.push(ShaderDefVal::Int("SECOND_PASS".into(), 1));
-            }
-            defs
-        },
-        entry_point: Some("downsample_second".into()),
-        zero_initialize_workgroup_memory: false,
-        constants: vec![],
-    });
 
     // Radiance map for specular environment maps
     let radiance = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
@@ -423,8 +307,8 @@ pub fn initialize_generated_environment_map_resources(
     });
 
     let pipelines = GeneratorPipelines {
-        downsample_first,
-        downsample_second,
+        downsample_first: downsampling.downsampling_pipeline_pass_1,
+        downsample_second: downsampling.downsampling_pipeline_pass_2,
         radiance,
         irradiance,
         copy: copy_pipeline,

--- a/crates/bevy_pbr/src/light_probe/generate.rs
+++ b/crates/bevy_pbr/src/light_probe/generate.rs
@@ -13,7 +13,9 @@
 //! These components are intended to be added to a camera.
 use bevy_app::{App, Plugin, Update};
 use bevy_asset::{embedded_asset, load_embedded_asset, AssetServer, Assets, RenderAssetUsages};
-use bevy_core_pipeline::mip_generation::{self, DownsampleShaders, DownsamplingConstants};
+use bevy_core_pipeline::mip_generation::{
+    self, DownsamplePass, DownsamplePipeline, DownsamplePipelineKey, DownsamplingConstants,
+};
 use bevy_ecs::{
     component::Component,
     entity::Entity,
@@ -26,15 +28,16 @@ use bevy_image::Image;
 use bevy_math::{Quat, UVec2, Vec2};
 use bevy_render::{
     diagnostic::RecordDiagnostics,
+    init_gpu_resource,
     render_asset::RenderAssets,
     render_resource::{
         binding_types::*, AddressMode, BindGroup, BindGroupEntries, BindGroupLayoutDescriptor,
         BindGroupLayoutEntries, CachedComputePipelineId, ComputePassDescriptor,
         ComputePipelineDescriptor, DownlevelFlags, Extent3d, FilterMode, MipmapFilterMode,
         PipelineCache, Sampler, SamplerBindingType, SamplerDescriptor, ShaderStages, ShaderType,
-        StorageTextureAccess, Texture, TextureAspect, TextureDescriptor, TextureDimension,
-        TextureFormat, TextureSampleType, TextureUsages, TextureView, TextureViewDescriptor,
-        TextureViewDimension, UniformBuffer,
+        SpecializedComputePipelines, StorageTextureAccess, Texture, TextureAspect,
+        TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType, TextureUsages,
+        TextureView, TextureViewDescriptor, TextureViewDimension, UniformBuffer,
     },
     renderer::{RenderAdapter, RenderContext, RenderDevice, RenderQueue},
     sync_component::{SyncComponent, SyncComponentPlugin},
@@ -154,7 +157,9 @@ impl Plugin for EnvironmentMapGenerationPlugin {
             )
             .add_systems(
                 RenderStartup,
-                initialize_generated_environment_map_resources,
+                initialize_generated_environment_map_resources
+                    .after(init_gpu_resource::<DownsamplePipeline>)
+                    .after(init_gpu_resource::<SpecializedComputePipelines<DownsamplePipeline>>),
             );
     }
 }
@@ -167,21 +172,23 @@ pub fn initialize_generated_environment_map_resources(
     render_adapter: Res<RenderAdapter>,
     pipeline_cache: Res<PipelineCache>,
     asset_server: Res<AssetServer>,
-    downsample_shaders: Res<DownsampleShaders>,
+    downsample_pipeline: Res<DownsamplePipeline>,
+    mut specialized_downsample_pipelines: ResMut<SpecializedComputePipelines<DownsamplePipeline>>,
 ) {
     // Combine the bind group and use read-write storage if it is supported
     let combine_bind_group =
         mip_generation::can_combine_downsampling_bind_groups(&render_adapter, &render_device);
 
-    let downsampling = mip_generation::create_downsampling_pipelines(
-        &render_device,
-        &pipeline_cache,
-        &downsample_shaders,
-        TextureFormat::Rgba16Float,
-        true,
-        combine_bind_group,
-    )
-    .expect("The downsample shader should support Rgba16Float");
+    let downsample_key_first = DownsamplePipelineKey {
+        texture_format: TextureFormat::Rgba16Float,
+        array_texture: true, // cubemap
+        combine_bind_groups: combine_bind_group,
+        pass: DownsamplePass::First,
+    };
+    let downsample_key_second = DownsamplePipelineKey {
+        pass: DownsamplePass::Second,
+        ..downsample_key_first
+    };
 
     // Bind group layouts
     let radiance = BindGroupLayoutDescriptor::new(
@@ -239,8 +246,8 @@ pub fn initialize_generated_environment_map_resources(
     );
 
     let layouts = GeneratorBindGroupLayouts {
-        downsampling_first: downsampling.downsampling_bind_group_layout_pass_1,
-        downsampling_second: downsampling.downsampling_bind_group_layout_pass_2,
+        downsampling_first: downsample_key_first.bind_group_layout(),
+        downsampling_second: downsample_key_second.bind_group_layout(),
         radiance,
         irradiance,
         copy,
@@ -307,8 +314,16 @@ pub fn initialize_generated_environment_map_resources(
     });
 
     let pipelines = GeneratorPipelines {
-        downsample_first: downsampling.downsampling_pipeline_pass_1,
-        downsample_second: downsampling.downsampling_pipeline_pass_2,
+        downsample_first: specialized_downsample_pipelines.specialize(
+            &pipeline_cache,
+            &downsample_pipeline,
+            downsample_key_first,
+        ),
+        downsample_second: specialized_downsample_pipelines.specialize(
+            &pipeline_cache,
+            &downsample_pipeline,
+            downsample_key_second,
+        ),
         radiance,
         irradiance,
         copy: copy_pipeline,


### PR DESCRIPTION
# Objective

Fixes bevyengine/bevy#25733. We were doing a find-and-replace on `##TEXTURE_FORMAT##` in `downsample.wesl` at runtime, which meant the file was never valid WESL.

# Solution

- Specialize the shader with shader defs instead. It declares one `@if(TEXTURE_FORMAT_*)` block per supported format, and `ARRAY_TEXTURE` picks the 2D or array variant.
- `DownsampleShaders::general` is now a single `Handle<Shader>`, specialized lazily by the pipeline cache instead of 40 shader assets created at startup.
- The shader is specialized through a new `DownsamplePipeline` resource and `SpecializedComputePipelines<DownsamplePipeline>`, like the other compute pipelines. The light probe generator uses it instead of its own copy of the layouts and defs.
- Renamed the `FIRST_PASS` and `SECOND_PASS` shader defs to `SPLIT_BIND_GROUP_FIRST` and `SPLIT_BIND_GROUP_SECOND`, since exactly one of those and `COMBINE_BIND_GROUP` is set.

I don't love the boilerplate in this approach, but don't see a better solution. I did prototype a working `constants::` version too, but rejected it since it seems like we're generally trying to move away from them.

# Testing

`dynamic_mip_generation` and `reflection_probes` render correctly.

---

Used Claude Code & Fable 5.1 to help explore various ways to do this, build tests to see what naga supports and what wesl supports (and what they disagree on) to try various approaches, then to build out multiple approaches, which I then reviewed, settled on this one, validated questions I had, cleaned up PR a bit, then wrote migration guide and here we are.


