### PR TITLE
Simplify to one(-ish) Schedule

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Main, MainSchedulePlugin, PlaceholderPlugin, Plugin, Plugins, PluginsState, SubApp, SubApps,
+    EntryPoint, MainSchedulePlugin, PlaceholderPlugin, Plugin, Plugins, PluginsState, SubApp, SubApps,
 };
 use alloc::{
     boxed::Box,
@@ -107,7 +107,7 @@ impl Debug for App {
 impl Default for App {
     fn default() -> Self {
         let mut app = App::empty();
-        app.sub_apps.main.update_schedule = Some(Main.intern());
+        app.sub_apps.main.update_schedule = Some(EntryPoint.intern());
 
         #[cfg(feature = "bevy_reflect")]
         {

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
     prelude::*,
     schedule::{
         InternedSystemSet, ScheduleBuildSettings, ScheduleCleanupPolicy, ScheduleError,
-        ScheduleLabel,
+        ScheduleLabel, SystemLocation,
     },
     system::{ScheduleSystem, SystemId, SystemInput},
 };
@@ -319,10 +319,10 @@ impl App {
     /// ```
     pub fn add_systems<M>(
         &mut self,
-        schedule: impl ScheduleLabel,
+        location: impl SystemLocation,
         systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
     ) -> &mut Self {
-        self.main_mut().add_systems(schedule, systems);
+        self.main_mut().add_systems(location, systems);
         self
     }
 

--- a/crates/bevy_app/src/hierarchy.rs
+++ b/crates/bevy_app/src/hierarchy.rs
@@ -11,7 +11,10 @@ use bevy_ecs::{
     name::Name,
     observer::On,
     query::{With, Without},
-    schedule::{common_conditions::on_message, IntoScheduleConfigs, ScheduleLabel, SystemSet},
+    schedule::{
+        common_conditions::on_message, IntoScheduleConfigs, ScheduleLabel, SystemLocation,
+        SystemSet,
+    },
     system::Query,
 };
 use bevy_platform::prelude::format;
@@ -23,20 +26,23 @@ use crate::{Last, Plugin};
 /// A plugin that verifies that [`Component`] `C` has parents that also have that component.
 pub struct ValidateParentHasComponentPlugin<C: Component> {
     schedule: Interned<dyn ScheduleLabel>,
+    extra_system_set: Option<Interned<dyn SystemSet>>,
     marker: PhantomData<fn() -> C>,
 }
 
 impl<C: Component> Default for ValidateParentHasComponentPlugin<C> {
     fn default() -> Self {
-        Self::in_schedule(Last)
+        Self::in_location(Last)
     }
 }
 
 impl<C: Component> ValidateParentHasComponentPlugin<C> {
     /// Creates an instance of this plugin that inserts systems in the provided schedule.
-    pub fn in_schedule(label: impl ScheduleLabel) -> Self {
+    pub fn in_location(location: impl SystemLocation) -> Self {
+        let (schedule, extra_system_set) = location.get_system_location();
         Self {
-            schedule: label.intern(),
+            schedule,
+            extra_system_set,
             marker: PhantomData,
         }
     }
@@ -44,14 +50,15 @@ impl<C: Component> ValidateParentHasComponentPlugin<C> {
 
 impl<C: Component> Plugin for ValidateParentHasComponentPlugin<C> {
     fn build(&self, app: &mut crate::App) {
+        let mut system = check_parent_has_component::<C>
+            .run_if(on_message::<CheckParentHasComponent<C>>)
+            .in_set(ValidateParentHasComponentSystems);
+        if let Some(extra_system_set) = self.extra_system_set.clone() {
+            system = system.in_set(extra_system_set);
+        }
         app.add_message::<CheckParentHasComponent<C>>()
             .add_observer(validate_parent_has_component::<C>)
-            .add_systems(
-                self.schedule,
-                check_parent_has_component::<C>
-                    .run_if(on_message::<CheckParentHasComponent<C>>)
-                    .in_set(ValidateParentHasComponentSystems),
-            );
+            .add_systems(self.schedule, system);
     }
 }
 

--- a/crates/bevy_app/src/hierarchy.rs
+++ b/crates/bevy_app/src/hierarchy.rs
@@ -25,8 +25,7 @@ use crate::{Last, Plugin};
 
 /// A plugin that verifies that [`Component`] `C` has parents that also have that component.
 pub struct ValidateParentHasComponentPlugin<C: Component> {
-    schedule: Interned<dyn ScheduleLabel>,
-    extra_system_set: Option<Interned<dyn SystemSet>>,
+    location: (Interned<dyn ScheduleLabel>, Option<Interned<dyn SystemSet>>),
     marker: PhantomData<fn() -> C>,
 }
 
@@ -39,10 +38,8 @@ impl<C: Component> Default for ValidateParentHasComponentPlugin<C> {
 impl<C: Component> ValidateParentHasComponentPlugin<C> {
     /// Creates an instance of this plugin that inserts systems in the provided schedule.
     pub fn in_location(location: impl SystemLocation) -> Self {
-        let (schedule, extra_system_set) = location.get_system_location();
         Self {
-            schedule,
-            extra_system_set,
+            location: location.get_system_location(),
             marker: PhantomData,
         }
     }
@@ -50,15 +47,14 @@ impl<C: Component> ValidateParentHasComponentPlugin<C> {
 
 impl<C: Component> Plugin for ValidateParentHasComponentPlugin<C> {
     fn build(&self, app: &mut crate::App) {
-        let mut system = check_parent_has_component::<C>
-            .run_if(on_message::<CheckParentHasComponent<C>>)
-            .in_set(ValidateParentHasComponentSystems);
-        if let Some(extra_system_set) = self.extra_system_set.clone() {
-            system = system.in_set(extra_system_set);
-        }
         app.add_message::<CheckParentHasComponent<C>>()
             .add_observer(validate_parent_has_component::<C>)
-            .add_systems(self.schedule, system);
+            .add_systems(
+                self.location,
+                check_parent_has_component::<C>
+                    .run_if(on_message::<CheckParentHasComponent<C>>)
+                    .in_set(ValidateParentHasComponentSystems),
+            );
     }
 }
 

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -62,8 +62,8 @@ pub mod prelude {
         app::{App, AppExit},
         main_schedule::{
             First, FixedFirst, FixedLast, FixedPostUpdate, FixedPreUpdate, FixedUpdate, Last, Main,
-            PostStartup, PostUpdate, PreStartup, PreUpdate, RunFixedMainLoop,
-            RunFixedMainLoopSystems, SpawnScene, Startup, Update,
+            PostStartup, PostUpdate, PreStartup, PreUpdate, RunFixedMainLoop, SpawnScene, Startup,
+            Update,
         },
         sub_app::SubApp,
         Plugin, PluginGroup, TaskPoolOptions, TaskPoolPlugin,

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -267,9 +267,11 @@ impl Plugin for MainSchedulePlugin {
 
         #[cfg(feature = "bevy_debug_stepping")]
         {
-            // TODO: Fix this.
             use bevy_ecs::schedule::{IntoScheduleConfigs, Stepping};
-            app.add_systems(Main, Stepping::begin_frame.before(Main::run_main));
+            app.add_systems(
+                EntryPoint,
+                Stepping::begin_frame.before(EntryPoint::run_main),
+            );
         }
     }
 }

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -24,7 +24,7 @@ use bevy_ecs::{
 /// Then it will run:
 /// * [`First`]
 /// * [`PreUpdate`]
-/// * [`StateTransition`] [^1]
+/// * `run_state_transition_schedule`, which runs the [`StateTransition`] [^1] schedule.
 /// * [`RunFixedMainLoop`]
 ///     * This will run [`FixedMain`] zero to many times, based on how much time has elapsed.
 /// * [`Update`]

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -15,8 +15,8 @@ use bevy_ecs::{
 ///        if `MyState` was added to the app with `MyState::Foo` as the initial state,
 ///        as well as [`OnEnter(MyComputedState)`] if it `compute`s to `Some(Self)` in `MyState::Foo`.
 ///      * If you want to run systems before any state transitions, regardless of which state is the starting state,
-///        for example, for registering required components, you can add your own custom startup schedule
-///        before [`StateTransition`]. See [`MainScheduleOrder::insert_startup_before`] for more details.
+///        for example, for registering required components, you can just add a system
+///        `.before(run_state_transition_schedule)` in [`StartupMain`].
 /// * [`PreStartup`]
 /// * [`Startup`]
 /// * [`PostStartup`]

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -1,13 +1,8 @@
 use crate::{App, Plugin};
-use alloc::{vec, vec::Vec};
 use bevy_ecs::{
-    resource::Resource,
-    schedule::{
-        InternedScheduleLabel, IntoScheduleConfigs, Schedule, ScheduleLabel,
-        SingleThreadedExecutor, SystemSet,
-    },
+    schedule::{IntoScheduleConfigs, ScheduleLabel, SystemSet},
     system::Local,
-    world::{Mut, World},
+    world::World,
 };
 
 /// The schedule that contains the app logic that is evaluated each tick of [`App::update()`].
@@ -56,28 +51,38 @@ use bevy_ecs::{
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct Main;
 
-/// The schedule that runs before [`Startup`].
+/// The schedule that runs once when the app starts.
 ///
 /// See the [`Main`] schedule for some details about how schedules are run.
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct StartupMain;
+
+/// The schedule that runs before [`Startup`].
+///
+/// See the [`Main`] schedule for some details about how schedules are run.
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(StartupMain)]
 pub struct PreStartup;
 
 /// The schedule that runs once when the app starts.
 ///
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(StartupMain)]
 pub struct Startup;
 
 /// The schedule that runs once after [`Startup`].
 ///
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(StartupMain)]
 pub struct PostStartup;
 
 /// Runs first in the schedule.
 ///
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(Main)]
 pub struct First;
 
 /// The schedule that contains logic that must run before [`Update`]. For example, a system that reads raw keyboard
@@ -88,33 +93,31 @@ pub struct First;
 /// [`PreUpdate`] abstracts out "pre work implementation details".
 ///
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(Main)]
 pub struct PreUpdate;
 
 /// Runs the [`FixedMain`] schedule in a loop according until all relevant elapsed time has been "consumed".
 ///
-/// If you need to order your variable timestep systems before or after
-/// the fixed update logic, use the [`RunFixedMainLoopSystems`] system set.
-///
-/// Note that in contrast to most other Bevy schedules, systems added directly to
-/// [`RunFixedMainLoop`] will *not* be parallelized between each other.
-///
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(Main)]
 pub struct RunFixedMainLoop;
 
 /// Runs first in the [`FixedMain`] schedule.
 ///
 /// See the [`FixedMain`] schedule for details on how fixed updates work.
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(FixedMain)]
 pub struct FixedFirst;
 
 /// The schedule that contains logic that must run before [`FixedUpdate`].
 ///
 /// See the [`FixedMain`] schedule for details on how fixed updates work.
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(FixedMain)]
 pub struct FixedPreUpdate;
 
 /// The schedule that contains most gameplay logic, which runs at a fixed rate rather than every render frame.
@@ -129,7 +132,8 @@ pub struct FixedPreUpdate;
 /// See the [`Update`] schedule for examples of systems that *should not* use this schedule.
 /// See the [`FixedMain`] schedule for details on how fixed updates work.
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(FixedMain)]
 pub struct FixedUpdate;
 
 /// The schedule that runs after the [`FixedUpdate`] schedule, for reacting
@@ -137,14 +141,16 @@ pub struct FixedUpdate;
 ///
 /// See the [`FixedMain`] schedule for details on how fixed updates work.
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(FixedMain)]
 pub struct FixedPostUpdate;
 
 /// The schedule that runs last in [`FixedMain`]
 ///
 /// See the [`FixedMain`] schedule for details on how fixed updates work.
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(FixedMain)]
 pub struct FixedLast;
 
 /// The schedule that contains systems which only run after a fixed period of time has elapsed.
@@ -169,7 +175,8 @@ pub struct FixedMain;
 ///
 /// See the [`FixedUpdate`] schedule for examples of systems that *should not* use this schedule.
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(Main)]
 pub struct Update;
 
 /// The schedule that contains scene spawning.
@@ -186,13 +193,15 @@ pub struct SpawnScene;
 /// [`PostUpdate`] abstracts out "implementation details" from users defining systems in [`Update`].
 ///
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(Main)]
 pub struct PostUpdate;
 
 /// Runs last in the schedule.
 ///
 /// See the [`Main`] schedule for some details about how schedules are run.
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(Main)]
 pub struct Last;
 
 /// Animation system set. This exists in [`PostUpdate`].
