### PR TITLE
Fix two comment typos in settings (src & example)

### DIFF
--- a/crates/bevy_settings/src/lib.rs
+++ b/crates/bevy_settings/src/lib.rs
@@ -47,7 +47,7 @@ use store_wasm::SettingsStore;
 /// appropriate filesystem location (depending on platform) for app settings. For platforms
 /// without filesystems, other storage mechanisms will be used.
 ///
-/// If you are do not have a domain name and cannot
+/// If you do not have a domain name and cannot
 /// afford one, use a reverse domain based on the URL of your repo (GitHub, GitLab, Codeberg
 /// and so on).
 ///

--- a/examples/app/settings.rs
+++ b/examples/app/settings.rs
@@ -41,7 +41,7 @@ struct Counter {
     count: i32,
 }
 
-/// A different settings group which has the name group name as the previous. The two groups will be
+/// A different settings group which has the same group name as the previous. The two groups will be
 /// merged into a single section in the config file.
 #[derive(Resource, SettingsGroup, Reflect)]
 #[reflect(Resource, SettingsGroup, Default)]


### PR DESCRIPTION
# Objective

- Improve documentation readability

## Solution

- Fix typos

## Testing

- Not required
