### PR TITLE
Configure WESL syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,6 @@
 *.png binary
 *.jpg binary
 *.ttf binary
+
+# Tells GitHub to syntax highlight WESL as WGSL and include them in the repo's language stats
+*.wesl linguist-language=WGSL


### PR DESCRIPTION
# Objective

- WESL language is not recognized by GitHub, making pull requests touching shader code more difficult to review, parse.
- Language statistics are excluded from the repository for shader code.

## Solution

- Add WESL file type for syntax highlighting as WGSL in `.gitattributes`

## Testing

- Checked on my branch for instance https://github.com/mate-h/bevy/blob/m/wesl/crates/bevy_pbr/src/ssr.wesl

---

## Showcase
<img width="993" height="853" alt="Screenshot 2026-09-12 at 9 42 23 AM" src="https://github.com/user-attachments/assets/a8f9de6b-2a9a-476d-9e69-21263dc7d210" />