@@ -208,100 +217,15 @@ pub enum SceneSpawnerSystems {
     SceneSpawn,
 }
 
-/// Defines the schedules to be run for the [`Main`] schedule, including
-/// their order.
-#[derive(Resource, Debug)]
-pub struct MainScheduleOrder {
-    /// The labels to run for the main phase of the [`Main`] schedule (in the order they will be run).
-    pub labels: Vec<InternedScheduleLabel>,
-    /// The labels to run for the startup phase of the [`Main`] schedule (in the order they will be run).
-    pub startup_labels: Vec<InternedScheduleLabel>,
-}
-
-impl Default for MainScheduleOrder {
-    fn default() -> Self {
-        Self {
-            labels: vec![
-                First.intern(),
-                PreUpdate.intern(),
-                RunFixedMainLoop.intern(),
-                Update.intern(),
-                SpawnScene.intern(),
-                PostUpdate.intern(),
-                Last.intern(),
-            ],
-            startup_labels: vec![PreStartup.intern(), Startup.intern(), PostStartup.intern()],
-        }
-    }
-}
-
-impl MainScheduleOrder {
-    /// Adds the given `schedule` after the `after` schedule in the main list of schedules.
-    pub fn insert_after(&mut self, after: impl ScheduleLabel, schedule: impl ScheduleLabel) {
-        let index = self
-            .labels
-            .iter()
-            .position(|current| (**current).eq(&after))
-            .unwrap_or_else(|| panic!("Expected {after:?} to exist"));
-        self.labels.insert(index + 1, schedule.intern());
-    }
-
-    /// Adds the given `schedule` before the `before` schedule in the main list of schedules.
-    pub fn insert_before(&mut self, before: impl ScheduleLabel, schedule: impl ScheduleLabel) {
-        let index = self
-            .labels
-            .iter()
-            .position(|current| (**current).eq(&before))
-            .unwrap_or_else(|| panic!("Expected {before:?} to exist"));
-        self.labels.insert(index, schedule.intern());
-    }
-
-    /// Adds the given `schedule` after the `after` schedule in the list of startup schedules.
-    pub fn insert_startup_after(
-        &mut self,
-        after: impl ScheduleLabel,
-        schedule: impl ScheduleLabel,
-    ) {
-        let index = self
-            .startup_labels
-            .iter()
-            .position(|current| (**current).eq(&after))
-            .unwrap_or_else(|| panic!("Expected {after:?} to exist"));
-        self.startup_labels.insert(index + 1, schedule.intern());
-    }
-
-    /// Adds the given `schedule` before the `before` schedule in the list of startup schedules.
-    pub fn insert_startup_before(
-        &mut self,
-        before: impl ScheduleLabel,
-        schedule: impl ScheduleLabel,
-    ) {
-        let index = self
-            .startup_labels
-            .iter()
-            .position(|current| (**current).eq(&before))
-            .unwrap_or_else(|| panic!("Expected {before:?} to exist"));
-        self.startup_labels.insert(index, schedule.intern());
-    }
-}
-
 impl Main {
     /// A system that runs the "main schedule"
     pub fn run_main(world: &mut World, mut run_at_least_once: Local<bool>) {
         if !*run_at_least_once {
-            world.resource_scope(|world, order: Mut<MainScheduleOrder>| {
-                for &label in &order.startup_labels {
-                    let _ = world.try_run_schedule(label);
-                }
-            });
+            world.run_schedule(StartupMain);
             *run_at_least_once = true;
         }
 
-        world.resource_scope(|world, order: Mut<MainScheduleOrder>| {
-            for &label in &order.labels {
-                let _ = world.try_run_schedule(label);
-            }
-        });
+        world.run_schedule(Main);
     }
 }
 
@@ -311,185 +235,34 @@ pub struct MainSchedulePlugin;
 impl Plugin for MainSchedulePlugin {
     fn build(&self, app: &mut App) {
         // simple "facilitator" schedules benefit from simpler single threaded scheduling
-        let mut main_schedule = Schedule::new(Main);
-        main_schedule.set_executor(SingleThreadedExecutor::new());
-        let mut fixed_main_schedule = Schedule::new(FixedMain);
-        fixed_main_schedule.set_executor(SingleThreadedExecutor::new());
-        let mut fixed_main_loop_schedule = Schedule::new(RunFixedMainLoop);
-        fixed_main_loop_schedule.set_executor(SingleThreadedExecutor::new());
-
-        app.add_schedule(main_schedule)
-            .add_schedule(fixed_main_schedule)
-            .add_schedule(fixed_main_loop_schedule)
-            .init_resource::<MainScheduleOrder>()
-            .init_resource::<FixedMainScheduleOrder>()
-            .add_systems(Main, Main::run_main)
-            .add_systems(FixedMain, FixedMain::run_fixed_main)
-            .configure_sets(PostUpdate, TransformGizmoRenderStep)
+        app.init_schedule(StartupMain)
+            .init_schedule(Main)
+            .init_schedule(FixedMain)
+            .configure_sets(StartupMain, (PreStartup, Startup, PostStartup).chain())
             .configure_sets(
-                RunFixedMainLoop,
+                Main,
+                (First, PreUpdate, RunFixedMainLoop, Update, PostUpdate, Last).chain(),
+            )
+            .configure_sets(Main, TransformGizmoRenderStep)
+            .configure_sets(
+                FixedMain,
                 (
-                    RunFixedMainLoopSystems::BeforeFixedMainLoop,
-                    RunFixedMainLoopSystems::FixedMainLoop,
-                    RunFixedMainLoopSystems::AfterFixedMainLoop,
+                    FixedFirst,
+                    FixedPreUpdate,
+                    FixedUpdate,
+                    FixedPostUpdate,
+                    FixedLast,
                 )
                     .chain(),
             );
 
         #[cfg(feature = "bevy_debug_stepping")]
         {
+            // TODO: Fix this.
             use bevy_ecs::schedule::{IntoScheduleConfigs, Stepping};
             app.add_systems(Main, Stepping::begin_frame.before(Main::run_main));
         }
     }
-}
-
-/// Defines the schedules to be run for the [`FixedMain`] schedule, including
-/// their order.
-#[derive(Resource, Debug)]
-pub struct FixedMainScheduleOrder {
-    /// The labels to run for the [`FixedMain`] schedule (in the order they will be run).
-    pub labels: Vec<InternedScheduleLabel>,
-}
-
-impl Default for FixedMainScheduleOrder {
-    fn default() -> Self {
-        Self {
-            labels: vec![
-                FixedFirst.intern(),
-                FixedPreUpdate.intern(),
-                FixedUpdate.intern(),
-                FixedPostUpdate.intern(),
-                FixedLast.intern(),
-            ],
-        }
-    }
-}
-
-impl FixedMainScheduleOrder {
-    /// Adds the given `schedule` after the `after` schedule
-    pub fn insert_after(&mut self, after: impl ScheduleLabel, schedule: impl ScheduleLabel) {
-        let index = self
-            .labels
-            .iter()
-            .position(|current| (**current).eq(&after))
-            .unwrap_or_else(|| panic!("Expected {after:?} to exist"));
-        self.labels.insert(index + 1, schedule.intern());
-    }
-
-    /// Adds the given `schedule` before the `before` schedule
-    pub fn insert_before(&mut self, before: impl ScheduleLabel, schedule: impl ScheduleLabel) {
-        let index = self
-            .labels
-            .iter()
-            .position(|current| (**current).eq(&before))
-            .unwrap_or_else(|| panic!("Expected {before:?} to exist"));
-        self.labels.insert(index, schedule.intern());
-    }
-}
-
-impl FixedMain {
-    /// A system that runs the fixed timestep's "main schedule"
-    pub fn run_fixed_main(world: &mut World) {
-        world.resource_scope(|world, order: Mut<FixedMainScheduleOrder>| {
-            for &label in &order.labels {
-                let _ = world.try_run_schedule(label);
-            }
-        });
-    }
-}
-
-/// Set enum for the systems that want to run inside [`RunFixedMainLoop`],
-/// but before or after the fixed update logic. Systems in this set
-/// will run exactly once per frame, regardless of the number of fixed updates.
-/// They will also run under a variable timestep.
-///
-/// This is useful for handling things that need to run every frame, but
-/// also need to be read by the fixed update logic. See the individual variants
-/// for examples of what kind of systems should be placed in each.
-///
-/// Note that in contrast to most other Bevy schedules, systems added directly to
-/// [`RunFixedMainLoop`] will *not* be parallelized between each other.
-#[derive(Debug, Hash, PartialEq, Eq, Copy, Clone, SystemSet)]
-pub enum RunFixedMainLoopSystems {
-    /// Runs before the fixed update logic.
-    ///
-    /// A good example of a system that fits here
-    /// is camera movement, which needs to be updated in a variable timestep,
-    /// as you want the camera to move with as much precision and updates as
-    /// the frame rate allows. A physics system that needs to read the camera
-    /// position and orientation, however, should run in the fixed update logic,
-    /// as it needs to be deterministic and run at a fixed rate for better stability.
-    /// Note that we are not placing the camera movement system in `Update`, as that
-    /// would mean that the physics system already ran at that point.
-    ///
-    /// # Example
-    /// ```
-    /// # use bevy_app::prelude::*;
-    /// # use bevy_ecs::prelude::*;
-    /// App::new()
-    ///   .add_systems(
-    ///     RunFixedMainLoop,
-    ///     update_camera_rotation.in_set(RunFixedMainLoopSystems::BeforeFixedMainLoop))
-    ///   .add_systems(FixedUpdate, update_physics);
-    ///
-    /// # fn update_camera_rotation() {}
-    /// # fn update_physics() {}
-    /// ```
-    BeforeFixedMainLoop,
-    /// Contains the fixed update logic.
-    /// Runs [`FixedMain`] zero or more times based on delta of
-    /// [`Time<Virtual>`] and [`Time::overstep`].
-    ///
-    /// Don't place systems here, use [`FixedUpdate`] and friends instead.
-    /// Use this system instead to order your systems to run specifically inbetween the fixed update logic and all
-    /// other systems that run in [`RunFixedMainLoopSystems::BeforeFixedMainLoop`] or [`RunFixedMainLoopSystems::AfterFixedMainLoop`].
-    ///
-    /// [`Time<Virtual>`]: https://docs.rs/bevy/latest/bevy/prelude/struct.Virtual.html
-    /// [`Time::overstep`]: https://docs.rs/bevy/latest/bevy/time/struct.Time.html#method.overstep
-    /// # Example
-    /// ```
-    /// # use bevy_app::prelude::*;
-    /// # use bevy_ecs::prelude::*;
-    /// App::new()
-    ///   .add_systems(FixedUpdate, update_physics)
-    ///   .add_systems(
-    ///     RunFixedMainLoop,
-    ///     (
-    ///       // This system will be called before all interpolation systems
-    ///       // that third-party plugins might add.
-    ///       prepare_for_interpolation
-    ///         .after(RunFixedMainLoopSystems::FixedMainLoop)
-    ///         .before(RunFixedMainLoopSystems::AfterFixedMainLoop),
-    ///     )
-    ///   );
-    ///
-    /// # fn prepare_for_interpolation() {}
-    /// # fn update_physics() {}
-    /// ```
-    FixedMainLoop,
-    /// Runs after the fixed update logic.
-    ///
-    /// A good example of a system that fits here
-    /// is a system that interpolates the transform of an entity between the last and current fixed update.
-    /// See the [fixed timestep example] for more details.
-    ///
-    /// [fixed timestep example]: https://github.com/bevyengine/bevy/blob/main/examples/movement/physics_in_fixed_timestep.rs
-    ///
-    /// # Example
-    /// ```
-    /// # use bevy_app::prelude::*;
-    /// # use bevy_ecs::prelude::*;
-    /// App::new()
-    ///   .add_systems(FixedUpdate, update_physics)
-    ///   .add_systems(
-    ///     RunFixedMainLoop,
-    ///     interpolate_transforms.in_set(RunFixedMainLoopSystems::AfterFixedMainLoop));
-    ///
-    /// # fn interpolate_transforms() {}
-    /// # fn update_physics() {}
-    /// ```
-    AfterFixedMainLoop,
 }
 
 /// A System set that runs all systems needed to render the transform gizmo to the screen, used in the `bevy_gizmos_render` crate

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -156,7 +156,8 @@ pub struct FixedLast;
 /// The schedule that contains systems which only run after a fixed period of time has elapsed.
 ///
 /// This is run by the [`RunFixedMainLoop`] schedule. If you need to order your variable timestep systems
-/// before or after the fixed update logic, use the [`RunFixedMainLoopSystems`] system set.
+/// before or after the fixed update logic, add the systems to [`RunFixedMainLoop`] and then add
+/// before/after the `run_fixed_main_schedule` system.
 ///
 /// Frequency of execution is configured by inserting `Time<Fixed>` resource, 64 Hz by default.
 /// See [this example](https://github.com/bevyengine/bevy/blob/latest/examples/time/time.rs).

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -1,6 +1,6 @@
 use crate::{App, Plugin};
 use bevy_ecs::{
-    schedule::{IntoScheduleConfigs, ScheduleLabel, SystemSet},
+    schedule::{IntoScheduleConfigs, Schedule, ScheduleLabel, SingleThreadedExecutor, SystemSet},
     system::Local,
     world::World,
 };
@@ -48,6 +48,9 @@ use bevy_ecs::{
 /// [`RenderPlugin`]: https://docs.rs/bevy/latest/bevy/render/struct.RenderPlugin.html
 /// [`PipelinedRenderingPlugin`]: https://docs.rs/bevy/latest/bevy/render/pipelined_rendering/struct.PipelinedRenderingPlugin.html
 /// [`SubApp`]: crate::SubApp
+#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct EntryPoint;
+
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct Main;
 
@@ -218,7 +221,7 @@ pub enum SceneSpawnerSystems {
     SceneSpawn,
 }
 
-impl Main {
+impl EntryPoint {
     /// A system that runs the "main schedule"
     pub fn run_main(world: &mut World, mut run_at_least_once: Local<bool>) {
         if !*run_at_least_once {
@@ -256,6 +259,7 @@ impl Plugin for MainSchedulePlugin {
                 )
                     .chain(),
             )
+            .add_systems(EntryPoint, EntryPoint::run_main)
             .add_systems(
                 Main,
                 run_spawn_scene_schedule.after(Update).before(PostUpdate),

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -255,6 +255,10 @@ impl Plugin for MainSchedulePlugin {
                     FixedLast,
                 )
                     .chain(),
+            )
+            .add_systems(
+                Main,
+                run_spawn_scene_schedule.after(Update).before(PostUpdate),
             );
 
         #[cfg(feature = "bevy_debug_stepping")]
@@ -264,6 +268,11 @@ impl Plugin for MainSchedulePlugin {
             app.add_systems(Main, Stepping::begin_frame.before(Main::run_main));
         }
     }
+}
+
+/// System to run the [`SpawnScene`] schedule.
+pub fn run_spawn_scene_schedule(world: &mut World) {
+    let _ = world.try_run_schedule(SpawnScene);
 }
 
 /// A System set that runs all systems needed to render the transform gizmo to the screen, used in the `bevy_gizmos_render` crate

--- a/crates/bevy_app/src/propagate.rs
+++ b/crates/bevy_app/src/propagate.rs
@@ -14,7 +14,7 @@ use bevy_ecs::{
     observer::On,
     query::{Changed, Has, Or, QueryFilter, With, Without},
     relationship::{Relationship, RelationshipTarget},
-    schedule::{IntoScheduleConfigs, ScheduleLabel, SystemSet},
+    schedule::{IntoScheduleConfigs, ScheduleLabel, SystemLocation, SystemSet},
     system::{Commands, Local, Query},
 };
 #[cfg(feature = "bevy_reflect")]
@@ -45,7 +45,7 @@ pub struct HierarchyPropagatePlugin<
     F: QueryFilter = (),
     R: Relationship = ChildOf,
 > {
-    schedule: Interned<dyn ScheduleLabel>,
+    location: (Interned<dyn ScheduleLabel>, Option<Interned<dyn SystemSet>>),
     _marker: PhantomData<fn() -> (C, F, R)>,
 }
 
@@ -53,9 +53,9 @@ impl<C: Component + Clone + PartialEq, F: QueryFilter, R: Relationship>
     HierarchyPropagatePlugin<C, F, R>
 {
     /// Construct the plugin. The propagation systems will be placed in the specified schedule.
-    pub fn new(schedule: impl ScheduleLabel) -> Self {
+    pub fn new(location: impl SystemLocation) -> Self {
         Self {
-            schedule: schedule.intern(),
+            location: location.get_system_location(),
             _marker: PhantomData,
         }
     }
@@ -151,7 +151,7 @@ impl<C: Component + Clone + PartialEq, F: QueryFilter + 'static, R: Relationship
 {
     fn build(&self, app: &mut App) {
         app.add_systems(
-            self.schedule,
+            self.location,
             (
                 update_source::<C, F, R>,
                 update_removed_limit::<C, F, R>,

--- a/crates/bevy_app/src/propagate.rs
+++ b/crates/bevy_app/src/propagate.rs
@@ -343,7 +343,7 @@ pub fn propagate_output<C: Component + Clone + PartialEq, F: QueryFilter>(
 mod tests {
     use bevy_ecs::schedule::Schedule;
 
-    use crate::{App, Update};
+    use crate::{App, Main};
 
     use super::*;
 
@@ -353,8 +353,8 @@ mod tests {
     #[test]
     fn test_simple_propagate() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -381,8 +381,8 @@ mod tests {
     #[test]
     fn test_remove_propagate() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -410,8 +410,8 @@ mod tests {
     #[test]
     fn test_remove_and_reinsert_propagate() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let parent = app.world_mut().spawn(Propagate(TestValue(1))).id();
         let child = app.world_mut().spawn_empty().insert(ChildOf(parent)).id();
@@ -436,8 +436,8 @@ mod tests {
     #[test]
     fn test_remove_orphan() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -464,8 +464,8 @@ mod tests {
     #[test]
     fn test_reparented() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -494,8 +494,8 @@ mod tests {
     #[test]
     fn test_reparented_with_prior() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -523,8 +523,8 @@ mod tests {
     #[test]
     fn test_detach_and_reattach_propagates_to_descendants() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -562,8 +562,8 @@ mod tests {
     #[test]
     fn test_propagate_over() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -588,8 +588,8 @@ mod tests {
     #[test]
     fn test_remove_propagate_over() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -638,8 +638,8 @@ mod tests {
     #[test]
     fn test_propagate_over_parent_removed() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -670,8 +670,8 @@ mod tests {
     #[test]
     fn test_orphaned_propagate_over() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -707,8 +707,8 @@ mod tests {
     #[test]
     fn test_propagate_stop() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -733,8 +733,8 @@ mod tests {
     #[test]
     fn test_remove_propagate_stop() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -770,8 +770,8 @@ mod tests {
     #[test]
     fn test_intermediate_override() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -813,9 +813,9 @@ mod tests {
         struct Marker;
 
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
+        app.add_schedule(Schedule::new(Main));
         app.add_plugins(HierarchyPropagatePlugin::<TestValue, With<Marker>>::new(
-            Update,
+            Main,
         ));
 
         let mut query = app.world_mut().query::<&TestValue>();
@@ -869,8 +869,8 @@ mod tests {
     #[test]
     fn test_removed_propagate_still_inherits() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 
@@ -903,8 +903,8 @@ mod tests {
     #[test]
     fn test_reparent_respects_stop() {
         let mut app = App::new();
-        app.add_schedule(Schedule::new(Update));
-        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Update));
+        app.add_schedule(Schedule::new(Main));
+        app.add_plugins(HierarchyPropagatePlugin::<TestValue>::new(Main));
 
         let mut query = app.world_mut().query::<&TestValue>();
 

--- a/crates/bevy_app/src/sub_app.rs
+++ b/crates/bevy_app/src/sub_app.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     prelude::*,
     schedule::{
         InternedScheduleLabel, InternedSystemSet, ScheduleBuildSettings, ScheduleCleanupPolicy,
-        ScheduleError, ScheduleLabel,
+        ScheduleError, ScheduleLabel, SystemLocation,
     },
     system::{ScheduleSystem, SystemId, SystemInput},
 };
@@ -223,11 +223,11 @@ impl SubApp {
     /// See [`App::add_systems`].
     pub fn add_systems<M>(
         &mut self,
-        schedule: impl ScheduleLabel,
+        location: impl SystemLocation,
         systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
     ) -> &mut Self {
         let mut schedules = self.world.resource_mut::<Schedules>();
-        schedules.add_systems(schedule, systems);
+        schedules.add_systems(location, systems);
 
         self
     }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -213,7 +213,7 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use bevy_app::{App, Plugin, PostUpdate, PreUpdate};
+use bevy_app::{App, Main, Plugin, PostUpdate, PreUpdate};
 use bevy_ecs::{prelude::Component, schedule::common_conditions::resource_exists};
 use bevy_ecs::{
     reflect::AppTypeRegistry,
@@ -418,7 +418,7 @@ impl Plugin for AssetPlugin {
             .init_asset::<()>()
             .add_message::<UntypedAssetLoadFailedEvent>()
             .configure_sets(
-                PreUpdate,
+                Main,
                 AssetTrackingSystems.after(handle_internal_asset_events),
             )
             // `handle_internal_asset_events` requires the use of `&mut World`,
@@ -750,7 +750,7 @@ mod tests {
         vec::Vec,
     };
     use async_channel::{Receiver, Sender};
-    use bevy_app::{App, TaskPoolPlugin, Update};
+    use bevy_app::{App, Main, TaskPoolPlugin, Update};
     use bevy_diagnostic::{DiagnosticsPlugin, DiagnosticsStore};
     use bevy_ecs::{
         message::MessageCursor,
@@ -1971,7 +1971,7 @@ mod tests {
 
         fn uses_assets(_asset: ResMut<Assets<CoolText>>) {}
         app.add_systems(Update, (uses_assets, uses_assets));
-        app.edit_schedule(Update, |s| {
+        app.edit_schedule(Main, |s| {
             s.set_build_settings(ScheduleBuildSettings {
                 ambiguity_detection: LogLevel::Error,
                 ..Default::default()
@@ -1979,7 +1979,7 @@ mod tests {
         });
 
         // running schedule does not error on ambiguity between the 2 uses_assets systems
-        app.world_mut().run_schedule(Update);
+        app.world_mut().run_schedule(Main);
     }
 
     // This test is not checking a requirement, but documenting a current limitation. We simply are

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -83,7 +83,7 @@ impl Plugin for AudioPlugin {
         app.insert_resource(self.global_volume)
             .insert_resource(DefaultSpatialScale(self.default_spatial_scale))
             .configure_sets(
-                PostUpdate,
+                Main,
                 AudioPlaybackSystems
                     .run_if(audio_output_available)
                     .after(TransformSystems::Propagate), // For spatial audio transforms

--- a/crates/bevy_camera/src/visibility/mod.rs
+++ b/crates/bevy_camera/src/visibility/mod.rs
@@ -42,7 +42,7 @@ use derive_more::derive::{Deref, DerefMut};
 pub use range::*;
 pub use render_layers::*;
 
-use bevy_app::{Plugin, PostUpdate, ValidateParentHasComponentPlugin};
+use bevy_app::{Main, Plugin, PostUpdate, ValidateParentHasComponentPlugin};
 use bevy_asset::prelude::AssetChanged;
 use bevy_asset::{AssetEventSystems, Assets};
 use bevy_ecs::{prelude::*, VariantDefaults};
@@ -502,17 +502,17 @@ impl Plugin for VisibilityPlugin {
             .register_required_components::<Mesh2d, Visibility>()
             .register_required_components::<Mesh2d, VisibilityClass>()
             .configure_sets(
-                PostUpdate,
+                Main,
                 (UpdateFrusta, VisibilityPropagate)
                     .before(CheckVisibility)
                     .after(TransformSystems::Propagate),
             )
             .configure_sets(
-                PostUpdate,
+                Main,
                 MarkNewlyHiddenEntitiesInvisible.after(CheckVisibility),
             )
             .configure_sets(
-                PostUpdate,
+                Main,
                 (CalculateBounds)
                     .before(CheckVisibility)
                     .after(TransformSystems::Propagate)

--- a/crates/bevy_camera_controller/src/free_camera.rs
+++ b/crates/bevy_camera_controller/src/free_camera.rs
@@ -15,7 +15,7 @@
 //! To configure the settings of this controller, modify the fields of the [`FreeCamera`] component.
 // TODO: Discuss switching camera to orthographic mode.
 
-use bevy_app::{App, Plugin, RunFixedMainLoop, RunFixedMainLoopSystems};
+use bevy_app::{App, Plugin, RunFixedMainLoop};
 use bevy_camera::Camera;
 use bevy_ecs::prelude::*;
 use bevy_input::keyboard::KeyCode;
@@ -28,7 +28,7 @@ use bevy_log::info;
 use bevy_math::curve::{Interval, SampleAutoCurve};
 use bevy_math::Curve;
 use bevy_math::{ops::exp, Dir3, EulerRot, Quat, StableInterpolate, Vec2, Vec3};
-use bevy_time::{Real, Time};
+use bevy_time::{run_fixed_main_schedule, Real, Time};
 use bevy_transform::prelude::Transform;
 use bevy_window::{CursorGrabMode, CursorOptions, Window};
 
@@ -47,7 +47,7 @@ impl Plugin for FreeCameraPlugin {
             RunFixedMainLoop,
             (run_freecamera_controller, rotate_freecam_to)
                 .chain()
-                .in_set(RunFixedMainLoopSystems::BeforeFixedMainLoop),
+                .before(run_fixed_main_schedule),
         );
     }
 }

--- a/crates/bevy_camera_controller/src/pan_camera.rs
+++ b/crates/bevy_camera_controller/src/pan_camera.rs
@@ -5,7 +5,7 @@
 //!
 //! To configure the settings of this controller, modify the fields of the [`PanCamera`] component.
 
-use bevy_app::{App, Plugin, RunFixedMainLoop, RunFixedMainLoopSystems};
+use bevy_app::{App, Plugin, RunFixedMainLoop};
 use bevy_camera::{Camera, RenderTarget};
 use bevy_ecs::prelude::*;
 use bevy_input::keyboard::KeyCode;
@@ -16,7 +16,7 @@ use bevy_picking::{
     events::{Drag, DragEnd, DragStart, Pointer},
     pointer::PointerButton,
 };
-use bevy_time::{Real, Time};
+use bevy_time::{run_fixed_main_schedule, Real, Time};
 use bevy_transform::components::GlobalTransform;
 use bevy_transform::prelude::Transform;
 use bevy_window::{PrimaryWindow, WindowRef};
@@ -32,7 +32,7 @@ impl Plugin for PanCameraPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(
             RunFixedMainLoop,
-            run_pancamera_controller.in_set(RunFixedMainLoopSystems::BeforeFixedMainLoop),
+            run_pancamera_controller.before(run_fixed_main_schedule),
         )
         .add_observer(add_window_observer)
         .add_observer(remove_window_observer);

--- a/crates/bevy_dev_tools/src/ci_testing/mod.rs
+++ b/crates/bevy_dev_tools/src/ci_testing/mod.rs
@@ -93,7 +93,7 @@ impl Plugin for CiTestingPlugin {
         // As a result, we must conditionally order the two systems using a system set.
         #[cfg(any(unix, windows))]
         app.configure_sets(
-            Update,
+            Main,
             EventSenderSystems.before(bevy_app::TerminalCtrlCHandlerPlugin::exit_on_flag),
         );
     }

--- a/crates/bevy_dev_tools/src/diagnostics_overlay.rs
+++ b/crates/bevy_dev_tools/src/diagnostics_overlay.rs
@@ -250,7 +250,7 @@ pub struct DiagnosticsOverlayPlugin;
 impl Plugin for DiagnosticsOverlayPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<DiagnosticsOverlayStyle>();
-        app.configure_sets(Update, DiagnosticsOverlaySystems::Rebuild);
+        app.configure_sets(Main, DiagnosticsOverlaySystems::Rebuild);
         app.add_systems(PreStartup, build_plane);
         app.add_systems(
             Update,

--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -1,6 +1,6 @@
 //! Module containing logic for FPS overlay.
 
-use bevy_app::{Plugin, Startup, Update};
+use bevy_app::{Main, Plugin, Startup, Update};
 use bevy_asset::Assets;
 use bevy_color::Color;
 use bevy_diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin};
@@ -86,7 +86,7 @@ impl Plugin for FpsOverlayPlugin {
 
         app.insert_resource(self.config.clone())
             .configure_sets(
-                Update,
+                Main,
                 FpsOverlaySystems::Customize.before(FpsOverlaySystems::UpdateText),
             )
             .add_systems(Startup, setup)

--- a/crates/bevy_dev_tools/src/schedule_data/plugin.rs
+++ b/crates/bevy_dev_tools/src/schedule_data/plugin.rs
@@ -135,7 +135,7 @@ fn collect_system_data(world: &mut World) -> Result<(), BevyError> {
 
 #[cfg(test)]
 mod tests {
-    use bevy_app::{App, PostUpdate, Update};
+    use bevy_app::{App, Main, SpawnScene};
 
     use crate::schedule_data::{
         plugin::collect_system_data_inner,
@@ -152,8 +152,8 @@ mod tests {
         fn a() {}
         fn b() {}
         fn c() {}
-        app.add_systems(Update, (a, b));
-        app.add_systems(PostUpdate, c);
+        app.add_systems(Main, (a, b));
+        app.add_systems(SpawnScene, c);
 
         // Normally users would use the plugin, but to avoid writing to disk in a test, we just call
         // the inner part of the system directly.
@@ -164,12 +164,12 @@ mod tests {
         assert_eq!(app_data.schedules.len(), 3);
         let first = &app_data.schedules[0];
         validate_message_update_system(first);
-        let post_update = &app_data.schedules[1];
-        assert_eq!(post_update.name, "PostUpdate");
-        assert_eq!(post_update.systems, [simple_system("c")]);
-        let update = &app_data.schedules[2];
-        assert_eq!(update.name, "Update");
-        assert_eq!(update.systems, [simple_system("a"), simple_system("b")]);
+        let main = &app_data.schedules[1];
+        assert_eq!(main.name, "Main");
+        assert_eq!(main.systems, [simple_system("a"), simple_system("b")]);
+        let spawn_scene = &app_data.schedules[2];
+        assert_eq!(spawn_scene.name, "SpawnScene");
+        assert_eq!(spawn_scene.systems, [simple_system("c")]);
     }
 
     #[test]
@@ -184,8 +184,8 @@ mod tests {
         let mut app = App::empty();
 
         fn a() {}
-        app.add_systems(Update, a);
-        app.world_mut().run_schedule(Update);
+        app.add_systems(Main, a);
+        app.world_mut().run_schedule(Main);
 
         // Normally users would use the plugin, but to avoid writing to disk in a test, we just call
         // the inner part of the system directly.
@@ -195,6 +195,6 @@ mod tests {
 
         // If the schedule is missing, this would panic! This could happen if there was an error
         // extracting the schedule data, and we didn't hokey-pokey safely.
-        app.world_mut().schedule_scope(Update, |_, _| {});
+        app.world_mut().schedule_scope(Main, |_, _| {});
     }
 }

--- a/crates/bevy_dev_tools/src/schedule_data/plugin.rs
+++ b/crates/bevy_dev_tools/src/schedule_data/plugin.rs
@@ -1,7 +1,7 @@
 //! Convenience plugin for automatically performing serialization of schedules on boot.
 use std::{fs::File, io::Write, path::PathBuf};
 
-use bevy_app::{App, Main, Plugin};
+use bevy_app::{App, EntryPoint, Plugin};
 use bevy_ecs::{
     error::{BevyError, ResultSeverityExt, Severity},
     intern::Interned,
@@ -41,7 +41,7 @@ pub struct SerializeSchedulesPlugin {
 impl Default for SerializeSchedulesPlugin {
     fn default() -> Self {
         Self {
-            schedule: Main.intern(),
+            schedule: EntryPoint.intern(),
         }
     }
 }
@@ -63,9 +63,9 @@ impl Plugin for SerializeSchedulesPlugin {
                 collect_system_data
                     .run_if(run_once)
                     .in_set(SerializeSchedulesSystems)
-                    // While we may not be in the `Main` schedule at all, the default is that, so we
+                    // While we may not be in the `EntryPoint` schedule at all, the default is that, so we
                     // should make this work properly in the default case.
-                    .before(Main::run_main),
+                    .before(EntryPoint::run_main),
             );
     }
 }

--- a/crates/bevy_dev_tools/src/schedule_data/serde.rs
+++ b/crates/bevy_dev_tools/src/schedule_data/serde.rs
@@ -478,7 +478,7 @@ pub enum ExtractAppDataError {
 ///
 /// This is public to allow other test modules in this crate to use its utilities.
 pub mod tests {
-    use bevy_app::{App, Update};
+    use bevy_app::{App, Main, Update};
     use bevy_ecs::{
         component::Component,
         query::{With, Without},
@@ -860,7 +860,7 @@ pub mod tests {
     fn linear_with_system_sets() {
         let mut app = App::empty();
 
-        app.configure_sets(Update, (MySet::<0>, MySet::<1>, MySet::<2>).chain());
+        app.configure_sets(Main, (MySet::<0>, MySet::<1>, MySet::<2>).chain());
 
         let data = app_data_from_app(&mut app).unwrap();
         // SubApps start with the First schedule by default.
@@ -897,8 +897,8 @@ pub mod tests {
         fn a() {}
 
         app.add_systems(Update, a.in_set(MySet::<0>))
-            .configure_sets(Update, MySet::<0>.in_set(MySet::<1>))
-            .configure_sets(Update, MySet::<1>.in_set(MySet::<2>));
+            .configure_sets(Main, MySet::<0>.in_set(MySet::<1>))
+            .configure_sets(Main, MySet::<1>.in_set(MySet::<2>));
 
         let data = app_data_from_app(&mut app).unwrap();
         // SubApps start with the First schedule by default.

--- a/crates/bevy_dev_tools/src/schedule_data/serde.rs
+++ b/crates/bevy_dev_tools/src/schedule_data/serde.rs
@@ -478,7 +478,7 @@ pub enum ExtractAppDataError {
 ///
 /// This is public to allow other test modules in this crate to use its utilities.
 pub mod tests {
-    use bevy_app::{App, Main, Update};
+    use bevy_app::{App, Main};
     use bevy_ecs::{
         component::Component,
         query::{With, Without},
@@ -813,7 +813,7 @@ pub mod tests {
         fn b() {}
         fn c() {}
 
-        app.add_systems(Update, (a, b, c).chain());
+        app.add_systems(Main, (a, b, c).chain());
 
         let data = app_data_from_app(&mut app).unwrap();
         // SubApps start with the First schedule by default.
@@ -821,7 +821,7 @@ pub mod tests {
         validate_message_update_system(&data.schedules[0]);
 
         let update = &data.schedules[1];
-        assert_eq!(update.name, "Update");
+        assert_eq!(update.name, "Main");
         assert_eq!(
             update.systems,
             [simple_system("a"), simple_system("b"), simple_system("c"),]
@@ -867,7 +867,7 @@ pub mod tests {
         assert_eq!(data.schedules.len(), 2);
         validate_message_update_system(&data.schedules[0]);
         let update = &data.schedules[1];
-        assert_eq!(update.name, "Update");
+        assert_eq!(update.name, "Main");
         assert_eq!(update.systems, []);
         assert_eq!(
             update.system_sets,
@@ -896,7 +896,7 @@ pub mod tests {
 
         fn a() {}
 
-        app.add_systems(Update, a.in_set(MySet::<0>))
+        app.add_systems(Main, a.in_set(MySet::<0>))
             .configure_sets(Main, MySet::<0>.in_set(MySet::<1>))
             .configure_sets(Main, MySet::<1>.in_set(MySet::<2>));
 
@@ -905,7 +905,7 @@ pub mod tests {
         assert_eq!(data.schedules.len(), 2);
         validate_message_update_system(&data.schedules[0]);
         let update = &data.schedules[1];
-        assert_eq!(update.name, "Update");
+        assert_eq!(update.name, "Main");
         assert_eq!(update.systems, [simple_system("a")]);
         assert_eq!(
             update.system_sets,
@@ -942,14 +942,14 @@ pub mod tests {
         fn c0() {}
         fn c1() {}
 
-        app.add_systems(Update, (((a0, a1), (b0, b1)).chain(), (c0, c1).chain()));
+        app.add_systems(Main, (((a0, a1), (b0, b1)).chain(), (c0, c1).chain()));
 
         let data = app_data_from_app(&mut app).unwrap();
         // SubApps start with the First schedule by default.
         assert_eq!(data.schedules.len(), 2);
         validate_message_update_system(&data.schedules[0]);
         let update = &data.schedules[1];
-        assert_eq!(update.name, "Update");
+        assert_eq!(update.name, "Main");
         assert_eq!(
             update.systems,
             [
@@ -1063,14 +1063,14 @@ pub mod tests {
         fn e0(_: Query<&mut MyComponent<9>>) {}
         fn e1(_: Query<&mut MyComponent<9>>) {}
 
-        app.add_systems(Update, (a0, a1, b0, b1, c0, c1, d0, d1, (e0, e1).chain()));
+        app.add_systems(Main, (a0, a1, b0, b1, c0, c1, d0, d1, (e0, e1).chain()));
 
         let data = app_data_from_app(&mut app).unwrap();
         // SubApps start with the First schedule by default.
         assert_eq!(data.schedules.len(), 2);
         validate_message_update_system(&data.schedules[0]);
         let update = &data.schedules[1];
-        assert_eq!(update.name, "Update");
+        assert_eq!(update.name, "Main");
         assert_eq!(
             update.components,
             [

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -27,8 +27,8 @@ use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::{format_ident, quote, ToTokens};
 use syn::{
-    parse_macro_input, parse_quote, punctuated::Punctuated, token::Comma, ConstParam, Data,
-    DeriveInput, Fields, GenericParam, TypeParam,
+    parse_macro_input, parse_quote, punctuated::Punctuated, spanned::Spanned, token::Comma,
+    ConstParam, Data, DeriveInput, Fields, GenericParam, TypeParam,
 };
 
 enum BundleFieldKind {
@@ -39,6 +39,8 @@ enum BundleFieldKind {
 const BUNDLE_ATTRIBUTE_NAME: &str = "bundle";
 const BUNDLE_ATTRIBUTE_IGNORE_NAME: &str = "ignore";
 const BUNDLE_ATTRIBUTE_NO_FROM_COMPONENTS: &str = "ignore_from_components";
+
+const SYSTEM_SET_DEFAULT_SCHEDULE: &str = "default_schedule";
 
 #[derive(Debug)]
 struct BundleAttributes {
@@ -516,13 +518,47 @@ pub fn derive_schedule_label(input: TokenStream) -> TokenStream {
 /// Derive macro generating an impl of the trait `SystemSet`.
 ///
 /// This does not work for unions.
-#[proc_macro_derive(SystemSet)]
+#[proc_macro_derive(SystemSet, attributes(default_schedule))]
 pub fn derive_system_set(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    let mut trait_path = bevy_ecs_path();
+    let bevy_ecs = bevy_ecs_path();
+    let mut trait_path = bevy_ecs.clone();
     trait_path.segments.push(format_ident!("schedule").into());
     trait_path.segments.push(format_ident!("SystemSet").into());
-    derive_label(input, "SystemSet", &trait_path)
+
+    let mut default_schedule = None;
+    for attr in input.attrs.iter() {
+        if attr.path().is_ident(SYSTEM_SET_DEFAULT_SCHEDULE) {
+            let path = match attr.parse_args::<syn::Path>() {
+                Ok(value) => value,
+                Err(e) => return e.into_compile_error().into(),
+            };
+            if default_schedule.is_some() {
+                return syn::Error::new(attr.span(), "duplicate default_schedule attribute")
+                    .into_compile_error()
+                    .into();
+            }
+            default_schedule = Some(path);
+        }
+    }
+
+    let mut label_impl = derive_label(input.clone(), "SystemSet", &trait_path);
+
+    if let Some(default_schedule) = default_schedule {
+        let ident = input.ident.clone();
+        let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+        label_impl.extend(TokenStream::from(quote! {
+            impl #impl_generics #bevy_ecs::schedule::SystemLocation for #ident #ty_generics #where_clause {
+                fn get_system_location(&self) -> (
+                    #bevy_ecs::intern::Interned<dyn #bevy_ecs::schedule::ScheduleLabel>,
+                    ::core::option::Option<#bevy_ecs::intern::Interned<dyn #bevy_ecs::schedule::SystemSet>>,
+                ) {
+                    (#default_schedule.intern(), Some(self.intern()))
+                }
+            }
+        }));
+    }
+    label_impl
 }
 
 pub(crate) fn bevy_ecs_path() -> syn::Path {

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -219,10 +219,15 @@ impl Schedules {
     /// Adds one or more systems to the [`Schedule`] matching the provided [`ScheduleLabel`].
     pub fn add_systems<M>(
         &mut self,
-        schedule: impl ScheduleLabel,
+        location: impl SystemLocation,
         systems: impl IntoScheduleConfigs<ScheduleSystem, M>,
     ) -> &mut Self {
-        self.entry(schedule).add_systems(systems);
+        let (schedule, system_set) = location.get_system_location();
+        if let Some(system_set) = system_set {
+            self.entry(schedule).add_systems(systems.in_set(system_set));
+        } else {
+            self.entry(schedule).add_systems(systems);
+        }
 
         self
     }

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -367,6 +367,16 @@ impl<T: ScheduleLabel> SystemLocation for T {
     }
 }
 
+// Implementation for a tuple of the location. This allows calling
+// `SystemLocation::get_system_location` and then using that returned value as a system location.
+impl SystemLocation for (Interned<dyn ScheduleLabel>, Option<Interned<dyn SystemSet>>) {
+    fn get_system_location(
+        &self,
+    ) -> (Interned<dyn ScheduleLabel>, Option<Interned<dyn SystemSet>>) {
+        self.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -147,6 +147,36 @@ define_label!(
     /// // Adding multiple systems to a set.
     /// schedule.add_systems((player_damage_calculation, enemy_damage_calculation).in_set(CombatSystems::DamageCalculation));
     /// ```
+    ///
+    /// ## Default schedules
+    ///
+    /// The derive macro for system sets also includes a `default_schedule` attribute. Providing a
+    /// [`ScheduleLabel`] in this attribute allows the system set to be used in place of the
+    /// [`ScheduleLabel`] in a [`Schedules::add_systems`] call.
+    ///
+    /// ```rust
+    /// use bevy_ecs::{prelude::*, schedule::{ScheduleLabel, SystemSet}};
+    ///
+    /// #[derive(ScheduleLabel, Debug, Clone, PartialEq, Eq, Hash)]
+    /// struct Main;
+    ///
+    /// #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+    /// #[default_schedule(Main)]
+    /// enum CombatSystems {
+    ///    TargetSelection,
+    ///    DamageCalculation,
+    ///    Cleanup,
+    /// }
+    ///
+    /// let mut schedules = Schedules::default();
+    ///
+    /// fn system() {}
+    ///
+    /// // `system` is added to the `Main` schedule, and is in the system set `CombatSystems::TargetSelection`.
+    /// schedules.add_systems(CombatSystems::TargetSelection, system);
+    /// ```
+    ///
+    /// [`Schedules::add_systems()`]: crate::schedule::Schedules::add_systems
     #[diagnostic::on_unimplemented(
         note = "consider annotating `{Self}` with `#[derive(SystemSet)]`"
     )]
@@ -309,6 +339,31 @@ where
     #[inline]
     fn into_system_set(self) -> Self::Set {
         SystemTypeSet::<F>::new()
+    }
+}
+
+/// Trait defining where systems should be placed according to this type.
+///
+/// This allows functions like [`Schedules::add_systems`] to support both [`ScheduleLabel`]s or
+/// types that have explicitly implemented this trait (usually through deriving [`SystemSet`] with
+/// the [`default_schedule`] attribute).
+///
+/// [`Schedules::add_systems`]: crate::schedule::Schedules::add_systems
+/// [`default_schedule`]: crate::schedule::SystemSet
+pub trait SystemLocation {
+    /// Returns the system location that this value represents.
+    ///
+    /// Systems will be added to the returned schedule, and also assigned the given system set (if
+    /// [`Some`]).
+    fn get_system_location(&self)
+        -> (Interned<dyn ScheduleLabel>, Option<Interned<dyn SystemSet>>);
+}
+
+impl<T: ScheduleLabel> SystemLocation for T {
+    fn get_system_location(
+        &self,
+    ) -> (Interned<dyn ScheduleLabel>, Option<Interned<dyn SystemSet>>) {
+        (self.intern(), None)
     }
 }
 

--- a/crates/bevy_feathers/src/lib.rs
+++ b/crates/bevy_feathers/src/lib.rs
@@ -22,7 +22,8 @@
 extern crate alloc;
 
 use bevy_app::{
-    HierarchyPropagatePlugin, Plugin, PluginGroup, PluginGroupBuilder, PostUpdate, PropagateSet,
+    HierarchyPropagatePlugin, Main, Plugin, PluginGroup, PluginGroupBuilder, PostUpdate,
+    PropagateSet,
 };
 use bevy_asset::embedded_asset;
 use bevy_ecs::{query::With, schedule::IntoScheduleConfigs};
@@ -87,7 +88,7 @@ impl Plugin for FeathersCorePlugin {
         // This needs to run in UiSystems::Propagate so the fonts are up-to-date for `measure_text_system`
         // and `detect_text_needs_rerender` in UiSystems::Content
         app.configure_sets(
-            PostUpdate,
+            Main,
             PropagateSet::<TextFont>::default().in_set(UiSystems::Propagate),
         );
 

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -91,7 +91,7 @@ use bevy_reflect::TypePath;
 
 use crate::{config::ErasedGizmoConfigGroup, gizmos::GizmoBuffer};
 
-use bevy_time::Fixed;
+use bevy_time::{run_fixed_main_schedule, Fixed};
 use bevy_utils::TypeIdIndexMap;
 use config::{DefaultGizmoConfigGroup, GizmoConfig, GizmoConfigGroup, GizmoConfigStore};
 use core::{any::TypeId, marker::PhantomData, mem};
@@ -161,15 +161,13 @@ impl AppGizmoBuilder for App {
             .init_resource::<GizmoStorage<Config, Swap<Fixed>>>()
             .add_systems(
                 RunFixedMainLoop,
-                start_gizmo_context::<Config, Fixed>
-                    .in_set(bevy_app::RunFixedMainLoopSystems::BeforeFixedMainLoop),
+                start_gizmo_context::<Config, Fixed>.before(run_fixed_main_schedule),
             )
             .add_systems(FixedFirst, clear_gizmo_context::<Config, Fixed>)
             .add_systems(FixedLast, collect_requested_gizmos::<Config, Fixed>)
             .add_systems(
                 RunFixedMainLoop,
-                end_gizmo_context::<Config, Fixed>
-                    .in_set(bevy_app::RunFixedMainLoopSystems::AfterFixedMainLoop),
+                end_gizmo_context::<Config, Fixed>.after(run_fixed_main_schedule),
             )
             .add_systems(
                 Last,

--- a/crates/bevy_gizmos/src/transform_gizmo.rs
+++ b/crates/bevy_gizmos/src/transform_gizmo.rs
@@ -16,7 +16,7 @@
 //! is optional -- the gizmo will use that camera automatically. When multiple cameras
 //! exist, the marker is required so the gizmo knows which one to use.
 
-use bevy_app::{App, Plugin, PostUpdate};
+use bevy_app::{App, Main, Plugin, PostUpdate};
 use bevy_camera::Camera;
 use bevy_color::Color;
 use bevy_ecs::{
@@ -200,7 +200,7 @@ pub struct TransformGizmoState {
 ///
 /// Add a run condition to control when the gizmo is active:
 /// ```ignore
-/// app.configure_sets(Update, TransformGizmoSystems.run_if(in_state(AppState::Editor)));
+/// app.configure_sets(Main, TransformGizmoSystems.run_if(in_state(AppState::Editor)));
 /// ```
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
 pub struct TransformGizmoSystems;
@@ -233,7 +233,7 @@ impl Plugin for TransformGizmoPlugin {
             .register_type::<TransformGizmoCamera>()
             .register_type::<TransformGizmoSettings>()
             .register_type::<TransformGizmoState>()
-            .configure_sets(PostUpdate, TransformGizmoSystems)
+            .configure_sets(Main, TransformGizmoSystems)
             .add_systems(
                 PostUpdate,
                 (

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -133,7 +133,7 @@ impl Plugin for IgnoreAmbiguitiesPlugin {
             // update_ime_position reads Window to reposition the IME cursor, while
             // update_text2d_layout writes Window bounds for text wrapping.
             app.ignore_ambiguity(
-                bevy_app::PostUpdate,
+                bevy_app::Main,
                 bevy_ui_widgets::ImeSystems::UpdatePosition,
                 bevy_sprite::update_text2d_layout,
             );
@@ -145,12 +145,12 @@ impl Plugin for IgnoreAmbiguitiesPlugin {
             && app.is_plugin_added::<bevy_ui::UiPlugin>()
         {
             app.ignore_ambiguity(
-                bevy_app::PostUpdate,
+                bevy_app::Main,
                 bevy_animation::advance_animations,
                 bevy_ui::ui_layout_system,
             );
             app.ignore_ambiguity(
-                bevy_app::PostUpdate,
+                bevy_app::Main,
                 bevy_animation::animate_targets,
                 bevy_ui::ui_layout_system,
             );

--- a/crates/bevy_light/src/lib.rs
+++ b/crates/bevy_light/src/lib.rs
@@ -4,7 +4,7 @@
 
 extern crate alloc;
 
-use bevy_app::{App, Plugin, PostUpdate, Update};
+use bevy_app::{App, Main, Plugin, PostUpdate, Update};
 use bevy_asset::{AssetApp, AssetEventSystems};
 use bevy_camera::{
     primitives::{Aabb, CascadesFrusta, CubemapFrusta, Frustum, Sphere},
@@ -170,7 +170,7 @@ impl Plugin for LightPlugin {
             .init_asset::<ScatteringMedium>()
             .register_required_components::<Camera3d, Clusters>()
             .configure_sets(
-                PostUpdate,
+                Main,
                 SimulationLightSystems::CheckLightVisibility
                     .ambiguous_with(SimulationLightSystems::CheckLightVisibility),
             )

--- a/crates/bevy_light/src/lib.rs
+++ b/crates/bevy_light/src/lib.rs
@@ -175,7 +175,7 @@ impl Plugin for LightPlugin {
                     .ambiguous_with(SimulationLightSystems::CheckLightVisibility),
             )
             .configure_sets(
-                PostUpdate,
+                Main,
                 SimulationLightSystems::AssignLightsToClusters
                     .before(bevy_app::TransformGizmoRenderStep),
             )

--- a/crates/bevy_picking/src/lib.rs
+++ b/crates/bevy_picking/src/lib.rs
@@ -392,14 +392,14 @@ impl Plugin for PickingPlugin {
                     .in_set(PickingSystems::Backend),
             )
             .configure_sets(
-                First,
+                Main,
                 (PickingSystems::Input, PickingSystems::PostInput)
                     .after(bevy_time::TimeSystems)
                     .after(bevy_ecs::message::MessageUpdateSystems)
                     .chain(),
             )
             .configure_sets(
-                PreUpdate,
+                Main,
                 (
                     PickingSystems::ProcessInput.run_if(PickingSettings::input_should_run),
                     PickingSystems::Backend,

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -829,18 +829,14 @@ impl Plugin for RemotePlugin {
                 .add_observer(cache_schedule_build_metadata);
         }
 
-        app.init_schedule(RemoteLast)
-            .world_mut()
-            .resource_mut::<MainScheduleOrder>()
-            .insert_after(Last, RemoteLast);
-
         app.insert_resource(remote_methods)
             .init_resource::<schemas::SchemaTypesMetadata>()
             .init_resource::<RemoteWatchingRequests>()
             .init_resource::<builtin_methods::BrpEventObservers>()
             .add_systems(PreStartup, setup_mailbox_channel)
+            .configure_sets(Main, RemoteLast.after(Last))
             .configure_sets(
-                RemoteLast,
+                Main,
                 (RemoteSystems::ProcessRequests, RemoteSystems::Cleanup).chain(),
             )
             .add_systems(
@@ -907,7 +903,8 @@ impl Plugin for RemotePlugin {
 }
 
 /// Schedule that contains all systems to process Bevy Remote Protocol requests
-#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[default_schedule(Main)]
 pub struct RemoteLast;
 
 /// The systems sets of the [`RemoteLast`] schedule.

--- a/crates/bevy_remote/src/lib.rs
+++ b/crates/bevy_remote/src/lib.rs
@@ -535,7 +535,7 @@
 extern crate alloc;
 
 use async_channel::{Receiver, Sender};
-use bevy_app::{prelude::*, MainScheduleOrder};
+use bevy_app::prelude::*;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     entity::Entity,
@@ -550,7 +550,7 @@ use bevy_ecs::{
 };
 use bevy_platform::collections::HashMap;
 #[cfg(feature = "bevy_render")]
-use bevy_render::{Render, RenderApp, RenderScheduleOrder, RenderStartup};
+use bevy_render::{Render, RenderApp, RenderStartup};
 use bevy_utils::prelude::default;
 use serde::{ser::SerializeMap, Deserialize, Serialize};
 use serde_json::Value;
@@ -852,6 +852,7 @@ impl Plugin for RemotePlugin {
         #[cfg(feature = "bevy_render")]
         {
             use bevy_ecs::schedule::common_conditions::run_once;
+            use bevy_render::RenderSystems;
 
             let Some(render_app) = app.get_sub_app_mut(RenderApp) else {
                 return;
@@ -875,19 +876,19 @@ impl Plugin for RemotePlugin {
             }
 
             render_app
-                .init_schedule(RemoteLast)
-                .world_mut()
-                .resource_mut::<RenderScheduleOrder>()
-                .insert_after(Render, RemoteLast);
-
-            render_app
                 .insert_resource(render_remote_methods)
                 .init_resource::<schemas::SchemaTypesMetadata>()
                 .init_resource::<RemoteWatchingRequests>()
                 .add_systems(RenderStartup, setup_mailbox_channel.run_if(run_once))
                 .configure_sets(
-                    RemoteLast,
-                    (RemoteSystems::ProcessRequests, RemoteSystems::Cleanup).chain(),
+                    Render,
+                    (
+                        RenderSystems::PostCleanup,
+                        // Run RemoteSystems stuff after all the rendering stuff.
+                        RemoteSystems::ProcessRequests,
+                        RemoteSystems::Cleanup,
+                    )
+                        .chain(),
                 )
                 .add_systems(
                     RemoteLast,

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -101,10 +101,7 @@ use batching::gpu_preprocessing::BatchingPlugin;
 use bevy_app::{App, AppLabel, First, Plugin, SubApp};
 use bevy_asset::{AssetApp, AssetServer};
 use bevy_derive::Deref;
-use bevy_ecs::{
-    prelude::*,
-    schedule::{InternedScheduleLabel, ScheduleLabel},
-};
+use bevy_ecs::{prelude::*, schedule::ScheduleLabel};
 use bevy_platform::time::Instant;
 use bevy_shader::{load_shader_library, Shader, ShaderLoader};
 use bevy_time::TimeSender;
@@ -241,49 +238,10 @@ impl GpuResourceAppExt for SubApp {
     }
 }
 
-/// The render recovery schedule. This schedule runs the [`RenderScheduleOrder`] schedules if
-/// we are in [`RenderState::Ready`], and is otherwise hidden from users.
+/// The render recovery schedule. This schedule runs the [`Render`] schedule if we are in
+/// [`RenderState::Ready`], and is otherwise hidden from users.
 #[derive(ScheduleLabel, Debug, Hash, PartialEq, Eq, Clone)]
 struct RenderRecovery;
-
-/// Defines the schedules to be run for the rendering, including their order.
-///
-/// This is the same approach as [`MainScheduleOrder`](`bevy_app::MainScheduleOrder`).
-#[derive(Resource, Debug)]
-pub struct RenderScheduleOrder {
-    /// The labels to run for the rendering schedule (in the order they will be run).
-    pub labels: Vec<InternedScheduleLabel>,
-}
-
-impl Default for RenderScheduleOrder {
-    fn default() -> Self {
-        Self {
-            labels: vec![First.intern(), Render.intern()],
-        }
-    }
-}
-
-impl RenderScheduleOrder {
-    /// Adds the given `schedule` after the `after` schedule
-    pub fn insert_after(&mut self, after: impl ScheduleLabel, schedule: impl ScheduleLabel) {
-        let index = self
-            .labels
-            .iter()
-            .position(|current| (**current).eq(&after))
-            .unwrap_or_else(|| panic!("Expected {after:?} to exist"));
-        self.labels.insert(index + 1, schedule.intern());
-    }
-
-    /// Adds the given `schedule` before the `before` schedule
-    pub fn insert_before(&mut self, before: impl ScheduleLabel, schedule: impl ScheduleLabel) {
-        let index = self
-            .labels
-            .iter()
-            .position(|current| (**current).eq(&before))
-            .unwrap_or_else(|| panic!("Expected {before:?} to exist"));
-        self.labels.insert(index, schedule.intern());
-    }
-}
 
 /// The main render schedule.
 ///
@@ -302,6 +260,7 @@ impl Render {
 
         schedule.configure_sets(
             (
+                First,
                 ExtractCommands,
                 PrepareMeshes,
                 CreateViews,
@@ -393,7 +352,6 @@ impl Plugin for RenderPlugin {
         app.init_resource::<RenderAssetBytesPerFrame>()
             .init_resource::<RenderErrorHandler>();
         if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.init_resource::<RenderScheduleOrder>();
             render_app.init_resource::<RenderAssetBytesPerFrameLimiter>();
             render_app.init_gpu_resource::<renderer::PendingCommandBuffers>();
             render_app.insert_resource(sender);
@@ -476,12 +434,9 @@ fn renderer_is_ready(state: Res<RenderState>) -> bool {
     matches!(*state, RenderState::Ready)
 }
 
-fn run_render_schedule(world: &mut World) {
-    world.resource_scope(|world, order: Mut<RenderScheduleOrder>| {
-        for &label in &order.labels {
-            let _ = world.try_run_schedule(label);
-        }
-    });
+/// System for running the [`Render`] schedule.
+pub fn run_render_schedule(world: &mut World) {
+    let _ = world.try_run_schedule(Render);
 }
 
 fn send_time(time_sender: Res<TimeSender>) {

--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -329,7 +329,7 @@ impl AppExtStates for App {
     }
 }
 
-/// Registers the [`StateTransition`] schedule in the [`MainScheduleOrder`] to enable state processing.
+/// Registers the [`StateTransition`] schedule in the [`Main`] schedule to enable state processing.
 #[derive(Default)]
 pub struct StatesPlugin;
 

--- a/crates/bevy_state/src/app.rs
+++ b/crates/bevy_state/src/app.rs
@@ -1,5 +1,9 @@
-use bevy_app::{App, MainScheduleOrder, Plugin, PreStartup, PreUpdate, SubApp};
-use bevy_ecs::{message::Messages, schedule::IntoScheduleConfigs, world::FromWorld};
+use bevy_app::{App, Main, Plugin, PreStartup, PreUpdate, RunFixedMainLoop, StartupMain, SubApp};
+use bevy_ecs::{
+    message::Messages,
+    schedule::IntoScheduleConfigs,
+    world::{FromWorld, World},
+};
 use bevy_utils::once;
 use log::warn;
 
@@ -331,11 +335,23 @@ pub struct StatesPlugin;
 
 impl Plugin for StatesPlugin {
     fn build(&self, app: &mut App) {
-        let mut schedule = app.world_mut().resource_mut::<MainScheduleOrder>();
-        schedule.insert_after(PreUpdate, StateTransition);
-        schedule.insert_startup_before(PreStartup, StateTransition);
+        app.add_systems(
+            StartupMain,
+            run_state_transition_schedule.before(PreStartup),
+        )
+        .add_systems(
+            Main,
+            run_state_transition_schedule
+                .after(PreUpdate)
+                .before(RunFixedMainLoop),
+        );
         setup_state_transitions_in_world(app.world_mut());
     }
+}
+
+/// System to run the [`StateTransition`] schedule to update the states.
+pub fn run_state_transition_schedule(world: &mut World) {
+    let _ = world.try_run_schedule(StateTransition);
 }
 
 #[cfg(test)]

--- a/crates/bevy_time/src/fixed.rs
+++ b/crates/bevy_time/src/fixed.rs
@@ -236,10 +236,8 @@ impl Default for Fixed {
     }
 }
 
-/// Runs [`FixedMain`] zero or more times based on delta of
-/// [`Time<Virtual>`](Virtual) and [`Time::overstep`].
-/// You can order your systems relative to this by using
-/// [`RunFixedMainLoopSystems`](bevy_app::prelude::RunFixedMainLoopSystems).
+/// Runs [`FixedMain`] zero or more times based on delta of [`Time<Virtual>`](Virtual) and
+/// [`Time::overstep`].
 pub fn run_fixed_main_schedule(world: &mut World) {
     let delta = world.resource::<Time<Virtual>>().delta();
     world

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -86,10 +86,7 @@ impl Plugin for TimePlugin {
                 .ambiguous_with(message_update_system),
         )
         .add_systems(PreUpdate, check_delayed_command_queues)
-        .add_systems(
-            RunFixedMainLoop,
-            run_fixed_main_schedule.in_set(RunFixedMainLoopSystems::FixedMainLoop),
-        )
+        .add_systems(RunFixedMainLoop, run_fixed_main_schedule)
         .add_systems(
             Last,
             silence_delayed_command_queues_on_exit

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -446,7 +446,7 @@ mod tests {
         layout::ui_surface::UiSurface, prelude::*, ui_layout_system,
         update::propagate_ui_target_cameras, ContentSize, LayoutContext,
     };
-    use bevy_app::{App, HierarchyPropagatePlugin, PostUpdate, PropagateSet, TaskPoolPlugin};
+    use bevy_app::{App, HierarchyPropagatePlugin, Main, PostUpdate, PropagateSet, TaskPoolPlugin};
     use bevy_camera::{Camera, Camera2d, ComputedCameraValues, RenderTargetInfo, Viewport};
     use bevy_ecs::{prelude::*, system::RunSystemOnce};
     use bevy_math::{Rect, UVec2, Vec2};
@@ -490,14 +490,14 @@ mod tests {
         );
 
         app.configure_sets(
-            PostUpdate,
+            Main,
             PropagateSet::<ComputedUiTargetCamera>::default()
                 .after(propagate_ui_target_cameras)
                 .before(ui_layout_system),
         );
 
         app.configure_sets(
-            PostUpdate,
+            Main,
             PropagateSet::<ComputedUiRenderTargetInfo>::default()
                 .after(propagate_ui_target_cameras)
                 .before(ui_layout_system),
@@ -1258,7 +1258,7 @@ mod tests {
         ));
 
         app.configure_sets(
-            PostUpdate,
+            Main,
             PropagateSet::<ComputedUiTargetCamera>::default()
                 .after(propagate_ui_target_cameras)
                 .before(ui_layout_system),

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -145,7 +145,7 @@ impl Plugin for UiPlugin {
             .init_resource::<UiScale>()
             .init_resource::<UiStack>()
             .configure_sets(
-                PostUpdate,
+                Main,
                 (
                     CameraUpdateSystems,
                     UiSystems::Prepare.after(AnimationSystems),
@@ -157,14 +157,14 @@ impl Plugin for UiPlugin {
                     .chain(),
             )
             .configure_sets(
-                PostUpdate,
+                Main,
                 PropagateSet::<ComputedUiTargetCamera>::default().in_set(UiSystems::Propagate),
             )
             .add_plugins(HierarchyPropagatePlugin::<ComputedUiTargetCamera>::new(
                 PostUpdate,
             ))
             .configure_sets(
-                PostUpdate,
+                Main,
                 PropagateSet::<ComputedUiRenderTargetInfo>::default().in_set(UiSystems::Propagate),
             )
             .add_plugins(HierarchyPropagatePlugin::<ComputedUiRenderTargetInfo>::new(
@@ -289,19 +289,16 @@ fn build_text_interop(app: &mut App) {
         ),
     );
 
-    app.configure_sets(
-        PostUpdate,
-        AmbiguousWithText.ambiguous_with(widget::text_system),
-    );
+    app.configure_sets(Main, AmbiguousWithText.ambiguous_with(widget::text_system));
 
     app.configure_sets(
-        PostUpdate,
+        Main,
         AmbiguousWithUpdateText2dLayout.ambiguous_with(bevy_sprite::update_text2d_layout),
     );
 
     // We cannot set this up in bevy_text as this would create a circular dependency between bevy_ui and bevy_text
     app.configure_sets(
-        PostUpdate,
+        Main,
         EditableTextSystems
             .after(UiSystems::Layout)
             .before(UiSystems::PostLayout),

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -180,6 +180,7 @@ mod tests {
     use crate::UiTargetCamera;
     use bevy_app::App;
     use bevy_app::HierarchyPropagatePlugin;
+    use bevy_app::Main;
     use bevy_app::PostUpdate;
     use bevy_app::PropagateSet;
     use bevy_camera::Camera;
@@ -198,18 +199,12 @@ mod tests {
         app.add_plugins(HierarchyPropagatePlugin::<ComputedUiTargetCamera>::new(
             PostUpdate,
         ));
-        app.configure_sets(
-            PostUpdate,
-            PropagateSet::<ComputedUiTargetCamera>::default(),
-        );
+        app.configure_sets(Main, PropagateSet::<ComputedUiTargetCamera>::default());
 
         app.add_plugins(HierarchyPropagatePlugin::<ComputedUiRenderTargetInfo>::new(
             PostUpdate,
         ));
-        app.configure_sets(
-            PostUpdate,
-            PropagateSet::<ComputedUiRenderTargetInfo>::default(),
-        );
+        app.configure_sets(Main, PropagateSet::<ComputedUiRenderTargetInfo>::default());
 
         app.add_systems(bevy_app::Update, propagate_ui_target_cameras);
 

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -151,7 +151,7 @@ impl Plugin for WindowPlugin {
             app.add_systems(Last, close_when_requested.before(ExitSystems));
         }
 
-        app.configure_sets(Last, OnAppExitSystems.after(ExitSystems));
+        app.configure_sets(Main, OnAppExitSystems.after(ExitSystems));
     }
 }
 

--- a/examples/ecs/custom_schedule.rs
+++ b/examples/ecs/custom_schedule.rs
@@ -1,8 +1,8 @@
 //! Demonstrates how to add custom schedules that run in Bevy's `Main` schedule, ordered relative to Bevy's built-in
-//! schedules such as `Update` or `Last`.
+//! system sets such as `Update` or `Last`.
 
 use bevy::{
-    app::MainScheduleOrder,
+    app::StartupMain,
     ecs::schedule::{ScheduleLabel, SingleThreadedExecutor},
     prelude::*,
 };
@@ -27,23 +27,26 @@ fn main() {
     app.add_schedule(custom_update_schedule);
 
     // Bevy `App`s have a `main_schedule_label` field that configures which schedule is run by the App's `runner`.
-    // By default, this is `Main`. The `Main` schedule is responsible for running Bevy's main schedules such as
-    // `Update`, `Startup` or `Last`.
+    // By default, this is `Main`. The `Main` schedule runs the bulk of Bevy's systems.
     //
-    // We can configure the `Main` schedule to run our custom update schedule relative to the existing ones by modifying
-    // the `MainScheduleOrder` resource.
-    //
-    // Note that we modify `MainScheduleOrder` directly in `main` and not in a startup system. The reason for this is
-    // that the `MainScheduleOrder` cannot be modified from systems that are run as part of the `Main` schedule.
-    let mut main_schedule_order = app.world_mut().resource_mut::<MainScheduleOrder>();
-    main_schedule_order.insert_after(Update, SingleThreadedUpdate);
+    // We can create an exclusive system to run our custom schedule and use system ordering to place
+    // that schedule where we need it to run.
+    fn run_single_threaded_update_schedule(world: &mut World) {
+        world.run_schedule(SingleThreadedUpdate);
+    }
+    app.add_systems(
+        Main,
+        run_single_threaded_update_schedule
+            .after(Update)
+            .before(PostUpdate),
+    );
 
-    // Adding a custom startup schedule works similarly, but needs to use `insert_startup_after`
-    // instead of `insert_after`.
+    // Adding a custom startup schedule works similarly, but with `StartupMain`.
     app.add_schedule(Schedule::new(CustomStartup));
-
-    let mut main_schedule_order = app.world_mut().resource_mut::<MainScheduleOrder>();
-    main_schedule_order.insert_startup_after(PreStartup, CustomStartup);
+    fn run_custom_startup(world: &mut World) {
+        world.run_schedule(CustomStartup);
+    }
+    app.add_systems(StartupMain, run_custom_startup.before(PreStartup));
 
     app.add_systems(SingleThreadedUpdate, single_threaded_update_system)
         .add_systems(CustomStartup, custom_startup_system)

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -328,7 +328,7 @@ fn main() {
         // "round": print_message_system, score_system
         // "after_round": score_check_system, game_over_system
         .configure_sets(
-            Update,
+            Main,
             // chain() will ensure sets run in the order they are listed
             (
                 MySystems::BeforeRound,

--- a/examples/ecs/nondeterministic_system_order.rs
+++ b/examples/ecs/nondeterministic_system_order.rs
@@ -22,7 +22,9 @@ fn main() {
         // We can modify the reporting strategy for system execution order ambiguities on a per-schedule basis.
         // You must do this for each schedule you want to inspect; child schedules executed within an inspected
         // schedule do not inherit this modification.
-        .edit_schedule(Update, |schedule| {
+        // Note: `Update` is a system-set, not a schedule. Adding systems to `Update` adds the
+        // system to the `Main` schedule, and in the `Update` system-set.
+        .edit_schedule(Main, |schedule| {
             schedule.set_build_settings(ScheduleBuildSettings {
                 ambiguity_detection: LogLevel::Warn,
                 ..default()

--- a/examples/movement/physics_in_fixed_timestep.rs
+++ b/examples/movement/physics_in_fixed_timestep.rs
@@ -70,17 +70,17 @@
 //! - The player's visual representation is stored in Bevy's regular `Transform` component.
 //! - Every frame, we go through the following steps:
 //!   - Accumulate the player's input and set the current speed in the `handle_input` system.
-//!     This is run in the `RunFixedMainLoop` schedule, ordered in `RunFixedMainLoopSystems::BeforeFixedMainLoop`,
+//!     This is run in the `RunFixedMainLoop` schedule, ordered before `run_fixed_main_schedule`,
 //!     which runs before the fixed timestep loop. This is run every frame.
-//!   - Rotate the camera based on the player's input. This is also run in `RunFixedMainLoopSystems::BeforeFixedMainLoop`.
+//!   - Rotate the camera based on the player's input. This is also run before `run_fixed_main_schedule`.
 //!   - Advance the physics simulation by one fixed timestep in the `advance_physics` system.
 //!     Accumulated input is consumed here.
 //!     This is run in the `FixedUpdate` schedule, which runs zero or multiple times per frame.
 //!   - Update the player's visual representation in the `interpolate_rendered_transform` system.
 //!     This interpolates between the player's previous and current position in the physics simulation.
-//!     It is run in the `RunFixedMainLoop` schedule, ordered in `RunFixedMainLoopSystems::AfterFixedMainLoop`,
+//!     It is run in the `RunFixedMainLoop` schedule, ordered after `run_fixed_main_schedule`,
 //!     which runs after the fixed timestep loop. This is run every frame.
-//!   - Update the camera's translation to the player's interpolated translation. This is also run in `RunFixedMainLoopSystems::AfterFixedMainLoop`.
+//!   - Update the camera's translation to the player's interpolated translation. This is also run after `run_fixed_main_schedule`.
 //!
 //!
 //! ## Controls
@@ -95,7 +95,10 @@
 
 use std::f32::consts::FRAC_PI_2;
 
-use bevy::{color::palettes::tailwind, input::mouse::AccumulatedMouseMotion, prelude::*};
+use bevy::{
+    color::palettes::tailwind, input::mouse::AccumulatedMouseMotion, prelude::*,
+    time::run_fixed_main_schedule,
+};
 
 fn main() {
     App::new()
@@ -122,7 +125,7 @@ fn main() {
                     accumulate_input,
                 )
                     .chain()
-                    .in_set(RunFixedMainLoopSystems::BeforeFixedMainLoop),
+                    .before(run_fixed_main_schedule),
                 (
                     // Clear our accumulated input after it was processed during the fixed timestep.
                     // By clearing the input *after* the fixed timestep, we can still use `AccumulatedInput` inside `FixedUpdate` if we need it.
@@ -135,7 +138,7 @@ fn main() {
                     translate_camera,
                 )
                     .chain()
-                    .in_set(RunFixedMainLoopSystems::AfterFixedMainLoop),
+                    .after(run_fixed_main_schedule),
             ),
         )
         .run();

--- a/examples/showcase/breakout.rs
+++ b/examples/showcase/breakout.rs
@@ -55,7 +55,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugins(
             stepping::SteppingPlugin::default()
-                .add_schedule(Update)
+                .add_schedule(Main)
                 .at(percent(35), percent(50)),
         )
         .insert_resource(Score(0))

--- a/examples/showcase/stepping.rs
+++ b/examples/showcase/stepping.rs
@@ -1,4 +1,4 @@
-use bevy::{app::MainScheduleOrder, ecs::schedule::*, prelude::*};
+use bevy::{app::EntryPoint, ecs::schedule::*, prelude::*};
 
 /// Independent [`Schedule`] for stepping systems.
 ///
@@ -41,8 +41,10 @@ impl Plugin for SteppingPlugin {
         // We need an independent schedule so we have access to all other
         // schedules through the `Stepping` resource
         app.init_schedule(DebugSchedule);
-        let mut order = app.world_mut().resource_mut::<MainScheduleOrder>();
-        order.insert_after(Update, DebugSchedule);
+        fn run_debug_schedule(world: &mut World) {
+            world.run_schedule(DebugSchedule);
+        }
+        app.add_systems(EntryPoint, run_debug_schedule.after(EntryPoint::run_main));
 
         // create our stepping resource
         let mut stepping = Stepping::new();

--- a/examples/stress_tests/many_components.rs
+++ b/examples/stress_tests/many_components.rs
@@ -13,6 +13,7 @@
 //! If no valid number is provided, for each argument there's a reasonable default.
 
 use bevy::{
+    app::Main,
     diagnostic::{
         DiagnosticPath, DiagnosticsPlugin, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin,
     },
@@ -23,7 +24,7 @@ use bevy::{
     },
     log::LogPlugin,
     platform::collections::HashSet,
-    prelude::{App, In, IntoSystem, Query, Schedule, SystemParamBuilder, Update},
+    prelude::{App, In, IntoSystem, Query, Schedule, SystemParamBuilder},
     ptr::{OwningPtr, PtrMut},
     MinimalPlugins,
 };
@@ -103,7 +104,7 @@ fn stress_test(num_entities: u32, num_components: u32, num_systems: u32) {
         .collect();
 
     // fill the schedule with systems
-    let mut schedule = Schedule::new(Update);
+    let mut schedule = Schedule::new(Main);
     for _ in 1..=num_systems {
         let num_access_components = rng.random_range(1..10);
         let access_components: Vec<ComponentId> = component_ids


### PR DESCRIPTION
# Objective

`SystemSet` is a collection of systems and other system sets. `Schedule` is also a collection of systems and system sets.
We could simplify `Schedules` by only storing very few schedules and make schedules like `First`, `Update` and `Last` into system sets. One benefit is that `Schedule`s can currently *never* run concurrently, even if none of the systems conflict. Putting everything in one big schedule with system sets can potentially increase parallelism.

## Solution

Simplify most schedules into one `Main` schedule.

## Testing

Already existing tests.

### AI Disclosure

I did not use AI in anyway, but full credit goes to @andriyDev, who I'm adopting this PR from.